### PR TITLE
feat(renderer): make default output size configurable

### DIFF
--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -28,8 +28,12 @@ import {
   type AudioAnalysisPayloadWithType,
   type OnFFTReadyCallback
 } from '$lib/audio/AudioAnalysisSystem';
-import { DEFAULT_OUTPUT_SIZE, DEFAULT_PREVIEW_SIZE } from './constants';
+import { DEFAULT_OUTPUT_SIZE, DEFAULT_PREVIEW_SIZE, PREVIEW_SCALE_FACTOR } from './constants';
 import { logger } from '$lib/utils/logger';
+import {
+  outputSize as outputSizeStore,
+  previewSize as previewSizeStore
+} from '../../stores/renderer.store';
 import { match, P } from 'ts-pattern';
 import { profiler, ProfilerCoordinator, typeFromNodeId } from '$lib/profiler';
 import { VirtualFilesystem, isVFSPath } from '$lib/vfs';
@@ -828,6 +832,11 @@ export class GLSystem {
    */
   setOutputSize(width: number, height: number) {
     this.outputSize = [width, height];
+    outputSizeStore.set([width, height]);
+    previewSizeStore.set([
+      Math.round(width / PREVIEW_SCALE_FACTOR),
+      Math.round(height / PREVIEW_SCALE_FACTOR)
+    ]);
     this.send('setOutputSize', { width, height });
   }
 

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -831,13 +831,20 @@ export class GLSystem {
    * Also updates the default preview size proportionally.
    */
   setOutputSize(width: number, height: number) {
-    this.outputSize = [width, height];
-    outputSizeStore.set([width, height]);
+    const outputWidth = Math.max(1, Math.min(8192, Math.round(width)));
+    const outputHeight = Math.max(1, Math.min(8192, Math.round(height)));
+
+    if (!Number.isFinite(outputWidth) || !Number.isFinite(outputHeight)) return;
+
+    this.outputSize = [outputWidth, outputHeight];
+    outputSizeStore.set([outputWidth, outputHeight]);
+
     previewSizeStore.set([
-      Math.round(width / PREVIEW_SCALE_FACTOR),
-      Math.round(height / PREVIEW_SCALE_FACTOR)
+      Math.round(outputWidth / PREVIEW_SCALE_FACTOR),
+      Math.round(outputHeight / PREVIEW_SCALE_FACTOR)
     ]);
-    this.send('setOutputSize', { width, height });
+
+    this.send('setOutputSize', { width: outputWidth, height: outputHeight });
   }
 
   /**

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -822,6 +822,16 @@ export class GLSystem {
   }
 
   /**
+   * Set the output (FBO) resolution for the patch.
+   * Affects all node FBOs (unless they have per-node @resolution overrides).
+   * Also updates the default preview size proportionally.
+   */
+  setOutputSize(width: number, height: number) {
+    this.outputSize = [width, height];
+    this.send('setOutputSize', { width, height });
+  }
+
+  /**
    * Set the background display size (viewport dimensions).
    * Only affects the background canvas blit target, not FBOs or node previews.
    */

--- a/ui/src/lib/components/CanvasPreviewLayout.svelte
+++ b/ui/src/lib/components/CanvasPreviewLayout.svelte
@@ -25,6 +25,7 @@
     width,
     height,
     style = '',
+    pixelated = false,
 
     topHandle,
     bottomHandle,
@@ -60,6 +61,7 @@
     width?: string | number;
     height?: string | number;
     style?: string;
+    pixelated?: boolean;
 
     topHandle?: Snippet;
     bottomHandle?: Snippet;
@@ -128,8 +130,8 @@
       width={typeof width === 'number' ? width : undefined}
       height={typeof height === 'number' ? height : undefined}
       style={typeof width === 'number' && typeof height === 'number'
-        ? `width:${width}px;height:${height}px;image-rendering:pixelated;${style}`
-        : `image-rendering:pixelated;${style}`}
+        ? `width:${width}px;height:${height}px;${pixelated ? 'image-rendering:pixelated;' : ''}${style}`
+        : `${pixelated ? 'image-rendering:pixelated;' : ''}${style}`}
     ></canvas>
   {/snippet}
 </ObjectPreviewLayout>

--- a/ui/src/lib/components/CanvasPreviewLayout.svelte
+++ b/ui/src/lib/components/CanvasPreviewLayout.svelte
@@ -128,8 +128,8 @@
       width={typeof width === 'number' ? width : undefined}
       height={typeof height === 'number' ? height : undefined}
       style={typeof width === 'number' && typeof height === 'number'
-        ? `width:${width}px;height:${height}px;${style}`
-        : style}
+        ? `width:${width}px;height:${height}px;image-rendering:pixelated;${style}`
+        : `image-rendering:pixelated;${style}`}
     ></canvas>
   {/snippet}
 </ObjectPreviewLayout>

--- a/ui/src/lib/components/CommandPalette.svelte
+++ b/ui/src/lib/components/CommandPalette.svelte
@@ -16,6 +16,7 @@
   } from '../../stores/ui.store';
   import { savePatchToLocalStorage, getUniquePatchName } from '$lib/save-load/save-local-storage';
   import { toast } from 'svelte-sonner';
+  import { GLSystem } from '$lib/canvas/GLSystem';
   import { useWebCodecs, toggleWebCodecs, toggleVideoStats } from '../../stores/video.store';
   import { renderFpsCap, FPS_CAP_OPTIONS } from '../../stores/renderer.store';
   import type { Node, Edge } from '@xyflow/svelte';
@@ -93,6 +94,7 @@
     | 'rename-list'
     | 'rename-name'
     | 'set-room'
+    | 'set-output-size'
     | 'offline-download';
 
   // Multi-stage state
@@ -102,6 +104,7 @@
   let savedPatches = $state<string[]>([]);
   let selectedPatchToRename = $state('');
   let roomName = $state('');
+  let outputSizeInput = $state('');
   let offlineProgress = $state<OfflineDownloadProgress>({
     current: 0,
     total: 0,
@@ -210,6 +213,11 @@
       description: 'Set a custom room ID for P2P communication between patches'
     },
     {
+      id: 'set-output-size',
+      name: 'Set Output Size',
+      description: 'Set the render resolution for this patch (e.g. 1920x1080)'
+    },
+    {
       id: 'generate-prompt',
       name: 'Patch to App',
       description: 'Generate an app from your patch or export as a specification',
@@ -307,7 +315,8 @@
       stage === 'rename-list' ||
       stage === 'rename-name' ||
       stage === 'commands' ||
-      stage === 'set-room'
+      stage === 'set-room' ||
+      stage === 'set-output-size'
     ) {
       setTimeout(() => {
         searchInput?.focus();
@@ -380,6 +389,8 @@
       renamePatch();
     } else if (stage === 'set-room' && roomName.trim()) {
       setRoom();
+    } else if (stage === 'set-output-size' && outputSizeInput.trim()) {
+      applyOutputSize();
     }
   }
 
@@ -532,6 +543,12 @@
       .with('set-room', () => {
         roomName = getSearchParam('room') || '';
         nextStage('set-room');
+      })
+      .with('set-output-size', () => {
+        const glSystem = GLSystem.getInstance();
+        const [w, h] = glSystem.outputSize;
+        outputSizeInput = `${w}x${h}`;
+        nextStage('set-output-size');
       })
       .with('prepare-offline', () => {
         nextStage('offline-download');
@@ -709,6 +726,28 @@
     }
   }
 
+  function applyOutputSize() {
+    const input = outputSizeInput.trim();
+    const match = input.match(/^(\d+)\s*[x×,]\s*(\d+)$/i);
+
+    if (!match) {
+      toast.error('Invalid format. Use WIDTHxHEIGHT (e.g. 1920x1080)');
+      return;
+    }
+
+    const width = Number(match[1]);
+    const height = Number(match[2]);
+
+    if (width < 1 || height < 1 || width > 8192 || height > 8192) {
+      toast.error('Size must be between 1 and 8192');
+      return;
+    }
+
+    GLSystem.getInstance().setOutputSize(width, height);
+    toast.success(`Output size set to ${width}×${height}`);
+    onCancel();
+  }
+
   function setRoom() {
     if (!roomName.trim()) {
       onCancel();
@@ -868,6 +907,18 @@
         class="w-full bg-transparent text-sm text-zinc-100 placeholder-zinc-400 outline-none"
       />
     </div>
+  {:else if stage === 'set-output-size'}
+    <div class="border-b border-zinc-700 p-3">
+      <div class="mb-2 text-xs text-zinc-400">Enter output resolution (WIDTHxHEIGHT):</div>
+      <input
+        bind:this={searchInput}
+        bind:value={outputSizeInput}
+        onkeydown={handleKeydown}
+        type="text"
+        placeholder="e.g. 1920x1080"
+        class="w-full bg-transparent font-mono text-sm text-zinc-100 placeholder-zinc-400 outline-none"
+      />
+    </div>
   {:else if stage === 'set-room'}
     <div class="border-b border-zinc-700 p-3">
       <div class="mb-2 text-xs text-zinc-400">Enter room ID for netsend/netrecv:</div>
@@ -949,6 +1000,16 @@
           >"
         </div>
       {/if}
+    {:else if stage === 'set-output-size'}
+      <div class="px-3 py-2 text-xs text-zinc-400">
+        {#if outputSizeInput.trim().match(/^(\d+)\s*[x×,]\s*(\d+)$/i)}
+          Output: <span class="font-mono text-green-300">{outputSizeInput.trim()}</span>
+        {:else if outputSizeInput.trim()}
+          <span class="text-red-400">Invalid format — use WIDTHxHEIGHT</span>
+        {:else}
+          Enter a resolution like 1920x1080, 1280x720, or 512x512
+        {/if}
+      </div>
     {:else if stage === 'set-room'}
       <!-- Show room info -->
       <div class="px-3 py-2 text-xs text-zinc-400">
@@ -1006,6 +1067,8 @@
       Enter Rename • Esc Back
     {:else if stage === 'set-room'}
       Enter Set Room • Esc Back
+    {:else if stage === 'set-output-size'}
+      Enter Apply • Esc Back
     {:else if stage === 'offline-download'}
       {#if offlineProgress.status === 'complete' || offlineProgress.status === 'error'}
         Esc Close

--- a/ui/src/lib/components/nodes/ButterchurnNode.svelte
+++ b/ui/src/lib/components/nodes/ButterchurnNode.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { useSvelteFlow } from '@xyflow/svelte';
   import { onMount, onDestroy } from 'svelte';
+  import { outputSize, previewSize } from '../../../stores/renderer.store';
 
   let butterchurn;
   let butterchurnPresets;
@@ -63,11 +64,12 @@
     presets = butterchurnPresets.getPresets();
 
     if (canvasElement) {
-      const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
+      const [previewWidth, previewHeight] = $previewSize;
+
       canvasElement.width = previewWidth;
       canvasElement.height = previewHeight;
 
-      const [outputWidth, outputHeight] = glSystem.outputSize;
+      const [outputWidth, outputHeight] = $outputSize;
 
       visualizer = butterchurn.createVisualizer(audioService.getAudioContext(), canvasElement, {
         width: outputWidth / 2,

--- a/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
+++ b/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
@@ -8,6 +8,7 @@
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { messages } from '$lib/objects/schemas/common';
   import { GLSystem, type UserUniformValue } from '$lib/canvas/GLSystem';
+  import { outputSize, previewWidth, previewHeight } from '../../../stores/renderer.store';
   import { toGLValue } from '$workers/rendering/glUniformUtils';
   import { CanvasMouseHandler } from '$lib/canvas/CanvasMouseHandler';
   import {
@@ -52,9 +53,6 @@
   let eventBus = PatchiesEventBus.getInstance();
   let glSystem = GLSystem.getInstance();
   let mouseHandler: CanvasMouseHandler | null = null;
-
-  // Preview canvas display size — always uses default, independent of @resolution
-  const [width, height] = GLSystem.defaultPreviewSize;
 
   let previewCanvas = $state<HTMLCanvasElement | undefined>();
   let previewBitmapContext: ImageBitmapRenderingContext;
@@ -259,7 +257,7 @@
   $effect(() => {
     if (!previewCanvas || !usesMouseUniform) return;
 
-    const [outputWidth, outputHeight] = glSystem.outputSize;
+    const [outputWidth, outputHeight] = $outputSize;
 
     mouseHandler = new CanvasMouseHandler({
       type: 'shadertoy',
@@ -336,8 +334,8 @@
   showPauseButton={true}
   nodrag={usesMouseUniform}
   bind:previewCanvas
-  {width}
-  {height}
+  width={$previewWidth}
+  height={$previewHeight}
   {selected}
   {editorReady}
   hasError={errorLines !== undefined && errorLines.length > 0}

--- a/ui/src/lib/components/nodes/HydraNode.svelte
+++ b/ui/src/lib/components/nodes/HydraNode.svelte
@@ -3,6 +3,7 @@
   import { onMount, onDestroy } from 'svelte';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
   import { MessageContext } from '$lib/messages/MessageContext';
+  import { outputSize, previewSize } from '../../../stores/renderer.store';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { match } from 'ts-pattern';
@@ -65,6 +66,18 @@
   let consoleRef: VirtualConsole | null = $state(null);
   let lineErrors: Record<number, string[]> | undefined = $state(undefined);
   let previousExecuteCode = $state<number | undefined>(undefined);
+
+  // Reactively update preview canvas dimensions when output size changes
+  $effect(() => {
+    if (!previewCanvas) return;
+
+    const [previewWidth, previewHeight] = $previewSize;
+
+    previewCanvas.width = previewWidth;
+    previewCanvas.height = previewHeight;
+    previewCanvas.style.width = `${previewWidth}px`;
+    previewCanvas.style.height = `${previewHeight}px`;
+  });
 
   const code = $derived(data.code || '');
   const errorLines = $derived(
@@ -173,13 +186,6 @@
 
     if (previewCanvas) {
       previewBitmapContext = previewCanvas.getContext('bitmaprenderer')!;
-
-      const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
-
-      previewCanvas.width = previewWidth;
-      previewCanvas.height = previewHeight;
-      previewCanvas.style.width = `${previewWidth}px`;
-      previewCanvas.style.height = `${previewHeight}px`;
     }
 
     glSystem.previewCanvasContexts[nodeId] = previewBitmapContext;
@@ -257,7 +263,7 @@
   $effect(() => {
     if (!usesMouseVariable || !previewCanvas || !glSystem) return;
 
-    const [outputWidth, outputHeight] = glSystem.outputSize;
+    const [outputWidth, outputHeight] = $outputSize;
 
     mouseHandler = new CanvasMouseHandler({
       type: 'simple',

--- a/ui/src/lib/components/nodes/ImageNode.svelte
+++ b/ui/src/lib/components/nodes/ImageNode.svelte
@@ -4,6 +4,12 @@
   import { onMount, onDestroy } from 'svelte';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import { GLSystem } from '$lib/canvas/GLSystem';
+  import {
+    outputWidth,
+    outputHeight,
+    previewWidth,
+    previewHeight
+  } from '../../../stores/renderer.store';
   import { MessageContext } from '$lib/messages/MessageContext';
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { match, P } from 'ts-pattern';
@@ -33,9 +39,6 @@
   let glSystem = GLSystem.getInstance();
   let canvasElement: HTMLCanvasElement | null = $state(null);
   let hasImage = $state(false);
-
-  const [defaultPreviewWidth, defaultPreviewHeight] = GLSystem.defaultPreviewSize;
-  const [defaultOutputWidth, defaultOutputHeight] = glSystem.outputSize;
 
   // Use VFS media composable for all file handling
   const vfsMedia = useVfsMedia({
@@ -182,11 +185,11 @@
           {#if vfsMedia.hasVfsPath && hasImage}
             <canvas
               bind:this={canvasElement}
-              width={node.data.width ?? defaultOutputWidth}
-              height={node.data.height ?? defaultOutputHeight}
+              width={node.data.width ?? $outputWidth}
+              height={node.data.height ?? $outputHeight}
               class="rounded-md {vfsMedia.isDragging ? 'ring-2 ring-blue-400' : ''}"
-              style="width: {node.width ?? defaultPreviewWidth}px; height: {node.height ??
-                defaultPreviewHeight}px"
+              style="width: {node.width ?? $previewWidth}px; height: {node.height ??
+                $previewHeight}px"
               ondragover={vfsMedia.handleDragOver}
               ondragleave={vfsMedia.handleDragLeave}
               ondrop={vfsMedia.handleDrop}
@@ -197,8 +200,8 @@
               needsFolderRelink={vfsMedia.needsFolderRelink}
               linkedFolderName={vfsMedia.linkedFolderName}
               vfsPath={node.data.vfsPath}
-              width={node.width ?? defaultPreviewWidth}
-              height={node.height ?? defaultPreviewHeight}
+              width={node.width ?? $previewWidth}
+              height={node.height ?? $previewHeight}
               isDragging={vfsMedia.isDragging}
               onRequestPermission={vfsMedia.requestFilePermission}
               onDragOver={vfsMedia.handleDragOver}
@@ -208,8 +211,8 @@
           {:else if vfsMedia.isLoading}
             <div
               class="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-zinc-600 bg-zinc-900 px-1 py-3"
-              style="width: {node.width ?? defaultPreviewWidth}px; height: {node.height ??
-                defaultPreviewHeight}px"
+              style="width: {node.width ?? $previewWidth}px; height: {node.height ??
+                $previewHeight}px"
             >
               <div
                 class="h-4 w-4 animate-spin rounded-full border-2 border-zinc-400 border-t-transparent"
@@ -220,8 +223,8 @@
             <VfsDropZone
               icon={ImageIcon}
               fileType="image"
-              width={node.width ?? defaultPreviewWidth}
-              height={node.height ?? defaultPreviewHeight}
+              width={node.width ?? $previewWidth}
+              height={node.height ?? $previewHeight}
               isDragging={vfsMedia.isDragging}
               onDoubleClick={vfsMedia.openFileDialog}
               onDragOver={vfsMedia.handleDragOver}

--- a/ui/src/lib/components/nodes/JSCanvasNode.svelte
+++ b/ui/src/lib/components/nodes/JSCanvasNode.svelte
@@ -3,6 +3,12 @@
   import { onMount, onDestroy } from 'svelte';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
   import { MessageContext } from '$lib/messages/MessageContext';
+  import {
+    outputWidth,
+    outputHeight,
+    previewWidth,
+    previewHeight
+  } from '../../../stores/renderer.store';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import CanvasPreviewLayout from '$lib/components/CanvasPreviewLayout.svelte';
@@ -84,9 +90,6 @@
 
   const { updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
-
-  const [outputWidth, outputHeight] = glSystem.outputSize;
-  const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
 
   let inletCount = $derived(data.inletCount ?? 1);
   let outletCount = $derived(data.outletCount ?? 0);
@@ -279,9 +282,9 @@
   nodrag={!dragEnabled}
   nopan={!panEnabled}
   nowheel={!wheelEnabled}
-  width={outputWidth}
-  height={outputHeight}
-  style={`width: ${previewWidth}px; height: ${previewHeight}px;`}
+  width={$outputWidth}
+  height={$outputHeight}
+  style={`width: ${$previewWidth}px; height: ${$previewHeight}px;`}
   {selected}
   {editorReady}
   hasError={lineErrors !== undefined}

--- a/ui/src/lib/components/nodes/ReglNode.svelte
+++ b/ui/src/lib/components/nodes/ReglNode.svelte
@@ -3,6 +3,12 @@
   import { onMount, onDestroy } from 'svelte';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
   import { MessageContext } from '$lib/messages/MessageContext';
+  import {
+    outputWidth,
+    outputHeight,
+    previewWidth,
+    previewHeight
+  } from '../../../stores/renderer.store';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import CanvasPreviewLayout from '$lib/components/CanvasPreviewLayout.svelte';
@@ -83,9 +89,6 @@
 
   const { updateNodeData, getEdges, deleteElements } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
-
-  const [outputWidth, outputHeight] = glSystem.outputSize;
-  const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
 
   let messageInletCount = $derived(data.messageInletCount ?? 1);
   let messageOutletCount = $derived(data.messageOutletCount ?? 0);
@@ -285,9 +288,9 @@
   nodrag={!dragEnabled}
   nopan={!panEnabled}
   nowheel={!wheelEnabled}
-  width={outputWidth}
-  height={outputHeight}
-  style={`width: ${previewWidth}px; height: ${previewHeight}px;`}
+  width={$outputWidth}
+  height={$outputHeight}
+  style={`width: ${$previewWidth}px; height: ${$previewHeight}px;`}
   {selected}
   {editorReady}
   hasError={lineErrors !== undefined}

--- a/ui/src/lib/components/nodes/ScreenCaptureNode.svelte
+++ b/ui/src/lib/components/nodes/ScreenCaptureNode.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { Monitor, Square } from '@lucide/svelte/icons';
   import { onMount, onDestroy } from 'svelte';
+  import { get } from 'svelte/store';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import { screenSchema } from '$lib/objects/schemas/screen';
   import { GLSystem } from '$lib/canvas/GLSystem';
+  import { outputWidth, outputHeight } from '../../../stores/renderer.store';
   import { MessageContext } from '$lib/messages/MessageContext';
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { match } from 'ts-pattern';
@@ -22,8 +24,6 @@
   let resizerCanvas: OffscreenCanvas | null = null;
   let resizerCtx: OffscreenCanvasRenderingContext2D | null = null;
 
-  const [MAX_UPLOAD_WIDTH, MAX_UPLOAD_HEIGHT] = glSystem.outputSize;
-
   const handleMessage: MessageCallbackFn = (message) => {
     match(message)
       .with(messages.bang, () => startCapture())
@@ -39,7 +39,9 @@
 
       if (videoElement) {
         videoElement.srcObject = stream;
+
         await videoElement.play();
+
         isCapturing = true;
         errorMessage = null;
 
@@ -77,9 +79,12 @@
       const videoHeight = videoElement.videoHeight;
 
       // Check if we need to resize (if video is larger than our max dimensions)
-      if (videoWidth > MAX_UPLOAD_WIDTH || videoHeight > MAX_UPLOAD_HEIGHT) {
+      const maxOutputWidth = get(outputWidth);
+      const maxOutputHeight = get(outputHeight);
+
+      if (videoWidth > maxOutputWidth || videoHeight > maxOutputHeight) {
         // Calculate scale to fit within max dimensions while preserving aspect ratio
-        const scale = Math.min(MAX_UPLOAD_WIDTH / videoWidth, MAX_UPLOAD_HEIGHT / videoHeight);
+        const scale = Math.min(maxOutputWidth / videoWidth, maxOutputHeight / videoHeight);
         const scaledWidth = Math.round(videoWidth * scale);
         const scaledHeight = Math.round(videoHeight * scale);
 

--- a/ui/src/lib/components/nodes/SwissGLNode.svelte
+++ b/ui/src/lib/components/nodes/SwissGLNode.svelte
@@ -9,6 +9,7 @@
   import { removeExcessVideoOutletEdges } from './outlet-edges';
   import { messages } from '$lib/objects/schemas/common';
   import { GLSystem } from '$lib/canvas/GLSystem';
+  import { previewSize } from '../../../stores/renderer.store';
   import CanvasPreviewLayout from '$lib/components/CanvasPreviewLayout.svelte';
   import { SettingsManager } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
@@ -63,6 +64,18 @@
   let lineErrors = $state<Record<number, string[]> | undefined>(undefined);
 
   const code = $derived(data.code || '');
+
+  // Reactively update preview canvas dimensions when output size changes
+  $effect(() => {
+    if (!previewCanvas) return;
+
+    const [previewWidth, previewHeight] = $previewSize;
+
+    previewCanvas.width = previewWidth;
+    previewCanvas.height = previewHeight;
+    previewCanvas.style.width = `${previewWidth}px`;
+    previewCanvas.style.height = `${previewHeight}px`;
+  });
 
   let videoInletCount = $derived(data.videoInletCount ?? 0);
   let videoOutletCount = $derived(data.videoOutletCount ?? 1);
@@ -143,12 +156,6 @@
 
     if (previewCanvas) {
       previewBitmapContext = previewCanvas.getContext('bitmaprenderer')!;
-
-      const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
-      previewCanvas.width = previewWidth;
-      previewCanvas.height = previewHeight;
-      previewCanvas.style.width = `${previewWidth}px`;
-      previewCanvas.style.height = `${previewHeight}px`;
     }
 
     glSystem.previewCanvasContexts[nodeId] = previewBitmapContext;

--- a/ui/src/lib/components/nodes/TextmodeNode.svelte
+++ b/ui/src/lib/components/nodes/TextmodeNode.svelte
@@ -3,6 +3,12 @@
   import { onMount, onDestroy } from 'svelte';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
   import { MessageContext } from '$lib/messages/MessageContext';
+  import {
+    outputWidth,
+    outputHeight,
+    previewWidth,
+    previewHeight
+  } from '../../../stores/renderer.store';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import CanvasPreviewLayout from '$lib/components/CanvasPreviewLayout.svelte';
@@ -83,9 +89,6 @@
 
   const { updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
-
-  const [outputWidth, outputHeight] = glSystem.outputSize;
-  const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
 
   let inletCount = $derived(data.inletCount ?? 1);
   let outletCount = $derived(data.outletCount ?? 0);
@@ -272,9 +275,9 @@
   nodrag={!dragEnabled}
   nopan={!panEnabled}
   nowheel={!wheelEnabled}
-  width={outputWidth}
-  height={outputHeight}
-  style={`width: ${previewWidth}px; height: ${previewHeight}px;`}
+  width={$outputWidth}
+  height={$outputHeight}
+  style={`width: ${$previewWidth}px; height: ${$previewHeight}px;`}
   {selected}
   {editorReady}
   hasError={lineErrors !== undefined}

--- a/ui/src/lib/components/nodes/ThreeDom.svelte
+++ b/ui/src/lib/components/nodes/ThreeDom.svelte
@@ -9,6 +9,7 @@
   import { messages } from '$lib/objects/schemas/common';
   import { PREVIEW_SCALE_FACTOR } from '$lib/canvas/constants';
   import { GLSystem } from '$lib/canvas/GLSystem';
+  import { outputSize } from '../../../stores/renderer.store';
   import { shouldShowHandles } from '../../../stores/ui.store';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { createCustomConsole } from '$lib/utils/createCustomConsole';
@@ -82,10 +83,8 @@
     createKVStore(nodeId)
   );
 
-  const [defaultOutputWidth, defaultOutputHeight] = glSystem.outputSize;
-
-  let outputWidth = $state(defaultOutputWidth);
-  let outputHeight = $state(defaultOutputHeight);
+  let outputWidth = $state($outputSize[0]);
+  let outputHeight = $state($outputSize[1]);
 
   let previewWidth = $derived.by(() => outputWidth / PREVIEW_SCALE_FACTOR);
   let previewHeight = $derived.by(() => outputHeight / PREVIEW_SCALE_FACTOR);

--- a/ui/src/lib/components/nodes/ThreeDom.svelte
+++ b/ui/src/lib/components/nodes/ThreeDom.svelte
@@ -82,8 +82,17 @@
     createKVStore(nodeId)
   );
 
+  let hasCustomResolution = false;
   let outputWidth = $state($outputSize[0]);
   let outputHeight = $state($outputSize[1]);
+
+  // Sync from global output size unless node has a custom setResolution() override
+  $effect(() => {
+    if (hasCustomResolution) return;
+
+    outputWidth = $outputSize[0];
+    outputHeight = $outputSize[1];
+  });
 
   let previewWidth = $derived.by(() => outputWidth / PREVIEW_SCALE_FACTOR);
   let previewHeight = $derived.by(() => outputHeight / PREVIEW_SCALE_FACTOR);
@@ -277,6 +286,7 @@
       renderer.setSize(width, height);
     }
 
+    hasCustomResolution = true;
     outputWidth = width;
     outputHeight = height;
   }

--- a/ui/src/lib/components/nodes/ThreeDom.svelte
+++ b/ui/src/lib/components/nodes/ThreeDom.svelte
@@ -72,7 +72,6 @@
 
   // Lazy-loaded Three.js
   let THREE: typeof import('three') | null = null;
-  let threeLoaded = $state(false);
 
   const { updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
@@ -318,7 +317,6 @@
       if (!THREE) {
         THREE = await import('three');
         renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
-        threeLoaded = true;
         customConsole.log('Three.js loaded!');
       }
 

--- a/ui/src/lib/components/nodes/ThreeNode.svelte
+++ b/ui/src/lib/components/nodes/ThreeNode.svelte
@@ -3,6 +3,12 @@
   import { onMount, onDestroy } from 'svelte';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
   import { MessageContext } from '$lib/messages/MessageContext';
+  import {
+    outputWidth,
+    outputHeight,
+    previewWidth,
+    previewHeight
+  } from '../../../stores/renderer.store';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import CanvasPreviewLayout from '$lib/components/CanvasPreviewLayout.svelte';
@@ -85,9 +91,6 @@
 
   const { updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
-
-  const [outputWidth, outputHeight] = glSystem.outputSize;
-  const [previewWidth, previewHeight] = GLSystem.defaultPreviewSize;
 
   let messageInletCount = $derived(data.messageInletCount ?? 1);
   let messageOutletCount = $derived(data.messageOutletCount ?? 0);
@@ -283,9 +286,9 @@
   nodrag={!dragEnabled}
   nopan={!panEnabled}
   nowheel={!wheelEnabled}
-  width={outputWidth}
-  height={outputHeight}
-  style={`width: ${previewWidth}px; height: ${previewHeight}px;`}
+  width={$outputWidth}
+  height={$outputHeight}
+  style={`width: ${$previewWidth}px; height: ${$previewHeight}px;`}
   {selected}
   {editorReady}
   hasError={lineErrors !== undefined}

--- a/ui/src/lib/components/nodes/VdoNinjaPushNode.svelte
+++ b/ui/src/lib/components/nodes/VdoNinjaPushNode.svelte
@@ -7,6 +7,7 @@
   import { MessageContext } from '$lib/messages/MessageContext';
   import { match, P } from 'ts-pattern';
   import { GLSystem } from '$lib/canvas/GLSystem';
+  import { outputSize } from '../../../stores/renderer.store';
   import { AudioService } from '$lib/audio/v2/AudioService';
   import { VdoNinjaPushNode as VdoNinjaPushAudioNode } from '$lib/audio/v2/nodes/VdoNinjaPushNode';
   import { capturePreviewFrame } from '$lib/ai/google';
@@ -111,13 +112,17 @@
 
     // Create video canvas for frame capture
     videoCanvas = document.createElement('canvas');
-    const [width, height] = glSystem.outputSize;
-    videoCanvas.width = width;
-    videoCanvas.height = height;
+
+    const [outputWidth, outputHeight] = $outputSize;
+
+    videoCanvas.width = outputWidth;
+    videoCanvas.height = outputHeight;
+
     videoCtx = videoCanvas.getContext('2d');
 
     // Create audio node for capturing audio from the pipeline
     const node = await audioService.createNode(nodeId, 'vdo.ninja.push');
+
     if (node && node instanceof VdoNinjaPushAudioNode) {
       audioNode = node;
     }
@@ -126,7 +131,7 @@
     try {
       await loadVdoNinjaSdk();
       sdkLoaded = true;
-    } catch (err) {
+    } catch {
       connectionStatus = 'error';
       errorMessage = 'Failed to load VDO.Ninja SDK';
       messageContext.send({ type: 'error', message: errorMessage });
@@ -136,7 +141,9 @@
   onDestroy(() => {
     disconnect();
     stopStreaming();
+
     audioService.removeNodeById(nodeId);
+
     if (messageContext) {
       messageContext.queue.removeCallback(handleMessage);
       messageContext.destroy();

--- a/ui/src/lib/components/nodes/VideoNode.svelte
+++ b/ui/src/lib/components/nodes/VideoNode.svelte
@@ -2,8 +2,15 @@
   import { Loader, OctagonX, Pause, Play, SkipBack, Upload, Video } from '@lucide/svelte/icons';
   import { NodeResizer, useSvelteFlow } from '@xyflow/svelte';
   import { onMount, onDestroy } from 'svelte';
+  import { get } from 'svelte/store';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import { GLSystem } from '$lib/canvas/GLSystem';
+  import {
+    outputWidth,
+    outputHeight,
+    previewWidth,
+    previewHeight
+  } from '../../../stores/renderer.store';
   import { MessageContext } from '$lib/messages/MessageContext';
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { AudioService } from '$lib/audio/v2/AudioService';
@@ -103,9 +110,6 @@
   let videoStats = $state<VideoStats | null>(null);
   let statsIntervalId: ReturnType<typeof setInterval> | null = null;
 
-  const [defaultPreviewWidth, defaultPreviewHeight] = GLSystem.defaultPreviewSize;
-  const [MAX_UPLOAD_WIDTH, MAX_UPLOAD_HEIGHT] = glSystem.outputSize;
-
   // Initialize bitmaprenderer context when canvas is bound
   $effect(() => {
     if (previewCanvas && !previewBitmapContext) {
@@ -174,17 +178,20 @@
           // Scale down for preview while maintaining aspect ratio
           const aspectRatio = videoWidth / videoHeight;
 
-          let previewWidth = defaultPreviewWidth;
-          let previewHeight = defaultPreviewWidth / aspectRatio;
+          const previewWidthValue = get(previewWidth);
+          const previewHeightValue = get(previewHeight);
 
-          if (previewHeight > defaultPreviewHeight) {
-            previewHeight = defaultPreviewHeight;
-            previewWidth = defaultPreviewHeight * aspectRatio;
+          let scaledW = previewWidthValue;
+          let scaledH = previewWidthValue / aspectRatio;
+
+          if (scaledH > previewHeightValue) {
+            scaledH = previewHeightValue;
+            scaledW = previewHeightValue * aspectRatio;
           }
 
           updateNode(nodeId, {
-            width: Math.round(previewWidth),
-            height: Math.round(previewHeight),
+            width: Math.round(scaledW),
+            height: Math.round(scaledH),
             data: {
               ...data,
               fileName: file.name,
@@ -517,9 +524,9 @@
     const videoHeight = videoElement.videoHeight;
 
     // Check if we need to resize (if video is larger than our max dimensions)
-    if (videoWidth > MAX_UPLOAD_WIDTH || videoHeight > MAX_UPLOAD_HEIGHT) {
+    if (videoWidth > $outputWidth || videoHeight > $outputHeight) {
       // Calculate scale to fit within max dimensions while preserving aspect ratio
-      const scale = Math.min(MAX_UPLOAD_WIDTH / videoWidth, MAX_UPLOAD_HEIGHT / videoHeight);
+      const scale = Math.min($outputWidth / videoWidth, $outputHeight / videoHeight);
       const scaledWidth = Math.round(videoWidth * scale);
       const scaledHeight = Math.round(videoHeight * scale);
 
@@ -747,15 +754,15 @@
               <!-- Canvas preview when MediaBunny is active (worker sends frames via bitmaprenderer) -->
               <canvas
                 bind:this={previewCanvas}
-                width={data.width || defaultPreviewWidth}
-                height={data.height || defaultPreviewHeight}
+                width={data.width || $previewWidth}
+                height={data.height || $previewHeight}
                 class="rounded-lg {vfsMedia.hasVfsPath &&
                 isVideoLoaded &&
                 webCodecsFirstFrameReceived
                   ? ''
                   : 'hidden'}"
-                style="width: {nodeWidth || defaultPreviewWidth}px; height: {nodeHeight ||
-                  defaultPreviewHeight}px"
+                style="width: {nodeWidth || $previewWidth}px; height: {nodeHeight ||
+                  $previewHeight}px"
                 ondragover={vfsMedia.handleDragOver}
                 ondragleave={vfsMedia.handleDragLeave}
                 ondrop={vfsMedia.handleDrop}
@@ -769,8 +776,8 @@
                 !webCodecsFirstFrameReceived
                   ? ''
                   : 'hidden'}"
-                style="width: {nodeWidth || defaultPreviewWidth}px; height: {nodeHeight ||
-                  defaultPreviewHeight}px"
+                style="width: {nodeWidth || $previewWidth}px; height: {nodeHeight ||
+                  $previewHeight}px"
                 muted
                 loop={data.loop ?? true}
                 ondragover={vfsMedia.handleDragOver}
@@ -807,8 +814,8 @@
               needsFolderRelink={vfsMedia.needsFolderRelink}
               linkedFolderName={vfsMedia.linkedFolderName}
               vfsPath={data.vfsPath}
-              width={nodeWidth ?? defaultPreviewWidth}
-              height={nodeHeight ?? defaultPreviewHeight}
+              width={nodeWidth ?? $previewWidth}
+              height={nodeHeight ?? $previewHeight}
               isDragging={vfsMedia.isDragging}
               onRequestPermission={vfsMedia.requestFilePermission}
               onDragOver={vfsMedia.handleDragOver}
@@ -821,8 +828,8 @@
 							{vfsMedia.isDragging
                 ? 'border-blue-400 bg-blue-50/10'
                 : 'border-dashed border-zinc-600 bg-zinc-900'}"
-              style="width: {nodeWidth ?? defaultPreviewWidth}px; height: {nodeHeight ??
-                defaultPreviewHeight}px"
+              style="width: {nodeWidth ?? $previewWidth}px; height: {nodeHeight ??
+                $previewHeight}px"
             >
               <svelte:component
                 this={errorMessage ? OctagonX : Loader}
@@ -844,8 +851,8 @@
             <VfsDropZone
               icon={Video}
               fileType="video"
-              width={nodeWidth ?? defaultPreviewWidth}
-              height={nodeHeight ?? defaultPreviewHeight}
+              width={nodeWidth ?? $previewWidth}
+              height={nodeHeight ?? $previewHeight}
               isDragging={vfsMedia.isDragging}
               onDoubleClick={vfsMedia.openFileDialog}
               onDragOver={vfsMedia.handleDragOver}

--- a/ui/src/lib/components/nodes/WebcamNode.svelte
+++ b/ui/src/lib/components/nodes/WebcamNode.svelte
@@ -4,6 +4,12 @@
   import { onMount, onDestroy } from 'svelte';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import { GLSystem } from '$lib/canvas/GLSystem';
+  import {
+    outputWidth,
+    outputHeight,
+    previewWidth,
+    previewHeight
+  } from '../../../stores/renderer.store';
   import { MessageContext } from '$lib/messages/MessageContext';
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { match } from 'ts-pattern';
@@ -85,9 +91,6 @@
   let videoStats = $state<VideoStats | null>(null);
   let statsIntervalId: ReturnType<typeof setInterval> | null = null;
 
-  const [defaultOutputWidth, defaultOutputHeight] = glSystem.outputSize;
-  const [defaultPreviewWidth, defaultPreviewHeight] = GLSystem.defaultPreviewSize;
-
   const handleMessage: MessageCallbackFn = (message) => {
     match(message)
       .with(webcamMessages.bang, () => startCapture())
@@ -102,8 +105,8 @@
     try {
       // Build video constraints with optional deviceId
       const videoConstraints: MediaTrackConstraints = {
-        width: { ideal: data.width ?? defaultOutputWidth },
-        height: { ideal: data.height ?? defaultOutputHeight }
+        width: { ideal: data.width ?? $outputWidth },
+        height: { ideal: data.height ?? $outputHeight }
       };
 
       // Use selected device if specified
@@ -119,8 +122,8 @@
       // Get actual video dimensions from the track
       const videoTrack = stream.getVideoTracks()[0];
       const settings = videoTrack.getSettings();
-      const actualWidth = settings.width ?? defaultOutputWidth;
-      const actualHeight = settings.height ?? defaultOutputHeight;
+      const actualWidth = settings.width ?? $outputWidth;
+      const actualHeight = settings.height ?? $outputHeight;
       const actualFrameRate = settings.frameRate ?? 30;
 
       // Reset profiler
@@ -390,13 +393,9 @@
     return `z-1 ${selected ? '' : 'opacity-40'}`;
   });
 
-  const canvasWidth = $derived(
-    data.width ? data.width / PREVIEW_SCALE_FACTOR : defaultPreviewWidth
-  );
+  const canvasWidth = $derived(data.width ? data.width / PREVIEW_SCALE_FACTOR : $previewWidth);
 
-  const canvasHeight = $derived(
-    data.height ? data.height / PREVIEW_SCALE_FACTOR : defaultPreviewHeight
-  );
+  const canvasHeight = $derived(data.height ? data.height / PREVIEW_SCALE_FACTOR : $previewHeight);
 </script>
 
 <div class="relative flex gap-x-3">
@@ -463,8 +462,8 @@
               muted
               autoplay
               playsinline
-              width={data.width ?? defaultOutputWidth}
-              height={data.height ?? defaultOutputHeight}
+              width={data.width ?? $outputWidth}
+              height={data.height ?? $outputHeight}
               style={`width: ${canvasWidth}px; height: ${canvasHeight}px;`}
             ></video>
 

--- a/ui/src/lib/save-load/serialize-patch.ts
+++ b/ui/src/lib/save-load/serialize-patch.ts
@@ -6,6 +6,7 @@ import type { VFSTree } from '$lib/vfs/types';
 import { VirtualFilesystem } from '$lib/vfs/VirtualFilesystem';
 import { currentPatchId, isCablesVisible } from '../../stores/ui.store';
 import { transportStore } from '../../stores/transport.store';
+import { GLSystem } from '$lib/canvas/GLSystem';
 
 export const PATCH_SAVE_VERSION = String(CURRENT_PATCH_VERSION);
 
@@ -13,6 +14,7 @@ export type PatchSettings = {
   cablesVisible?: boolean;
   bpm?: number;
   timeSignature?: [number, number];
+  outputSize?: [number, number];
 };
 
 export type PatchSaveFormat = {
@@ -45,7 +47,8 @@ export function serializePatch({
   const settings: PatchSettings = {
     cablesVisible: get(isCablesVisible),
     bpm: transport.bpm,
-    timeSignature: transport.timeSignature
+    timeSignature: transport.timeSignature,
+    outputSize: GLSystem.getInstance().outputSize
   };
 
   const patch: PatchSaveFormat = {

--- a/ui/src/lib/services/PatchManager.ts
+++ b/ui/src/lib/services/PatchManager.ts
@@ -298,8 +298,10 @@ export class PatchManager {
     }
 
     // Restore patch settings
+    const glSystem = GLSystem.getInstance();
+
     if (migrated.settings) {
-      const { cablesVisible, bpm, timeSignature } = migrated.settings;
+      const { cablesVisible, bpm, timeSignature, outputSize } = migrated.settings;
 
       if (cablesVisible !== undefined) {
         isCablesVisible.set(cablesVisible);
@@ -315,14 +317,20 @@ export class PatchManager {
         transportStore.setTimeSignature(numerator, denominator);
       }
 
-      const glSystem = GLSystem.getInstance();
-
-      if (migrated.settings.outputSize) {
-        const [w, h] = migrated.settings.outputSize;
-        glSystem.setOutputSize(w, h);
+      if (
+        Array.isArray(outputSize) &&
+        outputSize.length === 2 &&
+        Number.isFinite(outputSize[0]) &&
+        Number.isFinite(outputSize[1]) &&
+        outputSize[0] > 0 &&
+        outputSize[1] > 0
+      ) {
+        glSystem.setOutputSize(outputSize[0], outputSize[1]);
       } else {
         glSystem.setOutputSize(...DEFAULT_OUTPUT_SIZE);
       }
+    } else {
+      glSystem.setOutputSize(...DEFAULT_OUTPUT_SIZE);
     }
 
     // Immediately save migrated patch to autosave so reloads don't break

--- a/ui/src/lib/services/PatchManager.ts
+++ b/ui/src/lib/services/PatchManager.ts
@@ -16,6 +16,8 @@ import {
 import { isBackgroundOutputCanvasEnabled } from '../../stores/canvas.store';
 import { transportStore } from '../../stores/transport.store';
 import { DEFAULT_BPM, DEFAULT_TIME_SIGNATURE } from '$lib/transport/constants';
+import { GLSystem } from '$lib/canvas/GLSystem';
+import { DEFAULT_OUTPUT_SIZE } from '$lib/canvas/constants';
 import { get } from 'svelte/store';
 import type { CanvasContext } from './CanvasContext';
 import { logger } from '$lib/utils/logger';
@@ -312,6 +314,15 @@ export class PatchManager {
 
         transportStore.setTimeSignature(numerator, denominator);
       }
+
+      const glSystem = GLSystem.getInstance();
+
+      if (migrated.settings.outputSize) {
+        const [w, h] = migrated.settings.outputSize;
+        glSystem.setOutputSize(w, h);
+      } else {
+        glSystem.setOutputSize(...DEFAULT_OUTPUT_SIZE);
+      }
     }
 
     // Immediately save migrated patch to autosave so reloads don't break
@@ -353,6 +364,7 @@ export class PatchManager {
     isCablesVisible.set(true);
     transportStore.setBpm(DEFAULT_BPM);
     transportStore.setTimeSignature(DEFAULT_TIME_SIGNATURE[0], DEFAULT_TIME_SIGNATURE[1]);
+    GLSystem.getInstance().setOutputSize(...DEFAULT_OUTPUT_SIZE);
 
     generateNewPatchId();
     deleteSearchParam('id');

--- a/ui/src/stores/renderer.store.ts
+++ b/ui/src/stores/renderer.store.ts
@@ -1,4 +1,5 @@
-import { writable } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
+import { DEFAULT_OUTPUT_SIZE, DEFAULT_PREVIEW_SIZE } from '$lib/canvas/constants';
 
 type NodeId = string;
 
@@ -13,6 +14,17 @@ export const feedbackEdgeIds = writable<Set<string>>(new Set());
 
 /** When true, all node previews are disabled (Shift+P toggle). */
 export const allPreviewsDisabled = writable(false);
+
+/** Output (FBO) resolution for the current patch. Updates via GLSystem.setOutputSize(). */
+export const outputSize = writable<[number, number]>([...DEFAULT_OUTPUT_SIZE]);
+
+/** Preview size for node canvases. Updates when patch output size changes. */
+export const previewSize = writable<[number, number]>(DEFAULT_PREVIEW_SIZE);
+
+export const outputWidth = derived(outputSize, (s) => s[0]);
+export const outputHeight = derived(outputSize, (s) => s[1]);
+export const previewWidth = derived(previewSize, (s) => s[0]);
+export const previewHeight = derived(previewSize, (s) => s[1]);
 
 /** Available FPS cap options. 0 = unlimited (match display refresh rate). */
 export const FPS_CAP_OPTIONS = [0, 30, 60] as const;

--- a/ui/src/workers/rendering/PreviewRenderer.ts
+++ b/ui/src/workers/rendering/PreviewRenderer.ts
@@ -5,7 +5,8 @@ import type { PixelReadbackService } from './PixelReadbackService';
 import {
   DEFAULT_PREVIEW_MAX_FPS_CAP,
   DEFAULT_MAX_PREVIEWS_PER_FRAME_NO_OUTPUT,
-  DEFAULT_MAX_PREVIEWS_PER_FRAME_WITH_OUTPUT
+  DEFAULT_MAX_PREVIEWS_PER_FRAME_WITH_OUTPUT,
+  MIN_PREVIEW_SIZE_FOR_DOWNSCALE
 } from './constants';
 
 interface PendingRead {
@@ -161,17 +162,27 @@ export class PreviewRenderer {
       const fboNode = fboNodes.get(nodeId);
       if (!fboNode) continue;
 
-      // Use the node's own preview size, scaled by LOD multiplier
-      const [pw, ph] = fboNode.previewSize;
-      const previewSize: [number, number] =
-        this.previewScaleMultiplier > 1
-          ? [
-              Math.max(1, Math.floor(pw / this.previewScaleMultiplier)),
-              Math.max(1, Math.floor(ph / this.previewScaleMultiplier))
-            ]
-          : [pw, ph];
+      // Use the node's own preview size, scaled by LOD multiplier.
+      // For low-res nodes where the computed preview would be tiny
+      // (e.g. @resolution 30 → 7px preview), read at FBO native size instead
+      // so the browser can upscale crisply via CSS image-rendering: pixelated.
+      const [previewWidth, previewHeight] = fboNode.previewSize;
       const fboSize: [number, number] = [fboNode.texture.width, fboNode.texture.height];
-      this.initiateAsyncRead(nodeId, fboNode.framebuffer, previewSize, fboSize);
+
+      const useNativeSize =
+        previewWidth < MIN_PREVIEW_SIZE_FOR_DOWNSCALE ||
+        previewHeight < MIN_PREVIEW_SIZE_FOR_DOWNSCALE;
+
+      const readbackSize: [number, number] = useNativeSize
+        ? fboSize
+        : this.previewScaleMultiplier > 1
+          ? [
+              Math.max(1, Math.floor(previewWidth / this.previewScaleMultiplier)),
+              Math.max(1, Math.floor(previewHeight / this.previewScaleMultiplier))
+            ]
+          : [previewWidth, previewHeight];
+
+      this.initiateAsyncRead(nodeId, fboNode.framebuffer, readbackSize, fboSize);
     }
 
     return results;

--- a/ui/src/workers/rendering/constants.ts
+++ b/ui/src/workers/rendering/constants.ts
@@ -8,6 +8,12 @@ export const DEFAULT_MAX_PREVIEWS_PER_FRAME_WITH_OUTPUT = 20;
 export const DEFAULT_MAX_PREVIEWS_PER_FRAME_NO_OUTPUT = 20;
 
 /**
+ * Min preview dimension (px) before switching to native
+ * FBO readback for crisp low-res previews
+ **/
+export const MIN_PREVIEW_SIZE_FOR_DOWNSCALE = 64;
+
+/**
  * Zoom-based preview LOD tiers.
  * Each tier defines a zoom threshold and a scale multiplier applied to the base preview scale factor.
  * Tiers are evaluated top-to-bottom; the first matching threshold is used.

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -1587,6 +1587,24 @@ export class FBORenderer {
   }
 
   /**
+   * Set the output (FBO) resolution for the patch.
+   * Updates all node FBOs and Hydra renderers.
+   */
+  setOutputSize(width: number, height: number) {
+    this.outputSize = [width, height] as [number, number];
+
+    // Update all hydra renderers to match the new output size
+    for (const hydra of this.hydraByNode.values()) {
+      hydra?.hydra?.setResolution(width, height);
+    }
+
+    // Rebuild FBOs at the new output dimensions
+    if (this.renderGraph) {
+      this.buildFBOs(this.renderGraph);
+    }
+  }
+
+  /**
    * Set the background display size (viewport dimensions).
    * Only resizes the offscreen canvas used for final output blit.
    * Does NOT affect FBO sizes or node preview sizes.

--- a/ui/src/workers/rendering/renderWorker.ts
+++ b/ui/src/workers/rendering/renderWorker.ts
@@ -45,6 +45,7 @@ self.onmessage = (event) => {
     .with('setMouseData', () =>
       fboRenderer.setMouseData(data.nodeId, data.x, data.y, data.z, data.w)
     )
+    .with('setOutputSize', () => fboRenderer.setOutputSize(data.width, data.height))
     .with('setBackgroundSize', () => fboRenderer.setBackgroundSize(data.width, data.height))
     .with('setBitmap', () => fboRenderer.setBitmap(data.nodeId, data.bitmap))
     .with('removeBitmap', () => fboRenderer.removeBitmap(data.nodeId))


### PR DESCRIPTION
## Summary

- **Per-patch configurable output size** — stored in `PatchSettings`, saved/restored with patches, reset to default on new patch
- **Command palette "Set Output Size"** — accepts `WIDTHxHEIGHT` format (e.g. 1920x1080), validates 1–8192 range
- **Reactive `outputSize` and `previewSize` stores** — all 13 node components reactively update when output size changes (no stale values)
- **Derived stores** (`$outputWidth`, `$outputHeight`, `$previewWidth`, `$previewHeight`) for clean imports
- **Crisp low-res previews** — nodes with small `@resolution` now read back at FBO native size + CSS `image-rendering: pixelated` for sharp pixel art rendering

## Test plan

- [ ] Open command palette → "Set Output Size" → enter `1920x1080` → verify all node previews resize to 16:9 aspect ratio
- [ ] Save patch, reload → verify output size is restored
- [ ] Create new patch → verify output size resets to default (1008×654)
- [ ] Create a GLSL node with `// @resolution 30` → preview should show crisp pixelated sphere (not blurry)
- [ ] Default resolution GLSL node → preview should look smooth (not pixelated)
- [ ] Enter invalid format (e.g. "abc") → should show error toast
- [ ] Enter out-of-range size (e.g. 99999x99999) → should show error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command palette: set canvas output resolution (WIDTHxHEIGHT) with validation and success/error feedback.
  * Saved patches now remember output resolution.

* **Improvements**
  * Canvas previews can render with crisp pixelated styling.
  * Canvas nodes and previews update reactively when output/preview sizes change.
  * Preview renderer auto-selects optimal readback resolution for very small previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->