### PR TITLE
feat: add settings modal

### DIFF
--- a/ui/src/lib/components/BottomToolbar.svelte
+++ b/ui/src/lib/components/BottomToolbar.svelte
@@ -147,7 +147,7 @@
 
   // Menu item for overflow/drawer menus
   const menuItemClass =
-    'flex items-center gap-3 w-full px-4 py-3 text-left text-sm text-zinc-200 hover:bg-zinc-800 active:bg-zinc-700';
+    'flex cursor-pointer items-center gap-3 w-full px-4 py-3 text-left text-sm text-zinc-200 hover:bg-zinc-800 active:bg-zinc-700';
 
   function handleDelete() {
     const ok = confirm('Delete this element?');

--- a/ui/src/lib/components/BottomToolbar.svelte
+++ b/ui/src/lib/components/BottomToolbar.svelte
@@ -15,7 +15,8 @@
     Trash2,
     Cable,
     ClipboardPaste,
-    Ellipsis
+    Ellipsis,
+    Settings
   } from '@lucide/svelte/icons';
   import type { Node, Edge } from '@xyflow/svelte';
   import { match } from 'ts-pattern';
@@ -23,6 +24,7 @@
     isAiFeaturesVisible,
     isConnectionMode,
     isMobile,
+    isSettingsOpen,
     currentPatchName
   } from '../../stores/ui.store';
   import { aiButtonState } from '../../stores/ai-prompt.store';
@@ -416,6 +418,17 @@
               <button
                 class={menuItemClass}
                 onclick={() => {
+                  overflowOpen = false;
+                  setTimeout(() => isSettingsOpen.set(true), 0);
+                }}
+              >
+                <Settings class="h-5 w-5 text-zinc-400" />
+                <span>Settings</span>
+              </button>
+
+              <button
+                class={menuItemClass}
+                onclick={() => {
                   showStartupModal = true;
                   overflowOpen = false;
                 }}
@@ -527,6 +540,18 @@
               >
                 <FolderOpen class="h-4 w-4 text-zinc-400" />
                 <span>Load Patch</span>
+              </button>
+
+              <button
+                class="flex cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm text-zinc-200 hover:bg-zinc-800"
+                onclick={() => {
+                  overflowOpen = false;
+                  isSettingsOpen.set(true);
+                }}
+              >
+                <Settings class="h-4 w-4 text-zinc-400" />
+                <span>Settings</span>
+                <span class="ml-auto text-xs text-zinc-500">⌘,</span>
               </button>
 
               <button

--- a/ui/src/lib/components/CommandPalette.svelte
+++ b/ui/src/lib/components/CommandPalette.svelte
@@ -203,7 +203,8 @@
     {
       id: 'help-sparks',
       name: 'Getting Started: Sparks',
-      description: 'Open the Sparks tab for AI-generated patch ideas'
+      description: 'Open the Sparks tab for AI-generated patch ideas',
+      requiresAi: true
     },
     {
       id: 'help-shortcuts',

--- a/ui/src/lib/components/CommandPalette.svelte
+++ b/ui/src/lib/components/CommandPalette.svelte
@@ -12,7 +12,8 @@
     currentPatchId,
     currentPatchName as currentPatchNameStore,
     generateNewPatchId,
-    isCablesVisible
+    isCablesVisible,
+    isSettingsOpen
   } from '../../stores/ui.store';
   import { savePatchToLocalStorage, getUniquePatchName } from '$lib/save-load/save-local-storage';
   import { toast } from 'svelte-sonner';
@@ -26,7 +27,13 @@
   import { AudioService } from '$lib/audio/v2/AudioService';
   import type { PatchSaveFormat } from '$lib/save-load/serialize-patch';
   import { createAndCopyShareLink } from '$lib/save-load/share';
-  import { getSearchParam, setSearchParam } from '$lib/utils/search-params';
+
+  import {
+    applyOutputSize as applyOutputSizeAction,
+    applyRoom as applyRoomAction,
+    toggleVimMode,
+    getRoom
+  } from '$lib/utils/settings-actions';
   import { migratePatch } from '$lib/migration';
   import {
     downloadForOffline,
@@ -161,6 +168,11 @@
       id: 'open-output-screen',
       name: 'Open Output Screen',
       description: 'Open a secondary output screen for live performances.'
+    },
+    {
+      id: 'open-settings',
+      name: 'Settings',
+      description: 'Open the settings modal (⌘,)'
     },
     {
       id: 'toggle-sidebar',
@@ -480,6 +492,10 @@
         onCancel();
         onNewPatch?.();
       })
+      .with('open-settings', () => {
+        onCancel();
+        isSettingsOpen.set(true);
+      })
       .with('toggle-sidebar', () => {
         onCancel();
         onToggleSidebar?.();
@@ -489,10 +505,9 @@
         onBrowseObjects?.();
       })
       .with('toggle-vim-mode', () => {
-        const current = localStorage.getItem('editor.vim') === 'true';
-        localStorage.setItem('editor.vim', String(!current));
-
+        toggleVimMode();
         onCancel();
+
         window.location.reload();
       })
       .with('toggle-connect-mode', () => {
@@ -500,11 +515,13 @@
           // Exit connection mode - clear all connection state
           isConnectionMode.set(false);
           isConnecting.set(false);
+
           connectingFromHandleId.set(null);
         } else {
           // Enter connection mode
           isConnectionMode.set(true);
         }
+
         onCancel();
       })
       .with('ai-insert-object', () => {
@@ -542,7 +559,7 @@
         window.open('/docs/adding-objects', '_blank');
       })
       .with('set-room', () => {
-        roomName = getSearchParam('room') || '';
+        roomName = getRoom();
         nextStage('set-room');
       })
       .with('set-output-size', () => {
@@ -729,106 +746,13 @@
   }
 
   function applyOutputSize() {
-    const input = outputSizeInput.trim().toLowerCase();
-
-    // "clear" → remove explicit output size, adapt to screen on each load
-    if (input === 'clear') {
-      const glSystem = GLSystem.getInstance();
-      glSystem.clearOutputSize();
-
-      const [width, height] = glSystem.outputSize;
-      toast.success(`Output size cleared — using screen default (${width}×${height})`);
-
-      onCancel();
-      return;
-    }
-
-    // "screen" → use screen dimensions without DPR
-    if (input === 'screen') {
-      const [width, height] = getScreenOutputSize();
-
-      GLSystem.getInstance().setOutputSize(width, height);
-      toast.success(`Output size set to ${width}×${height}`);
-
-      onCancel();
-      return;
-    }
-
-    // "retina" → use screen dimensions × devicePixelRatio
-    if (input === 'retina') {
-      const dpr = window.devicePixelRatio || 1;
-      const width = Math.max(1, Math.min(8192, Math.round(window.innerWidth * dpr)));
-      const height = Math.max(1, Math.min(8192, Math.round(window.innerHeight * dpr)));
-
-      GLSystem.getInstance().setOutputSize(width, height);
-      toast.success(`Output size set to ${width}×${height} (${dpr}x DPR)`);
-
-      onCancel();
-      return;
-    }
-
-    // Resolution aliases (720p, 1080p, 2k, 4k)
-    const resolutionAliases: Record<string, [number, number]> = {
-      '720p': [1280, 720],
-      '1080p': [1920, 1080],
-      '2k': [2560, 1440],
-      '4k': [3840, 2160]
-    };
-
-    if (input in resolutionAliases) {
-      const [width, height] = resolutionAliases[input];
-
-      GLSystem.getInstance().setOutputSize(width, height);
-      toast.success(`Output size set to ${width}×${height} (${input})`);
-
-      onCancel();
-      return;
-    }
-
-    // "Nx" multiplier → multiply screen dimensions (e.g. 2x, 0.5x)
-    const multiplierMatch = input.match(/^(\d+\.?\d*)\s*x$/);
-    if (multiplierMatch) {
-      const multiplier = Math.min(4, Math.max(0.5, Number(multiplierMatch[1])));
-      const width = Math.min(8192, Math.round(window.innerWidth * multiplier));
-      const height = Math.min(8192, Math.round(window.innerHeight * multiplier));
-
-      GLSystem.getInstance().setOutputSize(width, height);
-      toast.success(`Output size set to ${width}×${height} (${multiplier}x)`);
-
-      onCancel();
-      return;
-    }
-
-    // "WxH" explicit dimensions
-    const match = input.match(/^(\d+)\s*[x×,]\s*(\d+)$/i);
-
-    if (!match) {
-      toast.error('Invalid format. Use WIDTHxHEIGHT, screen, retina, Nx, or clear');
-      return;
-    }
-
-    const width = Number(match[1]);
-    const height = Number(match[2]);
-
-    if (width < 1 || height < 1 || width > 8192 || height > 8192) {
-      toast.error('Size must be between 1 and 8192');
-      return;
-    }
-
-    GLSystem.getInstance().setOutputSize(width, height);
-    toast.success(`Output size set to ${width}×${height}`);
+    applyOutputSizeAction(outputSizeInput);
     onCancel();
   }
 
   function setRoom() {
-    if (!roomName.trim()) {
-      onCancel();
-      return;
-    }
-
-    setSearchParam('room', roomName.trim());
+    applyRoomAction(roomName);
     onCancel();
-    window.location.reload();
   }
 
   async function clearCacheAndServiceWorker() {

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -13,6 +13,7 @@
   import { onDestroy, onMount, tick } from 'svelte';
   import CommandPalette from './CommandPalette.svelte';
   import ObjectBrowserModal from './object-browser/ObjectBrowserModal.svelte';
+  import SettingsModal from './settings-modal/SettingsModal.svelte';
   import BottomToolbar from './BottomToolbar.svelte';
   import AiObjectPrompt from './AiObjectPrompt.svelte';
   import AiActivityTray from './AiActivityTray.svelte';
@@ -25,6 +26,7 @@
     connectingFromHandleId,
     isConnectionMode,
     isObjectBrowserOpen,
+    isSettingsOpen,
     isMobile,
     isSidebarOpen,
     sidebarWidth,
@@ -629,6 +631,7 @@
         if (!$isFullscreenActive) $isSidebarOpen = !$isSidebarOpen;
       },
       openObjectBrowser: () => ($isObjectBrowserOpen = true),
+      openSettings: () => ($isSettingsOpen = true),
       openCommandPalette: triggerCommandPalette,
       togglePlayPause: () => {
         if (Transport.isPlaying) {
@@ -1419,6 +1422,9 @@
       bind:open={$isObjectBrowserOpen}
       onSelectObject={handleObjectBrowserSelect}
     />
+
+    <!-- Settings Modal -->
+    <SettingsModal bind:open={$isSettingsOpen} />
 
     <!-- AI Object Prompt Dialogs — multiple concurrent instances supported -->
     {#each aiPromptInstances as instance (instance.id)}

--- a/ui/src/lib/components/dialogs/AIProviderSettingsDialog.svelte
+++ b/ui/src/lib/components/dialogs/AIProviderSettingsDialog.svelte
@@ -98,7 +98,7 @@
     $isAiFeaturesVisible = false;
     open = false;
     toast.success(
-      'All AI features hidden. Use "Ctrl/Cmd + K > Toggle AI Features" to re-enable them.'
+      'All AI features hidden. Re-enable in Settings (⌘,) under AI → Show AI features.'
     );
   }
 

--- a/ui/src/lib/components/settings-modal/SettingDropdown.svelte
+++ b/ui/src/lib/components/settings-modal/SettingDropdown.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  let {
+    value = $bindable(''),
+    options,
+    onchange
+  }: {
+    value?: string;
+    options: { value: string; label: string }[];
+    onchange?: (value: string) => void;
+  } = $props();
+
+  function handleChange(e: Event) {
+    const target = e.target as HTMLSelectElement;
+    value = target.value;
+    onchange?.(value);
+  }
+</script>
+
+<select
+  {value}
+  onchange={handleChange}
+  class="cursor-pointer rounded border border-white/10 bg-white/5 px-2 py-1 font-mono text-xs text-zinc-300 transition-colors outline-none hover:border-white/20 focus:border-orange-500/40"
+>
+  {#each options as opt (opt.value)}
+    <option value={opt.value} class="bg-zinc-900">{opt.label}</option>
+  {/each}
+</select>

--- a/ui/src/lib/components/settings-modal/SettingRow.svelte
+++ b/ui/src/lib/components/settings-modal/SettingRow.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let {
+    title,
+    description = '',
+    children
+  }: {
+    title: string;
+    description?: string;
+    children: Snippet;
+  } = $props();
+</script>
+
+<div class="flex items-center justify-between gap-4 border-b border-white/5 py-3 last:border-b-0">
+  <div class="min-w-0 flex-1">
+    <div class="text-sm text-zinc-200">{title}</div>
+
+    {#if description}
+      <div class="mt-0.5 text-xs text-zinc-500">{description}</div>
+    {/if}
+  </div>
+  <div class="shrink-0">
+    {@render children()}
+  </div>
+</div>

--- a/ui/src/lib/components/settings-modal/SettingToggle.svelte
+++ b/ui/src/lib/components/settings-modal/SettingToggle.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  let {
+    checked = $bindable(false),
+    onchange
+  }: {
+    checked?: boolean;
+    onchange?: (value: boolean) => void;
+  } = $props();
+
+  function handleClick() {
+    checked = !checked;
+    onchange?.(checked);
+  }
+</script>
+
+<button
+  type="button"
+  role="switch"
+  aria-checked={checked}
+  aria-label="Toggle"
+  onclick={handleClick}
+  class={[
+    'relative inline-flex h-5 w-9 cursor-pointer items-center rounded-full border-none transition-colors duration-200',
+    checked ? 'bg-orange-500' : 'bg-zinc-700'
+  ]}
+>
+  <span
+    class={[
+      'inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform duration-200',
+      checked ? 'translate-x-[18px]' : 'translate-x-[3px]'
+    ]}
+  ></span>
+</button>

--- a/ui/src/lib/components/settings-modal/SettingToggle.svelte
+++ b/ui/src/lib/components/settings-modal/SettingToggle.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   let {
-    checked = $bindable(false),
+    checked = false,
     onchange
   }: {
     checked?: boolean;
@@ -8,8 +8,7 @@
   } = $props();
 
   function handleClick() {
-    checked = !checked;
-    onchange?.(checked);
+    onchange?.(!checked);
   }
 </script>
 

--- a/ui/src/lib/components/settings-modal/SettingsModal.svelte
+++ b/ui/src/lib/components/settings-modal/SettingsModal.svelte
@@ -1,0 +1,253 @@
+<script lang="ts">
+  import { CATEGORY_INFO, type SettingsCategory } from './types';
+  import GeneralSettings from './categories/GeneralSettings.svelte';
+  import EditorSettings from './categories/EditorSettings.svelte';
+  import RenderingSettings from './categories/RenderingSettings.svelte';
+  import AISettings from './categories/AISettings.svelte';
+  import VisualSettings from './categories/VisualSettings.svelte';
+  import TransportSettings from './categories/TransportSettings.svelte';
+  import NetworkSettings from './categories/NetworkSettings.svelte';
+
+  let {
+    open = $bindable(false),
+    initialCategory = 'general' as SettingsCategory
+  }: {
+    open?: boolean;
+    initialCategory?: SettingsCategory;
+  } = $props();
+
+  let activeCategory = $state<SettingsCategory>(initialCategory);
+
+  $effect(() => {
+    if (open && initialCategory) {
+      activeCategory = initialCategory;
+    }
+  });
+
+  function handleClose() {
+    open = false;
+  }
+
+  const perUserCategories = CATEGORY_INFO.filter((c) => c.scope === 'per-user');
+  const perPatchCategories = CATEGORY_INFO.filter((c) => c.scope === 'per-patch');
+
+  const activeCategoryLabel = $derived(
+    CATEGORY_INFO.find((c) => c.id === activeCategory)?.label ?? ''
+  );
+
+  const activeCategoryScope = $derived(
+    CATEGORY_INFO.find((c) => c.id === activeCategory)?.scope ?? 'per-user'
+  );
+</script>
+
+{#if open}
+  <div class="fixed inset-0 z-50 flex items-center justify-center" role="presentation">
+    <!-- Backdrop -->
+    <div
+      class="fixed inset-0 animate-[ob-fade_0.2s_ease_both] bg-black/88 backdrop-blur-[12px]"
+      role="button"
+      tabindex="-1"
+      onclick={handleClose}
+      onkeydown={(e) => {
+        if (e.key === 'Escape') handleClose();
+      }}
+      aria-label="Close modal"
+    ></div>
+
+    <!-- Modal container -->
+    <div
+      class="relative z-10 m-0 flex h-dvh w-full max-w-[780px] animate-[ob-card-in_0.35s_cubic-bezier(0.22,0.61,0.36,1)_both] flex-col overflow-hidden rounded-[14px] border border-orange-500/18 bg-[#09090b] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.03),0_0_80px_rgba(249,115,22,0.06),0_40px_80px_rgba(0,0,0,0.8)] outline-none sm:m-4 sm:h-[85vh] sm:max-h-[720px] sm:flex-row"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="settings-title"
+      tabindex="-1"
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => {
+        if (e.key === 'Escape') {
+          e.stopPropagation();
+          handleClose();
+        }
+      }}
+    >
+      <!-- Corner ornaments -->
+      <span
+        class="pointer-events-none absolute top-3 left-3 z-[2] h-4 w-4 border-t border-l border-orange-500 opacity-40"
+        aria-hidden="true"
+      ></span>
+      <span
+        class="pointer-events-none absolute top-3 right-3 z-[2] h-4 w-4 border-t border-r border-orange-500 opacity-40"
+        aria-hidden="true"
+      ></span>
+      <span
+        class="pointer-events-none absolute bottom-3 left-3 z-[2] h-4 w-4 border-b border-l border-orange-500 opacity-40"
+        aria-hidden="true"
+      ></span>
+      <span
+        class="pointer-events-none absolute right-3 bottom-3 z-[2] h-4 w-4 border-r border-b border-orange-500 opacity-40"
+        aria-hidden="true"
+      ></span>
+
+      <!-- Radial glow -->
+      <div
+        class="pointer-events-none absolute -top-[60px] -right-[60px] -left-[60px] z-0 h-[240px] bg-[radial-gradient(ellipse_70%_60%_at_50%_35%,rgba(249,115,22,0.07),transparent_70%)]"
+        aria-hidden="true"
+      ></div>
+
+      <!-- Mobile: top tab bar -->
+      <div class="relative z-[1] shrink-0 border-b border-white/5 sm:hidden">
+        <div class="flex items-center justify-between px-4 pt-4 pb-0">
+          <span
+            id="settings-title"
+            class="font-mono text-[10px] tracking-[0.18em] text-zinc-500 uppercase"
+          >
+            settings
+          </span>
+          <button
+            onclick={handleClose}
+            class="shrink-0 cursor-pointer border-none bg-transparent p-1.5 font-mono text-[11px] leading-none text-zinc-500 transition-colors hover:text-zinc-300"
+            aria-label="Close modal"
+          >
+            ✕
+          </button>
+        </div>
+
+        <nav class="flex gap-0 overflow-x-auto px-2 pt-2">
+          {#each CATEGORY_INFO as cat (cat.id)}
+            <button
+              onclick={() => (activeCategory = cat.id)}
+              class={[
+                'relative cursor-pointer border-none bg-transparent px-3 py-2 font-mono text-[10px] tracking-[0.12em] whitespace-nowrap uppercase transition-colors',
+                activeCategory === cat.id ? 'text-orange-500' : 'text-zinc-500 hover:text-zinc-300'
+              ]}
+            >
+              {cat.label}
+              {#if activeCategory === cat.id}
+                <span class="absolute right-2 bottom-0 left-2 h-px bg-orange-500 opacity-80"></span>
+              {/if}
+            </button>
+          {/each}
+        </nav>
+      </div>
+
+      <!-- Desktop: sidebar -->
+      <div
+        class="relative z-[1] hidden w-[180px] shrink-0 flex-col border-r border-white/5 pt-5 pb-4 sm:flex"
+      >
+        <span class="mb-4 px-5 font-mono text-[10px] tracking-[0.18em] text-zinc-500 uppercase">
+          settings
+        </span>
+
+        <!-- Per-User section -->
+        <span class="mb-1 px-5 font-mono text-[9px] tracking-[0.2em] text-zinc-500 uppercase">
+          Per-User
+        </span>
+        <nav class="flex flex-col gap-0.5 px-2">
+          {#each perUserCategories as cat (cat.id)}
+            <button
+              onclick={() => (activeCategory = cat.id)}
+              class={[
+                'cursor-pointer rounded px-3 py-1.5 text-left font-mono text-[11px] tracking-wide transition-colors',
+                activeCategory === cat.id
+                  ? 'bg-white/8 text-orange-500'
+                  : 'bg-transparent text-zinc-400 hover:bg-white/4 hover:text-zinc-200'
+              ]}
+            >
+              {cat.label}
+            </button>
+          {/each}
+        </nav>
+
+        <!-- Divider -->
+        <div class="mx-4 my-3 border-t border-white/5"></div>
+
+        <!-- Per-Patch section -->
+        <span class="mb-1 px-5 font-mono text-[9px] tracking-[0.2em] text-zinc-500 uppercase">
+          Per-Patch
+        </span>
+        <nav class="flex flex-col gap-0.5 px-2">
+          {#each perPatchCategories as cat (cat.id)}
+            <button
+              onclick={() => (activeCategory = cat.id)}
+              class={[
+                'cursor-pointer rounded px-3 py-1.5 text-left font-mono text-[11px] tracking-wide transition-colors',
+                activeCategory === cat.id
+                  ? 'bg-white/8 text-orange-500'
+                  : 'bg-transparent text-zinc-400 hover:bg-white/4 hover:text-zinc-200'
+              ]}
+            >
+              {cat.label}
+            </button>
+          {/each}
+        </nav>
+      </div>
+
+      <!-- Content pane -->
+      <div class="relative z-[1] flex min-h-0 flex-1 flex-col overflow-hidden">
+        <!-- Header (desktop only — mobile has it in the tab bar) -->
+        <div
+          class="hidden shrink-0 items-center justify-between border-b border-white/5 px-6 py-4 sm:flex"
+        >
+          <h2 class="font-['Syne',sans-serif] text-sm font-medium text-zinc-200">
+            {activeCategoryLabel}
+          </h2>
+          <button
+            onclick={handleClose}
+            class="shrink-0 cursor-pointer border-none bg-transparent p-1.5 font-mono text-[11px] leading-none text-zinc-500 transition-colors hover:text-zinc-300"
+            aria-label="Close modal"
+          >
+            ✕
+          </button>
+        </div>
+
+        <!-- Mobile: category title + scope badge -->
+        <div class="flex items-center gap-2 px-5 pt-4 pb-1 sm:hidden">
+          <h2 class="font-['Syne',sans-serif] text-sm font-medium text-zinc-200">
+            {activeCategoryLabel}
+          </h2>
+          <span
+            class="rounded border border-white/8 px-1.5 py-0.5 font-mono text-[8px] tracking-[0.15em] text-zinc-500 uppercase"
+          >
+            {activeCategoryScope === 'per-patch' ? 'patch' : 'user'}
+          </span>
+        </div>
+
+        <!-- Settings content -->
+        <div
+          class="settings-scroll flex-1 overflow-y-auto px-5 py-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:px-6"
+        >
+          {#if activeCategory === 'general'}
+            <GeneralSettings />
+          {:else if activeCategory === 'editor'}
+            <EditorSettings />
+          {:else if activeCategory === 'rendering'}
+            <RenderingSettings />
+          {:else if activeCategory === 'ai'}
+            <AISettings />
+          {:else if activeCategory === 'visual'}
+            <VisualSettings />
+          {:else if activeCategory === 'transport'}
+            <TransportSettings />
+          {:else if activeCategory === 'network'}
+            <NetworkSettings />
+          {/if}
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .settings-scroll::-webkit-scrollbar {
+    width: 6px;
+  }
+  .settings-scroll::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .settings-scroll::-webkit-scrollbar-thumb {
+    background: #27272a;
+    border-radius: 3px;
+  }
+  .settings-scroll::-webkit-scrollbar-thumb:hover {
+    background: #3f3f46;
+  }
+</style>

--- a/ui/src/lib/components/settings-modal/categories/AISettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/AISettings.svelte
@@ -64,7 +64,7 @@
   );
 </script>
 
-<SettingRow title="Enable AI features" description="Show AI-powered tools and sparks">
+<SettingRow title="Show AI features" description="Show or hide AI-powered tools and sparks">
   <SettingToggle checked={$isAiFeaturesVisible} onchange={(v) => isAiFeaturesVisible.set(v)} />
 </SettingRow>
 

--- a/ui/src/lib/components/settings-modal/categories/AISettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/AISettings.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import SettingRow from '../SettingRow.svelte';
+  import SettingToggle from '../SettingToggle.svelte';
+  import SettingDropdown from '../SettingDropdown.svelte';
+  import { isAiFeaturesVisible } from '../../../../stores/ui.store';
+  import { aiSettings, type AIProviderType } from '../../../../stores/ai-settings.store';
+  import { chatSettingsStore } from '../../../../stores/chat-settings.store';
+
+  const providerOptions = [
+    { value: 'gemini', label: 'Gemini' },
+    { value: 'openrouter', label: 'OpenRouter' }
+  ];
+
+  const currentProvider = $derived($aiSettings.provider);
+
+  function handleProviderChange(value: string) {
+    aiSettings.updateSettings({ provider: value as AIProviderType });
+  }
+
+  function handleApiKeyInput(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const key = target.value;
+    if ($aiSettings.provider === 'gemini') {
+      aiSettings.updateSettings({ geminiApiKey: key });
+    } else {
+      aiSettings.updateSettings({ openRouterApiKey: key });
+    }
+  }
+
+  function handleTextModelInput(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const model = target.value;
+    if ($aiSettings.provider === 'gemini') {
+      aiSettings.updateSettings({ geminiTextModel: model });
+    } else {
+      aiSettings.updateSettings({ openRouterTextModel: model });
+    }
+  }
+
+  function handleImageModelInput(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const model = target.value;
+    if ($aiSettings.provider === 'gemini') {
+      aiSettings.updateSettings({ geminiImageModel: model });
+    } else {
+      aiSettings.updateSettings({ openRouterImageModel: model });
+    }
+  }
+
+  const currentApiKey = $derived(
+    $aiSettings.provider === 'gemini' ? $aiSettings.geminiApiKey : $aiSettings.openRouterApiKey
+  );
+
+  const currentTextModel = $derived(
+    $aiSettings.provider === 'gemini'
+      ? $aiSettings.geminiTextModel
+      : $aiSettings.openRouterTextModel
+  );
+
+  const currentImageModel = $derived(
+    $aiSettings.provider === 'gemini'
+      ? $aiSettings.geminiImageModel
+      : $aiSettings.openRouterImageModel
+  );
+</script>
+
+<SettingRow title="Enable AI features" description="Show AI-powered tools and sparks">
+  <SettingToggle checked={$isAiFeaturesVisible} onchange={(v) => isAiFeaturesVisible.set(v)} />
+</SettingRow>
+
+{#if $isAiFeaturesVisible}
+  <SettingRow title="AI provider" description="Choose between Gemini and OpenRouter">
+    <SettingDropdown
+      value={currentProvider}
+      options={providerOptions}
+      onchange={handleProviderChange}
+    />
+  </SettingRow>
+
+  <SettingRow title="API key" description="Your API key for the selected provider">
+    <input
+      type="password"
+      value={currentApiKey}
+      oninput={handleApiKeyInput}
+      placeholder="Enter API key"
+      class="w-48 rounded border border-white/10 bg-white/5 px-2 py-1 font-mono text-xs text-zinc-300 transition-colors outline-none placeholder:text-zinc-700 hover:border-white/20 focus:border-orange-500/40"
+    />
+  </SettingRow>
+
+  <SettingRow title="Text model" description="Model used for text generation">
+    <input
+      type="text"
+      value={currentTextModel}
+      oninput={handleTextModelInput}
+      class="w-48 rounded border border-white/10 bg-white/5 px-2 py-1 font-mono text-xs text-zinc-300 transition-colors outline-none hover:border-white/20 focus:border-orange-500/40"
+    />
+  </SettingRow>
+
+  <SettingRow title="Image model" description="Model used for image generation">
+    <input
+      type="text"
+      value={currentImageModel}
+      oninput={handleImageModelInput}
+      class="w-48 rounded border border-white/10 bg-white/5 px-2 py-1 font-mono text-xs text-zinc-300 transition-colors outline-none hover:border-white/20 focus:border-orange-500/40"
+    />
+  </SettingRow>
+
+  <SettingRow title="Expand thinking" description="Show AI reasoning steps in chat">
+    <SettingToggle
+      checked={$chatSettingsStore.expandThinking}
+      onchange={() => chatSettingsStore.toggleExpandThinking()}
+    />
+  </SettingRow>
+{/if}

--- a/ui/src/lib/components/settings-modal/categories/EditorSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/EditorSettings.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import SettingRow from '../SettingRow.svelte';
+  import SettingToggle from '../SettingToggle.svelte';
+  import { useVimInEditor } from '../../../../stores/editor.store';
+  import { setVimMode } from '$lib/utils/settings-actions';
+</script>
+
+<SettingRow title="Vim mode" description="Enable Vim keybindings in code editors (requires reload)">
+  <SettingToggle checked={$useVimInEditor} onchange={setVimMode} />
+</SettingRow>

--- a/ui/src/lib/components/settings-modal/categories/GeneralSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/GeneralSettings.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import SettingRow from '../SettingRow.svelte';
+  import SettingToggle from '../SettingToggle.svelte';
+  import { isBottomBarVisible } from '../../../../stores/ui.store';
+
+  let showStartupModal = $state(
+    typeof localStorage !== 'undefined'
+      ? localStorage.getItem('patchies-show-startup-modal') !== 'false'
+      : true
+  );
+
+  function handleStartupModalChange(value: boolean) {
+    localStorage.setItem('patchies-show-startup-modal', String(value));
+  }
+</script>
+
+<SettingRow title="Show startup modal" description="Show the welcome modal when opening Patchies">
+  <SettingToggle bind:checked={showStartupModal} onchange={handleStartupModalChange} />
+</SettingRow>
+
+<SettingRow title="Show bottom bar" description="Toggle the bottom toolbar visibility">
+  <SettingToggle checked={$isBottomBarVisible} onchange={(v) => isBottomBarVisible.set(v)} />
+</SettingRow>

--- a/ui/src/lib/components/settings-modal/categories/GeneralSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/GeneralSettings.svelte
@@ -2,20 +2,14 @@
   import SettingRow from '../SettingRow.svelte';
   import SettingToggle from '../SettingToggle.svelte';
   import { isBottomBarVisible } from '../../../../stores/ui.store';
-
-  let showStartupModal = $state(
-    typeof localStorage !== 'undefined'
-      ? localStorage.getItem('patchies-show-startup-modal') !== 'false'
-      : true
-  );
-
-  function handleStartupModalChange(value: boolean) {
-    localStorage.setItem('patchies-show-startup-modal', String(value));
-  }
+  import { showStartupModalOnLoad } from '../../../../stores/startup-modal.store';
 </script>
 
 <SettingRow title="Show startup modal" description="Show the welcome modal when opening Patchies">
-  <SettingToggle bind:checked={showStartupModal} onchange={handleStartupModalChange} />
+  <SettingToggle
+    checked={$showStartupModalOnLoad}
+    onchange={(v) => showStartupModalOnLoad.set(v)}
+  />
 </SettingRow>
 
 <SettingRow title="Show bottom bar" description="Toggle the bottom toolbar visibility">

--- a/ui/src/lib/components/settings-modal/categories/NetworkSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/NetworkSettings.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import SettingRow from '../SettingRow.svelte';
+  import { applyRoom, getRoom } from '$lib/utils/settings-actions';
+
+  let roomName = $state(getRoom());
+
+  function handleApplyRoom() {
+    applyRoom(roomName);
+  }
+</script>
+
+<SettingRow title="Room" description="Room ID for netsend/netrecv P2P communication">
+  <input
+    type="text"
+    bind:value={roomName}
+    onblur={handleApplyRoom}
+    onkeydown={(e) => {
+      if (e.key === 'Enter') handleApplyRoom();
+    }}
+    placeholder="No room set"
+    class="w-40 rounded border border-white/10 bg-white/5 px-2 py-1 font-mono text-xs text-zinc-300 transition-colors outline-none placeholder:text-zinc-700 hover:border-white/20 focus:border-orange-500/40"
+  />
+</SettingRow>

--- a/ui/src/lib/components/settings-modal/categories/RenderingSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/RenderingSettings.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import SettingRow from '../SettingRow.svelte';
+  import SettingToggle from '../SettingToggle.svelte';
+  import SettingDropdown from '../SettingDropdown.svelte';
+  import { isFpsMonitorVisible } from '../../../../stores/ui.store';
+  import { renderFpsCap, type FpsCap } from '../../../../stores/renderer.store';
+  import { useWebCodecs, showVideoStats } from '../../../../stores/video.store';
+
+  const fpsCapOptions = [
+    { value: '0', label: 'Unlimited' },
+    { value: '30', label: '30 FPS' },
+    { value: '60', label: '60 FPS' }
+  ];
+
+  const currentFpsCap = $derived(String($renderFpsCap));
+
+  function handleFpsCapChange(value: string) {
+    renderFpsCap.set(Number(value) as FpsCap);
+  }
+</script>
+
+<SettingRow title="Render FPS cap" description="Limit the rendering frame rate">
+  <SettingDropdown value={currentFpsCap} options={fpsCapOptions} onchange={handleFpsCapChange} />
+</SettingRow>
+
+<SettingRow title="Show FPS monitor" description="Display frames-per-second counter">
+  <SettingToggle checked={$isFpsMonitorVisible} onchange={(v) => isFpsMonitorVisible.set(v)} />
+</SettingRow>
+
+<SettingRow title="Show video stats" description="Overlay video decoding statistics">
+  <SettingToggle checked={$showVideoStats} onchange={(v) => showVideoStats.set(v)} />
+</SettingRow>
+
+<SettingRow
+  title="MediaBunny (WebCodecs)"
+  description="Use WebCodecs for video decoding (Chrome/Edge recommended)"
+>
+  <SettingToggle checked={$useWebCodecs} onchange={(v) => useWebCodecs.set(v)} />
+</SettingRow>

--- a/ui/src/lib/components/settings-modal/categories/TransportSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/TransportSettings.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import SettingRow from '../SettingRow.svelte';
+  import { transportStore } from '../../../../stores/transport.store';
+
+  function handleBpmInput(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const bpm = Number(target.value);
+    if (bpm > 0 && bpm <= 999) {
+      transportStore.update((s) => ({ ...s, bpm }));
+    }
+  }
+
+  function handleTimeSigNumInput(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const num = Number(target.value);
+    if (num > 0 && num <= 32) {
+      transportStore.update((s) => ({
+        ...s,
+        timeSignature: [num, s.timeSignature[1]]
+      }));
+    }
+  }
+
+  function handleTimeSigDenInput(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const den = Number(target.value);
+    if (den > 0 && den <= 32) {
+      transportStore.update((s) => ({
+        ...s,
+        timeSignature: [s.timeSignature[0], den]
+      }));
+    }
+  }
+</script>
+
+<SettingRow title="BPM" description="Beats per minute for this patch">
+  <input
+    type="number"
+    value={$transportStore.bpm}
+    oninput={handleBpmInput}
+    min="1"
+    max="999"
+    class="w-20 rounded border border-white/10 bg-white/5 px-2 py-1 font-mono text-xs text-zinc-300 transition-colors outline-none hover:border-white/20 focus:border-orange-500/40"
+  />
+</SettingRow>
+
+<SettingRow title="Time signature" description="Beats per bar for this patch">
+  <div class="flex items-center gap-1">
+    <input
+      type="number"
+      value={$transportStore.timeSignature[0]}
+      oninput={handleTimeSigNumInput}
+      min="1"
+      max="32"
+      class="w-12 rounded border border-white/10 bg-white/5 px-2 py-1 text-center font-mono text-xs text-zinc-300 transition-colors outline-none hover:border-white/20 focus:border-orange-500/40"
+    />
+    <span class="text-xs text-zinc-600">/</span>
+    <input
+      type="number"
+      value={$transportStore.timeSignature[1]}
+      oninput={handleTimeSigDenInput}
+      min="1"
+      max="32"
+      class="w-12 rounded border border-white/10 bg-white/5 px-2 py-1 text-center font-mono text-xs text-zinc-300 transition-colors outline-none hover:border-white/20 focus:border-orange-500/40"
+    />
+  </div>
+</SettingRow>

--- a/ui/src/lib/components/settings-modal/categories/VisualSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/VisualSettings.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import SettingRow from '../SettingRow.svelte';
+  import SettingToggle from '../SettingToggle.svelte';
+  import { isCablesVisible } from '../../../../stores/ui.store';
+  import { outputSize } from '../../../../stores/renderer.store';
+  import { applyOutputSize } from '$lib/utils/settings-actions';
+
+  const currentOutputSize = $derived(`${$outputSize[0]}x${$outputSize[1]}`);
+  let outputSizeInput = $state('');
+  let isEditingOutputSize = $state(false);
+
+  function startEditingOutputSize() {
+    outputSizeInput = currentOutputSize;
+    isEditingOutputSize = true;
+  }
+
+  function handleApplyOutputSize() {
+    isEditingOutputSize = false;
+    const input = outputSizeInput.trim();
+    if (!input || input === currentOutputSize) return;
+    applyOutputSize(input);
+  }
+</script>
+
+<SettingRow title="Show cables" description="Toggle connection cable visibility">
+  <SettingToggle checked={$isCablesVisible} onchange={(v) => isCablesVisible.set(v)} />
+</SettingRow>
+
+<SettingRow
+  title="Output size"
+  description="Render resolution (e.g. 1920x1080, screen, retina, 2x, 4k, or 'clear')"
+>
+  {#if isEditingOutputSize}
+    <input
+      type="text"
+      bind:value={outputSizeInput}
+      onblur={handleApplyOutputSize}
+      onkeydown={(e) => {
+        if (e.key === 'Enter') handleApplyOutputSize();
+        if (e.key === 'Escape') isEditingOutputSize = false;
+      }}
+      placeholder="1920x1080"
+      class="w-32 rounded border border-orange-500/40 bg-white/5 px-2 py-1 font-mono text-xs text-zinc-300 outline-none"
+    />
+  {:else}
+    <button
+      onclick={startEditingOutputSize}
+      class="cursor-pointer rounded border border-white/10 bg-white/5 px-2 py-1 font-mono text-xs text-zinc-300 transition-colors hover:border-white/20"
+    >
+      {currentOutputSize}
+    </button>
+  {/if}
+</SettingRow>

--- a/ui/src/lib/components/settings-modal/types.ts
+++ b/ui/src/lib/components/settings-modal/types.ts
@@ -1,0 +1,31 @@
+export const SETTINGS_CATEGORIES = [
+  // Per-User
+  'general',
+  'editor',
+  'rendering',
+  'ai',
+  // Per-Patch
+  'visual',
+  'transport',
+  'network'
+] as const;
+
+export type SettingsCategory = (typeof SETTINGS_CATEGORIES)[number];
+
+export type SettingsCategoryScope = 'per-user' | 'per-patch';
+
+export interface SettingsCategoryInfo {
+  id: SettingsCategory;
+  label: string;
+  scope: SettingsCategoryScope;
+}
+
+export const CATEGORY_INFO: SettingsCategoryInfo[] = [
+  { id: 'general', label: 'General', scope: 'per-user' },
+  { id: 'editor', label: 'Editor', scope: 'per-user' },
+  { id: 'rendering', label: 'Rendering', scope: 'per-user' },
+  { id: 'ai', label: 'AI', scope: 'per-user' },
+  { id: 'visual', label: 'Visual', scope: 'per-patch' },
+  { id: 'transport', label: 'Transport', scope: 'per-patch' },
+  { id: 'network', label: 'Network', scope: 'per-patch' }
+];

--- a/ui/src/lib/services/KeyboardShortcutManager.ts
+++ b/ui/src/lib/services/KeyboardShortcutManager.ts
@@ -56,6 +56,7 @@ export interface KeyboardShortcutActions {
   // UI toggles
   toggleSidebar: () => void;
   openObjectBrowser: () => void;
+  openSettings: () => void;
   openCommandPalette: () => void;
 
   // Transport
@@ -188,6 +189,14 @@ export class KeyboardShortcutManager {
     if (key === 'k' && isMod && !this.actions.isCommandPaletteOpen()) {
       event.preventDefault();
       this.actions.openCommandPalette();
+
+      return;
+    }
+
+    // CMD+,: Open settings
+    if (key === ',' && isMod && !isTyping) {
+      event.preventDefault();
+      this.actions.openSettings();
 
       return;
     }

--- a/ui/src/lib/utils/settings-actions.ts
+++ b/ui/src/lib/utils/settings-actions.ts
@@ -35,7 +35,7 @@ export function applyOutputSize(input: string): boolean {
     const glSystem = GLSystem.getInstance();
     glSystem.clearOutputSize();
     const [w, h] = glSystem.outputSize;
-    toast.success(`Output size cleared — using screen default (${w}×${h})`);
+    toast.success(`Output size cleared — using default (${w}×${h})`);
     return true;
   }
 

--- a/ui/src/lib/utils/settings-actions.ts
+++ b/ui/src/lib/utils/settings-actions.ts
@@ -58,7 +58,7 @@ export function applyOutputSize(input: string): boolean {
   }
 
   // Resolution aliases (720p, 1080p, 2k, 4k)
-  if (trimmed in RESOLUTION_ALIASES) {
+  if (Object.hasOwn(RESOLUTION_ALIASES, trimmed)) {
     const [width, height] = RESOLUTION_ALIASES[trimmed];
     GLSystem.getInstance().setOutputSize(width, height);
     toast.success(`Output size set to ${width}×${height} (${trimmed})`);
@@ -129,7 +129,7 @@ export function applyRoom(roomName: string): boolean {
   if (!trimmed) {
     const url = new URL(window.location.href);
     url.searchParams.delete('room');
-    window.history.replaceState({}, '', url);
+    window.history.replaceState(window.history.state, '', url);
     toast.success('Room cleared');
     return true;
   }

--- a/ui/src/lib/utils/settings-actions.ts
+++ b/ui/src/lib/utils/settings-actions.ts
@@ -1,0 +1,140 @@
+/**
+ * Shared setting action utilities used by both CommandPalette and SettingsModal.
+ * These encapsulate the logic for applying settings, keeping UI components thin.
+ */
+
+import { toast } from 'svelte-sonner';
+import { GLSystem } from '$lib/canvas/GLSystem';
+import { getScreenOutputSize } from '$lib/canvas/constants';
+import { useVimInEditor } from '../../stores/editor.store';
+import { getSearchParam, setSearchParam } from './search-params';
+
+// ── Output Size ──────────────────────────────────────────────────────
+
+export type OutputSizeResult =
+  | { ok: true; width: number; height: number; label: string }
+  | { ok: false };
+
+const RESOLUTION_ALIASES: Record<string, [number, number]> = {
+  '720p': [1280, 720],
+  '1080p': [1920, 1080],
+  '2k': [2560, 1440],
+  '4k': [3840, 2160]
+};
+
+/**
+ * Parse and apply an output size string.
+ * Supports: WxH, clear, screen, retina, Nx multiplier, 720p/1080p/2k/4k.
+ * Returns true if applied successfully.
+ */
+export function applyOutputSize(input: string): boolean {
+  const trimmed = input.trim().toLowerCase();
+
+  // "clear" → remove explicit output size
+  if (trimmed === 'clear') {
+    const glSystem = GLSystem.getInstance();
+    glSystem.clearOutputSize();
+    const [w, h] = glSystem.outputSize;
+    toast.success(`Output size cleared — using screen default (${w}×${h})`);
+    return true;
+  }
+
+  // "screen" → use screen dimensions without DPR
+  if (trimmed === 'screen') {
+    const [width, height] = getScreenOutputSize();
+    GLSystem.getInstance().setOutputSize(width, height);
+    toast.success(`Output size set to ${width}×${height}`);
+    return true;
+  }
+
+  // "retina" → use screen dimensions × devicePixelRatio
+  if (trimmed === 'retina') {
+    const dpr = window.devicePixelRatio || 1;
+    const width = Math.max(1, Math.min(8192, Math.round(window.innerWidth * dpr)));
+    const height = Math.max(1, Math.min(8192, Math.round(window.innerHeight * dpr)));
+    GLSystem.getInstance().setOutputSize(width, height);
+    toast.success(`Output size set to ${width}×${height} (${dpr}x DPR)`);
+    return true;
+  }
+
+  // Resolution aliases (720p, 1080p, 2k, 4k)
+  if (trimmed in RESOLUTION_ALIASES) {
+    const [width, height] = RESOLUTION_ALIASES[trimmed];
+    GLSystem.getInstance().setOutputSize(width, height);
+    toast.success(`Output size set to ${width}×${height} (${trimmed})`);
+    return true;
+  }
+
+  // "Nx" multiplier → multiply screen dimensions (e.g. 2x, 0.5x)
+  const multiplierMatch = trimmed.match(/^(\d+\.?\d*)\s*x$/);
+  if (multiplierMatch) {
+    const multiplier = Math.min(4, Math.max(0.5, Number(multiplierMatch[1])));
+    const width = Math.min(8192, Math.round(window.innerWidth * multiplier));
+    const height = Math.min(8192, Math.round(window.innerHeight * multiplier));
+    GLSystem.getInstance().setOutputSize(width, height);
+    toast.success(`Output size set to ${width}×${height} (${multiplier}x)`);
+    return true;
+  }
+
+  // "WxH" explicit dimensions
+  const match = trimmed.match(/^(\d+)\s*[x×,]\s*(\d+)$/i);
+  if (!match) {
+    toast.error('Invalid format. Use WIDTHxHEIGHT, screen, retina, Nx, or clear');
+    return false;
+  }
+
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+
+  if (width < 1 || height < 1 || width > 8192 || height > 8192) {
+    toast.error('Size must be between 1 and 8192');
+    return false;
+  }
+
+  GLSystem.getInstance().setOutputSize(width, height);
+  toast.success(`Output size set to ${width}×${height}`);
+  return true;
+}
+
+// ── Vim Mode ──────────────────────────────────────────────────────────
+
+/** Toggle vim mode and persist to localStorage + store. */
+export function setVimMode(enabled: boolean): void {
+  localStorage.setItem('editor.vim', String(enabled));
+  useVimInEditor.set(enabled);
+}
+
+export function toggleVimMode(): boolean {
+  const current = localStorage.getItem('editor.vim') === 'true';
+  setVimMode(!current);
+  return !current;
+}
+
+// ── Room ──────────────────────────────────────────────────────────────
+
+/** Get the current room ID from URL params. */
+export function getRoom(): string {
+  return getSearchParam('room') || '';
+}
+
+/**
+ * Apply a room ID. Pass empty string to clear.
+ * Returns true if a change was made.
+ */
+export function applyRoom(roomName: string): boolean {
+  const trimmed = roomName.trim();
+  const current = getRoom();
+  if (trimmed === current) return false;
+
+  if (!trimmed) {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('room');
+    window.history.replaceState({}, '', url);
+    toast.success('Room cleared');
+    return true;
+  }
+
+  setSearchParam('room', trimmed);
+  toast.success(`Room set to "${trimmed}" — reload to connect`);
+  return true;
+}

--- a/ui/src/stores/startup-modal.store.ts
+++ b/ui/src/stores/startup-modal.store.ts
@@ -1,0 +1,16 @@
+import { writable } from 'svelte/store';
+
+const STORAGE_KEY = 'patchies-show-startup-modal';
+
+function load(): boolean {
+  if (typeof localStorage === 'undefined') return true;
+  return localStorage.getItem(STORAGE_KEY) !== 'false';
+}
+
+export const showStartupModalOnLoad = writable(load());
+
+showStartupModalOnLoad.subscribe((value) => {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, String(value));
+  }
+});

--- a/ui/src/stores/ui.store.ts
+++ b/ui/src/stores/ui.store.ts
@@ -67,6 +67,7 @@ if (typeof localStorage !== 'undefined') {
 export const isConnectionMode = writable(false);
 
 export const isObjectBrowserOpen = writable(false);
+export const isSettingsOpen = writable(false);
 
 // Sidebar state - persisted to localStorage
 const storedSidebarOpen =

--- a/ui/static/content/topics/enabling-ai.md
+++ b/ui/static/content/topics/enabling-ai.md
@@ -4,9 +4,10 @@
 
 AI is optional with Patchies. By default, Patchies has no AI features enabled, and it has to be explicitly opted in.
 
-AI features are hidden unless an API key is present. You can also use `Ctrl/Cmd + K` then `Toggle AI Features` to hide all AI-based objects and AI generation features. It will stay hidden until you turn it back on.
+We believe in giving users the choice to use AI as a tool for code generation without forcing it on everyone. AI-enabled features are either hidden or disabled unless an API key is present.
 
-We believe in giving users the choice to use AI as a tool for code generation without forcing it on everyone.
+- You can toggle visibility in **Settings** (`Cmd/Ctrl + ,`) under **AI → Show AI features**.
+- You can also use the command palette (`Cmd/Ctrl + K` → `Toggle AI Features`) to quickly toggle AI features.
 
 ## Be mindful about API key security
 


### PR DESCRIPTION
## Summary

- Add a settings modal (`Cmd+,`) with categorized sidebar, surfacing all user-configurable settings that previously lived only in CommandPalette toggle commands
- Clearly separates **per-user** settings (General, Editor, Rendering, AI) from **per-patch** settings (Visual, Transport, Network)
- Mobile responsive: switches from sidebar layout to horizontal scrollable tab bar on small screens
- Extract shared settings logic (`applyOutputSize`, `applyRoom`, `setVimMode`) into `settings-actions.ts`, used by both CommandPalette and Settings modal — fixes a bug where CommandPalette's vim toggle wasn't updating the store

## Test plan

- [ ] Open settings with `Cmd+,` shortcut
- [ ] Open settings via command palette ("Settings")
- [ ] Open settings via bottom toolbar overflow menu
- [ ] Verify all toggles reflect current state and update correctly
- [ ] Test AI settings (provider switch, API key, models)
- [ ] Test patch settings (BPM, time signature, output size, room)
- [ ] Test output size special formats (screen, retina, 2x, 4k, clear)
- [ ] Resize to mobile width — verify tab bar layout
- [ ] Verify CommandPalette toggle commands still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings modal with full category UI (General, Editor, Rendering, AI, Visual, Transport, Network) plus toolbar and Command Palette access and Cmd/Ctrl+, shortcut.
  * New controls: toggles, dropdowns and inputs for FPS/output-size, Vim mode, AI provider/keys, BPM/time signature, room ID, and visibility options.
* **Chores**
  * Persistent startup-modal and settings-open state; user-facing success/error toasts for applying settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->