### PR TITLE
feat: per-node FBO resolution (@resolution + setResolution)

### DIFF
--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -316,11 +316,27 @@ export class GLSystem {
       })
       .with({ type: 'setTextureFormat' }, (data) => {
         // Update internal node data and rebuild render graph so fboRenderer picks up the new format
-        const idx = this.nodes.findIndex((n) => n.id === data.nodeId);
-        if (idx !== -1) {
-          const node = this.nodes[idx];
+        const index = this.nodes.findIndex((node) => node.id === data.nodeId);
+
+        if (index !== -1) {
+          const node = this.nodes[index];
+
           if ((node.data as Record<string, unknown>).fboFormat === data.format) return;
-          this.nodes[idx] = { ...node, data: { ...node.data, fboFormat: data.format } };
+
+          this.nodes[index] = { ...node, data: { ...node.data, fboFormat: data.format } };
+          this.updateRenderGraph(true);
+        }
+      })
+      .with({ type: 'setResolution' }, (data) => {
+        const index = this.nodes.findIndex((node) => node.id === data.nodeId);
+
+        if (index !== -1) {
+          const node = this.nodes[index];
+          const current = (node.data as Record<string, unknown>).resolution;
+
+          if (JSON.stringify(current) === JSON.stringify(data.resolution)) return;
+
+          this.nodes[index] = { ...node, data: { ...node.data, resolution: data.resolution } };
           this.updateRenderGraph(true);
         }
       })

--- a/ui/src/lib/canvas/shader-code-to-uniform-def.ts
+++ b/ui/src/lib/canvas/shader-code-to-uniform-def.ts
@@ -1,6 +1,7 @@
 import { match } from 'ts-pattern';
 import type { GLUniformDef } from '../../types/uniform-config';
 import type { SettingsField } from '$lib/settings/types';
+import type { FBOFormat, FBOResolution } from '$lib/rendering/types';
 
 export interface ParamDirective {
   name: string;
@@ -74,9 +75,39 @@ export function parseShaderDirectives(code: string): ShaderDirectives {
 }
 
 export function parseShaderName(code: string): string | undefined {
-  const m = /^[ \t]*\/\/\s*@title\s+(.+)$/m.exec(code);
+  const match = /^[ \t]*\/\/\s*@title\s+(.+)$/m.exec(code);
 
-  return m ? m[1].trim() : undefined;
+  return match ? match[1].trim() : undefined;
+}
+
+/** Parse `// @format rgba32f` directive. Returns 'rgba8' if absent. */
+export function detectFboFormat(code: string): FBOFormat {
+  const withoutBlocks = code.replace(/\/\*[\s\S]*?\*\//g, '');
+  const match = withoutBlocks.match(/^\s*\/\/\s*@format\s+(rgba8|rgba16f|rgba32f)\s*$/m);
+
+  return (match?.[1] as FBOFormat) ?? 'rgba8';
+}
+
+/** Parse `// @resolution 256` (or `256x128`, `1/2`, `1/4`) directive. */
+export function detectResolution(code: string): FBOResolution | undefined {
+  const withoutBlocks = code.replace(/\/\*[\s\S]*?\*\//g, '');
+  const match = withoutBlocks.match(/^\s*\/\/\s*@resolution\s+(.+)$/m);
+  if (!match) return undefined;
+
+  const resolution = match[1].trim();
+  if (resolution === '1/2' || resolution === '1/4') return resolution;
+
+  if (resolution.includes('x')) {
+    const parts = resolution.split('x').map(Number);
+
+    if (parts.length === 2 && parts.every(Number.isFinite)) {
+      return parts as [number, number];
+    }
+  }
+
+  const number = Number(resolution);
+
+  return Number.isFinite(number) ? number : undefined;
 }
 
 export function shaderCodeToUniformDefs(code: string): GLUniformDef[] {

--- a/ui/src/lib/codemirror/glsl.codemirror.ts
+++ b/ui/src/lib/codemirror/glsl.codemirror.ts
@@ -84,7 +84,7 @@ const includeHighlightTheme = EditorView.baseTheme({
 /**
  * Highlights `// @title`, `// @param`, and `// @primaryButton` metadata directives (spec 125).
  */
-const METADATA_DIRECTIVE_RE = /^[ \t]*\/\/\s*(@(?:title|param|primaryButton))\s+(.+)$/gm;
+const METADATA_DIRECTIVE_RE = /^[ \t]*\/\/\s*(@(?:title|param|primaryButton|resolution))\s+(.+)$/gm;
 
 const metadataKeywordMark = Decoration.mark({ class: 'cm-glsl-metadata-keyword' });
 const metadataValueMark = Decoration.mark({ class: 'cm-glsl-metadata-value' });

--- a/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
+++ b/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
@@ -12,7 +12,9 @@
   import {
     shaderCodeToUniformDefs,
     uniformDefsToSettingsSchema,
-    parseShaderName
+    parseShaderName,
+    detectFboFormat,
+    detectResolution
   } from '$lib/canvas/shader-code-to-uniform-def';
   import { removeExcessVideoOutletEdges } from './outlet-edges';
   import type { GLUniformDef } from '../../../types/uniform-config';
@@ -20,7 +22,6 @@
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { ConsoleOutputEvent, PrimaryButton } from '$lib/eventbus/events';
-  import type { FBOFormat } from '$lib/rendering/types';
 
   let {
     id: nodeId,
@@ -163,29 +164,6 @@
     }
 
     return max >= 0 ? max + 1 : 1;
-  }
-
-  function detectFboFormat(code: string): FBOFormat {
-    // Match // @format directive in single-line comments (don't strip comments first!)
-    // Only skip directives inside block comments.
-    const withoutBlocks = code.replace(/\/\*[\s\S]*?\*\//g, '');
-    const match = withoutBlocks.match(/^\s*\/\/\s*@format\s+(rgba8|rgba16f|rgba32f)\s*$/m);
-
-    return (match?.[1] as FBOFormat) ?? 'rgba8';
-  }
-
-  function detectResolution(code: string): number | [number, number] | '1/2' | '1/4' | undefined {
-    const withoutBlocks = code.replace(/\/\*[\s\S]*?\*\//g, '');
-    const m = withoutBlocks.match(/^\s*\/\/\s*@resolution\s+(.+)$/m);
-    if (!m) return undefined;
-    const val = m[1].trim();
-    if (val === '1/2' || val === '1/4') return val;
-    if (val.includes('x')) {
-      const parts = val.split('x').map(Number);
-      if (parts.length === 2 && parts.every(Number.isFinite)) return parts as [number, number];
-    }
-    const n = Number(val);
-    return Number.isFinite(n) ? n : undefined;
   }
 
   function detectPrimaryButton(code: string): PrimaryButton {

--- a/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
+++ b/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
@@ -174,6 +174,20 @@
     return (match?.[1] as FBOFormat) ?? 'rgba8';
   }
 
+  function detectResolution(code: string): number | [number, number] | '1/2' | '1/4' | undefined {
+    const withoutBlocks = code.replace(/\/\*[\s\S]*?\*\//g, '');
+    const m = withoutBlocks.match(/^\s*\/\/\s*@resolution\s+(.+)$/m);
+    if (!m) return undefined;
+    const val = m[1].trim();
+    if (val === '1/2' || val === '1/4') return val;
+    if (val.includes('x')) {
+      const parts = val.split('x').map(Number);
+      if (parts.length === 2 && parts.every(Number.isFinite)) return parts as [number, number];
+    }
+    const n = Number(val);
+    return Number.isFinite(n) ? n : undefined;
+  }
+
   function detectPrimaryButton(code: string): PrimaryButton {
     const withoutBlocks = code.replace(/\/\*[\s\S]*?\*\//g, '');
     const match = withoutBlocks.match(/^\s*\/\/\s*@primaryButton\s+(code|settings|run)\s*$/m);
@@ -216,6 +230,7 @@
       uniformValues: pruned,
       mrtCount: detectMrtCount(data.code),
       fboFormat: detectFboFormat(data.code),
+      resolution: detectResolution(data.code),
       primaryButton: nextPrimaryButton,
       _runRevision: Date.now()
     };

--- a/ui/src/lib/components/nodes/SwissGLNode.svelte
+++ b/ui/src/lib/components/nodes/SwissGLNode.svelte
@@ -98,7 +98,8 @@
         glSystem.upsertNode(nodeId, 'swgl', {
           code,
           mrtCount: m.outletCount,
-          fboFormat: runtimeFormat ?? detectFboFormat(code)
+          fboFormat: runtimeFormat ?? detectFboFormat(code),
+          resolution: detectResolution(code)
         });
       })
       .exhaustive();

--- a/ui/src/lib/components/nodes/SwissGLNode.svelte
+++ b/ui/src/lib/components/nodes/SwissGLNode.svelte
@@ -71,6 +71,20 @@
     return (m?.[1] as 'rgba8' | 'rgba16f' | 'rgba32f') ?? 'rgba8';
   }
 
+  function detectResolution(code: string): number | [number, number] | '1/2' | '1/4' | undefined {
+    const withoutBlocks = code.replace(/\/\*[\s\S]*?\*\//g, '');
+    const m = withoutBlocks.match(/^\s*\/\/\s*@resolution\s+(.+)$/m);
+    if (!m) return undefined;
+    const val = m[1].trim();
+    if (val === '1/2' || val === '1/4') return val;
+    if (val.includes('x')) {
+      const parts = val.split('x').map(Number);
+      if (parts.length === 2 && parts.every(Number.isFinite)) return parts as [number, number];
+    }
+    const n = Number(val);
+    return Number.isFinite(n) ? n : undefined;
+  }
+
   let videoInletCount = $derived(data.videoInletCount ?? 0);
   let videoOutletCount = $derived(data.videoOutletCount ?? 1);
   let messageInletCount = $derived(data.messageInletCount ?? 1);
@@ -177,7 +191,8 @@
     glSystem.upsertNode(nodeId, 'swgl', {
       code,
       mrtCount: data.videoOutletCount ?? 1,
-      fboFormat: detectFboFormat(code)
+      fboFormat: detectFboFormat(code),
+      resolution: detectResolution(code)
     });
 
     setTimeout(() => {
@@ -208,6 +223,7 @@
         code,
         mrtCount: data.videoOutletCount ?? 1,
         fboFormat: detectFboFormat(code),
+        resolution: detectResolution(code),
         _runRevision: Date.now()
       });
     } catch (error) {

--- a/ui/src/lib/components/nodes/SwissGLNode.svelte
+++ b/ui/src/lib/components/nodes/SwissGLNode.svelte
@@ -18,6 +18,7 @@
   import type { ConsoleOutputEvent, NodePortCountUpdateEvent } from '$lib/eventbus/events';
   import { AudioAnalysisSystem } from '$lib/audio/AudioAnalysisSystem';
   import { logger } from '$lib/utils/logger';
+  import { detectFboFormat, detectResolution } from '$lib/canvas/shader-code-to-uniform-def';
 
   let {
     id: nodeId,
@@ -62,28 +63,6 @@
   let lineErrors = $state<Record<number, string[]> | undefined>(undefined);
 
   const code = $derived(data.code || '');
-
-  function detectFboFormat(code: string): 'rgba8' | 'rgba16f' | 'rgba32f' {
-    // Match // @format directive in single-line comments (don't strip comments first!)
-    // Only skip directives inside block comments.
-    const withoutBlocks = code.replace(/\/\*[\s\S]*?\*\//g, '');
-    const m = withoutBlocks.match(/^\s*\/\/\s*@format\s+(rgba8|rgba16f|rgba32f)\s*$/m);
-    return (m?.[1] as 'rgba8' | 'rgba16f' | 'rgba32f') ?? 'rgba8';
-  }
-
-  function detectResolution(code: string): number | [number, number] | '1/2' | '1/4' | undefined {
-    const withoutBlocks = code.replace(/\/\*[\s\S]*?\*\//g, '');
-    const m = withoutBlocks.match(/^\s*\/\/\s*@resolution\s+(.+)$/m);
-    if (!m) return undefined;
-    const val = m[1].trim();
-    if (val === '1/2' || val === '1/4') return val;
-    if (val.includes('x')) {
-      const parts = val.split('x').map(Number);
-      if (parts.length === 2 && parts.every(Number.isFinite)) return parts as [number, number];
-    }
-    const n = Number(val);
-    return Number.isFinite(n) ? n : undefined;
-  }
 
   let videoInletCount = $derived(data.videoInletCount ?? 0);
   let videoOutletCount = $derived(data.videoOutletCount ?? 1);

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -151,7 +151,8 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
       'video-cube.three',
       'video-torus.three',
       'video-sphere.three',
-      'crate.three'
+      'crate.three',
+      'particles-from-texture.three'
     ]
   },
   {

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -145,14 +145,15 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     name: 'Three.js Demos',
     description: '3D graphics with Three.js',
     icon: 'Box',
-    requiredObjects: ['three'],
+    requiredObjects: ['three', 'glsl'],
     presets: [
       'three>',
       'video-cube.three',
       'video-torus.three',
       'video-sphere.three',
       'crate.three',
-      'point-cloud-from-texture.three'
+      'point-cloud-from-texture.three',
+      'position-field.gl'
     ]
   },
   {

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -152,7 +152,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
       'video-torus.three',
       'video-sphere.three',
       'crate.three',
-      'particles-from-texture.three'
+      'point-cloud-from-texture.three'
     ]
   },
   {

--- a/ui/src/lib/presets/builtin/glsl.presets.ts
+++ b/ui/src/lib/presets/builtin/glsl.presets.ts
@@ -68,6 +68,49 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   fragColor = o;
 }`;
 
+const POSITION_FIELD_GL = `// @title Position Field
+// @format rgba32f
+
+float hash(vec3 p) {
+  p = fract(p * 0.3183099 + vec3(0.1, 0.2, 0.3));
+  p *= 17.0;
+  return fract(p.x * p.y * p.z * (p.x + p.y + p.z));
+}
+
+float noise(vec3 p) {
+  vec3 i = floor(p);
+  vec3 f = fract(p);
+  f = f * f * (3.0 - 2.0 * f);
+  return mix(
+    mix(mix(hash(i + vec3(0,0,0)), hash(i + vec3(1,0,0)), f.x),
+        mix(hash(i + vec3(0,1,0)), hash(i + vec3(1,1,0)), f.x), f.y),
+    mix(mix(hash(i + vec3(0,0,1)), hash(i + vec3(1,0,1)), f.x),
+        mix(hash(i + vec3(0,1,1)), hash(i + vec3(1,1,1)), f.x), f.y),
+    f.z
+  );
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  float theta = uv.y * 3.14159265;
+  float phi   = uv.x * 6.28318530;
+
+  vec3 p = vec3(
+    sin(theta) * cos(phi),
+    sin(theta) * sin(phi),
+    cos(theta)
+  );
+
+  float t = iTime * 0.4;
+  float n = noise(p * 2.0 + vec3(0.0, 0.0, t));
+  float r = 1.0 + (n - 0.5) * 0.8;
+
+  float swirl = noise(p * 1.2 + vec3(t, 0.0, 0.0)) * 2.0;
+  float c = cos(swirl), s = sin(swirl);
+  p.xz = mat2(c, -s, s, c) * p.xz;
+
+  fragColor = vec4(p * r, 1.0);
+}`;
+
 export const GLSL_PRESETS: Record<string, { type: string; data: { code: string } }> = {
   'glsl>': { type: 'glsl', data: { code: PASSTHRU_GL.trim() } },
   'mix.gl': { type: 'glsl', data: { code: MIX_GL.trim() } },
@@ -75,5 +118,6 @@ export const GLSL_PRESETS: Record<string, { type: string; data: { code: string }
   'overlay.gl': { type: 'glsl', data: { code: OVERLAY_GL.trim() } },
   'fft-freq.gl': { type: 'glsl', data: { code: AUDIO_FFT_FREQ_GL.trim() } },
   'fft-waveform.gl': { type: 'glsl', data: { code: AUDIO_FFT_WAVEFORM_GL.trim() } },
-  'switcher.gl': { type: 'glsl', data: { code: SWITCHER_GL.trim() } }
+  'switcher.gl': { type: 'glsl', data: { code: SWITCHER_GL.trim() } },
+  'position-field.gl': { type: 'glsl', data: { code: POSITION_FIELD_GL.trim() } }
 };

--- a/ui/src/lib/presets/builtin/three.preset.ts
+++ b/ui/src/lib/presets/builtin/three.preset.ts
@@ -141,17 +141,26 @@ function draw(t) {
 // vertex count, row-major. Wire a GLSL/SwissGL node that outputs an rgba32f
 // texture (e.g. via `// @format rgba32f`) into inlet 0. Geometry auto-resizes
 // to match the incoming texture's dimensions.
-const PARTICLES_FROM_TEXTURE_THREE = `const {
+const POINT_CLOUD_FROM_TEXTURE = `const {
   Scene, PerspectiveCamera, BufferGeometry, BufferAttribute,
   Points, ShaderMaterial, AdditiveBlending, Sphere, Vector3
 } = THREE
 
 setVideoCount(1, 1)
+setPrimaryButton('settings')
+
+await settings.define([
+  { key: 'maxPoints', type: 'slider', label: 'Max Points', min: 1, max: 100000, step: 1, default: 65536 },
+  { key: 'pointSize', type: 'slider', label: 'Point Size', min: 0.001, max: 0.05, step: 0.001, default: 0.02 }
+])
+
+let maxPoints = settings.get('maxPoints')
+let pointSize = settings.get('pointSize')
 
 const material = new ShaderMaterial({
   uniforms: {
     positionMap: { value: null },
-    pointSize:   { value: 2.0 }
+    pointSize: { value: pointSize }
   },
   vertexShader: \`
     uniform sampler2D positionMap;
@@ -187,51 +196,75 @@ camera.lookAt(0, 0, 0)
 let points = null
 let currentW = 0
 let currentH = 0
-
-// Cap point count to keep GPU happy. If the texture is larger, we stride
-// through it evenly so the cloud still covers the full surface.
-const MAX_POINTS = 65536
+let needsRebuild = false
 
 function buildPoints(w, h) {
   if (points) {
     scene.remove(points)
     points.geometry.dispose()
   }
+
   const total = w * h
-  const stride = Math.max(1, Math.ceil(Math.sqrt(total / MAX_POINTS)))
+  const stride = Math.max(1, Math.ceil(Math.sqrt(total / maxPoints)))
+
   const sw = Math.ceil(w / stride)
   const sh = Math.ceil(h / stride)
-  const count = sw * sh
 
+  const count = sw * sh
   const refs = new Float32Array(count * 2)
-  let idx = 0
+
+  let index = 0
+
   for (let y = 0; y < sh; y++) {
     for (let x = 0; x < sw; x++) {
-      refs[idx++] = (x * stride + 0.5) / w
-      refs[idx++] = (y * stride + 0.5) / h
+      refs[index++] = (x * stride + 0.5) / w
+      refs[index++] = (y * stride + 0.5) / h
     }
   }
+
   const geometry = new BufferGeometry()
   geometry.setAttribute('position', new BufferAttribute(new Float32Array(count * 3), 3))
   geometry.setAttribute('ref', new BufferAttribute(refs, 2))
   geometry.boundingSphere = new Sphere(new Vector3(), 1e3)
+
   points = new Points(geometry, material)
   scene.add(points)
+
   currentW = w
   currentH = h
+  needsRebuild = false
 }
 
-function draw(t) {
-  const tex = getTexture(0)
-  if (tex && tex.image) {
-    const w = tex.image.width | 0
-    const h = tex.image.height | 0
-    if (w > 0 && h > 0 && (w !== currentW || h !== currentH)) {
-      buildPoints(w, h)
-    }
-    material.uniforms.positionMap.value = tex
+settings.onChange((key, value) => {
+  if (key === 'maxPoints') {
+    maxPoints = value
+    needsRebuild = true
   }
-  if (points) points.rotation.y = t * 0.0003
+
+  if (key === 'pointSize') {
+    pointSize = value
+    material.uniforms.pointSize.value = value
+  }
+})
+
+function draw(t) {
+  const texture = getTexture(0)
+
+  if (texture && texture.image) {
+    const width = texture.image.width | 0
+    const height = texture.image.height | 0
+
+    if (width > 0 && height > 0 && (width !== currentW || height !== currentH || needsRebuild)) {
+      buildPoints(width, height)
+    }
+
+    material.uniforms.positionMap.value = texture
+  }
+
+  if (points) {
+    points.rotation.y = t * 0.0003
+  }
+
   renderer.render(scene, camera)
 }`;
 
@@ -241,8 +274,8 @@ export const THREE_PRESETS: Record<string, { type: string; data: { code: string 
   'video-torus.three': { type: 'three', data: { code: VIDEO_TORUS_THREE.trim() } },
   'video-sphere.three': { type: 'three', data: { code: VIDEO_SPHERE_THREE.trim() } },
   'crate.three': { type: 'three', data: { code: CRATE_THREE.trim() } },
-  'particles-from-texture.three': {
+  'point-cloud-from-texture.three': {
     type: 'three',
-    data: { code: PARTICLES_FROM_TEXTURE_THREE.trim() }
+    data: { code: POINT_CLOUD_FROM_TEXTURE.trim() }
   }
 };

--- a/ui/src/lib/presets/builtin/three.preset.ts
+++ b/ui/src/lib/presets/builtin/three.preset.ts
@@ -136,10 +136,113 @@ function draw(t) {
   renderer.render(scene, camera)
 }`;
 
+// Stage 1 of spec 115: render a point cloud whose vertex positions come from
+// a float (rgba32f) texture on inlet 0. Convention: texture width × height =
+// vertex count, row-major. Wire a GLSL/SwissGL node that outputs an rgba32f
+// texture (e.g. via `// @format rgba32f`) into inlet 0. Geometry auto-resizes
+// to match the incoming texture's dimensions.
+const PARTICLES_FROM_TEXTURE_THREE = `const {
+  Scene, PerspectiveCamera, BufferGeometry, BufferAttribute,
+  Points, ShaderMaterial, AdditiveBlending, Sphere, Vector3
+} = THREE
+
+setVideoCount(1, 1)
+
+const material = new ShaderMaterial({
+  uniforms: {
+    positionMap: { value: null },
+    pointSize:   { value: 2.0 }
+  },
+  vertexShader: \`
+    uniform sampler2D positionMap;
+    uniform float pointSize;
+    attribute vec2 ref;
+    varying vec3 vPos;
+    void main() {
+      vec3 p = texture2D(positionMap, ref).xyz;
+      vPos = p;
+      vec4 mv = modelViewMatrix * vec4(p, 1.0);
+      gl_Position = projectionMatrix * mv;
+      gl_PointSize = pointSize * (300.0 / -mv.z);
+    }
+  \`,
+  fragmentShader: \`
+    varying vec3 vPos;
+    void main() {
+      vec2 d = gl_PointCoord - 0.5;
+      if (dot(d, d) > 0.25) discard;
+      gl_FragColor = vec4(0.5 + 0.5 * normalize(vPos), 1.0);
+    }
+  \`,
+  transparent: true,
+  blending: AdditiveBlending,
+  depthWrite: false
+})
+
+const scene = new Scene()
+const camera = new PerspectiveCamera(60, width / height, 0.1, 100)
+camera.position.set(0, 0, 3)
+camera.lookAt(0, 0, 0)
+
+let points = null
+let currentW = 0
+let currentH = 0
+
+// Cap point count to keep GPU happy. If the texture is larger, we stride
+// through it evenly so the cloud still covers the full surface.
+const MAX_POINTS = 65536
+
+function buildPoints(w, h) {
+  if (points) {
+    scene.remove(points)
+    points.geometry.dispose()
+  }
+  const total = w * h
+  const stride = Math.max(1, Math.ceil(Math.sqrt(total / MAX_POINTS)))
+  const sw = Math.ceil(w / stride)
+  const sh = Math.ceil(h / stride)
+  const count = sw * sh
+
+  const refs = new Float32Array(count * 2)
+  let idx = 0
+  for (let y = 0; y < sh; y++) {
+    for (let x = 0; x < sw; x++) {
+      refs[idx++] = (x * stride + 0.5) / w
+      refs[idx++] = (y * stride + 0.5) / h
+    }
+  }
+  const geometry = new BufferGeometry()
+  geometry.setAttribute('position', new BufferAttribute(new Float32Array(count * 3), 3))
+  geometry.setAttribute('ref', new BufferAttribute(refs, 2))
+  geometry.boundingSphere = new Sphere(new Vector3(), 1e3)
+  points = new Points(geometry, material)
+  scene.add(points)
+  currentW = w
+  currentH = h
+}
+
+function draw(t) {
+  const tex = getTexture(0)
+  if (tex && tex.image) {
+    const w = tex.image.width | 0
+    const h = tex.image.height | 0
+    if (w > 0 && h > 0 && (w !== currentW || h !== currentH)) {
+      buildPoints(w, h)
+    }
+    material.uniforms.positionMap.value = tex
+  }
+  if (points) points.rotation.y = t * 0.0003
+  renderer.render(scene, camera)
+}`;
+
 export const THREE_PRESETS: Record<string, { type: string; data: { code: string } }> = {
   'three>': { type: 'three', data: { code: PIPE_THREE.trim() } },
   'video-cube.three': { type: 'three', data: { code: VIDEO_CUBE_THREE.trim() } },
   'video-torus.three': { type: 'three', data: { code: VIDEO_TORUS_THREE.trim() } },
   'video-sphere.three': { type: 'three', data: { code: VIDEO_SPHERE_THREE.trim() } },
-  'crate.three': { type: 'three', data: { code: CRATE_THREE.trim() } }
+  'crate.three': { type: 'three', data: { code: CRATE_THREE.trim() } },
+  'particles-from-texture.three': {
+    type: 'three',
+    data: { code: PARTICLES_FROM_TEXTURE_THREE.trim() }
+  }
 };

--- a/ui/src/lib/rendering/types.ts
+++ b/ui/src/lib/rendering/types.ts
@@ -5,6 +5,9 @@ import type { PrimaryButton } from '$lib/eventbus/events';
 
 export type FBOFormat = 'rgba8' | 'rgba16f' | 'rgba32f';
 
+/** Per-node FBO resolution override. Default is full output size. */
+export type FBOResolution = number | [number, number] | '1/2' | '1/4';
+
 export type RenderNode = {
   id: string;
   inputs: string[]; // IDs of input nodes
@@ -23,6 +26,7 @@ export type RenderNode = {
         glUniformDefs: GLUniformDef[];
         mrtCount?: number;
         fboFormat?: FBOFormat;
+        resolution?: FBOResolution;
       };
     }
   | {
@@ -32,13 +36,25 @@ export type RenderNode = {
         videoInletCount?: number;
         videoOutletCount?: number;
         fboFormat?: FBOFormat;
+        resolution?: FBOResolution;
       };
     }
-  | { type: 'swgl'; data: { code: string; mrtCount?: number; fboFormat?: FBOFormat } }
-  | { type: 'canvas'; data: { code: string; fboFormat?: FBOFormat } }
-  | { type: 'textmode'; data: { code: string; fboFormat?: FBOFormat } }
-  | { type: 'three'; data: { code: string; fboFormat?: FBOFormat } }
-  | { type: 'regl'; data: { code: string; videoOutletCount?: number; fboFormat?: FBOFormat } }
+  | {
+      type: 'swgl';
+      data: { code: string; mrtCount?: number; fboFormat?: FBOFormat; resolution?: FBOResolution };
+    }
+  | { type: 'canvas'; data: { code: string; fboFormat?: FBOFormat; resolution?: FBOResolution } }
+  | { type: 'textmode'; data: { code: string; fboFormat?: FBOFormat; resolution?: FBOResolution } }
+  | { type: 'three'; data: { code: string; fboFormat?: FBOFormat; resolution?: FBOResolution } }
+  | {
+      type: 'regl';
+      data: {
+        code: string;
+        videoOutletCount?: number;
+        fboFormat?: FBOFormat;
+        resolution?: FBOResolution;
+      };
+    }
   | { type: 'projmap'; data: { surfaces: import('$objects/projmap/types').ProjMapSurface[] } }
   | { type: 'img'; data: unknown }
   | { type: 'bg.out'; data: unknown }
@@ -114,6 +130,9 @@ export interface FBONode {
 
   /** The FBO texture format this node was built with */
   fboFormat?: FBOFormat;
+
+  /** The per-node resolution this FBO was built with */
+  resolution?: FBOResolution;
 
   /** Previous frame textures — one per color attachment, only allocated for nodes in feedback loops */
   prevTextures?: regl.Texture2D[];
@@ -276,7 +295,8 @@ export type RenderWorkerMessage =
   | { type: 'settingsDefine'; nodeId: string; requestId: string; schema: unknown[] }
   | { type: 'settingsClear'; nodeId: string }
   | { type: 'includeProcessing'; nodeId: string; active: boolean }
-  | { type: 'setTextureFormat'; nodeId: string; format: FBOFormat };
+  | { type: 'setTextureFormat'; nodeId: string; format: FBOFormat }
+  | { type: 'setResolution'; nodeId: string; resolution: FBOResolution };
 
 export type PreviewState = Record<string, boolean>;
 

--- a/ui/src/workers/rendering/BaseWorkerRenderer.ts
+++ b/ui/src/workers/rendering/BaseWorkerRenderer.ts
@@ -163,6 +163,18 @@ export abstract class BaseWorkerRenderer<TConfig extends BaseRendererConfig = Ba
     });
   }
 
+  setResolution(widthOrPreset: number | '1/2' | '1/4', height?: number) {
+    const resolution =
+      typeof widthOrPreset === 'number' && typeof height === 'number'
+        ? [widthOrPreset, height]
+        : widthOrPreset;
+    self.postMessage({
+      type: 'setResolution',
+      nodeId: this.config.nodeId,
+      resolution
+    });
+  }
+
   setInteraction(mode: 'drag' | 'pan' | 'wheel' | 'interact', enabled: boolean) {
     self.postMessage({
       type: 'setInteraction',

--- a/ui/src/workers/rendering/CaptureRenderer.ts
+++ b/ui/src/workers/rendering/CaptureRenderer.ts
@@ -172,9 +172,10 @@ export class CaptureRenderer {
         const read = this.initiateVideoFrameRead(
           sourceId,
           fboNode.framebuffer,
-          undefined,
+          [fboNode.texture.width, fboNode.texture.height],
           validResolution
         );
+
         if (read) {
           readCache.set(cacheKey, read);
           reads.push(read);

--- a/ui/src/workers/rendering/PreviewRenderer.ts
+++ b/ui/src/workers/rendering/PreviewRenderer.ts
@@ -166,7 +166,8 @@ export class PreviewRenderer {
       if (!fboNode) continue;
 
       const customSize = getCustomSize?.(nodeId);
-      this.initiateAsyncRead(nodeId, fboNode.framebuffer, customSize);
+      const fboSize: [number, number] = [fboNode.texture.width, fboNode.texture.height];
+      this.initiateAsyncRead(nodeId, fboNode.framebuffer, customSize, fboSize);
     }
 
     return results;
@@ -244,7 +245,8 @@ export class PreviewRenderer {
   private initiateAsyncRead(
     nodeId: string,
     framebuffer: regl.Framebuffer2D,
-    customSize?: [number, number]
+    customSize?: [number, number],
+    sourceSize?: [number, number]
   ): void {
     const [pw, ph] = customSize ?? this.service.previewSize;
     const width = Math.floor(pw);
@@ -252,12 +254,14 @@ export class PreviewRenderer {
 
     if (width <= 0 || height <= 0) return;
 
-    const [sourceWidth, sourceHeight] = this.service.outputSize;
     const gl = this.gl;
 
     this.service.ensureIntermediateFboSize(width, height);
 
-    // Blit source to intermediate FBO with flip
+    // Blit source to intermediate FBO with flip.
+    // Use the FBO's actual texture dimensions, not the global output size —
+    // per-node resolution (spec 122) may differ from the output size.
+    const [sourceWidth, sourceHeight] = sourceSize ?? this.service.outputSize;
     const sourceFBO = getFramebuffer(framebuffer);
     const destFBO = getFramebuffer(this.service.getIntermediateFbo());
 
@@ -314,6 +318,7 @@ export class PreviewRenderer {
     }
 
     const selected: string[] = [];
+
     for (let i = 0; i < maxLimit; i++) {
       const idx = (this.previewRoundRobinIndex + i) % visibleEnabledPreviews.length;
       selected.push(visibleEnabledPreviews[idx]);

--- a/ui/src/workers/rendering/PreviewRenderer.ts
+++ b/ui/src/workers/rendering/PreviewRenderer.ts
@@ -268,6 +268,10 @@ export class PreviewRenderer {
     gl.bindFramebuffer(gl.READ_FRAMEBUFFER, sourceFBO);
     gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, destFBO);
 
+    // Use NEAREST when the source is smaller than the preview so the preview
+    // accurately shows individual pixels (important for @resolution debugging).
+    const filter = sourceWidth < width || sourceHeight < height ? gl.NEAREST : gl.LINEAR;
+
     gl.blitFramebuffer(
       0,
       0,
@@ -278,7 +282,7 @@ export class PreviewRenderer {
       width,
       0,
       gl.COLOR_BUFFER_BIT,
-      gl.LINEAR
+      filter
     );
 
     // Setup PBO for async read

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -1833,12 +1833,10 @@ export class FBORenderer {
     const fboNode = this.fboNodes.get(nodeId);
     if (!fboNode) return null;
 
-    const [sourceWidth, sourceHeight] = this.outputSize;
-
     return this.captureRenderer.capturePreviewBitmapSync(
       fboNode.framebuffer,
-      sourceWidth,
-      sourceHeight,
+      fboNode.texture.width,
+      fboNode.texture.height,
       customSize
     );
   }

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -227,13 +227,32 @@ export class FBORenderer {
 
   /** Resolve per-node resolution override to [width, height]. */
   private resolveNodeSize(resolution: FBOResolution | undefined): [number, number] {
-    const [outW, outH] = this.outputSize;
-    if (resolution == null) return [outW, outH];
-    if (resolution === '1/2') return [Math.floor(outW / 2), Math.floor(outH / 2)];
-    if (resolution === '1/4') return [Math.floor(outW / 4), Math.floor(outH / 4)];
-    if (typeof resolution === 'number') return [resolution, resolution];
-    if (Array.isArray(resolution)) return [resolution[0], resolution[1]];
-    return [outW, outH];
+    const [outputWidth, outputHeight] = this.outputSize;
+
+    if (resolution == null) {
+      return [outputWidth, outputHeight];
+    }
+
+    let width: number;
+    let height: number;
+
+    if (resolution === '1/2') {
+      width = Math.floor(outputWidth / 2);
+      height = Math.floor(outputHeight / 2);
+    } else if (resolution === '1/4') {
+      width = Math.floor(outputWidth / 4);
+      height = Math.floor(outputHeight / 4);
+    } else if (typeof resolution === 'number') {
+      width = Math.floor(resolution);
+      height = Math.floor(resolution);
+    } else if (Array.isArray(resolution)) {
+      width = Math.floor(resolution[0]);
+      height = Math.floor(resolution[1]);
+    } else {
+      return [outputWidth, outputHeight];
+    }
+
+    return [Math.max(1, width), Math.max(1, height)];
   }
 
   /**
@@ -288,8 +307,6 @@ export class FBORenderer {
 
   /** Build FBOs for all nodes in the render graph */
   async buildFBOs(renderGraph: RenderGraph) {
-    const [width, height] = this.outputSize;
-
     // Get the set of node IDs that will exist in the new graph
     const newNodeIds = new Set(renderGraph.nodes.map((n) => n.id));
 
@@ -662,13 +679,27 @@ export class FBORenderer {
         const sourceFbo = this.fboNodes.get(inlet0.sourceNodeId);
         if (!sourceFbo) return;
 
-        // Blit input FBO to output framebuffer
-        const [w, h] = this.outputSize;
+        // Blit input FBO to output framebuffer using source texture dimensions
+        const sourceWidth = sourceFbo.texture.width;
+        const sourceHeight = sourceFbo.texture.height;
         const gl = this.gl;
 
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, getFramebuffer(sourceFbo.framebuffer));
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, getFramebuffer(framebuffer));
-        gl.blitFramebuffer(0, 0, w, h, 0, 0, w, h, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+
+        gl.blitFramebuffer(
+          0,
+          0,
+          sourceWidth,
+          sourceHeight,
+          0,
+          0,
+          sourceWidth,
+          sourceHeight,
+          gl.COLOR_BUFFER_BIT,
+          gl.NEAREST
+        );
+
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
       },
       cleanup: () => {
@@ -923,7 +954,8 @@ export class FBORenderer {
   ): Promise<{ render: RenderFunction; cleanup: () => void } | null> {
     if (node.type !== 'glsl') return null;
 
-    const [width, height] = this.outputSize;
+    const nodeResolution = node.data.resolution;
+    const [width, height] = this.resolveNodeSize(nodeResolution);
 
     // Prepare uniform defaults to prevent crashes
     if (node.data.glUniformDefs) {
@@ -1220,7 +1252,8 @@ export class FBORenderer {
       const fboNode = this.fboNodes.get(nodeId);
       if (!fboNode?.prevFramebuffers?.length) continue;
 
-      const [w, h] = this.outputSize;
+      const width = fboNode.texture.width;
+      const height = fboNode.texture.height;
 
       const gl = this.gl;
       gl.bindFramebuffer(gl.READ_FRAMEBUFFER, getFramebuffer(fboNode.framebuffer));
@@ -1228,7 +1261,19 @@ export class FBORenderer {
       for (let i = 0; i < fboNode.prevFramebuffers.length; i++) {
         gl.readBuffer(gl.COLOR_ATTACHMENT0 + i);
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, getFramebuffer(fboNode.prevFramebuffers[i]));
-        gl.blitFramebuffer(0, 0, w, h, 0, 0, w, h, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+
+        gl.blitFramebuffer(
+          0,
+          0,
+          width,
+          height,
+          0,
+          0,
+          width,
+          height,
+          gl.COLOR_BUFFER_BIT,
+          gl.NEAREST
+        );
       }
 
       gl.bindFramebuffer(gl.FRAMEBUFFER, null);

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -679,26 +679,19 @@ export class FBORenderer {
         const sourceFbo = this.fboNodes.get(inlet0.sourceNodeId);
         if (!sourceFbo) return;
 
-        // Blit input FBO to output framebuffer using source texture dimensions
-        const sourceWidth = sourceFbo.texture.width;
-        const sourceHeight = sourceFbo.texture.height;
+        // Blit input FBO to output framebuffer.
+        // Source and destination may differ when the source uses @resolution.
+        const srcW = sourceFbo.texture.width;
+        const srcH = sourceFbo.texture.height;
+        const dstFbo = this.fboNodes.get(node.id);
+        const dstW = dstFbo?.texture.width ?? srcW;
+        const dstH = dstFbo?.texture.height ?? srcH;
         const gl = this.gl;
 
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, getFramebuffer(sourceFbo.framebuffer));
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, getFramebuffer(framebuffer));
 
-        gl.blitFramebuffer(
-          0,
-          0,
-          sourceWidth,
-          sourceHeight,
-          0,
-          0,
-          sourceWidth,
-          sourceHeight,
-          gl.COLOR_BUFFER_BIT,
-          gl.NEAREST
-        );
+        gl.blitFramebuffer(0, 0, srcW, srcH, 0, 0, dstW, dstH, gl.COLOR_BUFFER_BIT, gl.LINEAR);
 
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
       },

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -6,7 +6,8 @@ import type {
   FBONode,
   RenderFunction,
   UserParam,
-  FBOFormat
+  FBOFormat,
+  FBOResolution
 } from '../../lib/rendering/types';
 import type { ClockCommandMessage } from '$lib/transport/types';
 import {
@@ -224,6 +225,17 @@ export class FBORenderer {
     return JSON.stringify(node.data);
   }
 
+  /** Resolve per-node resolution override to [width, height]. */
+  private resolveNodeSize(resolution: FBOResolution | undefined): [number, number] {
+    const [outW, outH] = this.outputSize;
+    if (resolution == null) return [outW, outH];
+    if (resolution === '1/2') return [Math.floor(outW / 2), Math.floor(outH / 2)];
+    if (resolution === '1/4') return [Math.floor(outW / 4), Math.floor(outH / 4)];
+    if (typeof resolution === 'number') return [resolution, resolution];
+    if (Array.isArray(resolution)) return [resolution[0], resolution[1]];
+    return [outW, outH];
+  }
+
   /**
    * Create a regl texture, then re-initialize it with the correct WebGL2
    * internal format if float. regl doesn't support WebGL2 sized internal
@@ -347,6 +359,7 @@ export class FBORenderer {
       framebuffer: regl.Framebuffer2D;
       fingerprint: string;
       fboFormat: FBOFormat;
+      resolution?: FBOResolution;
     };
 
     const pending: PendingNode[] = [];
@@ -369,10 +382,16 @@ export class FBORenderer {
       const fboFormat: FBOFormat =
         ((node.data as Record<string, unknown>)?.fboFormat as FBOFormat) || 'rgba8';
 
+      // Per-node resolution override (spec 122)
+      const nodeResolution = (node.data as Record<string, unknown>)?.resolution as
+        | FBOResolution
+        | undefined;
+      const [nodeW, nodeH] = this.resolveNodeSize(nodeResolution);
+
       const canReuseFbo =
         existingFbo &&
-        existingFbo.texture.width === width &&
-        existingFbo.texture.height === height &&
+        existingFbo.texture.width === nodeW &&
+        existingFbo.texture.height === nodeH &&
         existingFbo.colorAttachments.length === mrtCount &&
         (existingFbo.fboFormat ?? 'rgba8') === fboFormat;
 
@@ -439,7 +458,7 @@ export class FBORenderer {
 
         // Create color attachments — one for standard nodes, N for MRT GLSL nodes
         colorAttachments = Array.from({ length: mrtCount }, () =>
-          this.createFboTexture(width, height, fboFormat)
+          this.createFboTexture(nodeW, nodeH, fboFormat)
         );
 
         if (mrtCount > 1) {
@@ -474,7 +493,14 @@ export class FBORenderer {
         }
       }
 
-      pending.push({ node, colorAttachments, framebuffer, fingerprint, fboFormat });
+      pending.push({
+        node,
+        colorAttachments,
+        framebuffer,
+        fingerprint,
+        fboFormat,
+        resolution: nodeResolution
+      });
     }
 
     // Phase 2 (parallel): create all renderers concurrently
@@ -499,7 +525,8 @@ export class FBORenderer {
 
     // Phase 3: collect results into FBO map
     for (let i = 0; i < pending.length; i++) {
-      const { node, colorAttachments, framebuffer, fingerprint, fboFormat } = pending[i];
+      const { node, colorAttachments, framebuffer, fingerprint, fboFormat, resolution } =
+        pending[i];
       const renderer = results[i];
 
       // If the renderer function is null, we skip defining this node.
@@ -528,7 +555,8 @@ export class FBORenderer {
         cleanup: renderer.cleanup,
         dataFingerprint: fingerprint,
         nodeType: node.type,
-        fboFormat
+        fboFormat,
+        resolution
       };
 
       this.fboNodes.set(node.id, fboNode);
@@ -555,9 +583,11 @@ export class FBORenderer {
       const feedbackNode = renderGraph.nodes.find((n) => n.id === nodeId);
       const feedbackData = feedbackNode?.data as Record<string, unknown> | undefined;
       const feedbackFormat: FBOFormat = (feedbackData?.fboFormat as FBOFormat) || 'rgba8';
+      const feedbackResolution = feedbackData?.resolution as FBOResolution | undefined;
+      const [fbW, fbH] = this.resolveNodeSize(feedbackResolution);
 
       fboNode.prevTextures = fboNode.colorAttachments.map(() =>
-        this.createFboTexture(width, height, feedbackFormat)
+        this.createFboTexture(fbW, fbH, feedbackFormat)
       );
 
       fboNode.prevFramebuffers = fboNode.prevTextures.map((prevTexture) =>

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -188,6 +188,35 @@ Downstream nodes sample float textures the same way — no code changes needed o
 the receiving end. The preview thumbnail clamps values for display, but the
 actual data on the wire stays float.
 
+## Output Resolution
+
+By default, the output FBO renders at full window resolution. For data
+textures, particle position maps, or any shader where you don't need
+millions of pixels, set a smaller resolution with the `@resolution`
+directive:
+
+```glsl
+// @resolution 256
+// @format rgba32f
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  fragColor = vec4(uv, sin(iTime), 1.0);  // 256×256 float texture
+}
+```
+
+| Value      | FBO size (at 1080p) | Use case                           |
+| ---------- | ------------------- | ---------------------------------- |
+| `256`      | 256×256             | Position maps, small data textures |
+| `512`      | 512×512             | Medium data textures               |
+| `256x128`  | 256×128             | Non-square data                    |
+| `1/2`      | 960×540             | Half resolution                    |
+| `1/4`      | 480×270             | Quarter resolution                 |
+| *(none)*   | 1920×1080           | Default. Full resolution           |
+
+Downstream nodes sample the texture with bilinear filtering — upscaling
+is automatic. Combine with `@format rgba32f` for GPGPU workflows like
+texture-encoded geometry (spec 115).
+
 ## Mouse Interaction
 
 If your shader uses the `iMouse` uniform (vec4), mouse interaction
@@ -198,7 +227,8 @@ is automatically enabled:
   - Positive when mouse down (ongoing drag)
   - Negative when mouse up (use `abs()` to get last position)
 
-When `iMouse` is detected, the node becomes interactive (drag is disabled to allow mouse input).
+When `iMouse` is detected, the node becomes interactive (drag is disabled to
+allow mouse input).
 
 ---
 

--- a/ui/static/content/objects/regl.md
+++ b/ui/static/content/objects/regl.md
@@ -237,6 +237,22 @@ receives its own texture.
 
 - `getTexture(index)` — get video input as regl Texture2D
 - `setVideoCount(inlets, outlets)` — set number of video inlets/outlets
+- `setResolution(size)` — set output FBO resolution (see below)
+
+## Output Resolution
+
+By default, the output renders at full window resolution. For data-heavy
+rendering where you don't need full-res pixels, call `setResolution()`:
+
+```javascript
+setResolution(256)       // 256×256
+setResolution(512, 256)  // 512×256
+setResolution('1/2')     // half resolution
+setResolution('1/4')     // quarter resolution
+```
+
+This reduces the FBO size so the GPU does less work per frame. Downstream
+nodes sample the texture with bilinear filtering — upscaling is automatic.
 
 ## Common Functions
 

--- a/ui/static/content/topics/javascript-runner.md
+++ b/ui/static/content/topics/javascript-runner.md
@@ -179,6 +179,27 @@ setInterval(() => {
 
 > **Tip**: For VFS, storage, audio reactivity, clock, AI, and presentation APIs, see [JS Integrations](/docs/js-integrations).
 
+### Output Resolution
+
+Visual objects (`three`, `regl`, `canvas`, `p5`, etc.) render at full
+window resolution by default. For data textures or lightweight renders,
+reduce the FBO size:
+
+```javascript
+setResolution(256)       // 256×256
+setResolution(512, 256)  // 512 wide, 256 tall
+setResolution('1/2')     // half resolution
+setResolution('1/4')     // quarter resolution
+```
+
+Downstream nodes sample the smaller texture with bilinear filtering —
+upscaling is automatic. Combine with `setTextureFormat('rgba32f')` for
+GPGPU workflows like texture-encoded geometry.
+
+> **Note**: GLSL and SwissGL nodes use the `// @resolution 256`
+> directive instead of `setResolution()`. See
+> [glsl](/docs/objects/glsl#output-resolution).
+
 ## See Also
 
 - [JS Modules](/docs/js-modules) — Importing npm packages and sharing code between objects

--- a/ui/static/content/topics/javascript-runner.md
+++ b/ui/static/content/topics/javascript-runner.md
@@ -197,8 +197,7 @@ upscaling is automatic. Combine with `setTextureFormat('rgba32f')` for
 GPGPU workflows like texture-encoded geometry.
 
 > **Note**: GLSL and SwissGL nodes use the `// @resolution 256`
-> directive instead of `setResolution()`. See
-> [glsl](/docs/objects/glsl#output-resolution).
+> directive instead of `setResolution()`, see [glsl](/docs/objects/glsl).
 
 ## See Also
 


### PR DESCRIPTION
## Summary

- Add `// @resolution 256` directive for GLSL/SwissGL nodes to control FBO size
- Add `setResolution()` JS API for Three.js, REGL, Canvas, P5, and other visual nodes
- Add `particles-from-texture.three` preset demonstrating texture-encoded geometry (spec 115 Stage 1)
- Per-node resolution resolves to `[width, height]` in fboRenderer, replacing global output size per node

## Details

Implements spec 122 §1 (Per-Node Resolution). Instead of a UI dropdown, resolution is set from code:

**GLSL directive**: `// @resolution 256` (also `256x128`, `1/2`, `1/4`)
**JS API**: `setResolution(256)`, `setResolution(512, 256)`, `setResolution('1/2')`

Both write to `node.data.resolution`, which fboRenderer reads when creating FBOs.

### Files changed

- **types.ts** — `FBOResolution` type, added to all visual RenderNode variants + FBONode + worker messages
- **GLSLCanvasNode / SwissGLNode** — `detectResolution()` parser alongside existing `detectFboFormat()`
- **fboRenderer.ts** — `resolveNodeSize()` helper, per-node size in buildFBOs + feedback textures
- **BaseWorkerRenderer.ts** — `setResolution()` method posts message to main thread
- **GLSystem.ts** — handles `setResolution` message, updates node data + rebuilds graph
- **glsl.codemirror.ts** — syntax highlighting for `@resolution`
- **Docs** — glsl.md, regl.md, javascript-runner.md, AI prompt

## Test plan

- [ ] Add `// @resolution 256` + `// @format rgba32f` to a GLSL node, verify FBO is 256×256 (check via profiler or GPU debugger)
- [ ] Wire that GLSL node into `particles-from-texture.three` preset, verify point cloud renders smoothly
- [ ] Test `setResolution(128)` in a Three.js node, verify reduced FBO size
- [ ] Test `// @resolution 1/2` and `1/4` in GLSL, verify proportional sizing
- [ ] Verify feedback loops work with per-node resolution (prev textures match node size)
- [ ] Verify syntax highlighting for `@resolution` in GLSL editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Output resolution control for GLSL, SwissGL, regl, canvas, three and visual JS nodes via @resolution or setResolution()
  * Added a new Three.js preset: point-cloud-from-texture
  * Added a new GLSL preset: position-field

* **Documentation**
  * Added/expanded Output Resolution guides for GLSL, regl, and JavaScript runner with examples and bilinear upscaling notes

* **Other**
  * Metadata parsing updated to recognize @resolution in shader source
<!-- end of auto-generated comment: release notes by coderabbit.ai -->