### PR TITLE
feat: setPrimaryButton API to swap the primary node button

### DIFF
--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -346,6 +346,13 @@ export class GLSystem {
           videoOutputEnabled: data.videoOutputEnabled
         });
       })
+      .with({ type: 'setPrimaryButton' }, (data) => {
+        this.eventBus.dispatch({
+          type: 'nodePrimaryButtonUpdate',
+          nodeId: data.nodeId,
+          primaryButton: data.primaryButton
+        });
+      })
       .with({ type: 'setMouseScope' }, (data) => {
         this.eventBus.dispatch({
           type: 'nodeMouseScopeUpdate',

--- a/ui/src/lib/codemirror/glsl.codemirror.ts
+++ b/ui/src/lib/codemirror/glsl.codemirror.ts
@@ -82,9 +82,9 @@ const includeHighlightTheme = EditorView.baseTheme({
 });
 
 /**
- * Highlights `// @title` and `// @param` metadata directives (spec 125).
+ * Highlights `// @title`, `// @param`, and `// @primaryButton` metadata directives (spec 125).
  */
-const METADATA_DIRECTIVE_RE = /^[ \t]*\/\/\s*(@(?:title|param))\s+(.+)$/gm;
+const METADATA_DIRECTIVE_RE = /^[ \t]*\/\/\s*(@(?:title|param|primaryButton))\s+(.+)$/gm;
 
 const metadataKeywordMark = Decoration.mark({ class: 'cm-glsl-metadata-keyword' });
 const metadataValueMark = Decoration.mark({ class: 'cm-glsl-metadata-value' });

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -122,7 +122,7 @@ const patchiesAPICompletions: Completion[] = [
     label: 'setPrimaryButton',
     type: 'function',
     detail: "('code' | 'settings' | 'run') => void",
-    info: 'Choose which button is shown as the primary action next to the overflow menu. Useful for code-stable nodes where settings or run is the action you reach for most.',
+    info: "Choose which button is shown as the primary action next to the overflow menu. Useful for code-stable nodes where settings or run is the action you reach for most. Note: 'run' falls back to 'code' on js/worker nodes since the entire node body is already a Run/Stop button.",
     apply: "setPrimaryButton('settings')"
   },
 

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -118,6 +118,13 @@ const patchiesAPICompletions: Completion[] = [
     info: 'Set output FBO texture format. Use rgba32f for unclamped float data (GPGPU, HDR).',
     apply: "setTextureFormat('rgba32f')"
   },
+  {
+    label: 'setPrimaryButton',
+    type: 'function',
+    detail: "('code' | 'settings' | 'run') => void",
+    info: 'Choose which button is shown as the primary action next to the overflow menu. Useful for code-stable nodes where settings or run is the action you reach for most.',
+    apply: "setPrimaryButton('settings')"
+  },
 
   // Timing Functions
   {
@@ -344,6 +351,7 @@ const topLevelOnlyFunctions = new Set([
   'setKeepAlive',
   'setMouseScope',
   'setPortCount',
+  'setPrimaryButton',
   'setRunOnMount',
   'setTextureFormat',
   'setVideoCount'
@@ -461,6 +469,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
     'three.dom'
   ],
   setTextureFormat: ['hydra', 'canvas', 'three', 'regl', 'swgl', 'textmode'],
+  setPrimaryButton: ['js', 'worker', 'p5', 'hydra', 'canvas', 'regl', 'swgl', 'textmode', 'three'],
   setVideoCount: ['hydra', 'regl', 'swgl', 'three', 'worker'],
   getTexture: ['hydra', 'regl', 'swgl', 'three'],
   onVideoFrame: ['worker'],

--- a/ui/src/lib/components/ObjectPreviewContextMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewContextMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     CircleHelp,
+    Code,
     Eye,
     EyeOff,
     Monitor,
@@ -27,6 +28,7 @@
     settingsSchema,
     showSettings,
     onSettingsToggle,
+    onCodeToggle,
     onBgOutputToggle,
     onPlaybackToggle,
     onOpenHelp,
@@ -44,6 +46,8 @@
     settingsSchema?: SettingsSchema;
     showSettings: boolean;
     onSettingsToggle: () => void;
+    /** Provided when code editor is NOT the primary button — adds an "Edit code" entry. */
+    onCodeToggle?: () => void;
     onBgOutputToggle: () => void;
     onPlaybackToggle: () => void;
     onOpenHelp: () => void;
@@ -56,6 +60,13 @@
     <ContextMenu.Item onclick={onrun}>
       <Play class="mr-2 h-4 w-4" />
       Run
+    </ContextMenu.Item>
+  {/if}
+
+  {#if onCodeToggle}
+    <ContextMenu.Item onclick={onCodeToggle}>
+      <Code class="mr-2 h-4 w-4" />
+      Edit code
     </ContextMenu.Item>
   {/if}
 

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -141,9 +141,16 @@
 
   let resizeObserver: ResizeObserver | null = null;
 
-  // Listen for setPrimaryButton() calls from worker code or // @primaryButton from GLSL
+  // Listen for setPrimaryButton() calls from worker code or // @primaryButton from GLSL.
+  // Note: this only reflects code-driven updates. Undo/redo of changes that touch
+  // node.data.primaryButton from elsewhere won't sync into the local state — would
+  // require threading `data` as a prop through every node component using this layout.
   function handlePrimaryButtonUpdate(e: NodePrimaryButtonUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+    // Defensive whitelist — TypeScript guarantees this at the type level, but the
+    // event bus is loosely typed at runtime so a buggy dispatcher could send anything.
+    if (e.primaryButton !== 'code' && e.primaryButton !== 'settings' && e.primaryButton !== 'run')
+      return;
     if (e.primaryButton === primaryButton) return;
 
     primaryButton = e.primaryButton;
@@ -253,6 +260,7 @@
                   <Tooltip.Trigger>
                     <button
                       class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
+                      aria-label="Edit code"
                       onclick={() => {
                         showEditor = !showEditor;
                         if (showEditor) showSettings = false;
@@ -269,6 +277,7 @@
                   <Tooltip.Trigger>
                     <button
                       class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
+                      aria-label={showSettings ? 'Hide settings' : 'Show settings'}
                       onclick={() => {
                         showSettings = !showSettings;
                         if (showSettings) showEditor = false;
@@ -286,6 +295,7 @@
                   <Tooltip.Trigger>
                     <button
                       class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
+                      aria-label="Run code (shift+enter)"
                       onclick={handleRun}
                     >
                       <Play class="h-4 w-4 text-zinc-300" />

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Code, Loader, Play, Terminal, X } from '@lucide/svelte/icons';
+  import { Code, Loader, Play, Settings as SettingsIcon, Terminal, X } from '@lucide/svelte/icons';
   import { onMount, type Snippet } from 'svelte';
   import * as Tooltip from './ui/tooltip';
   import * as ContextMenu from './ui/context-menu';
@@ -16,6 +16,8 @@
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { useNodeSetPaused } from '$lib/canvas/use-node-set-paused.svelte';
   import { useIncludeProcessing } from '$lib/canvas/use-include-processing.svelte';
+  import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+  import type { NodePrimaryButtonUpdateEvent, PrimaryButton } from '$lib/eventbus/events';
 
   let previewContainer: HTMLDivElement | null = null;
   const { getNode, updateNodeData } = useSvelteFlow();
@@ -87,6 +89,20 @@
   let showSettings = $state(false);
   let previewContainerWidth = $state(0);
 
+  // Which button is rendered as the primary (rightmost) action.
+  // Set via setPrimaryButton('settings'|'run'|'code') from worker code, or
+  // via // @primaryButton directive in GLSL. Persisted in node.data.primaryButton.
+  let primaryButton = $state<PrimaryButton>('code');
+
+  // Resolved primary — falls back to 'code' if the requested mode isn't usable
+  // (e.g. 'settings' selected but no schema yet, 'run' selected but no onrun).
+  let resolvedPrimary = $derived.by<PrimaryButton>(() => {
+    if (primaryButton === 'settings' && (!settingsSchema || settingsSchema.length === 0))
+      return 'code';
+    if (primaryButton === 'run' && !onrun) return 'code';
+    return primaryButton;
+  });
+
   function measureContainerWidth() {
     if (previewContainer) {
       previewContainerWidth = previewContainer.clientWidth;
@@ -125,6 +141,18 @@
 
   let resizeObserver: ResizeObserver | null = null;
 
+  // Listen for setPrimaryButton() calls from worker code or // @primaryButton from GLSL
+  function handlePrimaryButtonUpdate(e: NodePrimaryButtonUpdateEvent) {
+    if (e.nodeId !== nodeId) return;
+    if (e.primaryButton === primaryButton) return;
+
+    primaryButton = e.primaryButton;
+
+    if (nodeId) {
+      updateNodeData(nodeId, { primaryButton: e.primaryButton });
+    }
+  }
+
   onMount(() => {
     // Use ResizeObserver to re-measure width when container size changes
     if (previewWidth === undefined && previewContainer) {
@@ -135,8 +163,24 @@
       resizeObserver.observe(previewContainer);
     }
 
+    // Seed initial state from persisted node data (non-reactive lookup is fine here —
+    // future updates flow through the eventBus listener below).
+    if (nodeId) {
+      const node = getNode(nodeId);
+      const persisted = node?.data?.primaryButton as PrimaryButton | undefined;
+
+      if (persisted === 'settings' || persisted === 'run' || persisted === 'code') {
+        primaryButton = persisted;
+      }
+    }
+
+    const eventBus = PatchiesEventBus.getInstance();
+    eventBus.addEventListener('nodePrimaryButtonUpdate', handlePrimaryButtonUpdate);
+
     return () => {
       resizeObserver?.disconnect();
+
+      eventBus.removeEventListener('nodePrimaryButtonUpdate', handlePrimaryButtonUpdate);
     };
   });
 
@@ -152,10 +196,22 @@
 
   function handleBgOutputToggle() {
     if (!nodeId) return;
+
     const next = isOutputOverride ? null : nodeId;
     overrideOutputNodeId.set(next);
+
     GLSystem.getInstance().setOverrideOutputNode(next);
   }
+
+  const toggleCode = () => {
+    showEditor = !showEditor;
+
+    if (showEditor) {
+      showSettings = false;
+    }
+
+    measureContainerWidth();
+  };
 </script>
 
 <div class="relative flex gap-x-3">
@@ -185,27 +241,59 @@
                   showSettings = !showSettings;
                   if (showSettings) showEditor = false;
                 }}
+                onCodeToggle={resolvedPrimary === 'code' ? undefined : toggleCode}
                 onBgOutputToggle={handleBgOutputToggle}
                 onPlaybackToggle={handlePlaybackToggle}
                 onOpenHelp={handleOpenHelp}
                 {extraMenuItems}
               />
 
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  <button
-                    class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
-                    onclick={() => {
-                      showEditor = !showEditor;
-                      if (showEditor) showSettings = false;
-                      measureContainerWidth();
-                    }}
+              {#if resolvedPrimary === 'code'}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <button
+                      class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
+                      onclick={() => {
+                        showEditor = !showEditor;
+                        if (showEditor) showSettings = false;
+                        measureContainerWidth();
+                      }}
+                    >
+                      <Code class="h-4 w-4 text-zinc-300" />
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>Edit Code</Tooltip.Content>
+                </Tooltip.Root>
+              {:else if resolvedPrimary === 'settings'}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <button
+                      class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
+                      onclick={() => {
+                        showSettings = !showSettings;
+                        if (showSettings) showEditor = false;
+                      }}
+                    >
+                      <SettingsIcon class="h-4 w-4 text-zinc-300" />
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content
+                    >{showSettings ? 'Hide settings' : 'Show settings'}</Tooltip.Content
                   >
-                    <Code class="h-4 w-4 text-zinc-300" />
-                  </button>
-                </Tooltip.Trigger>
-                <Tooltip.Content>Edit Code</Tooltip.Content>
-              </Tooltip.Root>
+                </Tooltip.Root>
+              {:else if resolvedPrimary === 'run'}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <button
+                      class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
+                      onclick={handleRun}
+                    >
+                      <Play class="h-4 w-4 text-zinc-300" />
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>Run (shift+enter)</Tooltip.Content>
+                </Tooltip.Root>
+              {/if}
             </div>
           </div>
 
@@ -244,6 +332,13 @@
         showSettings = !showSettings;
         if (showSettings) showEditor = false;
       }}
+      onCodeToggle={resolvedPrimary === 'code'
+        ? undefined
+        : () => {
+            showEditor = !showEditor;
+            if (showEditor) showSettings = false;
+            measureContainerWidth();
+          }}
       onBgOutputToggle={handleBgOutputToggle}
       onPlaybackToggle={handlePlaybackToggle}
       onOpenHelp={handleOpenHelp}

--- a/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     CircleHelp,
+    Code,
     Eye,
     EyeOff,
     Ellipsis,
@@ -36,6 +37,7 @@
     onPreviewToggle,
     previewVisible = true,
     onSettingsToggle,
+    onCodeToggle,
     onBgOutputToggle,
     onPlaybackToggle,
     onOpenHelp,
@@ -53,6 +55,8 @@
     onPreviewToggle?: () => void;
     previewVisible?: boolean;
     onSettingsToggle?: () => void;
+    /** Provided when code editor is NOT the primary button — adds an "Edit code" entry to the menu. */
+    onCodeToggle?: () => void;
     onBgOutputToggle?: () => void;
     onPlaybackToggle?: () => void;
     onOpenHelp: () => void;
@@ -79,6 +83,19 @@
           <Play class="h-4 w-4 text-zinc-300" />
 
           <span>Run</span>
+        </button>
+      </Popover.Close>
+    {/if}
+
+    {#if onCodeToggle}
+      <Popover.Close class="contents">
+        <button
+          class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-zinc-700"
+          onclick={onCodeToggle}
+        >
+          <Code class="h-4 w-4 text-zinc-300" />
+
+          <span>Edit code</span>
         </button>
       </Popover.Close>
     {/if}

--- a/ui/src/lib/components/nodes/CodeBlockBase.svelte
+++ b/ui/src/lib/components/nodes/CodeBlockBase.svelte
@@ -283,11 +283,19 @@
 
   let minContainerWidth = $derived.by(() => {
     const baseWidth = 70;
-    let inletWidth = 15;
+    const inletWidth = 15;
     const totalInlets = inletCount + videoInletCount;
 
     return baseWidth + Math.max(Math.max(totalInlets, 2), Math.max(outletCount, 2)) * inletWidth;
   });
+
+  const toggleCode = () => {
+    toggleEditor();
+
+    if (showEditor) {
+      showSettings = false;
+    }
+  };
 </script>
 
 <div class="relative flex gap-x-3">
@@ -313,12 +321,7 @@
                 {settingsSchema}
                 onConsoleToggle={handleConsoleToggle}
                 onSettingsToggle={handleSettingsToggle}
-                onCodeToggle={resolvedPrimary === 'code'
-                  ? undefined
-                  : () => {
-                      toggleEditor();
-                      if (showEditor) showSettings = false;
-                    }}
+                onCodeToggle={resolvedPrimary === 'code' ? undefined : toggleCode}
               />
             {:else}
               <Tooltip.Root>
@@ -359,6 +362,7 @@
                   class="cursor-pointer rounded p-1 hover:bg-zinc-700"
                   onclick={() => {
                     toggleEditor();
+
                     if (showEditor) showSettings = false;
                   }}
                   aria-label="Edit code"

--- a/ui/src/lib/components/nodes/CodeBlockBase.svelte
+++ b/ui/src/lib/components/nodes/CodeBlockBase.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
-  import { Code, Loader, Package, Pause, Play, Terminal, X } from '@lucide/svelte/icons';
+  import {
+    Code,
+    Loader,
+    Package,
+    Pause,
+    Play,
+    Settings as SettingsIcon,
+    Terminal,
+    X
+  } from '@lucide/svelte/icons';
   import CodeBlockOverflowMenu from './CodeBlockOverflowMenu.svelte';
   import { useSvelteFlow } from '@xyflow/svelte';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
@@ -7,7 +16,11 @@
   import CodeEditor from '$lib/components/CodeEditor.svelte';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
-  import type { ConsoleOutputEvent } from '$lib/eventbus/events';
+  import type {
+    ConsoleOutputEvent,
+    NodePrimaryButtonUpdateEvent,
+    PrimaryButton
+  } from '$lib/eventbus/events';
   import type { SupportedLanguage } from '$lib/codemirror/types';
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings';
@@ -98,6 +111,21 @@
   let contentWidth = $state(100);
   let isFlashing = $state(false);
 
+  // Which button is rendered as the primary (rightmost) action.
+  // Set via setPrimaryButton('settings'|'code') from user code. 'run' is not
+  // a valid mode here because the entire body is already a giant Run/Stop button.
+  let primaryButton = $state<PrimaryButton>('code');
+
+  // Resolved primary — falls back to 'code' if 'settings' is requested but no
+  // schema exists, or if 'run' is requested (not supported in CodeBlockBase).
+  let resolvedPrimary = $derived.by<'code' | 'settings'>(() => {
+    if (primaryButton === 'settings' && settingsSchema && settingsSchema.length > 0) {
+      return 'settings';
+    }
+
+    return 'code';
+  });
+
   const code = $derived(data.code || '');
   let previousExecuteCode = $state<number | undefined>(undefined);
 
@@ -113,6 +141,14 @@
     if (event.messageType === 'error' && event.lineErrors) {
       lineErrors = event.lineErrors;
     }
+  }
+
+  // Listen for setPrimaryButton() calls from user code
+  function handlePrimaryButtonUpdate(event: NodePrimaryButtonUpdateEvent) {
+    if (event.nodeId !== nodeId) return;
+    if (event.primaryButton === primaryButton) return;
+    primaryButton = event.primaryButton;
+    updateNodeData(nodeId, { primaryButton: event.primaryButton });
   }
 
   // Watch for executeCode timestamp changes and re-run when it changes
@@ -155,6 +191,14 @@
   onMount(() => {
     // Listen for console output events to capture lineErrors
     eventBus.addEventListener('consoleOutput', handleConsoleOutput);
+    eventBus.addEventListener('nodePrimaryButtonUpdate', handlePrimaryButtonUpdate);
+
+    // Seed initial state from persisted node data
+    const persisted = (data as { primaryButton?: PrimaryButton }).primaryButton;
+
+    if (persisted === 'settings' || persisted === 'code' || persisted === 'run') {
+      primaryButton = persisted;
+    }
 
     updateContentWidth();
 
@@ -174,6 +218,7 @@
 
   onDestroy(() => {
     eventBus.removeEventListener('consoleOutput', handleConsoleOutput);
+    eventBus.removeEventListener('nodePrimaryButtonUpdate', handlePrimaryButtonUpdate);
   });
 
   async function executeCode() {
@@ -265,6 +310,12 @@
                 {settingsSchema}
                 onConsoleToggle={handleConsoleToggle}
                 onSettingsToggle={handleSettingsToggle}
+                onCodeToggle={resolvedPrimary === 'code'
+                  ? undefined
+                  : () => {
+                      toggleEditor();
+                      if (showEditor) showSettings = false;
+                    }}
               />
             {:else}
               <Tooltip.Root>
@@ -282,21 +333,40 @@
             {/if}
           {/if}
 
-          <Tooltip.Root>
-            <Tooltip.Trigger>
-              <button
-                class="cursor-pointer rounded p-1 hover:bg-zinc-700"
-                onclick={() => {
-                  toggleEditor();
-                  if (showEditor) showSettings = false;
-                }}
-                aria-label="Edit code"
-              >
-                <Code class="h-4 w-4 text-zinc-300" />
-              </button>
-            </Tooltip.Trigger>
-            <Tooltip.Content>Edit code</Tooltip.Content>
-          </Tooltip.Root>
+          {#if resolvedPrimary === 'settings'}
+            <Tooltip.Root>
+              <Tooltip.Trigger>
+                <button
+                  class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+                  onclick={handleSettingsToggle}
+                  aria-label="Settings"
+                >
+                  <SettingsIcon class="h-4 w-4 text-zinc-300" />
+                </button>
+              </Tooltip.Trigger>
+
+              <Tooltip.Content>
+                {showSettings ? 'Hide settings' : 'Show settings'}
+              </Tooltip.Content>
+            </Tooltip.Root>
+          {:else}
+            <Tooltip.Root>
+              <Tooltip.Trigger>
+                <button
+                  class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+                  onclick={() => {
+                    toggleEditor();
+                    if (showEditor) showSettings = false;
+                  }}
+                  aria-label="Edit code"
+                >
+                  <Code class="h-4 w-4 text-zinc-300" />
+                </button>
+              </Tooltip.Trigger>
+
+              <Tooltip.Content>Edit code</Tooltip.Content>
+            </Tooltip.Root>
+          {/if}
         </div>
       </div>
 

--- a/ui/src/lib/components/nodes/CodeBlockBase.svelte
+++ b/ui/src/lib/components/nodes/CodeBlockBase.svelte
@@ -80,6 +80,7 @@
       executeCode?: number;
       consoleHeight?: number;
       consoleWidth?: number;
+      primaryButton?: PrimaryButton;
     };
     selected: boolean;
     onExecute: () => Promise<void>;
@@ -112,9 +113,15 @@
   let isFlashing = $state(false);
 
   // Which button is rendered as the primary (rightmost) action.
+  // Source of truth is node.data.primaryButton — derived reactively so undo/redo
+  // and external mutations of node data flow through automatically.
   // Set via setPrimaryButton('settings'|'code') from user code. 'run' is not
   // a valid mode here because the entire body is already a giant Run/Stop button.
-  let primaryButton = $state<PrimaryButton>('code');
+  let primaryButton = $derived.by<PrimaryButton>(() => {
+    const v = data.primaryButton;
+    if (v === 'settings' || v === 'run' || v === 'code') return v;
+    return 'code';
+  });
 
   // Resolved primary — falls back to 'code' if 'settings' is requested but no
   // schema exists, or if 'run' is requested (not supported in CodeBlockBase).
@@ -143,12 +150,18 @@
     }
   }
 
-  // Listen for setPrimaryButton() calls from user code
+  // Listen for setPrimaryButton() calls from user code. Writes to node data;
+  // the local `primaryButton` is $derived from data and updates automatically.
   function handlePrimaryButtonUpdate(event: NodePrimaryButtonUpdateEvent) {
     if (event.nodeId !== nodeId) return;
+    // Defensive whitelist (event bus is loosely typed at runtime).
+    if (
+      event.primaryButton !== 'code' &&
+      event.primaryButton !== 'settings' &&
+      event.primaryButton !== 'run'
+    )
+      return;
     if (event.primaryButton === primaryButton) return;
-
-    primaryButton = event.primaryButton;
 
     updateNodeData(nodeId, { primaryButton: event.primaryButton });
   }
@@ -195,13 +208,6 @@
     // Listen for console output events to capture lineErrors
     eventBus.addEventListener('consoleOutput', handleConsoleOutput);
     eventBus.addEventListener('nodePrimaryButtonUpdate', handlePrimaryButtonUpdate);
-
-    // Seed initial state from persisted node data
-    const persisted = (data as { primaryButton?: PrimaryButton }).primaryButton;
-
-    if (persisted === 'settings' || persisted === 'code' || persisted === 'run') {
-      primaryButton = persisted;
-    }
 
     updateContentWidth();
 

--- a/ui/src/lib/components/nodes/CodeBlockBase.svelte
+++ b/ui/src/lib/components/nodes/CodeBlockBase.svelte
@@ -147,7 +147,9 @@
   function handlePrimaryButtonUpdate(event: NodePrimaryButtonUpdateEvent) {
     if (event.nodeId !== nodeId) return;
     if (event.primaryButton === primaryButton) return;
+
     primaryButton = event.primaryButton;
+
     updateNodeData(nodeId, { primaryButton: event.primaryButton });
   }
 
@@ -155,6 +157,7 @@
   $effect(() => {
     if (data.executeCode && data.executeCode !== previousExecuteCode) {
       previousExecuteCode = data.executeCode;
+
       executeCode();
     }
   });

--- a/ui/src/lib/components/nodes/CodeBlockOverflowMenu.svelte
+++ b/ui/src/lib/components/nodes/CodeBlockOverflowMenu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Ellipsis, Settings, Terminal } from '@lucide/svelte/icons';
+  import { Code, Ellipsis, Settings, Terminal } from '@lucide/svelte/icons';
   import * as Popover from '$lib/components/ui/popover';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import type { SettingsSchema } from '$lib/settings';
@@ -9,12 +9,15 @@
     showSettings,
     onConsoleToggle,
     onSettingsToggle,
+    onCodeToggle,
     settingsSchema
   }: {
     showConsole: boolean;
     showSettings: boolean;
     onConsoleToggle: () => void;
     onSettingsToggle: () => void;
+    /** Provided when code editor is NOT the primary button — adds an "Edit code" entry. */
+    onCodeToggle?: () => void;
     settingsSchema: SettingsSchema;
   } = $props();
 </script>
@@ -41,6 +44,19 @@
           <Settings class="h-4 w-4 text-zinc-300" />
 
           <span>{showSettings ? 'Hide settings' : 'Show settings'}</span>
+        </button>
+      </Popover.Close>
+    {/if}
+
+    {#if onCodeToggle}
+      <Popover.Close class="contents">
+        <button
+          class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-zinc-700"
+          onclick={onCodeToggle}
+        >
+          <Code class="h-4 w-4 text-zinc-300" />
+
+          <span>Edit code</span>
         </button>
       </Popover.Close>
     {/if}

--- a/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
+++ b/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
@@ -19,7 +19,8 @@
   import CanvasPreviewLayout from '$lib/components/CanvasPreviewLayout.svelte';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
-  import type { ConsoleOutputEvent } from '$lib/eventbus/events';
+  import type { ConsoleOutputEvent, PrimaryButton } from '$lib/eventbus/events';
+  import type { FBOFormat } from '$lib/rendering/types';
 
   let {
     id: nodeId,
@@ -164,18 +165,20 @@
     return max >= 0 ? max + 1 : 1;
   }
 
-  function detectFboFormat(code: string): 'rgba8' | 'rgba16f' | 'rgba32f' {
+  function detectFboFormat(code: string): FBOFormat {
     // Match // @format directive in single-line comments (don't strip comments first!)
     // Only skip directives inside block comments.
     const withoutBlocks = code.replace(/\/\*[\s\S]*?\*\//g, '');
-    const m = withoutBlocks.match(/^\s*\/\/\s*@format\s+(rgba8|rgba16f|rgba32f)\s*$/m);
-    return (m?.[1] as 'rgba8' | 'rgba16f' | 'rgba32f') ?? 'rgba8';
+    const match = withoutBlocks.match(/^\s*\/\/\s*@format\s+(rgba8|rgba16f|rgba32f)\s*$/m);
+
+    return (match?.[1] as FBOFormat) ?? 'rgba8';
   }
 
-  function detectPrimaryButton(code: string): 'code' | 'settings' | 'run' {
+  function detectPrimaryButton(code: string): PrimaryButton {
     const withoutBlocks = code.replace(/\/\*[\s\S]*?\*\//g, '');
-    const m = withoutBlocks.match(/^\s*\/\/\s*@primaryButton\s+(code|settings|run)\s*$/m);
-    return (m?.[1] as 'code' | 'settings' | 'run') ?? 'code';
+    const match = withoutBlocks.match(/^\s*\/\/\s*@primaryButton\s+(code|settings|run)\s*$/m);
+
+    return (match?.[1] as PrimaryButton) ?? 'code';
   }
 
   function updateShader() {
@@ -354,14 +357,14 @@
 
   {#snippet bottomHandle()}
     {#if (data.mrtCount ?? 1) > 1}
-      {#each Array(data.mrtCount ?? 1) as _, i}
+      {#each Array(data.mrtCount ?? 1) as _, index (index)}
         <StandardHandle
           port="outlet"
           type="video"
-          id={String(i)}
-          title={`Video output ${i}`}
+          id={String(index)}
+          title={`Video output ${index}`}
           total={data.mrtCount ?? 1}
-          index={i}
+          {index}
           {nodeId}
         />
       {/each}

--- a/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
+++ b/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
@@ -172,6 +172,12 @@
     return (m?.[1] as 'rgba8' | 'rgba16f' | 'rgba32f') ?? 'rgba8';
   }
 
+  function detectPrimaryButton(code: string): 'code' | 'settings' | 'run' {
+    const withoutBlocks = code.replace(/\/\*[\s\S]*?\*\//g, '');
+    const m = withoutBlocks.match(/^\s*\/\/\s*@primaryButton\s+(code|settings|run)\s*$/m);
+    return (m?.[1] as 'code' | 'settings' | 'run') ?? 'code';
+  }
+
   function updateShader() {
     // Clear console on re-run
     consoleRef?.clearConsole();
@@ -199,12 +205,15 @@
 
     uniformValues = pruned;
 
+    const nextPrimaryButton = detectPrimaryButton(data.code);
+
     const nextData = {
       ...data,
       glUniformDefs: nextDefs,
       uniformValues: pruned,
       mrtCount: detectMrtCount(data.code),
       fboFormat: detectFboFormat(data.code),
+      primaryButton: nextPrimaryButton,
       _runRevision: Date.now()
     };
 
@@ -213,6 +222,13 @@
 
     updateNodeData(nodeId, nextData);
     glSystem.upsertNode(nodeId, 'glsl', nextData, { force: true }); // force rebuild even if code hasn't changed
+
+    // Notify the layout (and any other listeners) that the primary button changed
+    eventBus.dispatch({
+      type: 'nodePrimaryButtonUpdate',
+      nodeId,
+      primaryButton: nextPrimaryButton
+    });
 
     // Push uniform values (including @param defaults) to the GL system
     for (const [name, value] of Object.entries(pruned)) {

--- a/ui/src/lib/components/nodes/JSBlockNode.svelte
+++ b/ui/src/lib/components/nodes/JSBlockNode.svelte
@@ -204,6 +204,13 @@
               nodeId: id,
               paused: false
             }),
+          setPrimaryButton: (primaryButton: 'code' | 'settings' | 'run') => {
+            PatchiesEventBus.getInstance().dispatch({
+              type: 'nodePrimaryButtonUpdate',
+              nodeId,
+              primaryButton
+            });
+          },
           settings: settingsAPI
         },
         onSchedulerCallbackRegistered: () => {

--- a/ui/src/lib/components/nodes/JSBlockNode.svelte
+++ b/ui/src/lib/components/nodes/JSBlockNode.svelte
@@ -205,10 +205,12 @@
               paused: false
             }),
           setPrimaryButton: (primaryButton: 'code' | 'settings' | 'run') => {
+            // 'run' is meaningless on js nodes — the whole body is already a Run/Stop button
+            const normalized = primaryButton === 'run' ? 'code' : primaryButton;
             PatchiesEventBus.getInstance().dispatch({
               type: 'nodePrimaryButtonUpdate',
               nodeId,
-              primaryButton
+              primaryButton: normalized
             });
           },
           settings: settingsAPI

--- a/ui/src/lib/eventbus/events.ts
+++ b/ui/src/lib/eventbus/events.ts
@@ -12,6 +12,7 @@ export type PatchiesEvent =
   | NodeInteractionUpdateEvent
   | NodeVideoOutputEnabledUpdateEvent
   | NodeMouseScopeUpdateEvent
+  | NodePrimaryButtonUpdateEvent
   | NodeReplaceEvent
   | IframePostMessageEvent
   | FileRelinkedEvent
@@ -121,6 +122,14 @@ export interface NodeMouseScopeUpdateEvent {
   type: 'nodeMouseScopeUpdate';
   nodeId: string;
   scope: 'global' | 'local';
+}
+
+export type PrimaryButton = 'code' | 'settings' | 'run';
+
+export interface NodePrimaryButtonUpdateEvent {
+  type: 'nodePrimaryButtonUpdate';
+  nodeId: string;
+  primaryButton: PrimaryButton;
 }
 
 export interface NodeReplaceEvent {

--- a/ui/src/lib/js-runner/WorkerNodeSystem.ts
+++ b/ui/src/lib/js-runner/WorkerNodeSystem.ts
@@ -1,4 +1,5 @@
 import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+import type { PrimaryButton } from '$lib/eventbus/events';
 import type { SendMessageOptions } from '$lib/messages/MessageContext';
 import { MessageSystem, type MessageCallbackFn, type Message } from '$lib/messages/MessageSystem';
 import { MessageChannelRegistry } from '$lib/messages/MessageChannelRegistry';
@@ -78,7 +79,7 @@ export type WorkerResponse = { nodeId: string } & (
   | { type: 'sendMessage'; data: unknown; options?: SendMessageOptions }
   | { type: 'setPortCount'; inletCount: number; outletCount: number }
   | { type: 'setTitle'; title: string }
-  | { type: 'setPrimaryButton'; primaryButton: 'code' | 'settings' | 'run' }
+  | { type: 'setPrimaryButton'; primaryButton: PrimaryButton }
   | { type: 'setRunOnMount'; runOnMount: boolean }
   | { type: 'callbackRegistered'; callbackType: 'message' | 'interval' | 'timeout' }
   | { type: 'flash' }
@@ -260,10 +261,12 @@ export class WorkerNodeSystem {
         });
       })
       .with({ type: 'setPrimaryButton' }, (event) => {
+        // 'run' is meaningless on worker nodes — the whole body is already a Run/Stop button
+        const primaryButton = event.primaryButton === 'run' ? 'code' : event.primaryButton;
         this.eventBus.dispatch({
           type: 'nodePrimaryButtonUpdate',
           nodeId,
-          primaryButton: event.primaryButton
+          primaryButton
         });
       })
       .with({ type: 'setRunOnMount' }, (event) => {

--- a/ui/src/lib/js-runner/WorkerNodeSystem.ts
+++ b/ui/src/lib/js-runner/WorkerNodeSystem.ts
@@ -78,6 +78,7 @@ export type WorkerResponse = { nodeId: string } & (
   | { type: 'sendMessage'; data: unknown; options?: SendMessageOptions }
   | { type: 'setPortCount'; inletCount: number; outletCount: number }
   | { type: 'setTitle'; title: string }
+  | { type: 'setPrimaryButton'; primaryButton: 'code' | 'settings' | 'run' }
   | { type: 'setRunOnMount'; runOnMount: boolean }
   | { type: 'callbackRegistered'; callbackType: 'message' | 'interval' | 'timeout' }
   | { type: 'flash' }
@@ -256,6 +257,13 @@ export class WorkerNodeSystem {
           type: 'nodeTitleUpdate',
           nodeId,
           title: event.title
+        });
+      })
+      .with({ type: 'setPrimaryButton' }, (event) => {
+        this.eventBus.dispatch({
+          type: 'nodePrimaryButtonUpdate',
+          nodeId,
+          primaryButton: event.primaryButton
         });
       })
       .with({ type: 'setRunOnMount' }, (event) => {

--- a/ui/src/lib/rendering/types.ts
+++ b/ui/src/lib/rendering/types.ts
@@ -1,6 +1,7 @@
 import type regl from 'regl';
 import type { ProfilerCategory, RenderFrameStats, TimingStats } from '$lib/profiler/types';
 import type { GLUniformDef } from '../../types/uniform-config';
+import type { PrimaryButton } from '$lib/eventbus/events';
 
 export type FBOFormat = 'rgba8' | 'rgba16f' | 'rgba32f';
 
@@ -199,7 +200,7 @@ export type RenderWorkerMessage =
   | { type: 'setHidePorts'; nodeId: string; hidePorts: boolean }
   | { type: 'setDragEnabled'; nodeId: string; dragEnabled: boolean }
   | { type: 'setVideoOutputEnabled'; nodeId: string; videoOutputEnabled: boolean }
-  | { type: 'setPrimaryButton'; nodeId: string; primaryButton: 'code' | 'settings' | 'run' }
+  | { type: 'setPrimaryButton'; nodeId: string; primaryButton: PrimaryButton }
   | { type: 'setMouseScope'; nodeId: string; scope: MouseScope }
   | {
       type: 'setInteraction';

--- a/ui/src/lib/rendering/types.ts
+++ b/ui/src/lib/rendering/types.ts
@@ -199,6 +199,7 @@ export type RenderWorkerMessage =
   | { type: 'setHidePorts'; nodeId: string; hidePorts: boolean }
   | { type: 'setDragEnabled'; nodeId: string; dragEnabled: boolean }
   | { type: 'setVideoOutputEnabled'; nodeId: string; videoOutputEnabled: boolean }
+  | { type: 'setPrimaryButton'; nodeId: string; primaryButton: 'code' | 'settings' | 'run' }
   | { type: 'setMouseScope'; nodeId: string; scope: MouseScope }
   | {
       type: 'setInteraction';

--- a/ui/src/workers/js/jsWorker.ts
+++ b/ui/src/workers/js/jsWorker.ts
@@ -266,6 +266,10 @@ function createWorkerContext(nodeId: string) {
     postResponse({ type: 'setTitle', nodeId, title });
   };
 
+  const setPrimaryButton = (primaryButton: 'code' | 'settings' | 'run') => {
+    postResponse({ type: 'setPrimaryButton', nodeId, primaryButton });
+  };
+
   const setRunOnMount = (runOnMount: boolean) => {
     postResponse({ type: 'setRunOnMount', nodeId, runOnMount });
   };
@@ -418,6 +422,7 @@ function createWorkerContext(nodeId: string) {
     onCleanup,
     setPortCount,
     setTitle,
+    setPrimaryButton,
     setRunOnMount,
     requestAnimationFrame,
     fft,
@@ -535,6 +540,7 @@ async function executeCode(nodeId: string, processedCode: string) {
     'setPortCount',
     'setRunOnMount',
     'setTitle',
+    'setPrimaryButton',
     'getVfsUrl',
     'flash',
     'setVideoCount',
@@ -559,6 +565,7 @@ async function executeCode(nodeId: string, processedCode: string) {
     ctx.setPortCount,
     ctx.setRunOnMount,
     ctx.setTitle,
+    ctx.setPrimaryButton,
     ctx.getVfsUrl,
     ctx.flash,
     ctx.setVideoCount,

--- a/ui/src/workers/js/jsWorker.ts
+++ b/ui/src/workers/js/jsWorker.ts
@@ -5,6 +5,7 @@
 
 import { match } from 'ts-pattern';
 import type { WorkerMessage, WorkerResponse } from '$lib/js-runner/WorkerNodeSystem';
+import type { PrimaryButton } from '$lib/eventbus/events';
 import type { Message } from '$lib/messages/MessageSystem';
 import { FFTAnalysis } from '$lib/audio/FFTAnalysis';
 import { parseJSError, countLines } from '$lib/js-runner/js-error-parser';
@@ -266,7 +267,7 @@ function createWorkerContext(nodeId: string) {
     postResponse({ type: 'setTitle', nodeId, title });
   };
 
-  const setPrimaryButton = (primaryButton: 'code' | 'settings' | 'run') => {
+  const setPrimaryButton = (primaryButton: PrimaryButton) => {
     postResponse({ type: 'setPrimaryButton', nodeId, primaryButton });
   };
 

--- a/ui/src/workers/rendering/BaseWorkerRenderer.ts
+++ b/ui/src/workers/rendering/BaseWorkerRenderer.ts
@@ -179,6 +179,14 @@ export abstract class BaseWorkerRenderer<TConfig extends BaseRendererConfig = Ba
     });
   }
 
+  setPrimaryButton(primaryButton: 'code' | 'settings' | 'run') {
+    self.postMessage({
+      type: 'setPrimaryButton',
+      nodeId: this.config.nodeId,
+      primaryButton
+    });
+  }
+
   // ── Mouse ──
 
   createMouseObject() {
@@ -257,6 +265,7 @@ export abstract class BaseWorkerRenderer<TConfig extends BaseRendererConfig = Ba
       noWheel: () => this.setInteraction('wheel', false),
       noInteract: () => this.setInteraction('interact', false),
       noOutput: () => this.setVideoOutputEnabled(false),
+      setPrimaryButton: this.setPrimaryButton.bind(this),
       clock: this.renderer.createWorkerClock(),
       settings: this.settingsProxy!.settings
     };

--- a/ui/src/workers/rendering/BaseWorkerRenderer.ts
+++ b/ui/src/workers/rendering/BaseWorkerRenderer.ts
@@ -1,6 +1,7 @@
 import type regl from 'regl';
 import type { FBORenderer } from './fboRenderer';
 import type { RenderParams } from '$lib/rendering/types';
+import type { PrimaryButton } from '$lib/eventbus/events';
 import type { Message } from '$lib/messages/MessageSystem';
 import type { AudioAnalysisPayloadWithType } from '$lib/audio/AudioAnalysisSystem';
 import type { SendMessageOptions } from '$lib/messages/MessageContext';
@@ -179,7 +180,7 @@ export abstract class BaseWorkerRenderer<TConfig extends BaseRendererConfig = Ba
     });
   }
 
-  setPrimaryButton(primaryButton: 'code' | 'settings' | 'run') {
+  setPrimaryButton(primaryButton: PrimaryButton) {
     self.postMessage({
       type: 'setPrimaryButton',
       nodeId: this.config.nodeId,


### PR DESCRIPTION
## Summary

Adds a JS API and GLSL directive for choosing which button sits in the primary (rightmost) slot of a node, next to the overflow menu. Until now this was always **Code** — but for code-stable nodes (e.g. a Hydra patch driven by sliders), reaching for **Settings** is more useful.

- **JS API** (canvas-style nodes): `setPrimaryButton('code' | 'settings' | 'run')`
- **JS API** (`js`/`worker`): `setPrimaryButton('code' | 'settings')` — `'run'` falls back to `'code'` since the node body is already a giant Run/Stop button
- **GLSL directive**: `// @primaryButton settings`
- Persisted in `node.data.primaryButton`, so it survives reloads and patch save/load
- Falls back to `'code'` when the requested mode isn't usable (e.g. `'settings'` requested but no schema, `'run'` requested but no `onrun` callback)
- When primary ≠ `code`, an "Edit code" entry appears in the overflow + right-click menus so the editor stays reachable

### Example

```js
await settings.define([
  { key: 'freq', label: 'Freq', type: 'slider', min: 1, max: 100, default: 30 }
]);
setPrimaryButton('settings');
osc(() => settings.get('freq'), 0.1, 0.8).out(o0);
```

```glsl
// @primaryButton settings
// @param speed slider 0..1 = 0.5
```

### Wiring

- Worker → main: `setPrimaryButton` posted from `BaseWorkerRenderer` and `jsWorker.ts`, routed via `GLSystem` / `WorkerNodeSystem` into a new `nodePrimaryButtonUpdate` event
- `ObjectPreviewLayout` and `CodeBlockBase` listen for the event, persist via `updateNodeData`, and seed initial state from `getNode().data.primaryButton` on mount
- `GLSLCanvasNode` parses the directive in `updateShader()` and dispatches the same event
- Completion added in `patchies-completions.ts` for `js`, `worker`, `p5`, `hydra`, `canvas`, `regl`, `swgl`, `textmode`, `three`

## Test plan

- [ ] Hydra: `setPrimaryButton('settings')` swaps the rightmost button to the gear icon, and the Code button moves into the overflow menu
- [ ] GLSL: `// @primaryButton settings` swaps the button on save/run, persists across reload
- [ ] `js` / `worker` node: `setPrimaryButton('settings')` swaps the button; `setPrimaryButton('run')` is silently ignored (falls back to Code)
- [ ] Fallback: `setPrimaryButton('settings')` with no `settings.define(...)` schema falls back to Code
- [ ] Right-click menu shows "Edit code" when primary ≠ code
- [ ] Persistence: state survives full page reload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to configure the primary action button (code, settings, or run) for nodes, with selections persisting across sessions.
  * New `setPrimaryButton()` function available in JavaScript nodes to programmatically set the primary action button.
  * Support for `@primaryButton` directive in GLSL code to specify the primary action.
  * Added "Edit code" menu option to context menus when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->