### PR TITLE
decouple preview size from background output size

### DIFF
--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -28,7 +28,7 @@ import {
   type AudioAnalysisPayloadWithType,
   type OnFFTReadyCallback
 } from '$lib/audio/AudioAnalysisSystem';
-import { DEFAULT_OUTPUT_SIZE, PREVIEW_SCALE_FACTOR } from './constants';
+import { DEFAULT_OUTPUT_SIZE, DEFAULT_PREVIEW_SIZE } from './constants';
 import { logger } from '$lib/utils/logger';
 import { match, P } from 'ts-pattern';
 import { profiler, ProfilerCoordinator, typeFromNodeId } from '$lib/profiler';
@@ -118,10 +118,8 @@ export class GLSystem {
 
   public outputSize = DEFAULT_OUTPUT_SIZE;
 
-  public previewSize: [width: number, height: number] = [
-    this.outputSize[0] / PREVIEW_SCALE_FACTOR,
-    this.outputSize[1] / PREVIEW_SCALE_FACTOR
-  ];
+  /** Default preview size for nodes without a resolution override. */
+  public static defaultPreviewSize = DEFAULT_PREVIEW_SIZE;
 
   static getInstance() {
     if (!GLSystem.instance) {
@@ -823,32 +821,12 @@ export class GLSystem {
     return true;
   }
 
-  setPreviewSize(width: number, height: number) {
-    this.previewSize = [width, height];
-
-    for (const nodeId in this.previewCanvasContexts) {
-      const context = this.previewCanvasContexts[nodeId];
-
-      if (context) {
-        const canvas = context.canvas;
-        canvas.width = width;
-        canvas.height = height;
-
-        // re-create the context to accommodate the new size
-        delete this.previewCanvasContexts[nodeId];
-
-        this.previewCanvasContexts[nodeId] = canvas.getContext(
-          'bitmaprenderer'
-        ) as ImageBitmapRenderingContext;
-      }
-    }
-
-    this.send('setPreviewSize', { width, height });
-  }
-
-  setOutputSize(width: number, height: number) {
-    this.outputSize = [width, height];
-    this.send('setOutputSize', { width, height });
+  /**
+   * Set the background display size (viewport dimensions).
+   * Only affects the background canvas blit target, not FBOs or node previews.
+   */
+  setBackgroundSize(width: number, height: number) {
+    this.send('setBackgroundSize', { width, height });
   }
 
   setBitmapSource(nodeId: string, source: ImageBitmapSource) {

--- a/ui/src/lib/canvas/constants.ts
+++ b/ui/src/lib/canvas/constants.ts
@@ -9,6 +9,48 @@ export const WEBGL_OPTIONAL_EXTENSIONS = [
 export const DEFAULT_OUTPUT_SIZE = [1008, 654] as [width: number, height: number];
 export const PREVIEW_SCALE_FACTOR = 4;
 
+export const DEFAULT_PREVIEW_SIZE: [number, number] = [
+  Math.floor(DEFAULT_OUTPUT_SIZE[0] / PREVIEW_SCALE_FACTOR),
+  Math.floor(DEFAULT_OUTPUT_SIZE[1] / PREVIEW_SCALE_FACTOR)
+];
+
+/**
+ * Compute preview size from a per-node FBO resolution override.
+ * Used by node components to derive their preview canvas dimensions.
+ */
+export function getPreviewSizeForResolution(
+  resolution: number | [number, number] | string | undefined
+): [number, number] {
+  if (resolution == null) return DEFAULT_PREVIEW_SIZE;
+
+  const [outW, outH] = DEFAULT_OUTPUT_SIZE;
+
+  // Fractional: '1/2', '1/4', etc.
+  if (typeof resolution === 'string') {
+    const match = resolution.match(/^1\/(\d+)$/);
+    if (match) {
+      const divisor = Number(match[1]);
+      return [
+        Math.max(1, Math.floor(outW / divisor / PREVIEW_SCALE_FACTOR)),
+        Math.max(1, Math.floor(outH / divisor / PREVIEW_SCALE_FACTOR))
+      ];
+    }
+    return DEFAULT_PREVIEW_SIZE;
+  }
+
+  // Square: 256 → 64x64
+  if (typeof resolution === 'number') {
+    const s = Math.max(1, Math.floor(resolution / PREVIEW_SCALE_FACTOR));
+    return [s, s];
+  }
+
+  // Explicit: [512, 256] → [128, 64]
+  return [
+    Math.max(1, Math.floor(resolution[0] / PREVIEW_SCALE_FACTOR)),
+    Math.max(1, Math.floor(resolution[1] / PREVIEW_SCALE_FACTOR))
+  ];
+}
+
 export const DEFAULT_GLSL_CODE = `// uniforms: iResolution, iTime, iMouse
 // you can define your own uniforms!
 

--- a/ui/src/lib/canvas/constants.ts
+++ b/ui/src/lib/canvas/constants.ts
@@ -10,8 +10,8 @@ export const DEFAULT_OUTPUT_SIZE = [1008, 654] as [width: number, height: number
 export const PREVIEW_SCALE_FACTOR = 4;
 
 export const DEFAULT_PREVIEW_SIZE: [number, number] = [
-  Math.floor(DEFAULT_OUTPUT_SIZE[0] / PREVIEW_SCALE_FACTOR),
-  Math.floor(DEFAULT_OUTPUT_SIZE[1] / PREVIEW_SCALE_FACTOR)
+  Math.round(DEFAULT_OUTPUT_SIZE[0] / PREVIEW_SCALE_FACTOR),
+  Math.round(DEFAULT_OUTPUT_SIZE[1] / PREVIEW_SCALE_FACTOR)
 ];
 
 /**
@@ -23,16 +23,22 @@ export function getPreviewSizeForResolution(
 ): [number, number] {
   if (resolution == null) return DEFAULT_PREVIEW_SIZE;
 
-  const [outW, outH] = DEFAULT_OUTPUT_SIZE;
+  const [outputWidth, outputHeight] = DEFAULT_OUTPUT_SIZE;
 
   // Fractional: '1/2', '1/4', etc.
   if (typeof resolution === 'string') {
     const match = resolution.match(/^1\/(\d+)$/);
+
     if (match) {
       const divisor = Number(match[1]);
+
+      if (!Number.isFinite(divisor) || divisor <= 0) {
+        return DEFAULT_PREVIEW_SIZE;
+      }
+
       return [
-        Math.max(1, Math.floor(outW / divisor / PREVIEW_SCALE_FACTOR)),
-        Math.max(1, Math.floor(outH / divisor / PREVIEW_SCALE_FACTOR))
+        Math.max(1, Math.floor(outputWidth / divisor / PREVIEW_SCALE_FACTOR)),
+        Math.max(1, Math.floor(outputHeight / divisor / PREVIEW_SCALE_FACTOR))
       ];
     }
     return DEFAULT_PREVIEW_SIZE;
@@ -40,11 +46,25 @@ export function getPreviewSizeForResolution(
 
   // Square: 256 → 64x64
   if (typeof resolution === 'number') {
-    const s = Math.max(1, Math.floor(resolution / PREVIEW_SCALE_FACTOR));
-    return [s, s];
+    if (!Number.isFinite(resolution) || resolution <= 0) {
+      return DEFAULT_PREVIEW_SIZE;
+    }
+
+    const size = Math.max(1, Math.floor(resolution / PREVIEW_SCALE_FACTOR));
+
+    return [size, size];
   }
 
   // Explicit: [512, 256] → [128, 64]
+  if (
+    !Number.isFinite(resolution[0]) ||
+    !Number.isFinite(resolution[1]) ||
+    resolution[0] <= 0 ||
+    resolution[1] <= 0
+  ) {
+    return DEFAULT_PREVIEW_SIZE;
+  }
+
   return [
     Math.max(1, Math.floor(resolution[0] / PREVIEW_SCALE_FACTOR)),
     Math.max(1, Math.floor(resolution[1] / PREVIEW_SCALE_FACTOR))

--- a/ui/src/lib/components/BackgroundOutputCanvas.svelte
+++ b/ui/src/lib/components/BackgroundOutputCanvas.svelte
@@ -17,7 +17,7 @@
 
     if (resizeTimer !== null) clearTimeout(resizeTimer);
     resizeTimer = setTimeout(() => {
-      glSystem.setOutputSize(width, height);
+      glSystem.setBackgroundSize(width, height);
       resizeTimer = null;
     }, 150);
   }
@@ -27,7 +27,7 @@
 
     glSystem.backgroundOutputCanvasContext = bitmapContext;
     // Call directly (no debounce) on mount so initial size is set immediately.
-    glSystem.setOutputSize(window.innerWidth, window.innerHeight);
+    glSystem.setBackgroundSize(window.innerWidth, window.innerHeight);
     outputCanvasElement.width = window.innerWidth;
     outputCanvasElement.height = window.innerHeight;
 

--- a/ui/src/lib/components/nodes/ButterchurnNode.svelte
+++ b/ui/src/lib/components/nodes/ButterchurnNode.svelte
@@ -63,7 +63,7 @@
     presets = butterchurnPresets.getPresets();
 
     if (canvasElement) {
-      const [previewWidth, previewHeight] = glSystem.previewSize;
+      const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
       canvasElement.width = previewWidth;
       canvasElement.height = previewHeight;
 

--- a/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
+++ b/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
@@ -9,6 +9,7 @@
   import { messages } from '$lib/objects/schemas/common';
   import { GLSystem, type UserUniformValue } from '$lib/canvas/GLSystem';
   import { CanvasMouseHandler } from '$lib/canvas/CanvasMouseHandler';
+  import { getPreviewSizeForResolution } from '$lib/canvas/constants';
   import {
     shaderCodeToUniformDefs,
     uniformDefsToSettingsSchema,
@@ -50,9 +51,11 @@
   let glSystem = GLSystem.getInstance();
   let mouseHandler: CanvasMouseHandler | null = null;
 
-  // Preview canvas display size
-  let width = $state(glSystem.previewSize[0]);
-  let height = $state(glSystem.previewSize[1]);
+  // Preview canvas display size — derived from per-node resolution
+  const previewSize = $derived(getPreviewSizeForResolution(detectResolution(data.code)));
+
+  let width = $derived(previewSize[0]);
+  let height = $derived(previewSize[1]);
 
   let previewCanvas = $state<HTMLCanvasElement | undefined>();
   let previewBitmapContext: ImageBitmapRenderingContext;

--- a/ui/src/lib/components/nodes/HydraNode.svelte
+++ b/ui/src/lib/components/nodes/HydraNode.svelte
@@ -174,7 +174,7 @@
     if (previewCanvas) {
       previewBitmapContext = previewCanvas.getContext('bitmaprenderer')!;
 
-      const [previewWidth, previewHeight] = glSystem.previewSize;
+      const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
 
       previewCanvas.width = previewWidth;
       previewCanvas.height = previewHeight;

--- a/ui/src/lib/components/nodes/ImageNode.svelte
+++ b/ui/src/lib/components/nodes/ImageNode.svelte
@@ -34,7 +34,7 @@
   let canvasElement: HTMLCanvasElement | null = $state(null);
   let hasImage = $state(false);
 
-  const [defaultPreviewWidth, defaultPreviewHeight] = glSystem.previewSize;
+  const [defaultPreviewWidth, defaultPreviewHeight] = GLSystem.defaultPreviewSize;
   const [defaultOutputWidth, defaultOutputHeight] = glSystem.outputSize;
 
   // Use VFS media composable for all file handling

--- a/ui/src/lib/components/nodes/JSCanvasNode.svelte
+++ b/ui/src/lib/components/nodes/JSCanvasNode.svelte
@@ -86,7 +86,7 @@
   const updateNodeInternals = useUpdateNodeInternals();
 
   const [outputWidth, outputHeight] = glSystem.outputSize;
-  const [previewWidth, previewHeight] = glSystem.previewSize;
+  const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
 
   let inletCount = $derived(data.inletCount ?? 1);
   let outletCount = $derived(data.outletCount ?? 0);

--- a/ui/src/lib/components/nodes/ReglNode.svelte
+++ b/ui/src/lib/components/nodes/ReglNode.svelte
@@ -85,7 +85,7 @@
   const updateNodeInternals = useUpdateNodeInternals();
 
   const [outputWidth, outputHeight] = glSystem.outputSize;
-  const [previewWidth, previewHeight] = glSystem.previewSize;
+  const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
 
   let messageInletCount = $derived(data.messageInletCount ?? 1);
   let messageOutletCount = $derived(data.messageOutletCount ?? 0);

--- a/ui/src/lib/components/nodes/SwissGLNode.svelte
+++ b/ui/src/lib/components/nodes/SwissGLNode.svelte
@@ -64,6 +64,19 @@
   let lineErrors = $state<Record<number, string[]> | undefined>(undefined);
 
   const code = $derived(data.code || '');
+  const previewSize = $derived(getPreviewSizeForResolution(detectResolution(code)));
+
+  // Reactively update preview canvas dimensions when resolution changes
+  $effect(() => {
+    if (!previewCanvas) return;
+
+    const [previewWidth, previewHeight] = previewSize;
+
+    previewCanvas.width = previewWidth;
+    previewCanvas.height = previewHeight;
+    previewCanvas.style.width = `${previewWidth}px`;
+    previewCanvas.style.height = `${previewHeight}px`;
+  });
 
   let videoInletCount = $derived(data.videoInletCount ?? 0);
   let videoOutletCount = $derived(data.videoOutletCount ?? 1);
@@ -144,12 +157,6 @@
 
     if (previewCanvas) {
       previewBitmapContext = previewCanvas.getContext('bitmaprenderer')!;
-
-      const [previewWidth, previewHeight] = getPreviewSizeForResolution(detectResolution(code));
-      previewCanvas.width = previewWidth;
-      previewCanvas.height = previewHeight;
-      previewCanvas.style.width = `${previewWidth}px`;
-      previewCanvas.style.height = `${previewHeight}px`;
     }
 
     glSystem.previewCanvasContexts[nodeId] = previewBitmapContext;

--- a/ui/src/lib/components/nodes/SwissGLNode.svelte
+++ b/ui/src/lib/components/nodes/SwissGLNode.svelte
@@ -9,6 +9,7 @@
   import { removeExcessVideoOutletEdges } from './outlet-edges';
   import { messages } from '$lib/objects/schemas/common';
   import { GLSystem } from '$lib/canvas/GLSystem';
+  import { getPreviewSizeForResolution } from '$lib/canvas/constants';
   import CanvasPreviewLayout from '$lib/components/CanvasPreviewLayout.svelte';
   import { SettingsManager } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
@@ -144,7 +145,7 @@
     if (previewCanvas) {
       previewBitmapContext = previewCanvas.getContext('bitmaprenderer')!;
 
-      const [previewWidth, previewHeight] = glSystem.previewSize;
+      const [previewWidth, previewHeight] = getPreviewSizeForResolution(detectResolution(code));
       previewCanvas.width = previewWidth;
       previewCanvas.height = previewHeight;
       previewCanvas.style.width = `${previewWidth}px`;

--- a/ui/src/lib/components/nodes/TextmodeNode.svelte
+++ b/ui/src/lib/components/nodes/TextmodeNode.svelte
@@ -85,7 +85,7 @@
   const updateNodeInternals = useUpdateNodeInternals();
 
   const [outputWidth, outputHeight] = glSystem.outputSize;
-  const [previewWidth, previewHeight] = glSystem.previewSize;
+  const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
 
   let inletCount = $derived(data.inletCount ?? 1);
   let outletCount = $derived(data.outletCount ?? 0);

--- a/ui/src/lib/components/nodes/ThreeNode.svelte
+++ b/ui/src/lib/components/nodes/ThreeNode.svelte
@@ -87,7 +87,7 @@
   const updateNodeInternals = useUpdateNodeInternals();
 
   const [outputWidth, outputHeight] = glSystem.outputSize;
-  const [previewWidth, previewHeight] = glSystem.previewSize;
+  const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
 
   let messageInletCount = $derived(data.messageInletCount ?? 1);
   let messageOutletCount = $derived(data.messageOutletCount ?? 0);

--- a/ui/src/lib/components/nodes/VideoNode.svelte
+++ b/ui/src/lib/components/nodes/VideoNode.svelte
@@ -103,7 +103,7 @@
   let videoStats = $state<VideoStats | null>(null);
   let statsIntervalId: ReturnType<typeof setInterval> | null = null;
 
-  const [defaultPreviewWidth, defaultPreviewHeight] = glSystem.previewSize;
+  const [defaultPreviewWidth, defaultPreviewHeight] = GLSystem.defaultPreviewSize;
   const [MAX_UPLOAD_WIDTH, MAX_UPLOAD_HEIGHT] = glSystem.outputSize;
 
   // Initialize bitmaprenderer context when canvas is bound

--- a/ui/src/lib/components/nodes/WebcamNode.svelte
+++ b/ui/src/lib/components/nodes/WebcamNode.svelte
@@ -86,7 +86,7 @@
   let statsIntervalId: ReturnType<typeof setInterval> | null = null;
 
   const [defaultOutputWidth, defaultOutputHeight] = glSystem.outputSize;
-  const [defaultPreviewWidth, defaultPreviewHeight] = glSystem.previewSize;
+  const [defaultPreviewWidth, defaultPreviewHeight] = GLSystem.defaultPreviewSize;
 
   const handleMessage: MessageCallbackFn = (message) => {
     match(message)

--- a/ui/src/lib/rendering/types.ts
+++ b/ui/src/lib/rendering/types.ts
@@ -134,6 +134,9 @@ export interface FBONode {
   /** The per-node resolution this FBO was built with */
   resolution?: FBOResolution;
 
+  /** The preview readback size for this node (FBO size / PREVIEW_SCALE_FACTOR) */
+  previewSize: [number, number];
+
   /** Previous frame textures — one per color attachment, only allocated for nodes in feedback loops */
   prevTextures?: regl.Texture2D[];
 

--- a/ui/src/workers/rendering/CaptureRenderer.ts
+++ b/ui/src/workers/rendering/CaptureRenderer.ts
@@ -51,9 +51,9 @@ export class CaptureRenderer {
     framebuffer: regl.Framebuffer2D,
     sourceWidth: number,
     sourceHeight: number,
-    customSize?: [number, number]
+    customSize: [number, number]
   ): ImageBitmap {
-    const [pw, ph] = customSize ?? this.service.previewSize;
+    const [pw, ph] = customSize;
     const width = Math.floor(pw);
     const height = Math.floor(ph);
 
@@ -152,11 +152,12 @@ export class CaptureRenderer {
           const tempFbo = this.regl.framebuffer({ color: externalTexture });
           tempFbos.push(tempFbo);
 
+          const texSize: [number, number] = [externalTexture.width, externalTexture.height];
           const read = this.initiateVideoFrameRead(
             sourceId,
             tempFbo,
-            [externalTexture.width, externalTexture.height],
-            validResolution
+            texSize,
+            validResolution ?? texSize
           );
           if (read) {
             readCache.set(cacheKey, read);
@@ -173,7 +174,7 @@ export class CaptureRenderer {
           sourceId,
           fboNode.framebuffer,
           [fboNode.texture.width, fboNode.texture.height],
-          validResolution
+          validResolution ?? fboNode.previewSize
         );
 
         if (read) {
@@ -206,16 +207,16 @@ export class CaptureRenderer {
   private initiateVideoFrameRead(
     sourceNodeId: string,
     framebuffer: regl.Framebuffer2D,
-    customSourceSize?: [number, number],
-    customOutputSize?: [number, number]
+    customSourceSize: [number, number],
+    customOutputSize: [number, number]
   ): PendingVideoFrameRead | null {
-    const [pw, ph] = customOutputSize ?? this.service.previewSize;
+    const [pw, ph] = customOutputSize;
     const width = Math.floor(pw);
     const height = Math.floor(ph);
 
     if (width <= 0 || height <= 0) return null;
 
-    const [sourceWidth, sourceHeight] = customSourceSize ?? this.service.outputSize;
+    const [sourceWidth, sourceHeight] = customSourceSize;
     const gl = this.gl;
 
     this.service.ensureIntermediateFboSize(width, height);

--- a/ui/src/workers/rendering/PixelReadbackService.ts
+++ b/ui/src/workers/rendering/PixelReadbackService.ts
@@ -17,10 +17,6 @@ export class PixelReadbackService {
   public regl: regl.Regl;
   public profiler: RenderingProfiler;
 
-  // Size configuration
-  public outputSize: [number, number];
-  public previewSize: [number, number];
-
   // PBO pool for async reads
   private pboPool: WebGLBuffer[] = [];
 
@@ -34,23 +30,17 @@ export class PixelReadbackService {
   private intermediateFbo: regl.Framebuffer2D | null = null;
   private intermediateTexture: regl.Texture2D | null = null;
 
-  constructor(
-    gl: WebGL2RenderingContext,
-    reglInstance: regl.Regl,
-    profiler: RenderingProfiler,
-    outputSize: [number, number],
-    previewSize: [number, number]
-  ) {
+  constructor(gl: WebGL2RenderingContext, reglInstance: regl.Regl, profiler: RenderingProfiler) {
     this.gl = gl;
     this.regl = reglInstance;
     this.profiler = profiler;
-    this.outputSize = outputSize;
-    this.previewSize = previewSize;
     this.createIntermediateFbo();
   }
 
   private createIntermediateFbo(): void {
-    const [width, height] = this.previewSize;
+    // Start with a small 1x1 FBO — ensureIntermediateFboSize will resize as needed
+    const width = 1;
+    const height = 1;
 
     this.intermediateTexture = this.regl.texture({
       width,
@@ -66,17 +56,6 @@ export class PixelReadbackService {
   }
 
   // ===== Public API =====
-
-  setPreviewSize(width: number, height: number): void {
-    this.previewSize = [width, height];
-    this.intermediateFbo?.destroy();
-    this.intermediateTexture?.destroy();
-    this.createIntermediateFbo();
-  }
-
-  setOutputSize(outputSize: [number, number]): void {
-    this.outputSize = outputSize;
-  }
 
   // ===== PBO Pool =====
 

--- a/ui/src/workers/rendering/PreviewRenderer.ts
+++ b/ui/src/workers/rendering/PreviewRenderer.ts
@@ -88,15 +88,12 @@ export class PreviewRenderer {
     this.allPreviewsDisabled = disabled;
   }
 
-  /** Update preview readback resolution. Called only when LOD tier changes (gated by sender). */
-  setPreviewScaleMultiplier(multiplier: number, baseScaleFactor: number): void {
-    const [outW, outH] = this.service.outputSize;
-    const scaleFactor = baseScaleFactor * multiplier || 1;
+  /** LOD scale multiplier applied to per-node preview sizes. 1 = full, 2 = half, etc. */
+  private previewScaleMultiplier = 1;
 
-    this.service.setPreviewSize(
-      Math.max(1, Math.floor(outW / scaleFactor)),
-      Math.max(1, Math.floor(outH / scaleFactor))
-    );
+  /** Update preview LOD multiplier. Called only when LOD tier changes (gated by sender). */
+  setPreviewScaleMultiplier(multiplier: number): void {
+    this.previewScaleMultiplier = multiplier;
   }
 
   removeNode(nodeId: string): void {
@@ -127,8 +124,7 @@ export class PreviewRenderer {
    */
   renderPreviewBitmaps(
     fboNodes: Map<string, FBONode>,
-    isOutputEnabled: boolean,
-    getCustomSize?: (nodeId: string) => [number, number] | undefined
+    isOutputEnabled: boolean
   ): Map<string, ImageBitmap> {
     const results = this.frameResults;
     results.clear();
@@ -165,9 +161,17 @@ export class PreviewRenderer {
       const fboNode = fboNodes.get(nodeId);
       if (!fboNode) continue;
 
-      const customSize = getCustomSize?.(nodeId);
+      // Use the node's own preview size, scaled by LOD multiplier
+      const [pw, ph] = fboNode.previewSize;
+      const previewSize: [number, number] =
+        this.previewScaleMultiplier > 1
+          ? [
+              Math.max(1, Math.floor(pw / this.previewScaleMultiplier)),
+              Math.max(1, Math.floor(ph / this.previewScaleMultiplier))
+            ]
+          : [pw, ph];
       const fboSize: [number, number] = [fboNode.texture.width, fboNode.texture.height];
-      this.initiateAsyncRead(nodeId, fboNode.framebuffer, customSize, fboSize);
+      this.initiateAsyncRead(nodeId, fboNode.framebuffer, previewSize, fboSize);
     }
 
     return results;
@@ -245,12 +249,10 @@ export class PreviewRenderer {
   private initiateAsyncRead(
     nodeId: string,
     framebuffer: regl.Framebuffer2D,
-    customSize?: [number, number],
-    sourceSize?: [number, number]
+    previewSize: [number, number],
+    sourceSize: [number, number]
   ): void {
-    const [pw, ph] = customSize ?? this.service.previewSize;
-    const width = Math.floor(pw);
-    const height = Math.floor(ph);
+    const [width, height] = previewSize;
 
     if (width <= 0 || height <= 0) return;
 
@@ -259,9 +261,7 @@ export class PreviewRenderer {
     this.service.ensureIntermediateFboSize(width, height);
 
     // Blit source to intermediate FBO with flip.
-    // Use the FBO's actual texture dimensions, not the global output size —
-    // per-node resolution (spec 122) may differ from the output size.
-    const [sourceWidth, sourceHeight] = sourceSize ?? this.service.outputSize;
+    const [sourceWidth, sourceHeight] = sourceSize;
     const sourceFBO = getFramebuffer(framebuffer);
     const destFBO = getFramebuffer(this.service.getIntermediateFbo());
 

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -49,6 +49,7 @@ import type { WorkerSettingsProxy } from '../shared/workerSettingsProxy';
 
 export class FBORenderer {
   public outputSize = DEFAULT_OUTPUT_SIZE;
+  public backgroundSize: [number, number] = [...DEFAULT_OUTPUT_SIZE];
 
   public renderGraph: RenderGraph | null = null;
 
@@ -192,20 +193,8 @@ export class FBORenderer {
       data: new Uint8Array([0, 0, 0, 0])
     });
 
-    // Calculate preview size from output size
-    const previewSize: [number, number] = [
-      Math.floor(this.outputSize[0] / PREVIEW_SCALE_FACTOR),
-      Math.floor(this.outputSize[1] / PREVIEW_SCALE_FACTOR)
-    ];
-
     // Create shared pixel readback service
-    this.pixelReadbackService = new PixelReadbackService(
-      this.gl,
-      this.regl,
-      this.profiler,
-      this.outputSize,
-      previewSize
-    );
+    this.pixelReadbackService = new PixelReadbackService(this.gl, this.regl, this.profiler);
 
     // Create renderers that use the shared service
     this.previewRenderer = new PreviewRenderer(this.pixelReadbackService);
@@ -566,6 +555,10 @@ export class FBORenderer {
         continue;
       }
 
+      const nodeSize = this.resolveNodeSize(resolution);
+      // Canvas/textmode nodes use output/2 for sharper previews (vs output/4 for GL nodes)
+      const isCanvasNode = node.type === 'canvas' || node.type === 'textmode';
+      const previewScaleFactor = isCanvasNode ? PREVIEW_SCALE_FACTOR / 2 : PREVIEW_SCALE_FACTOR;
       const fboNode: FBONode = {
         id: node.id,
         framebuffer,
@@ -576,7 +569,11 @@ export class FBORenderer {
         dataFingerprint: fingerprint,
         nodeType: node.type,
         fboFormat,
-        resolution
+        resolution,
+        previewSize: [
+          Math.max(1, Math.floor(nodeSize[0] / previewScaleFactor)),
+          Math.max(1, Math.floor(nodeSize[1] / previewScaleFactor))
+        ]
       };
 
       this.fboNodes.set(node.id, fboNode);
@@ -1385,17 +1382,7 @@ export class FBORenderer {
    * This introduces 1 frame of latency but eliminates GPU stalls (~3ms per read).
    */
   renderPreviewBitmaps(): Map<string, ImageBitmap> {
-    return this.previewRenderer.renderPreviewBitmaps(
-      this.fboNodes,
-      this.isOutputEnabled,
-      (nodeId) => (this.canvasByNode.has(nodeId) ? this.canvasOutputSize : undefined)
-    );
-  }
-
-  // HACK: use a different preview size for canvas nodes
-  // this is to make the canvas preview looks sharper
-  get canvasOutputSize(): [number, number] {
-    return [this.outputSize[0] / 2, this.outputSize[1] / 2];
+    return this.previewRenderer.renderPreviewBitmaps(this.fboNodes, this.isOutputEnabled);
   }
 
   /** Set which nodes are visible in the viewport for preview culling */
@@ -1408,9 +1395,9 @@ export class FBORenderer {
     this.previewRenderer.setAllPreviewsDisabled(disabled);
   }
 
-  /** Update preview readback resolution. Called only when LOD tier changes. */
+  /** Update preview LOD multiplier. Called only when LOD tier changes. */
   setPreviewScaleMultiplier(multiplier: number) {
-    this.previewRenderer.setPreviewScaleMultiplier(multiplier, PREVIEW_SCALE_FACTOR);
+    this.previewRenderer.setPreviewScaleMultiplier(multiplier);
   }
 
   /** Enable/disable all profiling (per-node draw timing + frame stats). */
@@ -1446,7 +1433,7 @@ export class FBORenderer {
   }
 
   private renderNodeToMainOutput(node: FBONode): void {
-    const [renderWidth, renderHeight] = this.outputSize;
+    const [backgroundWidth, backgroundHeight] = this.backgroundSize;
 
     if (!this.isOutputEnabled) {
       return;
@@ -1458,13 +1445,16 @@ export class FBORenderer {
     }
 
     const gl = this.regl._gl as WebGL2RenderingContext;
+
     let framebuffer: regl.Framebuffer2D | null = null;
 
-    let sourceWidth = renderWidth;
-    let sourceHeight = renderHeight;
+    // Source size comes from the node's FBO (not the background)
+    let sourceWidth = node.texture.width;
+    let sourceHeight = node.texture.height;
 
     if (this.videoTextures.has(node.id)) {
       const tex = this.videoTextures.getDestinationTexture(node.id)!;
+
       // Use cached FBO instead of creating new one every frame (fixes massive leak)
       framebuffer = this.videoTextures.getDestinationFBO(node.id) || null;
       sourceWidth = tex.width;
@@ -1477,22 +1467,48 @@ export class FBORenderer {
       return;
     }
 
-    gl.viewport(0, 0, renderWidth, renderHeight);
+    gl.viewport(0, 0, backgroundWidth, backgroundHeight);
     gl.bindFramebuffer(gl.READ_FRAMEBUFFER, getFramebuffer(framebuffer));
     gl.readBuffer(gl.COLOR_ATTACHMENT0 + this.outputOutletIndex);
     gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
 
+    // Cover-mode blit: crop the source to match the background's aspect ratio,
+    // so the output fills the screen without stretching (spec 128).
+    const sourceAspect = sourceWidth / sourceHeight;
+    const backgroundAspect = backgroundWidth / backgroundHeight;
+
+    let sourceX0 = 0;
+    let sourceY0 = 0;
+    let sourceX1 = sourceWidth;
+    let sourceY1 = sourceHeight;
+
+    if (sourceAspect > backgroundAspect) {
+      // Source is wider — crop sides
+      const cropWidth = sourceHeight * backgroundAspect;
+      const offset = (sourceWidth - cropWidth) / 2;
+
+      sourceX0 = Math.floor(offset);
+      sourceX1 = Math.floor(offset + cropWidth);
+    } else if (sourceAspect < backgroundAspect) {
+      // Source is taller — crop top/bottom
+      const cropHeight = sourceWidth / backgroundAspect;
+      const offset = (sourceHeight - cropHeight) / 2;
+
+      sourceY0 = Math.floor(offset);
+      sourceY1 = Math.floor(offset + cropHeight);
+    }
+
     gl.blitFramebuffer(
+      sourceX0,
+      sourceY0,
+      sourceX1,
+      sourceY1,
       0,
       0,
-      sourceWidth,
-      sourceHeight,
-      0,
-      0,
-      renderWidth,
-      renderHeight,
+      backgroundWidth,
+      backgroundHeight,
       gl.COLOR_BUFFER_BIT,
-      gl.NEAREST
+      gl.LINEAR
     );
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
@@ -1570,37 +1586,15 @@ export class FBORenderer {
     return textureMap;
   }
 
-  async setPreviewSize(width: number, height: number) {
-    this.pixelReadbackService.setPreviewSize(width, height);
-
-    await this.buildFBOs(this.renderGraph!);
-  }
-
-  setOutputSize(width: number, height: number) {
-    this.outputSize = [width, height] as [w: number, h: number];
-
-    // Update all hydra renderers to match the new output size
-    for (const hydra of this.hydraByNode.values()) {
-      hydra?.hydra?.setResolution(width, height);
-    }
-
+  /**
+   * Set the background display size (viewport dimensions).
+   * Only resizes the offscreen canvas used for final output blit.
+   * Does NOT affect FBO sizes or node preview sizes.
+   */
+  setBackgroundSize(width: number, height: number) {
+    this.backgroundSize = [width, height] as [number, number];
     this.offscreenCanvas.width = width;
     this.offscreenCanvas.height = height;
-
-    // Update pixel readback service's output size reference
-    this.pixelReadbackService.setOutputSize(this.outputSize);
-
-    // Update projection map render targets to match the new output size
-    for (const projmap of this.projmapByNode.values()) {
-      projmap?.resizeOutput(width, height);
-    }
-
-    // Rebuild FBOs at the new output dimensions so GLSL shaders render into
-    // correctly-sized framebuffers (old FBOs would leave stale pixels in the
-    // expanded area after a resize).
-    if (this.renderGraph) {
-      this.buildFBOs(this.renderGraph);
-    }
   }
 
   /**
@@ -1810,6 +1804,13 @@ export class FBORenderer {
    * This is a synchronous capture for on-demand use (export, Gemini, etc.)
    */
   capturePreviewBitmap(nodeId: string, customSize?: [number, number]): ImageBitmap | null {
+    const fboNode = this.fboNodes.get(nodeId);
+    const defaultPreview: [number, number] = [
+      Math.floor(DEFAULT_OUTPUT_SIZE[0] / PREVIEW_SCALE_FACTOR),
+      Math.floor(DEFAULT_OUTPUT_SIZE[1] / PREVIEW_SCALE_FACTOR)
+    ];
+    const fallbackSize = customSize ?? fboNode?.previewSize ?? defaultPreview;
+
     const externalTexture = this.videoTextures.getDestinationTexture(nodeId);
 
     if (externalTexture) {
@@ -1821,21 +1822,20 @@ export class FBORenderer {
           sourceFbo,
           externalTexture.width,
           externalTexture.height,
-          customSize
+          fallbackSize
         );
 
         return bitmap;
       }
     }
 
-    const fboNode = this.fboNodes.get(nodeId);
     if (!fboNode) return null;
 
     return this.captureRenderer.capturePreviewBitmapSync(
       fboNode.framebuffer,
       fboNode.texture.width,
       fboNode.texture.height,
-      customSize
+      fallbackSize
     );
   }
 

--- a/ui/src/workers/rendering/renderWorker.ts
+++ b/ui/src/workers/rendering/renderWorker.ts
@@ -45,8 +45,7 @@ self.onmessage = (event) => {
     .with('setMouseData', () =>
       fboRenderer.setMouseData(data.nodeId, data.x, data.y, data.z, data.w)
     )
-    .with('setPreviewSize', () => fboRenderer.setPreviewSize(data.width, data.height))
-    .with('setOutputSize', () => fboRenderer.setOutputSize(data.width, data.height))
+    .with('setBackgroundSize', () => fboRenderer.setBackgroundSize(data.width, data.height))
     .with('setBitmap', () => fboRenderer.setBitmap(data.nodeId, data.bitmap))
     .with('removeBitmap', () => fboRenderer.removeBitmap(data.nodeId))
     .with('removeUniformData', () => fboRenderer.removeUniformData(data.nodeId))


### PR DESCRIPTION
## Summary

- **Decouple node preview size from background output size** (spec 128). Previously, sending a node to background called `setOutputSize(window.innerWidth, window.innerHeight)` which changed every node's FBO and preview dimensions — breaking patch layouts on different screen sizes.
- **Preview size is now per-node**, derived from each node's FBO resolution (`@resolution` / `setResolution()` or `DEFAULT_OUTPUT_SIZE`) divided by `PREVIEW_SCALE_FACTOR`. Background resizing no longer affects node previews or FBOs.
- **Cover-mode background blit** — when the source FBO aspect ratio differs from the viewport, the output is center-cropped instead of stretched. No more squished spheres.
- Removes global `previewSize` from `GLSystem` and `PixelReadbackService`, adds `setBackgroundSize()` (replaces `setOutputSize()` for background canvas), migrates canvas node sharper preview hack into per-node preview sizes.

## Test plan

- [ ] Create a GLSL node with `// @resolution 256` — preview should be square (64×64)
- [ ] Create a default GLSL node — preview should be 252×164 (unchanged from before)
- [ ] Send a node to background — should fill screen without stretching (cover mode)
- [ ] Resize browser window with background active — previews stay the same size
- [ ] Test on portrait-oriented window — background crops top/bottom, sphere stays circular
- [ ] Verify canvas/textmode nodes have sharper previews (output/2 scale)
- [ ] Verify LOD tier scaling still works (many nodes → smaller previews)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Previews now compute sizes per-node based on shader/video resolution and a new default preview size.
  * Added a background-size API to control the main canvas independently of previews.

* **Changes**
  * Background canvas resizing separated from preview management for smoother responsiveness.
  * Final output blits use aspect-cover cropping and smoother scaling for better visual quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->