### PR TITLE
feat(surface): fullscreen interactive canvas overlay

### DIFF
--- a/docs/design-docs/specs/126-surface-fullscreen-interaction.md
+++ b/docs/design-docs/specs/126-surface-fullscreen-interaction.md
@@ -1,0 +1,282 @@
+# 126. Surface — Fullscreen Interaction Node
+
+## Overview
+
+`surface` is a fullscreen transparent canvas overlay for mouse and touch interactivity in Patchies.
+It enables live performance scenarios where the user draws, paints, or interacts with the canvas
+in fullscreen — while the FBO video pipeline continues rendering underneath.
+
+## Problem
+
+Patchies has no way to capture pointer/touch input at fullscreen scale today. DOM-renderer nodes
+(P5, canvas.dom, textmode.dom, three.dom) render to small preview canvases inside the node editor.
+There is no mechanism to paint/draw/select across the full screen during a performance.
+
+## Design
+
+### Core Concept
+
+`surface` is a fullscreen `canvas.dom` variant:
+
+- Creates a **fullscreen transparent canvas** fixed to the browser viewport (no node-editor chrome)
+- Captures all pointer and touch events from the full screen
+- Runs user code on the **main thread** using the Canvas 2D API — zero interaction lag
+- **Auto-freezes all DOM-renderer nodes** on activation (they are now invisible behind the overlay)
+- **FBO pipeline keeps running** — renders to the background canvas, visible through the transparent overlay
+
+### DOM-Renderer Nodes (auto-frozen on surface activation)
+
+These render to their own canvas elements and are occluded by the fullscreen overlay:
+
+- `p5`
+- `canvas.dom`
+- `textmode.dom`
+- `three.dom`
+
+FBO-renderer nodes (`hydra`, `regl`, `glsl`, `swgl`, `canvas`, `three`, `textmode`) are unaffected.
+
+### Three States
+
+| State        | Canvas                           | XYFlow                  | Description                                             |
+| ------------ | -------------------------------- | ----------------------- | ------------------------------------------------------- |
+| `preview`    | inline in node (like canvas.dom) | visible                 | **Default.** Interactive canvas inside the node editor. |
+| `fullscreen` | fullscreen overlay               | hidden (`display:none`) | Full interaction mode. DOM-renderer nodes frozen.       |
+| `stopped`    | none                             | visible                 | Paused/stopped. Performance optimization, not default.  |
+
+**State transitions:**
+
+- `preview` → `fullscreen`: click **Go Live** button on node / send `bang` / call `activate()`
+- `fullscreen` → `preview`: press **Escape** / click floating exit badge / send `{type: 'exit'}` / call `deactivate()`
+- `preview` ↔ `stopped`: click **Stop/Play** button on node (pause canvas to save CPU)
+
+Escape always returns to `preview`, never to `stopped`.
+
+---
+
+## User-Facing API
+
+Available globals inside the code editor (same as `canvas.dom`):
+
+```js
+canvas // HTMLCanvasElement — always at fullscreen resolution (window.innerWidth × window.innerHeight)
+ctx    // CanvasRenderingContext2D
+width  // = window.innerWidth  (constant regardless of preview vs fullscreen mode)
+height // = window.innerHeight (constant regardless of preview vs fullscreen mode)
+mouse  // { x, y, down, buttons } — normalized 0–1 coords
+```
+
+In `preview` mode the canvas is CSS-scaled down to fit the node (same `PREVIEW_SCALE_FACTOR`
+pattern as `canvas.dom`). `width`/`height` always report fullscreen dimensions so user code
+behaves identically in both modes.
+
+### Draw Modes
+
+`draw` is a magic named function — define it and the runner calls it automatically on each
+rAF frame (same pattern as `canvas.dom`):
+
+```js
+function draw() {
+  ctx.clearRect(0, 0, width, height)
+  // draw your frame here
+  requestAnimationFrame(draw)
+}
+
+draw()
+```
+
+```js
+setDrawMode('always')   // rAF loop — redraws every frame (default)
+setDrawMode('interact') // redraws only on pointer/touch events — saves CPU when idle
+setDrawMode('manual')   // user calls redraw() explicitly
+```
+
+```js
+redraw() // trigger one draw pass (useful in manual mode)
+```
+
+### Video Output
+
+```js
+noOutput() // disable CPU→GPU texture copy (default: enabled, same as canvas.dom)
+```
+
+CPU→GPU copy is expensive. Call `noOutput()` if you don't need to composite the overlay
+into the FBO pipeline.
+
+### Surface Activation
+
+```js
+activate() // enter fullscreen state: show overlay, hide XYFlow, freeze DOM-renderer nodes
+deactivate() // return to preview state: remove overlay, restore XYFlow and frozen nodes
+```
+
+Messages also trigger these:
+
+```js
+// bang or { type: 'activate' } → calls activate()
+// { type: 'exit' }             → calls deactivate()
+```
+
+### Browser Fullscreen (optional)
+
+```js
+goFullscreen() // call document.documentElement.requestFullscreen()
+exitFullscreen() // call document.exitFullscreen()
+```
+
+`surface` does NOT auto-fullscreen on activation. Use `goFullscreen()` explicitly,
+or combine with activation:
+
+```js
+recv((msg) => {
+  if (msg.type === 'live') {
+    activate()
+    goFullscreen()
+  }
+
+  if (msg.type === 'exit') {
+    deactivate()
+    exitFullscreen()
+  }
+})
+```
+
+### Interaction Callbacks
+
+```js
+onPointer((event) => {
+  // event: { x, y, pressure, buttons, type: 'down'|'move'|'up' }
+  // coordinates normalized 0–1
+})
+
+onTouch((touches) => {
+  // touches: Array<{ x, y, pressure, id }>
+  // coordinates normalized 0–1
+})
+```
+
+### Message Outlets
+
+| Outlet    | Type    | Description                                                                  |
+| --------- | ------- | ---------------------------------------------------------------------------- |
+| `pointer` | message | `{ x, y, pressure, buttons, type }` on every pointer event                   |
+| `touch`   | message | `[{ x, y, pressure, id }, ...]` on every touch event                         |
+| `video`   | video   | Overlay canvas as FBO texture (only present when `noOutput()` is NOT called) |
+
+### Other APIs (inherited from canvas.dom)
+
+```js
+setPortCount(inlets, outlets)
+setTitle(title)
+noInteract()   // disable drag/pan/wheel on the node itself
+noDrag()
+noPan()
+noWheel()
+recv((msg) => { ... })
+send(outlet, msg)
+```
+
+---
+
+## Example Usage
+
+```js
+// Draw red rectangles wherever the user clicks
+setDrawMode('interact')
+
+onPointer((e) => {
+  if (!e.down) return
+  ctx.fillStyle = 'rgba(255, 0, 0, 0.5)'
+  ctx.fillRect(e.x * width - 25, e.y * height - 25, 50, 50)
+  redraw()
+})
+```
+
+```js
+// Flower blooms performance: send pointer position as messages,
+// receive bloom regions back from a JS node
+setDrawMode('interact')
+noOutput()
+
+onPointer((e) => {
+  if (e.type === 'down') send(0, {x: e.x, y: e.y})
+})
+```
+
+---
+
+## Implementation Plan
+
+### 1. Overlay Canvas Management (`SurfaceOverlay.ts`)
+
+Singleton that manages the fullscreen canvas:
+
+- Creates a `<canvas>` fixed to viewport (`position: fixed; inset: 0; pointer-events: all; z-index: [above video, below XYFlow]`)
+- Resizes on `window.resize`
+- Tracks active `surface` node ID — last activated wins (previous surface node is effectively displaced but not destroyed)
+- `activate(nodeId)` / `deactivate(nodeId)`
+
+### 2. DOM Renderer Freeze (`SurfaceOverlay.ts`)
+
+Uses the existing `pauseObject`/`unpauseObject` mechanism — dispatches `nodeSetPaused` events
+via `PatchiesEventBus` (same API exposed in `js-integrations`).
+
+On `activate()`:
+
+- Enumerate all nodes in the current patch
+- For any node whose type is in `DOM_RENDERER_TYPES = ['p5', 'canvas.dom', 'textmode.dom', 'three.dom']`, dispatch `{ type: 'nodeSetPaused', nodeId, paused: true }`
+- Store frozen node IDs for later restoration
+
+On `deactivate()`:
+
+- Dispatch `{ type: 'nodeSetPaused', nodeId, paused: false }` for only the nodes frozen by this activation
+
+### 3. `Surface.svelte` Component
+
+Based on `CanvasDom.svelte` with these differences:
+
+- Canvas element is the overlay canvas from `SurfaceOverlay`, not an inline preview canvas
+- `setDrawMode()` added to `extraContext`
+- `onPointer()` / `onTouch()` added to `extraContext`
+- `pointer` and `touch` message outlets added
+- On mount: calls `SurfaceOverlay.activate(nodeId)`
+- On destroy: calls `SurfaceOverlay.deactivate(nodeId)`
+- Preview thumbnail: live scaled `drawImage` copy from overlay canvas each frame; hidden when `document.fullscreenElement` is active (no point rendering the thumbnail you can't see)
+- **NodeResizer** enabled with `keepAspectRatio: true`, locked to the aspect ratio of `window.innerWidth / window.innerHeight`. This ensures the preview always matches the proportions of the fullscreen output — no surprises when going live. The inline canvas dimensions are derived from the node's resized width/height.
+
+### 4. Node Registration
+
+- `src/lib/nodes/node-types.ts` — add `'surface'`
+- `src/lib/nodes/defaultNodeData.ts` — add default data
+- `src/lib/components/object-browser/get-categorized-objects.ts` — add to Visual category
+- `src/lib/ai/object-descriptions-types.ts` — add to OBJECT_TYPE_LIST
+- `src/lib/ai/object-prompts/` — add `surface.ts` prompt + register in `index.ts`
+- `src/lib/extensions/object-packs.ts` — add to Visual pack
+- `static/content/objects/surface.md` — documentation
+
+### 5. Z-Index Layer Order
+
+```
+z-index:
+  XYFlow HTML canvas (node editor)   ← top
+  surface overlay canvas             ← new layer
+  video output canvas (background)   ← existing
+```
+
+The overlay must be above the video output but below the XYFlow layer when the node editor
+is visible. In performance/fullscreen mode, XYFlow may be hidden entirely.
+
+### 6. XYFlow Sleep During Fullscreen
+
+XYFlow has no continuous rAF draw loop — it's reactive/event-driven. However the XYFlow
+container still participates in browser paint and compositing (SVG edges, Svelte reactivity)
+even when not visible.
+
+On `SurfaceOverlay.activate()`: set a Svelte store `isFullscreenActive = true`, bind
+`display: none` on the XYFlow wrapper element to this store. This removes XYFlow from paint
+and compositing entirely without destroying component state.
+
+On `SurfaceOverlay.deactivate()`: set `isFullscreenActive = false` to restore the node editor.
+
+Do NOT unmount/destroy the XYFlow component — `display: none` is sufficient and avoids
+state loss.

--- a/docs/design-docs/specs/126-surface-fullscreen-interaction.md
+++ b/docs/design-docs/specs/126-surface-fullscreen-interaction.md
@@ -45,8 +45,8 @@ FBO-renderer nodes (`hydra`, `regl`, `glsl`, `swgl`, `canvas`, `three`, `textmod
 
 **State transitions:**
 
-- `preview` → `fullscreen`: click **Go Live** button on node / send `bang` / call `activate()`
-- `fullscreen` → `preview`: press **Shift+Escape** / click floating exit badge / send `{type: 'exit'}` / call `deactivate()`
+- `preview` → `fullscreen`: click **Go Live** button on node / send `bang` / send `{ type: 'expand' }` / call `activate()`
+- `fullscreen` → `preview`: press **Shift+Escape** / click floating exit badge / send `{ type: 'collapse' }` / call `deactivate()`
 - `preview` ↔ `stopped`: click **Stop/Play** button on node (pause canvas to save CPU)
 
 Escape always returns to `preview`, never to `stopped`.
@@ -113,8 +113,8 @@ deactivate() // return to preview state: remove overlay, restore XYFlow and froz
 Messages also trigger these:
 
 ```js
-// bang or { type: 'activate' } → calls activate()
-// { type: 'exit' }             → calls deactivate()
+// bang or { type: 'expand' }   → calls activate()
+// { type: 'collapse' }         → calls deactivate()
 ```
 
 ### Browser Fullscreen (optional)
@@ -256,7 +256,7 @@ Based on `CanvasDom.svelte` with these differences:
 
 ### 5. Z-Index Layer Order
 
-```
+```text
 z-index:
   XYFlow HTML canvas (node editor)   ← top
   surface overlay canvas             ← new layer

--- a/docs/design-docs/specs/126-surface-fullscreen-interaction.md
+++ b/docs/design-docs/specs/126-surface-fullscreen-interaction.md
@@ -46,7 +46,7 @@ FBO-renderer nodes (`hydra`, `regl`, `glsl`, `swgl`, `canvas`, `three`, `textmod
 **State transitions:**
 
 - `preview` → `fullscreen`: click **Go Live** button on node / send `bang` / call `activate()`
-- `fullscreen` → `preview`: press **Escape** / click floating exit badge / send `{type: 'exit'}` / call `deactivate()`
+- `fullscreen` → `preview`: press **Shift+Escape** / click floating exit badge / send `{type: 'exit'}` / call `deactivate()`
 - `preview` ↔ `stopped`: click **Stop/Play** button on node (pause canvas to save CPU)
 
 Escape always returns to `preview`, never to `stopped`.

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -16,6 +16,11 @@
 @custom-variant dark (&:is(.dark *));
 @variant pointer-coarse (@media (pointer: coarse));
 
+html,
+body {
+  overscroll-behavior: none;
+}
+
 :root {
   --radius: 0.625rem;
   --background: oklch(1 0 0);

--- a/ui/src/lib/ai/object-descriptions-types.ts
+++ b/ui/src/lib/ai/object-descriptions-types.ts
@@ -46,6 +46,7 @@ export const OBJECT_TYPE_LIST = `## Basic Control & UI
 - vue: write custom user interface and component using Vue.js
 - p5: P5.js. readable code, great for shorter interactive sketches with mouse/keyboard via p5's API
 - canvas.dom: HTML5 Canvas on main thread. supports mouse/keyboard, lower overhead than p5, best for heavy visuals needing interactivity
+- surface: Fullscreen interactive canvas overlay. captures pointer/touch input across the entire screen. auto-freezes other DOM-renderer nodes. use for live performance drawing, painting, or touch interaction. setDrawMode('always'|'interact'|'manual'), onPointer(cb), onTouch(cb), activate(), deactivate()
 - canvas: HTML5 Canvas on web worker. no mouse/keyboard, highest performance. can chain into the rendering pipeline at high speed (e.g. video texture for glsl/hydra)
 - hydra: Live coding video synthesis with Hydra
 - glsl: GLSL fragment shaders for visual effects

--- a/ui/src/lib/ai/object-descriptions-types.ts
+++ b/ui/src/lib/ai/object-descriptions-types.ts
@@ -46,7 +46,7 @@ export const OBJECT_TYPE_LIST = `## Basic Control & UI
 - vue: write custom user interface and component using Vue.js
 - p5: P5.js. readable code, great for shorter interactive sketches with mouse/keyboard via p5's API
 - canvas.dom: HTML5 Canvas on main thread. supports mouse/keyboard, lower overhead than p5, best for heavy visuals needing interactivity
-- surface: Fullscreen interactive canvas overlay. captures pointer/touch input across the entire screen. auto-freezes other DOM-renderer nodes. use for live performance drawing, painting, or touch interaction. setDrawMode('always'|'interact'|'manual'), onPointer(cb), onTouch(cb), activate(), deactivate()
+- surface: Fullscreen interactive canvas overlay. captures mouse/touch input across the entire screen. use for live performance drawing, painting, or touch interaction.
 - canvas: HTML5 Canvas on web worker. no mouse/keyboard, highest performance. can chain into the rendering pipeline at high speed (e.g. video texture for glsl/hydra)
 - hydra: Live coding video synthesis with Hydra
 - glsl: GLSL fragment shaders for visual effects

--- a/ui/src/lib/ai/object-prompts/index.ts
+++ b/ui/src/lib/ai/object-prompts/index.ts
@@ -37,6 +37,7 @@ import { sampleratePrompt } from './samplerate~';
 import { sliderPrompt } from './slider';
 import { soundfilePrompt } from './soundfile~';
 import { strudelPrompt } from './strudel';
+import { surfacePrompt } from './surface';
 import { swglPrompt } from './swgl';
 import { textboxPrompt } from './textbox';
 import { togglePrompt } from './toggle';
@@ -89,6 +90,7 @@ export const objectPrompts: Record<string, string> = {
   msg: msgPrompt,
   textbox: textboxPrompt,
   canvas: canvasPrompt,
+  surface: surfacePrompt,
   strudel: strudelPrompt,
   python: pythonPrompt,
   ruby: rubyPrompt,

--- a/ui/src/lib/ai/object-prompts/surface.ts
+++ b/ui/src/lib/ai/object-prompts/surface.ts
@@ -1,0 +1,51 @@
+export const surfacePrompt = `## surface Object Instructions
+
+Fullscreen interactive canvas overlay for live performance. Captures pointer/touch input. Auto-freezes DOM-renderer nodes (p5, canvas.dom) while keeping the FBO video pipeline running underneath.
+
+**Surface-specific methods:**
+- ctx: 2D canvas context
+- width, height: always window dimensions (updated on resize)
+- mouse: {x, y, down, buttons} — normalized 0–1
+- onPointer(({ x, y, buttons, down, type }) => {}) — pointer events (type: 'move'|'down'|'up')
+- onTouch((touches) => {}) — multi-touch: array of { id, x, y, pressure }
+- onKeyDown(event => {}) — keyboard down
+- onKeyUp(event => {}) — keyboard up
+- setDrawMode('always'|'interact'|'manual') — control render loop
+- redraw() — trigger a draw in manual mode
+- activate() / deactivate() — enter/exit fullscreen from code
+- noOutput() — hide video output port
+
+**Coordinate system:**
+- All pointer/touch coords are normalized 0–1
+- Multiply by width/height to get pixel coordinates: x * width, y * height
+
+**Default behaviors to apply unless there's a reason not to:**
+- Call noOutput() unless the sketch explicitly outputs video to another node.
+- Use setDrawMode('interact') for sketches that only update on input (saves CPU).
+- Do NOT call setCanvasSize — the surface always fills the window.
+- Do NOT call noDrag/noPan/noWheel — the surface canvas is non-interactive by default.
+
+**Performance:**
+- setDrawMode('always') for animated sketches
+- setDrawMode('interact') for input-reactive sketches (no continuous rAF needed)
+- setDrawMode('manual') + redraw() for fully manual control
+
+Example - Paint on touch/pointer:
+\`\`\`json
+{
+  "type": "surface",
+  "data": {
+    "code": "noOutput(); ctx.fillStyle = '#000'; ctx.fillRect(0, 0, width, height); onPointer(({ x, y, down, type }) => { if (!down) return; ctx.beginPath(); ctx.arc(x * width, y * height, 20, 0, Math.PI * 2); ctx.fillStyle = 'rgba(255,255,255,0.8)'; ctx.fill(); });"
+  }
+}
+\`\`\`
+
+Example - Multi-touch ripples:
+\`\`\`json
+{
+  "type": "surface",
+  "data": {
+    "code": "noOutput(); setDrawMode('always'); const ripples = []; onTouch((touches) => { for (const t of touches) ripples.push({ x: t.x * width, y: t.y * height, r: 0, a: 1 }); }); function draw() { ctx.fillStyle = 'rgba(0,0,0,0.1)'; ctx.fillRect(0, 0, width, height); for (let i = ripples.length - 1; i >= 0; i--) { const r = ripples[i]; ctx.beginPath(); ctx.arc(r.x, r.y, r.r, 0, Math.PI * 2); ctx.strokeStyle = \`rgba(100,200,255,\${r.a})\`; ctx.lineWidth = 2; ctx.stroke(); r.r += 4; r.a -= 0.02; if (r.a <= 0) ripples.splice(i, 1); } requestAnimationFrame(draw); } draw();"
+  }
+}
+\`\`\``;

--- a/ui/src/lib/ai/object-prompts/surface.ts
+++ b/ui/src/lib/ai/object-prompts/surface.ts
@@ -45,7 +45,7 @@ Example - Multi-touch ripples:
 {
   "type": "surface",
   "data": {
-    "code": "noOutput(); setDrawMode('always'); const ripples = []; onTouch((touches) => { for (const t of touches) ripples.push({ x: t.x * width, y: t.y * height, r: 0, a: 1 }); }); function draw() { ctx.fillStyle = 'rgba(0,0,0,0.1)'; ctx.fillRect(0, 0, width, height); for (let i = ripples.length - 1; i >= 0; i--) { const r = ripples[i]; ctx.beginPath(); ctx.arc(r.x, r.y, r.r, 0, Math.PI * 2); ctx.strokeStyle = \`rgba(100,200,255,\${r.a})\`; ctx.lineWidth = 2; ctx.stroke(); r.r += 4; r.a -= 0.02; if (r.a <= 0) ripples.splice(i, 1); } requestAnimationFrame(draw); } draw();"
+    "code": "noOutput(); setDrawMode('always'); const ripples = []; onTouch((touches) => { for (const t of touches) ripples.push({ x: t.x * width, y: t.y * height, r: 0, a: 1 }); }); function draw() { ctx.fillStyle = 'rgba(0,0,0,0.1)'; ctx.fillRect(0, 0, width, height); for (let i = ripples.length - 1; i >= 0; i--) { const r = ripples[i]; ctx.beginPath(); ctx.arc(r.x, r.y, r.r, 0, Math.PI * 2); ctx.strokeStyle = \`rgba(100,200,255,\${r.a})\`; ctx.lineWidth = 2; ctx.stroke(); r.r += 4; r.a -= 0.02; if (r.a <= 0) ripples.splice(i, 1); } }"
   }
 }
 \`\`\``;

--- a/ui/src/lib/canvas/SurfaceListeners.ts
+++ b/ui/src/lib/canvas/SurfaceListeners.ts
@@ -64,15 +64,34 @@ export class SurfaceListeners {
 
     const onPointerMove = (e: PointerEvent) => {
       const { x, y } = normalize(e.clientX, e.clientY);
-      opts.onPointer({ x, y, pressure: 0, buttons: e.buttons, down: e.buttons > 0, type: 'move' });
+      try {
+        opts.onPointer({
+          x,
+          y,
+          pressure: 0,
+          buttons: e.buttons,
+          down: e.buttons > 0,
+          type: 'move'
+        });
+      } catch (err) {
+        handleCodeError(err, opts.code, opts.nodeId, opts.customConsole, opts.wrapperOffset);
+      }
     };
     const onPointerDown = (e: PointerEvent) => {
       const { x, y } = normalize(e.clientX, e.clientY);
-      opts.onPointer({ x, y, pressure: 0, buttons: e.buttons || 1, down: true, type: 'down' });
+      try {
+        opts.onPointer({ x, y, pressure: 0, buttons: e.buttons || 1, down: true, type: 'down' });
+      } catch (err) {
+        handleCodeError(err, opts.code, opts.nodeId, opts.customConsole, opts.wrapperOffset);
+      }
     };
     const onPointerUp = (e: PointerEvent) => {
       const { x, y } = normalize(e.clientX, e.clientY);
-      opts.onPointer({ x, y, pressure: 0, buttons: 0, down: false, type: 'up' });
+      try {
+        opts.onPointer({ x, y, pressure: 0, buttons: 0, down: false, type: 'up' });
+      } catch (err) {
+        handleCodeError(err, opts.code, opts.nodeId, opts.customConsole, opts.wrapperOffset);
+      }
     };
     const onPointerLeave = () => opts.onLeave();
 

--- a/ui/src/lib/canvas/SurfaceListeners.ts
+++ b/ui/src/lib/canvas/SurfaceListeners.ts
@@ -1,0 +1,102 @@
+import { handleCodeError } from '$lib/js-runner/handleCodeError';
+
+export type PointerEvent_ = {
+  x: number;
+  y: number;
+  pressure: number;
+  buttons: number;
+  down: boolean;
+  type: string;
+};
+
+export type TouchPoint = {
+  id: number;
+  x: number;
+  y: number;
+  pressure: number;
+};
+
+export interface SurfaceListenersOptions {
+  onPointer: (e: PointerEvent_) => void;
+  onTouch: ((touches: TouchPoint[]) => void) | null;
+  /** Called when pointer leaves the canvas */
+  onLeave: () => void;
+  /** For error reporting */
+  code: string;
+  nodeId: string;
+  customConsole: ReturnType<typeof import('$lib/utils/createCustomConsole').createCustomConsole>;
+  wrapperOffset: number;
+}
+
+export class SurfaceListeners {
+  private cleanup: (() => void) | null = null;
+
+  attach(canvas: HTMLCanvasElement, opts: SurfaceListenersOptions): void {
+    this.detach();
+
+    const normalize = (clientX: number, clientY: number) => {
+      const rect = canvas.getBoundingClientRect();
+      return {
+        x: (clientX - rect.left) / rect.width,
+        y: (clientY - rect.top) / rect.height
+      };
+    };
+
+    const normalizeTouches = (e: TouchEvent): TouchPoint[] => {
+      const rect = canvas.getBoundingClientRect();
+      return Array.from(e.touches).map((t) => ({
+        id: t.identifier,
+        x: (t.clientX - rect.left) / rect.width,
+        y: (t.clientY - rect.top) / rect.height,
+        pressure: t.force ?? 0
+      }));
+    };
+
+    const fireTouches = (e: TouchEvent) => {
+      e.preventDefault();
+      if (!opts.onTouch) return;
+      try {
+        opts.onTouch(normalizeTouches(e));
+      } catch (err) {
+        handleCodeError(err, opts.code, opts.nodeId, opts.customConsole, opts.wrapperOffset);
+      }
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      const { x, y } = normalize(e.clientX, e.clientY);
+      opts.onPointer({ x, y, pressure: 0, buttons: e.buttons, down: e.buttons > 0, type: 'move' });
+    };
+    const onPointerDown = (e: PointerEvent) => {
+      const { x, y } = normalize(e.clientX, e.clientY);
+      opts.onPointer({ x, y, pressure: 0, buttons: e.buttons || 1, down: true, type: 'down' });
+    };
+    const onPointerUp = (e: PointerEvent) => {
+      const { x, y } = normalize(e.clientX, e.clientY);
+      opts.onPointer({ x, y, pressure: 0, buttons: 0, down: false, type: 'up' });
+    };
+    const onPointerLeave = () => opts.onLeave();
+
+    canvas.addEventListener('pointermove', onPointerMove);
+    canvas.addEventListener('pointerdown', onPointerDown);
+    canvas.addEventListener('pointerup', onPointerUp);
+    canvas.addEventListener('pointerleave', onPointerLeave);
+    canvas.addEventListener('touchstart', fireTouches, { passive: false });
+    canvas.addEventListener('touchmove', fireTouches, { passive: false });
+    canvas.addEventListener('touchend', fireTouches, { passive: false });
+
+    this.cleanup = () => {
+      canvas.removeEventListener('pointermove', onPointerMove);
+      canvas.removeEventListener('pointerdown', onPointerDown);
+      canvas.removeEventListener('pointerup', onPointerUp);
+      canvas.removeEventListener('pointerleave', onPointerLeave);
+      canvas.removeEventListener('touchstart', fireTouches);
+      canvas.removeEventListener('touchmove', fireTouches);
+      canvas.removeEventListener('touchend', fireTouches);
+    };
+  }
+
+  detach(): void {
+    this.cleanup?.();
+    this.cleanup = null;
+  }
+}

--- a/ui/src/lib/canvas/SurfaceOverlay.ts
+++ b/ui/src/lib/canvas/SurfaceOverlay.ts
@@ -1,5 +1,6 @@
 import { writable } from 'svelte/store';
 import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+import { isSidebarOpen } from '../../stores/ui.store';
 
 /**
  * DOM-renderer node types that get auto-frozen when surface goes fullscreen.
@@ -107,6 +108,7 @@ export class SurfaceOverlay {
 
     this._onExit = onExit;
     isFullscreenActive.set(true);
+    isSidebarOpen.set(false);
     this._showBadge(onExit);
   }
 
@@ -144,7 +146,8 @@ export class SurfaceOverlay {
   private _showBadge(onExit: () => void): void {
     this._removeBadge();
 
-    const badge = document.createElement('div');
+    const badge = document.createElement('button');
+    badge.type = 'button';
     badge.style.cssText = `
       position: fixed;
       bottom: 16px;

--- a/ui/src/lib/canvas/SurfaceOverlay.ts
+++ b/ui/src/lib/canvas/SurfaceOverlay.ts
@@ -1,0 +1,187 @@
+import { writable } from 'svelte/store';
+import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+
+/**
+ * DOM-renderer node types that get auto-frozen when surface goes fullscreen.
+ * These render to their own canvas elements and are occluded by the overlay.
+ */
+const DOM_RENDERER_TYPES = new Set(['p5', 'canvas.dom', 'textmode.dom', 'three.dom']);
+
+/**
+ * Svelte store — true when a surface node is in fullscreen mode.
+ * Bind `display: none` on the XYFlow wrapper to this store.
+ */
+export const isFullscreenActive = writable(false);
+
+export class SurfaceOverlay {
+  private static _instance: SurfaceOverlay | null = null;
+
+  private _canvas: HTMLCanvasElement;
+  private _ctx: CanvasRenderingContext2D;
+  private _activeNodeId: string | null = null;
+  private _frozenNodeIds: string[] = [];
+  private _badge: HTMLDivElement | null = null;
+  private _onEscape: (e: KeyboardEvent) => void;
+  private _onExit: (() => void) | null = null;
+
+  static getInstance(): SurfaceOverlay {
+    if (!SurfaceOverlay._instance) {
+      SurfaceOverlay._instance = new SurfaceOverlay();
+    }
+    return SurfaceOverlay._instance;
+  }
+
+  private constructor() {
+    this._canvas = document.createElement('canvas');
+    this._canvas.style.cssText =
+      'position: fixed; inset: 0; display: none; z-index: 50; pointer-events: none;';
+    document.body.appendChild(this._canvas);
+
+    this._ctx = this._canvas.getContext('2d')!;
+    this._resize();
+
+    window.addEventListener('resize', this._resize.bind(this));
+
+    this._onEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && e.shiftKey && this._activeNodeId) {
+        this.deactivate(this._activeNodeId);
+      }
+    };
+    window.addEventListener('keydown', this._onEscape);
+  }
+
+  get canvas(): HTMLCanvasElement {
+    return this._canvas;
+  }
+
+  get ctx(): CanvasRenderingContext2D {
+    return this._ctx;
+  }
+
+  get width(): number {
+    return this._canvas.width;
+  }
+
+  get height(): number {
+    return this._canvas.height;
+  }
+
+  get activeNodeId(): string | null {
+    return this._activeNodeId;
+  }
+
+  private _resize() {
+    this._canvas.width = window.innerWidth;
+    this._canvas.height = window.innerHeight;
+    this._canvas.style.width = '100vw';
+    this._canvas.style.height = '100vh';
+  }
+
+  /**
+   * Activate fullscreen mode for a surface node.
+   * @param nodeId - The surface node's ID
+   * @param nodes - All current patch nodes (to find DOM-renderer nodes to freeze)
+   * @param onExit - Callback invoked when user exits via Escape or badge
+   */
+  activate(nodeId: string, nodes: { id: string; type?: string }[], onExit: () => void): void {
+    // Last activated wins — displace previous
+    if (this._activeNodeId && this._activeNodeId !== nodeId) {
+      this._deactivateInternal(this._activeNodeId, false);
+    }
+
+    this._activeNodeId = nodeId;
+
+    // Show canvas + enable pointer events
+    this._canvas.style.display = 'block';
+    this._canvas.style.pointerEvents = 'all';
+
+    // Freeze DOM-renderer nodes (not the surface node itself)
+    const eventBus = PatchiesEventBus.getInstance();
+    this._frozenNodeIds = [];
+    for (const node of nodes) {
+      if (node.type && DOM_RENDERER_TYPES.has(node.type) && node.id !== nodeId) {
+        eventBus.dispatch({ type: 'nodeSetPaused', nodeId: node.id, paused: true });
+        this._frozenNodeIds.push(node.id);
+      }
+    }
+
+    this._onExit = onExit;
+    isFullscreenActive.set(true);
+    this._showBadge(onExit);
+  }
+
+  /**
+   * Deactivate fullscreen mode for a surface node.
+   * No-op if this node isn't the active one.
+   */
+  deactivate(nodeId: string): void {
+    if (this._activeNodeId !== nodeId) return;
+    this._deactivateInternal(nodeId, true);
+  }
+
+  private _deactivateInternal(nodeId: string, unfreeze: boolean): void {
+    if (this._activeNodeId !== nodeId) return;
+    this._activeNodeId = null;
+
+    this._canvas.style.display = 'none';
+    this._canvas.style.pointerEvents = 'none';
+
+    if (unfreeze) {
+      const eventBus = PatchiesEventBus.getInstance();
+      for (const id of this._frozenNodeIds) {
+        eventBus.dispatch({ type: 'nodeSetPaused', nodeId: id, paused: false });
+      }
+      this._frozenNodeIds = [];
+    }
+
+    isFullscreenActive.set(false);
+    this._removeBadge();
+    const onExit = this._onExit;
+    this._onExit = null;
+    onExit?.();
+  }
+
+  private _showBadge(onExit: () => void): void {
+    this._removeBadge();
+
+    const badge = document.createElement('div');
+    badge.style.cssText = `
+      position: fixed;
+      bottom: 16px;
+      right: 16px;
+      z-index: 51;
+      background: rgba(0,0,0,0.5);
+      color: rgba(255,255,255,0.6);
+      font-family: ui-monospace, monospace;
+      font-size: 12px;
+      padding: 6px 10px;
+      border-radius: 6px;
+      cursor: pointer;
+      border: 1px solid rgba(255,255,255,0.15);
+      transition: color 0.15s, background 0.15s;
+      user-select: none;
+    `;
+    badge.textContent = 'Exit surface (Shift+Esc)';
+    badge.addEventListener('mouseenter', () => {
+      badge.style.color = 'rgba(255,255,255,0.9)';
+      badge.style.background = 'rgba(0,0,0,0.75)';
+    });
+    badge.addEventListener('mouseleave', () => {
+      badge.style.color = 'rgba(255,255,255,0.6)';
+      badge.style.background = 'rgba(0,0,0,0.5)';
+    });
+    badge.addEventListener('click', () => {
+      onExit();
+    });
+
+    document.body.appendChild(badge);
+    this._badge = badge;
+  }
+
+  private _removeBadge(): void {
+    if (this._badge) {
+      this._badge.remove();
+      this._badge = null;
+    }
+  }
+}

--- a/ui/src/lib/canvas/constants.ts
+++ b/ui/src/lib/canvas/constants.ts
@@ -156,6 +156,25 @@ endin
 
 schedule("Main", 0, 0, 0)`;
 
+export const DEFAULT_SURFACE_CODE = `// surface — fullscreen interactive canvas
+// mouse.x, mouse.y are normalized 0–1 coords
+// width, height are always window dimensions
+
+function draw() {
+  ctx.clearRect(0, 0, width, height)
+
+  if (mouse.down) {
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.8)'
+    ctx.beginPath()
+    ctx.arc(mouse.x * width, mouse.y * height, 30, 0, Math.PI * 2)
+    ctx.fill()
+  }
+
+  requestAnimationFrame(draw)
+}
+
+draw()`;
+
 export const DEFAULT_THREE_CODE = `const { Scene, PerspectiveCamera, BoxGeometry, Mesh, MeshNormalMaterial } = THREE
 
 const scene = new Scene()

--- a/ui/src/lib/canvas/constants.ts
+++ b/ui/src/lib/canvas/constants.ts
@@ -156,9 +156,11 @@ endin
 
 schedule("Main", 0, 0, 0)`;
 
-export const DEFAULT_SURFACE_CODE = `// surface — fullscreen interactive canvas
-// mouse.x, mouse.y are normalized 0–1 coords
-// width, height are always window dimensions
+export const DEFAULT_SURFACE_CODE = `setPortCount(1, 1)
+noOutput()
+
+// x, y are normalized 0–1 coords; width/height are window dimensions
+onPointer(data => send(data))
 
 function draw() {
   ctx.clearRect(0, 0, width, height)

--- a/ui/src/lib/components/CanvasPreviewLayout.svelte
+++ b/ui/src/lib/components/CanvasPreviewLayout.svelte
@@ -2,6 +2,7 @@
   import type { Snippet } from 'svelte';
   import ObjectPreviewLayout from './ObjectPreviewLayout.svelte';
   import type { SettingsSchema } from '$lib/settings';
+  import type { ExtraMenuItem } from './ObjectPreviewOverflowMenu.svelte';
 
   let {
     title,
@@ -35,7 +36,8 @@
     settingsSchema = undefined,
     settingsValues = {},
     onSettingsValueChange = undefined,
-    onSettingsRevertAll = undefined
+    onSettingsRevertAll = undefined,
+    extraMenuItems = undefined
   }: {
     title: string;
     nodeId?: string;
@@ -69,6 +71,7 @@
     settingsValues?: Record<string, unknown>;
     onSettingsValueChange?: (key: string, value: unknown) => void;
     onSettingsRevertAll?: () => void;
+    extraMenuItems?: ExtraMenuItem[];
   } = $props();
 
   // Build the interaction class string based on individual flags
@@ -105,6 +108,7 @@
   {settingsValues}
   {onSettingsValueChange}
   {onSettingsRevertAll}
+  {extraMenuItems}
 >
   {#snippet preview()}
     <canvas

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -602,7 +602,9 @@
       paste: () => pasteNode('keyboard'),
       undo: () => historyManager.undo(),
       redo: () => historyManager.redo(),
-      toggleSidebar: () => ($isSidebarOpen = !$isSidebarOpen),
+      toggleSidebar: () => {
+        if (!$isFullscreenActive) $isSidebarOpen = !$isSidebarOpen;
+      },
       openObjectBrowser: () => ($isObjectBrowserOpen = true),
       openCommandPalette: triggerCommandPalette,
       togglePlayPause: () => {
@@ -1031,7 +1033,7 @@
 
 <div class="flow-container relative flex h-dvh w-full">
   <!-- Background output canvas lives outside the flow editor so it stays visible during surface fullscreen -->
-  <div class="pointer-events-none absolute inset-0 z-[-1]">
+  <div class="pointer-events-none absolute inset-0 z-0">
     <BackgroundOutputCanvas />
   </div>
   <!-- Sidebar (Files / Presets) -->

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -87,6 +87,7 @@
   import { Transport } from '$lib/transport';
   import { transportStore } from '../../stores/transport.store';
   import { allPreviewsDisabled } from '../../stores/renderer.store';
+  import { isFullscreenActive } from '$lib/canvas/SurfaceOverlay';
   import { PREVIEW_ZOOM_LOD_TIERS } from '$workers/rendering/constants';
   import { initializeVFS } from '$lib/vfs';
   import {
@@ -1028,7 +1029,11 @@
   }
 </script>
 
-<div class="flow-container flex h-dvh w-full">
+<div class="flow-container relative flex h-dvh w-full">
+  <!-- Background output canvas lives outside the flow editor so it stays visible during surface fullscreen -->
+  <div class="pointer-events-none absolute inset-0 z-[-1]">
+    <BackgroundOutputCanvas />
+  </div>
   <!-- Sidebar (Files / Presets) -->
   <SidebarPanel
     bind:open={$isSidebarOpen}
@@ -1043,7 +1048,7 @@
   />
 
   <!-- Main content area -->
-  <div class="relative flex flex-1 flex-col">
+  <div class="relative flex flex-1 flex-col" class:hidden={$isFullscreenActive}>
     <!-- URL Loading Indicator -->
     {#if isLoadingFromUrl && !($isMobile && $isSidebarOpen)}
       <div class="top-safe-4 absolute left-1/2 z-50 -translate-x-1/2 transform">
@@ -1265,8 +1270,6 @@
         }}
       >
         <BackgroundPattern />
-
-        <BackgroundOutputCanvas />
 
         <Controls class={$isBottomBarVisible && !$isMobile ? '' : '!hidden'} />
       </SvelteFlow>

--- a/ui/src/lib/components/ObjectPreviewContextMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewContextMenu.svelte
@@ -12,6 +12,7 @@
   } from '@lucide/svelte/icons';
   import * as ContextMenu from './ui/context-menu';
   import type { SettingsSchema } from '$lib/settings';
+  import type { ExtraMenuItem } from './ObjectPreviewOverflowMenu.svelte';
 
   let {
     onrun,
@@ -28,7 +29,8 @@
     onSettingsToggle,
     onBgOutputToggle,
     onPlaybackToggle,
-    onOpenHelp
+    onOpenHelp,
+    extraMenuItems
   }: {
     onrun?: () => void;
     showBgOutputOption: boolean;
@@ -45,6 +47,7 @@
     onBgOutputToggle: () => void;
     onPlaybackToggle: () => void;
     onOpenHelp: () => void;
+    extraMenuItems?: ExtraMenuItem[];
   } = $props();
 </script>
 
@@ -54,7 +57,15 @@
       <Play class="mr-2 h-4 w-4" />
       Run
     </ContextMenu.Item>
+  {/if}
 
+  {#if extraMenuItems && extraMenuItems.length > 0}
+    {#each extraMenuItems as item}
+      <ContextMenu.Item onclick={item.onclick}>
+        <item.icon class="mr-2 h-4 w-4 {item.variant === 'danger' ? 'text-red-400' : ''}" />
+        <span class={item.variant === 'danger' ? 'text-red-400' : ''}>{item.label}</span>
+      </ContextMenu.Item>
+    {/each}
     <ContextMenu.Separator />
   {/if}
 
@@ -99,6 +110,16 @@
         Show preview
       {/if}
     </ContextMenu.Item>
+  {/if}
+
+  {#if extraMenuItems && extraMenuItems.length > 0}
+    <ContextMenu.Separator />
+    {#each extraMenuItems as item}
+      <ContextMenu.Item onclick={item.onclick}>
+        <item.icon class="mr-2 h-4 w-4 {item.variant === 'danger' ? 'text-red-400' : ''}" />
+        <span class={item.variant === 'danger' ? 'text-red-400' : ''}>{item.label}</span>
+      </ContextMenu.Item>
+    {/each}
   {/if}
 
   <ContextMenu.Separator />

--- a/ui/src/lib/components/ObjectPreviewContextMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewContextMenu.svelte
@@ -112,16 +112,6 @@
     </ContextMenu.Item>
   {/if}
 
-  {#if extraMenuItems && extraMenuItems.length > 0}
-    <ContextMenu.Separator />
-    {#each extraMenuItems as item}
-      <ContextMenu.Item onclick={item.onclick}>
-        <item.icon class="mr-2 h-4 w-4 {item.variant === 'danger' ? 'text-red-400' : ''}" />
-        <span class={item.variant === 'danger' ? 'text-red-400' : ''}>{item.label}</span>
-      </ContextMenu.Item>
-    {/each}
-  {/if}
-
   <ContextMenu.Separator />
 
   <ContextMenu.Item onclick={onOpenHelp}>

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -8,6 +8,7 @@
   import { useSvelteFlow } from '@xyflow/svelte';
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings';
+  import type { ExtraMenuItem } from './ObjectPreviewOverflowMenu.svelte';
   import { transportStore } from '../../stores/transport.store';
   import { isSidebarOpen, sidebarView } from '../../stores/ui.store';
   import { helpViewStore } from '../../stores/help-view.store';
@@ -42,7 +43,8 @@
     settingsSchema = undefined,
     settingsValues = {},
     onSettingsValueChange = undefined,
-    onSettingsRevertAll = undefined
+    onSettingsRevertAll = undefined,
+    extraMenuItems = undefined
   }: {
     title: string;
     nodeId?: string;
@@ -68,6 +70,7 @@
     settingsValues?: Record<string, unknown>;
     onSettingsValueChange?: (key: string, value: unknown) => void;
     onSettingsRevertAll?: () => void;
+    extraMenuItems?: ExtraMenuItem[];
   } = $props();
 
   useNodeSetPaused(
@@ -185,6 +188,7 @@
                 onBgOutputToggle={handleBgOutputToggle}
                 onPlaybackToggle={handlePlaybackToggle}
                 onOpenHelp={handleOpenHelp}
+                {extraMenuItems}
               />
 
               <Tooltip.Root>
@@ -243,6 +247,7 @@
       onBgOutputToggle={handleBgOutputToggle}
       onPlaybackToggle={handlePlaybackToggle}
       onOpenHelp={handleOpenHelp}
+      {extraMenuItems}
     />
   </ContextMenu.Root>
 

--- a/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
@@ -14,6 +14,14 @@
   import * as Popover from './ui/popover';
   import type { SettingsSchema } from '$lib/settings';
   import Separator from './ui/separator/separator.svelte';
+  import type { Component } from 'svelte';
+
+  export interface ExtraMenuItem {
+    label: string;
+    icon: Component<{ class?: string }>;
+    onclick: () => void;
+    variant?: 'default' | 'danger';
+  }
 
   let {
     onrun,
@@ -30,7 +38,8 @@
     onSettingsToggle,
     onBgOutputToggle,
     onPlaybackToggle,
-    onOpenHelp
+    onOpenHelp,
+    extraMenuItems
   }: {
     onrun?: () => void;
     settingsSchema?: SettingsSchema;
@@ -47,6 +56,7 @@
     onBgOutputToggle?: () => void;
     onPlaybackToggle?: () => void;
     onOpenHelp: () => void;
+    extraMenuItems?: ExtraMenuItem[];
   } = $props();
 </script>
 
@@ -71,7 +81,22 @@
           <span>Run</span>
         </button>
       </Popover.Close>
+    {/if}
 
+    {#if extraMenuItems && extraMenuItems.length > 0}
+      {#each extraMenuItems as item}
+        <Popover.Close class="contents">
+          <button
+            class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-zinc-700"
+            onclick={item.onclick}
+          >
+            <item.icon
+              class="h-4 w-4 {item.variant === 'danger' ? 'text-red-400' : 'text-zinc-300'}"
+            />
+            <span class={item.variant === 'danger' ? 'text-red-400' : ''}>{item.label}</span>
+          </button>
+        </Popover.Close>
+      {/each}
       <Separator />
     {/if}
 

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -319,6 +319,7 @@
     if (keyboardListenerHandlers) {
       document.removeEventListener('keydown', keyboardListenerHandlers.keydown);
       document.removeEventListener('keyup', keyboardListenerHandlers.keyup);
+
       keyboardListenerHandlers = null;
     }
 
@@ -330,7 +331,10 @@
 
     // Swap pointer listeners
     overlayListeners.detach();
-    if (previewCanvas) previewListeners.attach(previewCanvas, listenerOpts());
+
+    if (previewCanvas) {
+      previewListeners.attach(previewCanvas, listenerOpts());
+    }
 
     // Re-run code with preview canvas
     runCode();
@@ -357,6 +361,7 @@
   function togglePlayback() {
     if (data.paused) {
       updateNodeData(nodeId, { paused: false });
+
       if (pausedCallback) {
         animationFrameId = requestAnimationFrame((time) => {
           pausedCallback!(time);
@@ -365,8 +370,10 @@
       }
     } else {
       updateNodeData(nodeId, { paused: true });
+
       if (animationFrameId !== null) {
         cancelAnimationFrame(animationFrameId);
+
         animationFrameId = null;
       }
     }
@@ -383,7 +390,9 @@
     dragEnabled = false;
     panEnabled = true;
     wheelEnabled = true;
+
     updateNodeData(nodeId, { videoOutput: true });
+
     drawMode = 'always';
     pointerCallback = null;
     touchCallback = null;
@@ -391,6 +400,7 @@
 
     if (animationFrameId !== null) {
       cancelAnimationFrame(animationFrameId);
+
       animationFrameId = null;
     }
 
@@ -488,7 +498,10 @@
           },
           cancelAnimationFrame: (id: number) => {
             cancelAnimationFrame(id);
-            if (animationFrameId === id) animationFrameId = null;
+
+            if (animationFrameId === id) {
+              animationFrameId = null;
+            }
           }
         }
       });
@@ -537,21 +550,32 @@
   });
 
   onDestroy(() => {
-    if (animationFrameId !== null) cancelAnimationFrame(animationFrameId);
+    if (animationFrameId !== null) {
+      cancelAnimationFrame(animationFrameId);
+    }
+
     stopThumbnailLoop();
+
     previewListeners.detach();
     overlayListeners.detach();
 
     window.removeEventListener('resize', debouncedHandleWindowResize);
-    if (resizeDebounceTimer !== null) clearTimeout(resizeDebounceTimer);
+
+    if (resizeDebounceTimer !== null) {
+      clearTimeout(resizeDebounceTimer);
+    }
+
     if (keyboardListenerHandlers) {
       document.removeEventListener('keydown', keyboardListenerHandlers.keydown);
       document.removeEventListener('keyup', keyboardListenerHandlers.keyup);
+
       keyboardListenerHandlers = null;
     }
 
     // Deactivate overlay if this node was active
-    if (isFullscreen) SurfaceOverlay.getInstance().deactivate(nodeId);
+    if (isFullscreen) {
+      SurfaceOverlay.getInstance().deactivate(nodeId);
+    }
 
     eventBus.removeEventListener('consoleOutput', handleConsoleOutput);
     glSystem?.removeNode(nodeId);
@@ -561,6 +585,7 @@
   const handleClass = $derived.by(() => {
     if (!data.hidePorts) return '';
     if (!selected && $shouldShowHandles) return 'z-1 transition-opacity';
+
     return `z-1 transition-opacity ${selected ? '' : 'sm:opacity-0 opacity-30 group-hover:opacity-100'}`;
   });
 </script>

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -7,7 +7,13 @@
   import CanvasPreviewLayout from '$lib/components/CanvasPreviewLayout.svelte';
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { match } from 'ts-pattern';
-  import { messages } from '$lib/objects/schemas';
+  import { messages, SurfaceExpand, SurfaceCollapse } from '$lib/objects/schemas';
+  import { schema } from '$lib/objects/schemas/types';
+
+  const surfaceMessages = {
+    expand: schema(SurfaceExpand),
+    collapse: schema(SurfaceCollapse)
+  };
   import { PREVIEW_SCALE_FACTOR } from '$lib/canvas/constants';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { SurfaceOverlay } from '$lib/canvas/SurfaceOverlay';
@@ -164,17 +170,9 @@
       match(message)
         .with(messages.setCode, ({ value }) => setCodeAndUpdate(value))
         .with(messages.run, () => runCode())
-        .otherwise((msg: unknown) => {
-          const m = msg as Record<string, unknown>;
-          // bang or { type: 'activate' } → go fullscreen
-          if (msg === 'bang' || m?.type === 'activate') {
-            enterFullscreen();
-          }
-          // { type: 'exit' } → exit fullscreen
-          if (m?.type === 'exit') {
-            exitSurface();
-          }
-        });
+        .with(surfaceMessages.expand, () => enterFullscreen())
+        .with(surfaceMessages.collapse, () => exitSurface())
+        .otherwise(() => {});
     } catch (error) {
       console.error('Error handling message:', error);
     }
@@ -200,7 +198,7 @@
     }
 
     const pointerOutletIdx = videoOutputEnabled ? 1 : 0;
-    jsRunner.getMessageContext(nodeId).send(pointerOutletIdx, event);
+    jsRunner.getMessageContext(nodeId).send(event, { to: pointerOutletIdx });
 
     if (drawMode === 'interact') triggerDraw();
   }
@@ -218,11 +216,11 @@
 
   // ── Bitmap output ────────────────────────────────────────────────────────
 
-  async function sendBitmap() {
+  function sendBitmap() {
     if (!activeCanvas) return;
     if (!videoOutputEnabled) return;
     if (!glSystem.hasOutgoingVideoConnections(nodeId)) return;
-    await glSystem.setBitmapSource(nodeId, activeCanvas);
+    glSystem.setBitmapSource(nodeId, activeCanvas);
   }
 
   // ── Thumbnail copy ───────────────────────────────────────────────────────

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -486,6 +486,22 @@
 
   // ── Lifecycle ────────────────────────────────────────────────────────────
 
+  function handleWindowResize() {
+    outputWidth = window.innerWidth;
+    outputHeight = window.innerHeight;
+
+    // Resize preview canvas to new dimensions
+    if (previewCanvas) {
+      previewCanvas.width = outputWidth;
+      previewCanvas.height = outputHeight;
+      previewCanvas.style.width = `${outputWidth / PREVIEW_SCALE_FACTOR}px`;
+      previewCanvas.style.height = `${outputHeight / PREVIEW_SCALE_FACTOR}px`;
+    }
+
+    // Re-run code so user code sees new width/height
+    runCode();
+  }
+
   onMount(() => {
     const messageContext = jsRunner.getMessageContext(nodeId);
     messageContext.queue.addCallback(handleMessage);
@@ -499,6 +515,8 @@
       cleanupPreviewListeners = setupPointerListeners(previewCanvas);
     }
 
+    window.addEventListener('resize', handleWindowResize);
+
     setTimeout(() => {
       runCode();
       startThumbnailLoop();
@@ -510,6 +528,8 @@
     stopThumbnailLoop();
     cleanupPreviewListeners?.();
     cleanupOverlayListeners?.();
+
+    window.removeEventListener('resize', handleWindowResize);
 
     // Deactivate overlay if this node was active
     if (isFullscreen) SurfaceOverlay.getInstance().deactivate(nodeId);

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -19,7 +19,7 @@
   import type { ConsoleOutputEvent } from '$lib/eventbus/events';
   import { CANVAS_DOM_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
   import type { ExtraMenuItem } from '$lib/components/ObjectPreviewOverflowMenu.svelte';
-  import { Expand, Shrink } from '@lucide/svelte/icons';
+  import { Expand, Shrink, Eraser } from '@lucide/svelte/icons';
   import { profiler } from '$lib/profiler';
 
   // Error reporting offset reuse (surface is structurally identical to canvas.dom)
@@ -108,12 +108,23 @@
   // Mouse state (normalized 0–1)
   let mouse = $state({ x: 0, y: 0, down: false, buttons: 0 });
 
+  function clearCanvas() {
+    if (activeCanvas && activeCtx) {
+      activeCtx.clearRect(0, 0, activeCanvas.width, activeCanvas.height);
+    }
+  }
+
   const extraMenuItems: ExtraMenuItem[] = $derived([
     {
       label: isFullscreen ? 'Exit surface' : 'Go Live',
       icon: isFullscreen ? Shrink : Expand,
       onclick: () => (isFullscreen ? exitSurface() : enterFullscreen()),
       variant: isFullscreen ? 'danger' : 'default'
+    },
+    {
+      label: 'Clear canvas',
+      icon: Eraser,
+      onclick: clearCanvas
     }
   ]);
 

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -18,6 +18,8 @@
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { ConsoleOutputEvent } from '$lib/eventbus/events';
   import { CANVAS_DOM_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
+  import type { ExtraMenuItem } from '$lib/components/ObjectPreviewOverflowMenu.svelte';
+  import { Expand, Shrink } from '@lucide/svelte/icons';
   import { profiler } from '$lib/profiler';
 
   // Error reporting offset reuse (surface is structurally identical to canvas.dom)
@@ -105,6 +107,15 @@
 
   // Mouse state (normalized 0–1)
   let mouse = $state({ x: 0, y: 0, down: false, buttons: 0 });
+
+  const extraMenuItems: ExtraMenuItem[] = $derived([
+    {
+      label: isFullscreen ? 'Exit surface' : 'Go Live',
+      icon: isFullscreen ? Shrink : Expand,
+      onclick: () => (isFullscreen ? exitSurface() : enterFullscreen()),
+      variant: isFullscreen ? 'danger' : 'default'
+    }
+  ]);
 
   const { updateNodeData, getNodes } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
@@ -565,18 +576,9 @@
   {selected}
   {editorReady}
   hasError={lineErrors !== undefined}
+  {extraMenuItems}
 >
   {#snippet topHandle()}
-    <!-- Go Live button -->
-    <button
-      class="absolute top-1 right-1 z-10 cursor-pointer rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors {isFullscreen
-        ? 'bg-red-600 text-white hover:bg-red-700'
-        : 'bg-zinc-700 text-zinc-300 hover:bg-zinc-600'}"
-      onclick={() => (isFullscreen ? exitSurface() : enterFullscreen())}
-    >
-      {isFullscreen ? 'Exit' : 'Go Live'}
-    </button>
-
     {#each Array.from({ length: inletCount }) as _, index (index)}
       <TypedHandle
         port="inlet"

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -113,6 +113,17 @@
     onKeyUp?: (event: KeyboardEvent) => void;
   } = {};
 
+  let keyboardListenerHandlers: {
+    keydown: (e: KeyboardEvent) => void;
+    keyup: (e: KeyboardEvent) => void;
+  } | null = null;
+
+  let resizeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  const debouncedHandleWindowResize = () => {
+    if (resizeDebounceTimer !== null) clearTimeout(resizeDebounceTimer);
+    resizeDebounceTimer = setTimeout(() => handleWindowResize(), 150);
+  };
+
   // Mouse state (normalized 0–1)
   let mouse = $state({ x: 0, y: 0, down: false, buttons: 0 });
 
@@ -204,8 +215,7 @@
   // ── Draw mode & rAF ──────────────────────────────────────────────────────
 
   function triggerDraw() {
-    if (drawMode !== 'manual') return;
-    // In manual mode, redraw() calls here; nothing else needed
+    if (drawMode !== 'manual' && drawMode !== 'interact') return;
     if (pausedCallback) {
       pausedCallback(performance.now());
       sendBitmap();
@@ -288,6 +298,13 @@
     // Stop thumbnail loop (XYFlow is hidden anyway)
     stopThumbnailLoop();
 
+    // Attach keyboard listeners
+    const handleKeyDown = (e: KeyboardEvent) => keyboardCallbacks.onKeyDown?.(e);
+    const handleKeyUp = (e: KeyboardEvent) => keyboardCallbacks.onKeyUp?.(e);
+    keyboardListenerHandlers = { keydown: handleKeyDown, keyup: handleKeyUp };
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('keyup', handleKeyUp);
+
     // Re-run code with overlay canvas
     runCode();
   }
@@ -297,6 +314,13 @@
     isFullscreen = false;
 
     SurfaceOverlay.getInstance().deactivate(nodeId);
+
+    // Remove keyboard listeners
+    if (keyboardListenerHandlers) {
+      document.removeEventListener('keydown', keyboardListenerHandlers.keydown);
+      document.removeEventListener('keyup', keyboardListenerHandlers.keyup);
+      keyboardListenerHandlers = null;
+    }
 
     // Switch active canvas back to preview
     if (previewCanvas) {
@@ -450,7 +474,7 @@
           requestAnimationFrame: (callback: FrameRequestCallback) => {
             pausedCallback = callback;
 
-            if (data.paused || drawMode === 'manual') {
+            if (data.paused || drawMode === 'manual' || drawMode === 'interact') {
               return -1;
             }
 
@@ -504,7 +528,7 @@
       previewListeners.attach(previewCanvas, listenerOpts());
     }
 
-    window.addEventListener('resize', handleWindowResize);
+    window.addEventListener('resize', debouncedHandleWindowResize);
 
     setTimeout(() => {
       runCode();
@@ -518,7 +542,13 @@
     previewListeners.detach();
     overlayListeners.detach();
 
-    window.removeEventListener('resize', handleWindowResize);
+    window.removeEventListener('resize', debouncedHandleWindowResize);
+    if (resizeDebounceTimer !== null) clearTimeout(resizeDebounceTimer);
+    if (keyboardListenerHandlers) {
+      document.removeEventListener('keydown', keyboardListenerHandlers.keydown);
+      document.removeEventListener('keyup', keyboardListenerHandlers.keyup);
+      keyboardListenerHandlers = null;
+    }
 
     // Deactivate overlay if this node was active
     if (isFullscreen) SurfaceOverlay.getInstance().deactivate(nodeId);

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -47,6 +47,7 @@
       executeCode?: number;
       showConsole?: boolean;
       paused?: boolean;
+      videoOutput?: boolean;
     };
     selected?: boolean;
   } = $props();
@@ -74,7 +75,7 @@
   let dragEnabled = $state(false);
   let panEnabled = $state(true);
   let wheelEnabled = $state(true);
-  let videoOutputEnabled = $state(true);
+  let videoOutputEnabled = $derived(data.videoOutput ?? true);
   let editorReady = $state(false);
   let animationFrameId: number | null = null;
   let pausedCallback: FrameRequestCallback | null = null;
@@ -196,9 +197,6 @@
         handleCodeError(err, data.code, nodeId, customConsole, SURFACE_WRAPPER_OFFSET);
       }
     }
-
-    const pointerOutletIdx = videoOutputEnabled ? 1 : 0;
-    jsRunner.getMessageContext(nodeId).send(event, { to: pointerOutletIdx });
 
     if (drawMode === 'interact') triggerDraw();
   }
@@ -361,7 +359,7 @@
     dragEnabled = false;
     panEnabled = true;
     wheelEnabled = true;
-    videoOutputEnabled = true;
+    updateNodeData(nodeId, { videoOutput: true });
     drawMode = 'always';
     pointerCallback = null;
     touchCallback = null;
@@ -444,7 +442,7 @@
             wheelEnabled = false;
           },
           noOutput: () => {
-            videoOutputEnabled = false;
+            updateNodeData(nodeId, { videoOutput: false });
             updateNodeInternals(nodeId);
           },
 
@@ -578,31 +576,20 @@
         port="outlet"
         spec={{ handleType: 'video', handleId: '0' }}
         title="Video output"
-        total={outletCount + 2}
+        total={outletCount + 1}
         index={0}
         class={handleClass}
         {nodeId}
       />
     {/if}
 
-    <!-- pointer outlet -->
-    <TypedHandle
-      port="outlet"
-      spec={{ handleId: videoOutputEnabled ? 1 : 0 }}
-      title="Pointer events"
-      total={videoOutputEnabled ? outletCount + 2 : outletCount + 1}
-      index={videoOutputEnabled ? 1 : 0}
-      class={handleClass}
-      {nodeId}
-    />
-
     {#each Array.from({ length: outletCount }) as _, index (index)}
       <TypedHandle
         port="outlet"
-        spec={{ handleId: index + (videoOutputEnabled ? 2 : 1) }}
+        spec={{ handleId: index + (videoOutputEnabled ? 1 : 0) }}
         title={`Outlet ${index}`}
-        total={videoOutputEnabled ? outletCount + 2 : outletCount + 1}
-        index={index + (videoOutputEnabled ? 2 : 1)}
+        total={videoOutputEnabled ? outletCount + 1 : outletCount}
+        index={index + (videoOutputEnabled ? 1 : 0)}
         class={handleClass}
         {nodeId}
       />

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -11,6 +11,7 @@
   import { PREVIEW_SCALE_FACTOR } from '$lib/canvas/constants';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { SurfaceOverlay } from '$lib/canvas/SurfaceOverlay';
+  import { SurfaceListeners } from '$lib/canvas/SurfaceListeners';
   import { shouldShowHandles } from '../../../stores/ui.store';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { createCustomConsole } from '$lib/utils/createCustomConsole';
@@ -181,15 +182,6 @@
 
   // ── Pointer helpers ──────────────────────────────────────────────────────
 
-  function normalizePointer(clientX: number, clientY: number, sourceCanvas: HTMLCanvasElement) {
-    const rect = sourceCanvas.getBoundingClientRect();
-    // Map to normalized 0–1 in fullscreen space
-    return {
-      x: (clientX - rect.left) / rect.width,
-      y: (clientY - rect.top) / rect.height
-    };
-  }
-
   function dispatchPointer(x: number, y: number, buttons: number, type: string) {
     const down = buttons > 0;
     mouse.x = x;
@@ -199,7 +191,6 @@
 
     const event = { x, y, pressure: 0, buttons, down, type };
 
-    // Fire user callback
     if (pointerCallback) {
       try {
         pointerCallback(event);
@@ -208,44 +199,10 @@
       }
     }
 
-    // Send to pointer outlet (outlet index after video outlet)
     const pointerOutletIdx = videoOutputEnabled ? 1 : 0;
     jsRunner.getMessageContext(nodeId).send(pointerOutletIdx, event);
 
-    if (drawMode === 'interact') {
-      triggerDraw();
-    }
-  }
-
-  function setupPointerListeners(canvas: HTMLCanvasElement): () => void {
-    const onPointerMove = (e: PointerEvent) => {
-      const { x, y } = normalizePointer(e.clientX, e.clientY, canvas);
-      dispatchPointer(x, y, e.buttons, 'move');
-    };
-    const onPointerDown = (e: PointerEvent) => {
-      const { x, y } = normalizePointer(e.clientX, e.clientY, canvas);
-      dispatchPointer(x, y, e.buttons || 1, 'down');
-    };
-    const onPointerUp = (e: PointerEvent) => {
-      const { x, y } = normalizePointer(e.clientX, e.clientY, canvas);
-      dispatchPointer(x, y, 0, 'up');
-    };
-    const onPointerLeave = () => {
-      mouse.down = false;
-      mouse.buttons = 0;
-    };
-
-    canvas.addEventListener('pointermove', onPointerMove);
-    canvas.addEventListener('pointerdown', onPointerDown);
-    canvas.addEventListener('pointerup', onPointerUp);
-    canvas.addEventListener('pointerleave', onPointerLeave);
-
-    return () => {
-      canvas.removeEventListener('pointermove', onPointerMove);
-      canvas.removeEventListener('pointerdown', onPointerDown);
-      canvas.removeEventListener('pointerup', onPointerUp);
-      canvas.removeEventListener('pointerleave', onPointerLeave);
-    };
+    if (drawMode === 'interact') triggerDraw();
   }
 
   // ── Draw mode & rAF ──────────────────────────────────────────────────────
@@ -294,8 +251,26 @@
 
   // ── Fullscreen activation ────────────────────────────────────────────────
 
-  let cleanupPreviewListeners: (() => void) | null = null;
-  let cleanupOverlayListeners: (() => void) | null = null;
+  const previewListeners = new SurfaceListeners();
+  const overlayListeners = new SurfaceListeners();
+
+  function listenerOpts() {
+    return {
+      onPointer: (e: import('$lib/canvas/SurfaceListeners').PointerEvent_) =>
+        dispatchPointer(e.x, e.y, e.buttons, e.type),
+      get onTouch() {
+        return touchCallback;
+      },
+      onLeave: () => {
+        mouse.down = false;
+        mouse.buttons = 0;
+      },
+      code: data.code,
+      nodeId,
+      customConsole,
+      wrapperOffset: SURFACE_WRAPPER_OFFSET
+    };
+  }
 
   function enterFullscreen() {
     if (isFullscreen) return;
@@ -311,9 +286,8 @@
     activeCtx = overlay.ctx;
 
     // Swap pointer listeners
-    cleanupPreviewListeners?.();
-    cleanupPreviewListeners = null;
-    cleanupOverlayListeners = setupPointerListeners(overlay.canvas);
+    previewListeners.detach();
+    overlayListeners.attach(overlay.canvas, listenerOpts());
 
     // Stop thumbnail loop (XYFlow is hidden anyway)
     stopThumbnailLoop();
@@ -335,16 +309,13 @@
     }
 
     // Swap pointer listeners
-    cleanupOverlayListeners?.();
-    cleanupOverlayListeners = null;
-    if (previewCanvas) {
-      cleanupPreviewListeners = setupPointerListeners(previewCanvas);
-    }
+    overlayListeners.detach();
+    if (previewCanvas) previewListeners.attach(previewCanvas, listenerOpts());
 
     // Re-run code with preview canvas
     runCode();
 
-    // Restart thumbnail loop (now drawing overlay → preview thumbnail)
+    // Restart thumbnail loop
     startThumbnailLoop();
   }
 
@@ -534,7 +505,7 @@
     setupPreviewCanvas();
 
     if (previewCanvas) {
-      cleanupPreviewListeners = setupPointerListeners(previewCanvas);
+      previewListeners.attach(previewCanvas, listenerOpts());
     }
 
     window.addEventListener('resize', handleWindowResize);
@@ -548,8 +519,8 @@
   onDestroy(() => {
     if (animationFrameId !== null) cancelAnimationFrame(animationFrameId);
     stopThumbnailLoop();
-    cleanupPreviewListeners?.();
-    cleanupOverlayListeners?.();
+    previewListeners.detach();
+    overlayListeners.detach();
 
     window.removeEventListener('resize', handleWindowResize);
 

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -1,0 +1,637 @@
+<script lang="ts">
+  import { useSvelteFlow, useUpdateNodeInternals } from '@xyflow/svelte';
+  import { onMount, onDestroy } from 'svelte';
+  import CodeEditor from '$lib/components/CodeEditor.svelte';
+  import { JSRunner } from '$lib/js-runner/JSRunner';
+  import TypedHandle from '$lib/components/TypedHandle.svelte';
+  import CanvasPreviewLayout from '$lib/components/CanvasPreviewLayout.svelte';
+  import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
+  import { match } from 'ts-pattern';
+  import { messages } from '$lib/objects/schemas';
+  import { PREVIEW_SCALE_FACTOR } from '$lib/canvas/constants';
+  import { GLSystem } from '$lib/canvas/GLSystem';
+  import { SurfaceOverlay } from '$lib/canvas/SurfaceOverlay';
+  import { shouldShowHandles } from '../../../stores/ui.store';
+  import VirtualConsole from '$lib/components/VirtualConsole.svelte';
+  import { createCustomConsole } from '$lib/utils/createCustomConsole';
+  import { handleCodeError } from '$lib/js-runner/handleCodeError';
+  import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+  import type { ConsoleOutputEvent } from '$lib/eventbus/events';
+  import { CANVAS_DOM_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
+  import { profiler } from '$lib/profiler';
+
+  // Error reporting offset reuse (surface is structurally identical to canvas.dom)
+  const SURFACE_WRAPPER_OFFSET = CANVAS_DOM_WRAPPER_OFFSET;
+
+  let {
+    id: nodeId,
+    data,
+    selected
+  }: {
+    id: string;
+    data: {
+      title: string;
+      code: string;
+      inletCount?: number;
+      outletCount?: number;
+      hidePorts?: boolean;
+      executeCode?: number;
+      showConsole?: boolean;
+      paused?: boolean;
+    };
+    selected?: boolean;
+  } = $props();
+
+  let consoleRef: VirtualConsole | null = $state(null);
+  let lineErrors = $state<Record<number, string[]> | undefined>(undefined);
+
+  const eventBus = PatchiesEventBus.getInstance();
+
+  function handleConsoleOutput(event: ConsoleOutputEvent) {
+    if (event.nodeId !== nodeId) return;
+    if (event.messageType === 'error' && event.lineErrors) {
+      lineErrors = event.lineErrors;
+    }
+  }
+
+  const customConsole = createCustomConsole(nodeId);
+  const jsRunner = JSRunner.getInstance();
+  const glSystem = GLSystem.getInstance();
+
+  // The inline preview canvas (always in the node, shown in preview mode)
+  let previewCanvas = $state<HTMLCanvasElement | undefined>();
+  let previewCtx: CanvasRenderingContext2D | null = null;
+
+  let dragEnabled = $state(false);
+  let panEnabled = $state(true);
+  let wheelEnabled = $state(true);
+  let videoOutputEnabled = $state(true);
+  let editorReady = $state(false);
+  let animationFrameId: number | null = null;
+  let pausedCallback: FrameRequestCallback | null = null;
+
+  // Whether the overlay is currently fullscreen
+  let isFullscreen = $state(false);
+
+  // Which canvas is currently active (preview inline canvas OR overlay canvas)
+  let activeCanvas: HTMLCanvasElement | null = null;
+  let activeCtx: CanvasRenderingContext2D | null = null;
+
+  // Thumbnail copy loop frame id
+  let thumbnailFrameId: number | null = null;
+
+  // Draw mode: 'always' | 'interact' | 'manual'
+  type DrawMode = 'always' | 'interact' | 'manual';
+  let drawMode: DrawMode = 'always';
+
+  // User-registered callbacks
+  let pointerCallback:
+    | ((e: {
+        x: number;
+        y: number;
+        pressure: number;
+        buttons: number;
+        down: boolean;
+        type: string;
+      }) => void)
+    | null = null;
+  let touchCallback:
+    | ((touches: { x: number; y: number; pressure: number; id: number }[]) => void)
+    | null = null;
+  let keyboardCallbacks: {
+    onKeyDown?: (event: KeyboardEvent) => void;
+    onKeyUp?: (event: KeyboardEvent) => void;
+  } = {};
+
+  // Mouse state (normalized 0–1)
+  let mouse = $state({ x: 0, y: 0, down: false, buttons: 0 });
+
+  const { updateNodeData, getNodes } = useSvelteFlow();
+  const updateNodeInternals = useUpdateNodeInternals();
+
+  let inletCount = $derived(data.inletCount ?? 1);
+  let outletCount = $derived(data.outletCount ?? 0);
+  let previousExecuteCode = $state<number | undefined>(undefined);
+
+  // Canvas dimensions = always window dimensions
+  let outputWidth = $state(window.innerWidth);
+  let outputHeight = $state(window.innerHeight);
+  let previewWidth = $derived(outputWidth / PREVIEW_SCALE_FACTOR);
+  let previewHeight = $derived(outputHeight / PREVIEW_SCALE_FACTOR);
+
+  $effect(() => {
+    if (data.executeCode && data.executeCode !== previousExecuteCode) {
+      previousExecuteCode = data.executeCode;
+      runCode();
+    }
+  });
+
+  const setPortCount = (newInletCount = 1, newOutletCount = 0) => {
+    updateNodeData(nodeId, { inletCount: newInletCount, outletCount: newOutletCount });
+    updateNodeInternals(nodeId);
+  };
+
+  const setCodeAndUpdate = (newCode: string) => {
+    updateNodeData(nodeId, { code: newCode });
+    setTimeout(() => runCode());
+  };
+
+  const handleMessage: MessageCallbackFn = (message, _meta) => {
+    try {
+      match(message)
+        .with(messages.setCode, ({ value }) => setCodeAndUpdate(value))
+        .with(messages.run, () => runCode())
+        .otherwise((msg: unknown) => {
+          const m = msg as Record<string, unknown>;
+          // bang or { type: 'activate' } → go fullscreen
+          if (msg === 'bang' || m?.type === 'activate') {
+            enterFullscreen();
+          }
+          // { type: 'exit' } → exit fullscreen
+          if (m?.type === 'exit') {
+            exitSurface();
+          }
+        });
+    } catch (error) {
+      console.error('Error handling message:', error);
+    }
+  };
+
+  // ── Pointer helpers ──────────────────────────────────────────────────────
+
+  function normalizePointer(clientX: number, clientY: number, sourceCanvas: HTMLCanvasElement) {
+    const rect = sourceCanvas.getBoundingClientRect();
+    // Map to normalized 0–1 in fullscreen space
+    return {
+      x: (clientX - rect.left) / rect.width,
+      y: (clientY - rect.top) / rect.height
+    };
+  }
+
+  function dispatchPointer(x: number, y: number, buttons: number, type: string) {
+    const down = buttons > 0;
+    mouse.x = x;
+    mouse.y = y;
+    mouse.buttons = buttons;
+    mouse.down = down;
+
+    const event = { x, y, pressure: 0, buttons, down, type };
+
+    // Fire user callback
+    if (pointerCallback) {
+      try {
+        pointerCallback(event);
+      } catch (err) {
+        handleCodeError(err, data.code, nodeId, customConsole, SURFACE_WRAPPER_OFFSET);
+      }
+    }
+
+    // Send to pointer outlet (outlet index after video outlet)
+    const pointerOutletIdx = videoOutputEnabled ? 1 : 0;
+    jsRunner.getMessageContext(nodeId).send(pointerOutletIdx, event);
+
+    if (drawMode === 'interact') {
+      triggerDraw();
+    }
+  }
+
+  function setupPointerListeners(canvas: HTMLCanvasElement): () => void {
+    const onPointerMove = (e: PointerEvent) => {
+      const { x, y } = normalizePointer(e.clientX, e.clientY, canvas);
+      dispatchPointer(x, y, e.buttons, 'move');
+    };
+    const onPointerDown = (e: PointerEvent) => {
+      const { x, y } = normalizePointer(e.clientX, e.clientY, canvas);
+      dispatchPointer(x, y, e.buttons || 1, 'down');
+    };
+    const onPointerUp = (e: PointerEvent) => {
+      const { x, y } = normalizePointer(e.clientX, e.clientY, canvas);
+      dispatchPointer(x, y, 0, 'up');
+    };
+    const onPointerLeave = () => {
+      mouse.down = false;
+      mouse.buttons = 0;
+    };
+
+    canvas.addEventListener('pointermove', onPointerMove);
+    canvas.addEventListener('pointerdown', onPointerDown);
+    canvas.addEventListener('pointerup', onPointerUp);
+    canvas.addEventListener('pointerleave', onPointerLeave);
+
+    return () => {
+      canvas.removeEventListener('pointermove', onPointerMove);
+      canvas.removeEventListener('pointerdown', onPointerDown);
+      canvas.removeEventListener('pointerup', onPointerUp);
+      canvas.removeEventListener('pointerleave', onPointerLeave);
+    };
+  }
+
+  // ── Draw mode & rAF ──────────────────────────────────────────────────────
+
+  function triggerDraw() {
+    if (drawMode !== 'manual') return;
+    // In manual mode, redraw() calls here; nothing else needed
+    if (pausedCallback) {
+      pausedCallback(performance.now());
+      sendBitmap();
+    }
+  }
+
+  // ── Bitmap output ────────────────────────────────────────────────────────
+
+  async function sendBitmap() {
+    if (!activeCanvas) return;
+    if (!videoOutputEnabled) return;
+    if (!glSystem.hasOutgoingVideoConnections(nodeId)) return;
+    await glSystem.setBitmapSource(nodeId, activeCanvas);
+  }
+
+  // ── Thumbnail copy ───────────────────────────────────────────────────────
+
+  function startThumbnailLoop() {
+    if (thumbnailFrameId !== null) return;
+
+    function copyFrame() {
+      if (isFullscreen || !previewCanvas || !previewCtx || !activeCanvas) {
+        thumbnailFrameId = null;
+        return;
+      }
+      previewCtx.drawImage(activeCanvas, 0, 0, previewCanvas.width, previewCanvas.height);
+      thumbnailFrameId = requestAnimationFrame(copyFrame);
+    }
+
+    thumbnailFrameId = requestAnimationFrame(copyFrame);
+  }
+
+  function stopThumbnailLoop() {
+    if (thumbnailFrameId !== null) {
+      cancelAnimationFrame(thumbnailFrameId);
+      thumbnailFrameId = null;
+    }
+  }
+
+  // ── Fullscreen activation ────────────────────────────────────────────────
+
+  let cleanupPreviewListeners: (() => void) | null = null;
+  let cleanupOverlayListeners: (() => void) | null = null;
+
+  function enterFullscreen() {
+    if (isFullscreen) return;
+    isFullscreen = true;
+
+    const overlay = SurfaceOverlay.getInstance();
+    const nodes = getNodes().map((n) => ({ id: n.id, type: n.type }));
+
+    overlay.activate(nodeId, nodes, () => exitSurface());
+
+    // Switch active canvas to overlay
+    activeCanvas = overlay.canvas;
+    activeCtx = overlay.ctx;
+
+    // Swap pointer listeners
+    cleanupPreviewListeners?.();
+    cleanupPreviewListeners = null;
+    cleanupOverlayListeners = setupPointerListeners(overlay.canvas);
+
+    // Stop thumbnail loop (XYFlow is hidden anyway)
+    stopThumbnailLoop();
+
+    // Re-run code with overlay canvas
+    runCode();
+  }
+
+  function exitSurface() {
+    if (!isFullscreen) return;
+    isFullscreen = false;
+
+    SurfaceOverlay.getInstance().deactivate(nodeId);
+
+    // Switch active canvas back to preview
+    if (previewCanvas) {
+      activeCanvas = previewCanvas;
+      activeCtx = previewCtx;
+    }
+
+    // Swap pointer listeners
+    cleanupOverlayListeners?.();
+    cleanupOverlayListeners = null;
+    if (previewCanvas) {
+      cleanupPreviewListeners = setupPointerListeners(previewCanvas);
+    }
+
+    // Re-run code with preview canvas
+    runCode();
+
+    // Restart thumbnail loop (now drawing overlay → preview thumbnail)
+    startThumbnailLoop();
+  }
+
+  // ── Canvas setup ─────────────────────────────────────────────────────────
+
+  function setupPreviewCanvas() {
+    if (!previewCanvas) return;
+
+    previewCanvas.width = outputWidth;
+    previewCanvas.height = outputHeight;
+    previewCanvas.style.width = `${previewWidth}px`;
+    previewCanvas.style.height = `${previewHeight}px`;
+
+    previewCtx = previewCanvas.getContext('2d');
+    activeCanvas = previewCanvas;
+    activeCtx = previewCtx;
+  }
+
+  function togglePlayback() {
+    if (data.paused) {
+      updateNodeData(nodeId, { paused: false });
+      if (pausedCallback) {
+        animationFrameId = requestAnimationFrame((time) => {
+          pausedCallback!(time);
+          sendBitmap();
+        });
+      }
+    } else {
+      updateNodeData(nodeId, { paused: true });
+      if (animationFrameId !== null) {
+        cancelAnimationFrame(animationFrameId);
+        animationFrameId = null;
+      }
+    }
+  }
+
+  // ── Code execution ───────────────────────────────────────────────────────
+
+  async function runCode() {
+    if (!activeCanvas || !activeCtx) return;
+
+    consoleRef?.clearConsole();
+    lineErrors = undefined;
+
+    dragEnabled = false;
+    panEnabled = true;
+    wheelEnabled = true;
+    videoOutputEnabled = true;
+    drawMode = 'always';
+    pointerCallback = null;
+    touchCallback = null;
+    keyboardCallbacks = {};
+
+    if (animationFrameId !== null) {
+      cancelAnimationFrame(animationFrameId);
+      animationFrameId = null;
+    }
+
+    const canvas = activeCanvas;
+    const ctx = activeCtx;
+
+    try {
+      const processedCode = await jsRunner.preprocessCode(data.code, { nodeId });
+      if (processedCode === null) return;
+
+      await jsRunner.executeJavaScript(nodeId, processedCode, {
+        customConsole,
+        setPortCount,
+        setTitle: (title: string) => updateNodeData(nodeId, { title }),
+        setHidePorts: (hidePorts: boolean) => updateNodeData(nodeId, { hidePorts }),
+        extraContext: {
+          canvas,
+          ctx,
+          get width() {
+            return outputWidth;
+          },
+          get height() {
+            return outputHeight;
+          },
+          mouse,
+
+          // Draw mode
+          setDrawMode: (mode: DrawMode) => {
+            drawMode = mode;
+          },
+          redraw: () => {
+            if (pausedCallback) {
+              pausedCallback(performance.now());
+              sendBitmap();
+            }
+          },
+
+          // Surface activation
+          activate: () => enterFullscreen(),
+          deactivate: () => exitSurface(),
+
+          // Browser fullscreen (separate from surface activation)
+          goFullscreen: () => document.documentElement.requestFullscreen?.(),
+          exitFullscreen: () => document.exitFullscreen?.(),
+
+          // Interaction callbacks
+          onPointer: (cb: typeof pointerCallback) => {
+            pointerCallback = cb;
+          },
+          onTouch: (cb: typeof touchCallback) => {
+            touchCallback = cb;
+          },
+          onKeyDown: (callback: (event: KeyboardEvent) => void) => {
+            keyboardCallbacks.onKeyDown = callback;
+          },
+          onKeyUp: (callback: (event: KeyboardEvent) => void) => {
+            keyboardCallbacks.onKeyUp = callback;
+          },
+
+          // Interaction flags (for the node itself)
+          noDrag: () => {
+            dragEnabled = false;
+          },
+          noPan: () => {
+            panEnabled = false;
+          },
+          noWheel: () => {
+            wheelEnabled = false;
+          },
+          noInteract: () => {
+            dragEnabled = false;
+            panEnabled = false;
+            wheelEnabled = false;
+          },
+          noOutput: () => {
+            videoOutputEnabled = false;
+            updateNodeInternals(nodeId);
+          },
+
+          // rAF override — respects draw mode and paused state
+          requestAnimationFrame: (callback: FrameRequestCallback) => {
+            pausedCallback = callback;
+
+            if (data.paused || drawMode === 'manual') {
+              return -1;
+            }
+
+            animationFrameId = requestAnimationFrame((time) => {
+              profiler.measure(nodeId, 'draw', () => {
+                callback(time);
+                sendBitmap();
+              });
+            });
+            return animationFrameId;
+          },
+          cancelAnimationFrame: (id: number) => {
+            cancelAnimationFrame(id);
+            if (animationFrameId === id) animationFrameId = null;
+          }
+        }
+      });
+    } catch (error) {
+      handleCodeError(error, data.code, nodeId, customConsole, SURFACE_WRAPPER_OFFSET);
+    }
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+
+  onMount(() => {
+    const messageContext = jsRunner.getMessageContext(nodeId);
+    messageContext.queue.addCallback(handleMessage);
+    eventBus.addEventListener('consoleOutput', handleConsoleOutput);
+
+    glSystem.upsertNode(nodeId, 'img', {});
+
+    setupPreviewCanvas();
+
+    if (previewCanvas) {
+      cleanupPreviewListeners = setupPointerListeners(previewCanvas);
+    }
+
+    setTimeout(() => {
+      runCode();
+      startThumbnailLoop();
+    }, 50);
+  });
+
+  onDestroy(() => {
+    if (animationFrameId !== null) cancelAnimationFrame(animationFrameId);
+    stopThumbnailLoop();
+    cleanupPreviewListeners?.();
+    cleanupOverlayListeners?.();
+
+    // Deactivate overlay if this node was active
+    if (isFullscreen) SurfaceOverlay.getInstance().deactivate(nodeId);
+
+    eventBus.removeEventListener('consoleOutput', handleConsoleOutput);
+    glSystem?.removeNode(nodeId);
+    jsRunner.destroy(nodeId);
+  });
+
+  const handleClass = $derived.by(() => {
+    if (!data.hidePorts) return '';
+    if (!selected && $shouldShowHandles) return 'z-1 transition-opacity';
+    return `z-1 transition-opacity ${selected ? '' : 'sm:opacity-0 opacity-30 group-hover:opacity-100'}`;
+  });
+</script>
+
+<CanvasPreviewLayout
+  title={data.title ?? 'surface'}
+  objectType="surface"
+  {nodeId}
+  onrun={runCode}
+  onPlaybackToggle={togglePlayback}
+  paused={data.paused}
+  showPauseButton={true}
+  bind:previewCanvas
+  nodrag={!dragEnabled}
+  nopan={!panEnabled}
+  nowheel={!wheelEnabled}
+  tabindex={0}
+  width={outputWidth}
+  height={outputHeight}
+  style={`width: ${previewWidth}px; height: ${previewHeight}px;`}
+  {selected}
+  {editorReady}
+  hasError={lineErrors !== undefined}
+>
+  {#snippet topHandle()}
+    <!-- Go Live button -->
+    <button
+      class="absolute top-1 right-1 z-10 cursor-pointer rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors {isFullscreen
+        ? 'bg-red-600 text-white hover:bg-red-700'
+        : 'bg-zinc-700 text-zinc-300 hover:bg-zinc-600'}"
+      onclick={() => (isFullscreen ? exitSurface() : enterFullscreen())}
+    >
+      {isFullscreen ? 'Exit' : 'Go Live'}
+    </button>
+
+    {#each Array.from({ length: inletCount }) as _, index (index)}
+      <TypedHandle
+        port="inlet"
+        spec={{ handleId: index }}
+        title={`Inlet ${index}`}
+        total={inletCount}
+        {index}
+        class={handleClass}
+        {nodeId}
+      />
+    {/each}
+  {/snippet}
+
+  {#snippet bottomHandle()}
+    {#if videoOutputEnabled}
+      <TypedHandle
+        port="outlet"
+        spec={{ handleType: 'video', handleId: '0' }}
+        title="Video output"
+        total={outletCount + 2}
+        index={0}
+        class={handleClass}
+        {nodeId}
+      />
+    {/if}
+
+    <!-- pointer outlet -->
+    <TypedHandle
+      port="outlet"
+      spec={{ handleId: videoOutputEnabled ? 1 : 0 }}
+      title="Pointer events"
+      total={videoOutputEnabled ? outletCount + 2 : outletCount + 1}
+      index={videoOutputEnabled ? 1 : 0}
+      class={handleClass}
+      {nodeId}
+    />
+
+    {#each Array.from({ length: outletCount }) as _, index (index)}
+      <TypedHandle
+        port="outlet"
+        spec={{ handleId: index + (videoOutputEnabled ? 2 : 1) }}
+        title={`Outlet ${index}`}
+        total={videoOutputEnabled ? outletCount + 2 : outletCount + 1}
+        index={index + (videoOutputEnabled ? 2 : 1)}
+        class={handleClass}
+        {nodeId}
+      />
+    {/each}
+  {/snippet}
+
+  {#snippet codeEditor()}
+    <CodeEditor
+      value={data.code}
+      language="javascript"
+      nodeType="surface"
+      placeholder="Write your surface interaction code here..."
+      class="nodrag h-64 w-full resize-none"
+      onrun={runCode}
+      onchange={(newCode) => {
+        updateNodeData(nodeId, { code: newCode });
+      }}
+      onready={() => (editorReady = true)}
+      {lineErrors}
+      {nodeId}
+    />
+  {/snippet}
+
+  {#snippet console()}
+    <div class="mt-3 w-full" class:hidden={!data.showConsole}>
+      <VirtualConsole
+        bind:this={consoleRef}
+        {nodeId}
+        placeholder="Surface errors will appear here."
+        maxHeight="200px"
+      />
+    </div>
+  {/snippet}
+</CanvasPreviewLayout>

--- a/ui/src/lib/extensions/object-packs.ts
+++ b/ui/src/lib/extensions/object-packs.ts
@@ -83,7 +83,7 @@ export const BUILT_IN_PACKS: ExtensionPack[] = [
     name: '2D Graphics',
     description: 'Interactive 2D canvas objects',
     icon: 'Palette',
-    objects: ['p5', 'canvas', 'canvas.dom', 'textmode', 'textmode.dom']
+    objects: ['p5', 'canvas', 'canvas.dom', 'surface', 'textmode', 'textmode.dom']
   },
   {
     id: 'video-synthesis',

--- a/ui/src/lib/nodes/defaultNodeData.ts
+++ b/ui/src/lib/nodes/defaultNodeData.ts
@@ -337,6 +337,11 @@ export function getDefaultNodeData(nodeType: string): NodeData {
       skipFrames: 1
     }))
     .with('ngea', () => ({ tuning: 'Khong Wong Yai', index: 0 }))
-    .with('surface', () => ({ code: DEFAULT_SURFACE_CODE, showConsole: true }))
+    .with('surface', () => ({
+      code: DEFAULT_SURFACE_CODE,
+      showConsole: true,
+      inletCount: 1,
+      outletCount: 1
+    }))
     .otherwise(() => ({}));
 }

--- a/ui/src/lib/nodes/defaultNodeData.ts
+++ b/ui/src/lib/nodes/defaultNodeData.ts
@@ -16,7 +16,8 @@ import {
   DEFAULT_CSOUND_CODE,
   DEFAULT_TEXTMODE_CODE,
   DEFAULT_THREE_CODE,
-  DEFAULT_REGL_CODE
+  DEFAULT_REGL_CODE,
+  DEFAULT_SURFACE_CODE
 } from '$lib/canvas/constants';
 import { DEFAULT_P5_CODE } from '$lib/p5/constants';
 import { DEFAULT_HYDRA_CODE } from '$lib/hydra/constants';
@@ -336,5 +337,6 @@ export function getDefaultNodeData(nodeType: string): NodeData {
       skipFrames: 1
     }))
     .with('ngea', () => ({ tuning: 'Khong Wong Yai', index: 0 }))
+    .with('surface', () => ({ code: DEFAULT_SURFACE_CODE, showConsole: true }))
     .otherwise(() => ({}));
 }

--- a/ui/src/lib/nodes/node-types.ts
+++ b/ui/src/lib/nodes/node-types.ts
@@ -102,6 +102,7 @@ import VisionDetectNode from '$objects/mediapipe/components/VisionDetectNode.sve
 import VisionGestureNode from '$objects/mediapipe/components/VisionGestureNode.svelte';
 import VisionClassifyNode from '$objects/mediapipe/components/VisionClassifyNode.svelte';
 import NgeaNode from '$objects/ngea/components/NgeaNode.svelte';
+import SurfaceNode from '$lib/components/nodes/SurfaceNode.svelte';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const nodeTypes: Record<string, any> = {
@@ -208,7 +209,8 @@ export const nodeTypes: Record<string, any> = {
   'vision.detect': VisionDetectNode,
   'vision.gesture': VisionGestureNode,
   'vision.classify': VisionClassifyNode,
-  ngea: NgeaNode
+  ngea: NgeaNode,
+  surface: SurfaceNode
 } as const;
 
 export const nodeNames = Object.keys(nodeTypes) as (keyof typeof nodeTypes)[];

--- a/ui/src/lib/objects/schemas/index.ts
+++ b/ui/src/lib/objects/schemas/index.ts
@@ -7,6 +7,7 @@ export * from './p5';
 export * from './hydra';
 export * from './glsl';
 export * from './canvas';
+export * from './surface';
 export * from './swgl';
 export * from './textmode';
 export * from './three';
@@ -99,6 +100,7 @@ import { p5Schema } from './p5';
 import { hydraSchema } from './hydra';
 import { glslSchema } from './glsl';
 import { canvasSchema, canvasDomSchema } from './canvas';
+import { surfaceSchema } from './surface';
 import { swglSchema } from './swgl';
 import { textmodeSchema, textmodeDomSchema } from './textmode';
 import { threeSchema, threeDomSchema } from './three';
@@ -208,6 +210,7 @@ export const objectSchemas: ObjectSchemaRegistry = {
   glsl: glslSchema,
   canvas: canvasSchema,
   'canvas.dom': canvasDomSchema,
+  surface: surfaceSchema,
   swgl: swglSchema,
   textmode: textmodeSchema,
   'textmode.dom': textmodeDomSchema,

--- a/ui/src/lib/objects/schemas/surface.ts
+++ b/ui/src/lib/objects/schemas/surface.ts
@@ -1,0 +1,69 @@
+import { Type } from '@sinclair/typebox';
+import { msg } from './helpers';
+import type { ObjectSchema } from './types';
+import { Run, SetCode } from './common';
+
+export const SurfaceExpand = msg('expand', {});
+export const SurfaceCollapse = msg('collapse', {});
+
+export const surfaceSchema: ObjectSchema = {
+  type: 'surface',
+  category: 'video',
+  description: 'Fullscreen transparent canvas overlay for pointer and touch interaction',
+  inlets: [
+    {
+      id: 'message',
+      description: 'Control messages',
+      messages: [
+        { schema: SetCode, description: 'Set the code in the editor' },
+        { schema: Run, description: 'Evaluate code and update visuals' },
+        { schema: SurfaceExpand, description: 'Enter fullscreen surface mode' },
+        { schema: SurfaceCollapse, description: 'Exit fullscreen surface mode' }
+      ]
+    }
+  ],
+  outlets: [
+    {
+      id: 'video',
+      description: 'Video output',
+      handle: {
+        handleType: 'video'
+      }
+    },
+    {
+      id: 'pointer',
+      description: 'Pointer events',
+      messages: [
+        {
+          schema: Type.Object({
+            x: Type.Number({ description: 'X coordinate of the pointer event' }),
+            y: Type.Number({ description: 'Y coordinate of the pointer event' }),
+            buttons: Type.Number({ description: 'Bitmask of pressed buttons' }),
+            down: Type.Boolean({ description: 'Whether the pointer is currently down' }),
+            type: Type.Union(
+              [
+                Type.Literal('pointerdown'),
+                Type.Literal('pointermove'),
+                Type.Literal('pointerup'),
+                Type.Literal('pointercancel')
+              ],
+              { description: 'Type of pointer event' }
+            )
+          }),
+          description: 'Pointer event object with x, y, buttons, down, and type'
+        }
+      ]
+    }
+  ],
+  tags: ['graphics', 'interaction', 'touch', 'pointer', 'mouse', 'fullscreen', 'overlay', '2d'],
+  hasDynamicOutlets: true,
+  handlePatterns: {
+    inlet: { template: 'in-{index}', description: 'Message inlets (0-indexed)' },
+    outlet: {
+      template: 'video-out-{index}',
+      handleType: 'video',
+      description:
+        'Video output at index 0, pointer events at index 1, message outlets use out-{index}'
+    }
+  }
+};

--- a/ui/src/lib/objects/schemas/surface.ts
+++ b/ui/src/lib/objects/schemas/surface.ts
@@ -1,4 +1,3 @@
-import { Type } from '@sinclair/typebox';
 import { msg } from './helpers';
 import type { ObjectSchema } from './types';
 import { Run, SetCode } from './common';
@@ -29,30 +28,6 @@ export const surfaceSchema: ObjectSchema = {
       handle: {
         handleType: 'video'
       }
-    },
-    {
-      id: 'pointer',
-      description: 'Pointer events',
-      messages: [
-        {
-          schema: Type.Object({
-            x: Type.Number({ description: 'X coordinate of the pointer event' }),
-            y: Type.Number({ description: 'Y coordinate of the pointer event' }),
-            buttons: Type.Number({ description: 'Bitmask of pressed buttons' }),
-            down: Type.Boolean({ description: 'Whether the pointer is currently down' }),
-            type: Type.Union(
-              [
-                Type.Literal('pointerdown'),
-                Type.Literal('pointermove'),
-                Type.Literal('pointerup'),
-                Type.Literal('pointercancel')
-              ],
-              { description: 'Type of pointer event' }
-            )
-          }),
-          description: 'Pointer event object with x, y, buttons, down, and type'
-        }
-      ]
     }
   ],
   tags: ['graphics', 'interaction', 'touch', 'pointer', 'mouse', 'fullscreen', 'overlay', '2d'],
@@ -62,8 +37,7 @@ export const surfaceSchema: ObjectSchema = {
     outlet: {
       template: 'video-out-{index}',
       handleType: 'video',
-      description:
-        'Video output at index 0, pointer events at index 1, message outlets use out-{index}'
+      description: 'Video output at index 0, message outlets use out-{index}'
     }
   }
 };

--- a/ui/static/content/objects/surface.md
+++ b/ui/static/content/objects/surface.md
@@ -1,0 +1,120 @@
+The `surface` object creates a fullscreen transparent canvas
+overlay for capturing pointer and touch events.
+
+Unlike `canvas.dom`, the surface is designed for live performance.
+It hides the node editor and takes over the entire screen
+while keeping the video pipeline running underneath.
+
+This lets you keep mouse-interactive visuals on the surface
+while GPU-intensive shaders run in the background without interruption.
+
+## States
+
+| State | Description |
+|-------|-------------|
+| **Preview** | Default. Small canvas preview in the node editor, interactive. |
+| **Fullscreen** | Full-screen overlay. Node editor hidden, video pipeline visible beneath. |
+
+Use **Go Live** in the node menu (or send `{ type: 'expand' }`) to enter
+fullscreen. Press **Shift+Esc** or send `{ type: 'collapse' }` to exit.
+
+## Getting Started
+
+```javascript
+onPointer(({ x, y, down }) => {
+  if (!down) return;
+
+  ctx.beginPath();
+  ctx.arc(x * width, y * height, 20, 0, Math.PI * 2);
+  ctx.fill();
+});
+```
+
+## Coordinate System
+
+All coordinates are normalized to **0–1** relative to the canvas size.
+Multiply by `width` / `height` to get pixel coordinates:
+
+```javascript
+const px = x * width;
+const py = y * height;
+```
+
+## Pointer Events
+
+`onPointer(callback)` fires on every pointer move and click:
+
+```javascript
+onPointer(({ x, y, buttons, down, type }) => {
+  // type: 'move' | 'down' | 'up'
+  // buttons: bitmask (1 = left, 2 = right, 4 = middle)
+});
+```
+
+Pointer events are also sent to the **pointer outlet** as messages.
+
+## Touch Events
+
+`onTouch(callback)` fires with all active touch points:
+
+```javascript
+onTouch((touches) => {
+  for (const { id, x, y, pressure } of touches) {
+    ctx.beginPath();
+    ctx.arc(x * width, y * height, 30 * (pressure || 0.5), 0, Math.PI * 2);
+    ctx.fill();
+  }
+});
+```
+
+## Draw Modes
+
+By default, we draw the canvas on every frame.
+To optimize performance, switch to `'interact'` (draw only on pointer activity)
+or `'manual'` (draw only when `redraw()` is called):
+
+```javascript
+setDrawMode('always');   // Draw every frame (default)
+setDrawMode('interact'); // Draw only on pointer activity
+setDrawMode('manual');   // Draw only when redraw() is called
+```
+
+## Activation API
+
+You can programmatically enter or exit fullscreen surface mode thru JavaScript:
+
+```javascript
+activate();    // Enter fullscreen surface mode
+deactivate();  // Exit fullscreen surface mode
+```
+
+Or, send messages to the inlet:
+
+```ts
+{ type: 'expand' }    → enter fullscreen
+{ type: 'collapse' }  → exit fullscreen
+```
+
+## Window Resize
+
+The canvas automatically resizes to the window. `width` and `height` always
+reflect the current window dimensions.
+
+## JavaScript Functions
+
+All [Patchies JavaScript Runner](/docs/javascript-runner) functions are available,
+plus:
+
+- `onPointer(cb)` — register pointer event callback
+- `onTouch(cb)` — register touch event callback
+- `onKeyDown(cb)` / `onKeyUp(cb)` — keyboard callbacks
+- `setDrawMode('always'|'interact'|'manual')` — control render loop
+- `redraw()` — manually trigger a draw (manual mode)
+- `activate()` / `deactivate()` — enter/exit fullscreen
+- `noOutput()` — hide video output port
+
+## See Also
+
+- [canvas.dom](/docs/objects/canvas.dom) - main thread canvas without fullscreen
+- [canvas](/docs/objects/canvas) - offscreen canvas (faster for video chaining)
+- [p5](/docs/objects/p5) - P5.js creative coding environment

--- a/ui/static/content/objects/surface.md
+++ b/ui/static/content/objects/surface.md
@@ -81,7 +81,7 @@ setDrawMode('manual');   // Draw only when redraw() is called
 
 ## Activation API
 
-You can programmatically enter or exit fullscreen surface mode thru JavaScript:
+You can programmatically enter or exit fullscreen surface mode through JavaScript:
 
 ```javascript
 activate();    // Enter fullscreen surface mode


### PR DESCRIPTION
## Summary

- Adds a new `surface` node — a fullscreen transparent canvas overlay for live performance pointer/touch interaction
- Auto-freezes DOM-renderer nodes (p5, canvas.dom, etc.) on activation while keeping the FBO video pipeline running underneath
- Hides the node editor during fullscreen; background canvas output remains visible

## Key Features

- **Three states**: preview (default, small canvas in node), fullscreen (full screen overlay), stopped
- **Pointer & touch events**: `onPointer(cb)` and `onTouch(cb)` with normalized 0–1 coords; multi-touch supported
- **Draw modes**: `setDrawMode('always'|'interact'|'manual')` + `redraw()`
- **Go Live / Exit**: via three-dots menu, right-click context menu, or messages `{ type: 'expand' }` / `{ type: 'collapse' }`
- **Window resize**: canvas auto-resizes to window dimensions
- **Video output**: opt-in via removing `noOutput()` from code; persisted in node data
- **Default code**: ships with `setPortCount(1,1)` + `onPointer(data => send(data))` so pointer forwarding works out of the box

## Files

- `SurfaceNode.svelte` — main node component
- `SurfaceOverlay.ts` — singleton managing the fullscreen canvas + DOM node freeze/unfreeze
- `SurfaceListeners.ts` — extracted pointer/touch event listener class
- `surface.ts` (schema) — inlet messages incl. expand/collapse
- `surface.md` (docs) + `surface.ts` (AI prompt)
- `CanvasPreviewLayout` / `ObjectPreviewLayout` / overflow & context menus — extended with `extraMenuItems` prop for custom node actions
- `app.css` — `overscroll-behavior: none` to prevent macOS elastic bounce

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Surface object: a fullscreen transparent interactive canvas overlay for live performance drawing and touch interactions. Supports pointer and multi-touch input capture with preview and fullscreen modes. Toggle fullscreen via UI or Shift+Esc shortcut while underlying content continues rendering.

* **Documentation**
  * Added comprehensive Surface object documentation with usage examples and API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->