### PR TITLE
feat(expr~, fexpr~): add multi-outlet support

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "patchies-web",
@@ -101,7 +100,7 @@
         "@tailwindcss/forms": "^0.5.9",
         "@tailwindcss/typography": "^0.5.15",
         "@tailwindcss/vite": "^4.0.0",
-        "@types/audioworklet": "^0.0.82",
+        "@types/audioworklet": "^0.0.97",
         "@types/diff": "^8.0.0",
         "@types/dom-mediacapture-transform": "^0.1.11",
         "@types/dompurify": "^3.2.0",
@@ -915,7 +914,7 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
-    "@types/audioworklet": ["@types/audioworklet@0.0.82", "", {}, "sha512-mz8L7mnKAPa2X1eicnQUbNRdSbCpEZoH5N3jbP9j7LDGkPIfH5KcVkz2nWLlu2SlkDMTUzjf2reJ/qDzG1CqvA=="],
+    "@types/audioworklet": ["@types/audioworklet@0.0.97", "", {}, "sha512-z4RRI9147KXm3b1U4dR/XFfsxSR5yymEWEJT+Td0tCJyRkyGccIXEL09W7c5TcbDd51qKR/+LrO2SPC1SL2RLA=="],
 
     "@types/chai": ["@types/chai@5.2.2", "", { "dependencies": { "@types/deep-eql": "*" } }, "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,7 +32,7 @@
     "@tailwindcss/forms": "^0.5.9",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.0.0",
-    "@types/audioworklet": "^0.0.82",
+    "@types/audioworklet": "^0.0.97",
     "@types/diff": "^8.0.0",
     "@types/dom-mediacapture-transform": "^0.1.11",
     "@types/dompurify": "^3.2.0",

--- a/ui/src/app.d.ts
+++ b/ui/src/app.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="audioworklet" />
+
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
 declare global {

--- a/ui/src/lib/audio/expression-processor.ts
+++ b/ui/src/lib/audio/expression-processor.ts
@@ -176,7 +176,8 @@ class ExpressionProcessor extends AudioWorkletProcessor {
 
   private compileExpression(expressionString: string): ExprDspFn | null {
     try {
-      const renamedExpression = expressionString.replace(/\$(\d+)/g, 'x$1');
+      // Normalize newlines to spaces so multi-line expressions (e.g. ternaries) work
+      const renamedExpression = expressionString.replace(/\n/g, ' ').replace(/\$(\d+)/g, 'x$1');
       const parser = this.createParser();
       const expr = parser.parse(renamedExpression);
 
@@ -195,6 +196,8 @@ class ExpressionProcessor extends AudioWorkletProcessor {
 
   /**
    * Set a single expression (backwards compat, single outlet).
+   * Newlines are converted to semicolons so expr-eval treats them
+   * as sequential statements (evaluates all, returns last value).
    */
   private setExpression(expressionString: string): void {
     if (!expressionString || expressionString.trim() === '') {
@@ -204,7 +207,8 @@ class ExpressionProcessor extends AudioWorkletProcessor {
 
     this.resetPhasorState();
 
-    const fn = this.compileExpression(expressionString);
+    const normalized = expressionString.replace(/\n/g, ';');
+    const fn = this.compileExpression(normalized);
     this.evaluators = fn ? [fn] : [];
   }
 

--- a/ui/src/lib/audio/expression-processor.ts
+++ b/ui/src/lib/audio/expression-processor.ts
@@ -130,7 +130,7 @@ class ExpressionProcessor extends AudioWorkletProcessor {
   };
 
   private createParser(): Parser {
-    const p = new Parser({
+    const parser = new Parser({
       operators: {
         add: true,
         concatenate: true,
@@ -148,8 +148,9 @@ class ExpressionProcessor extends AudioWorkletProcessor {
       }
     });
 
-    p.functions.phasor = this.phasor;
-    return p;
+    parser.functions.phasor = this.phasor;
+
+    return parser;
   }
 
   // Parameter names shared by all evaluators

--- a/ui/src/lib/audio/expression-processor.ts
+++ b/ui/src/lib/audio/expression-processor.ts
@@ -209,6 +209,7 @@ class ExpressionProcessor extends AudioWorkletProcessor {
 
     const normalized = expressionString.replace(/\n/g, ';');
     const fn = this.compileExpression(normalized);
+
     this.evaluators = fn ? [fn] : [];
   }
 

--- a/ui/src/lib/audio/expression-processor.ts
+++ b/ui/src/lib/audio/expression-processor.ts
@@ -5,6 +5,12 @@ interface ExpressionMessage {
   expression: string;
 }
 
+interface MultiExpressionMessage {
+  type: 'set-expressions';
+  assignments: string[];
+  outletExpressions: string[];
+}
+
 interface InletValuesMessage {
   type: 'set-inlet-values';
   values: number[];
@@ -47,7 +53,7 @@ type ExprDspFn = (
 ) => number;
 
 class ExpressionProcessor extends AudioWorkletProcessor {
-  private evaluator: ExprDspFn | null = null;
+  private evaluators: ExprDspFn[] = [];
   private inletValues: number[] = new Array(10).fill(0);
 
   // Phasor state: up to 10 independent phasors per expression
@@ -65,9 +71,14 @@ class ExpressionProcessor extends AudioWorkletProcessor {
 
   constructor() {
     super();
-    this.port.onmessage = (event: MessageEvent<ExpressionMessage | InletValuesMessage>) => {
+
+    this.port.onmessage = (
+      event: MessageEvent<ExpressionMessage | MultiExpressionMessage | InletValuesMessage>
+    ) => {
       if (event.data.type === 'set-expression') {
         this.setExpression(event.data.expression);
+      } else if (event.data.type === 'set-expressions') {
+        this.setExpressions(event.data.assignments, event.data.outletExpressions);
       } else if (event.data.type === 'set-inlet-values') {
         this.setInletValues(event.data.values);
       }
@@ -118,18 +129,8 @@ class ExpressionProcessor extends AudioWorkletProcessor {
     return this.phasorPhases[idx];
   };
 
-  private setExpression(expressionString: string): void {
-    if (!expressionString || expressionString.trim() === '') {
-      this.evaluator = null;
-      return;
-    }
-
-    // Reset phasor state when expression changes
-    this.phasorPhases.fill(0);
-    this.phasorTriggerPrev.fill(0);
-    this.phasorIndex = 0;
-
-    const parser = new Parser({
+  private createParser(): Parser {
+    const p = new Parser({
       operators: {
         add: true,
         concatenate: true,
@@ -147,43 +148,87 @@ class ExpressionProcessor extends AudioWorkletProcessor {
       }
     });
 
-    // Add phasor as a custom function
-    parser.functions.phasor = this.phasor;
+    p.functions.phasor = this.phasor;
+    return p;
+  }
 
+  // Parameter names shared by all evaluators
+  private static parameterNames = [
+    // Signal inputs s1-s9 (1-indexed)
+    ...Array.from({ length: 9 }, (_, i) => `s${i + 1}`),
+
+    // Backwards compat: `s` is alias for s1
+    's',
+
+    // Other parameters
+    'i',
+    't',
+    'channel',
+    'bufferSize',
+    'samples',
+    'input',
+    'inputs',
+
+    // Inlet values x1-x9
+    ...Array.from({ length: 9 }, (_, i) => `x${i + 1}`)
+  ];
+
+  private compileExpression(expressionString: string): ExprDspFn | null {
     try {
-      // Replace $1, $2, etc. with x1, x2, etc. for expr-eval compatibility
       const renamedExpression = expressionString.replace(/\$(\d+)/g, 'x$1');
-
+      const parser = this.createParser();
       const expr = parser.parse(renamedExpression);
 
-      // Create parameter names:
-      // s1-s9 (samples from each audio input, 1-indexed to match $1-$9), s (backwards compat alias for s1),
-      // i (sample index), t (time in seconds), channel, bufferSize,
-      // samples (current channel samples), input (first input), inputs (all inputs), x1-x9 (inlet values)
-      const parameterNames = [
-        // Signal inputs s1-s9 (1-indexed)
-        ...Array.from({ length: 9 }, (_, i) => `s${i + 1}`),
-
-        // Backwards compat: `s` is alias for s1
-        's',
-
-        // Other parameters
-        'i',
-        't',
-        'channel',
-        'bufferSize',
-        'samples',
-        'input',
-        'inputs',
-
-        // Inlet values x1-x9
-        ...Array.from({ length: 9 }, (_, i) => `x${i + 1}`)
-      ];
-
-      this.evaluator = expr.toJSFunction(parameterNames.join(',')) as ExprDspFn;
+      return expr.toJSFunction(ExpressionProcessor.parameterNames.join(',')) as ExprDspFn;
     } catch (error) {
       console.error('Failed to compile expression:', error);
+      return null;
     }
+  }
+
+  private resetPhasorState(): void {
+    this.phasorPhases.fill(0);
+    this.phasorTriggerPrev.fill(0);
+    this.phasorIndex = 0;
+  }
+
+  /**
+   * Set a single expression (backwards compat, single outlet).
+   */
+  private setExpression(expressionString: string): void {
+    if (!expressionString || expressionString.trim() === '') {
+      this.evaluators = [];
+      return;
+    }
+
+    this.resetPhasorState();
+
+    const fn = this.compileExpression(expressionString);
+    this.evaluators = fn ? [fn] : [];
+  }
+
+  /**
+   * Set multiple outlet expressions with shared assignments.
+   */
+  private setExpressions(assignments: string[], outletExpressions: string[]): void {
+    this.resetPhasorState();
+
+    const prefix = assignments.length > 0 ? assignments.join(';') + ';' : '';
+    const fns: ExprDspFn[] = [];
+
+    for (const outletExpr of outletExpressions) {
+      const fn = this.compileExpression(prefix + outletExpr);
+
+      if (fn) {
+        fns.push(fn);
+      } else {
+        // If any expression fails, clear all
+        this.evaluators = [];
+        return;
+      }
+    }
+
+    this.evaluators = fns;
   }
 
   private setInletValues(values: number[]): void {
@@ -194,15 +239,14 @@ class ExpressionProcessor extends AudioWorkletProcessor {
   }
 
   process(inputs: Float32Array[][], outputs: Float32Array[][]): boolean {
-    const input = inputs[0] || [];
-    const output = outputs[0] || [];
-
-    // Keep the expression node alive even without evaluator
-    if (!this.evaluator) {
-      // Pass through silence if no evaluator
-      for (let channel = 0; channel < output.length; channel++) {
-        if (output[channel]) {
-          output[channel].fill(0);
+    // Keep the expression node alive even without evaluators
+    if (this.evaluators.length === 0) {
+      // Pass through silence on all outputs
+      for (const output of outputs) {
+        for (let channel = 0; channel < output.length; channel++) {
+          if (output[channel]) {
+            output[channel].fill(0);
+          }
         }
       }
 
@@ -210,10 +254,11 @@ class ExpressionProcessor extends AudioWorkletProcessor {
     }
 
     try {
+      const input = inputs[0] || [];
       const bufferSize = input[0] ? input[0].length : 128;
 
       // Always process at least one channel, even without input
-      const channelCount = Math.max(output.length, 1);
+      const channelCount = Math.max(outputs[0]?.length ?? 0, 1);
 
       // Pre-allocate silent buffer once (reused for missing channels)
       if (!this.silentBuffer || this.silentBuffer.length !== bufferSize) {
@@ -222,23 +267,22 @@ class ExpressionProcessor extends AudioWorkletProcessor {
 
       // Snapshot inlet values once per process() call (not per sample)
       const args = this.inletArgs;
+
       for (let k = 0; k < 9; k++) {
         args[k] = this.inletValues[k];
       }
 
       // Sample-first loop so phasor state is consistent across channels
       for (let i = 0; i < bufferSize; i++) {
-        // Reset phasor index at start of each sample
+        // Reset phasor index at start of each sample (shared across all evaluators)
         this.phasorIndex = 0;
 
         const t = (currentFrame + i) / sampleRate;
 
         for (let channel = 0; channel < channelCount; channel++) {
           const samples = input[channel] || this.silentBuffer;
-          const outs = output[channel] || this.silentBuffer;
 
           // Extract sample from each input (s1-s9, 1-indexed)
-          // inputs[n][channel][i] = sample i from channel of input n
           const s1 = inputs[0]?.[channel]?.[i] ?? 0;
           const s2 = inputs[1]?.[channel]?.[i] ?? 0;
           const s3 = inputs[2]?.[channel]?.[i] ?? 0;
@@ -249,45 +293,44 @@ class ExpressionProcessor extends AudioWorkletProcessor {
           const s8 = inputs[7]?.[channel]?.[i] ?? 0;
           const s9 = inputs[8]?.[channel]?.[i] ?? 0;
 
-          try {
-            // Call evaluator with: s1-s9, s (alias for s1), i, t, channel, bufferSize, samples, input, inputs, x1-x9
-            const result = this.evaluator(
-              s1,
-              s2,
-              s3,
-              s4,
-              s5,
-              s6,
-              s7,
-              s8,
-              s9, // samples from each input (1-indexed)
-              s1, // backwards compat: `s` = s1
-              i, // sample index in buffer
-              t, // current time in seconds
-              channel, // current channel number
-              bufferSize, // buffer size
-              samples, // current channel samples array
-              input, // first input (all channels)
-              inputs, // all inputs
-              args[0],
-              args[1],
-              args[2],
-              args[3],
-              args[4],
-              args[5],
-              args[6],
-              args[7],
-              args[8]
-            );
+          // Evaluate each outlet expression and write to corresponding output
+          for (let outIdx = 0; outIdx < this.evaluators.length; outIdx++) {
+            const outs = outputs[outIdx]?.[channel] || this.silentBuffer;
 
-            if (typeof result !== 'number' || isNaN(result)) {
+            try {
+              const result = this.evaluators[outIdx](
+                s1,
+                s2,
+                s3,
+                s4,
+                s5,
+                s6,
+                s7,
+                s8,
+                s9,
+                s1, // backwards compat: `s` = s1
+                i,
+                t,
+                channel,
+                bufferSize,
+                samples,
+                input,
+                inputs,
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args[4],
+                args[5],
+                args[6],
+                args[7],
+                args[8]
+              );
+
+              outs[i] = typeof result === 'number' && !isNaN(result) ? result : 0;
+            } catch {
               outs[i] = 0;
-              continue;
             }
-
-            outs[i] = result;
-          } catch {
-            outs[i] = 0;
           }
         }
       }

--- a/ui/src/lib/audio/fexpr-processor.ts
+++ b/ui/src/lib/audio/fexpr-processor.ts
@@ -1,8 +1,15 @@
 import { Parser } from 'expr-eval';
+import { transformFExprExpression } from './fexpr-transform';
 
 interface ExpressionMessage {
   type: 'set-expression';
   expression: string;
+}
+
+interface MultiExpressionMessage {
+  type: 'set-expressions';
+  assignments: string[];
+  outletExpressions: string[];
 }
 
 interface InletValuesMessage {
@@ -35,8 +42,16 @@ type FExprDspFn = (
   s8: (offset?: number) => number,
   s9: (offset?: number) => number,
 
-  // y1 accessor function (output history, -1 = previous output, etc.)
+  // y1-y9 accessor functions (output history per outlet, -1 = previous output, etc.)
   y1: (offset: number) => number,
+  y2: (offset: number) => number,
+  y3: (offset: number) => number,
+  y4: (offset: number) => number,
+  y5: (offset: number) => number,
+  y6: (offset: number) => number,
+  y7: (offset: number) => number,
+  y8: (offset: number) => number,
+  y9: (offset: number) => number,
 
   // Other parameters
   i: number,
@@ -58,23 +73,28 @@ const HISTORY_SIZE = 128; // Web Audio block size
 const MAX_SIGNAL_INLETS = 9;
 
 class FExprProcessor extends AudioWorkletProcessor {
-  private evaluator: FExprDspFn | null = null;
+  private evaluators: FExprDspFn[] = [];
   private inletValues: number[] = new Array(10).fill(0);
 
   // History buffers for input samples (one per inlet)
   // Circular buffer: historyIndex points to current sample position
   private inputHistory: Float32Array[] = [];
-  private outputHistory: Float32Array = new Float32Array(HISTORY_SIZE);
-  private historyIndex = 0;
+
+  // Per-outlet output history buffers
+  private outputHistories: Float32Array[] = [new Float32Array(HISTORY_SIZE)];
 
   // Pre-allocated accessor functions to avoid allocation in hot path
   private inputAccessors: Array<(offset?: number) => number> = [];
-  private outputAccessor: (offset: number) => number;
+
+  // Per-outlet output accessors: y1, y2, etc.
+  private outputAccessors: Array<(offset: number) => number> = [];
 
   // Pre-extracted inlet values array
   private inletArgs: [number, number, number, number, number, number, number, number, number] = [
     0, 0, 0, 0, 0, 0, 0, 0, 0
   ];
+
+  private historyIndex = 0;
 
   constructor() {
     super();
@@ -87,25 +107,46 @@ class FExprProcessor extends AudioWorkletProcessor {
     // Create accessor functions for each input
     for (let i = 0; i < MAX_SIGNAL_INLETS; i++) {
       const history = this.inputHistory[i];
+
       this.inputAccessors.push((offset: number = 0) => {
         return this.getHistorySample(history, offset);
       });
     }
 
-    // Create output accessor
-    this.outputAccessor = (offset: number) => {
-      // Output history only allows negative offsets (previous samples)
-      if (offset >= 0) return 0;
-      return this.getHistorySample(this.outputHistory, offset);
-    };
+    // Initialize with 1 output accessor
+    this.rebuildOutputAccessors(1);
 
-    this.port.onmessage = (event: MessageEvent<ExpressionMessage | InletValuesMessage>) => {
+    this.port.onmessage = (
+      event: MessageEvent<ExpressionMessage | MultiExpressionMessage | InletValuesMessage>
+    ) => {
       if (event.data.type === 'set-expression') {
         this.setExpression(event.data.expression);
+      } else if (event.data.type === 'set-expressions') {
+        this.setExpressions(event.data.assignments, event.data.outletExpressions);
       } else if (event.data.type === 'set-inlet-values') {
         this.setInletValues(event.data.values);
       }
     };
+  }
+
+  /**
+   * Rebuild output history buffers and accessor functions for a given outlet count.
+   */
+  private rebuildOutputAccessors(outletCount: number): void {
+    this.outputHistories = [];
+    this.outputAccessors = [];
+
+    for (let i = 0; i < outletCount; i++) {
+      const history = new Float32Array(HISTORY_SIZE);
+
+      this.outputHistories.push(history);
+
+      this.outputAccessors.push((offset: number) => {
+        if (offset >= 0) return 0;
+
+        return this.getHistorySample(history, offset);
+      });
+    }
   }
 
   /**
@@ -135,20 +176,8 @@ class FExprProcessor extends AudioWorkletProcessor {
     return s1 + (s2 - s1) * -frac;
   }
 
-  private setExpression(expressionString: string): void {
-    if (!expressionString || expressionString.trim() === '') {
-      this.evaluator = null;
-      return;
-    }
-
-    // Reset history when expression changes
-    for (const history of this.inputHistory) {
-      history.fill(0);
-    }
-    this.outputHistory.fill(0);
-    this.historyIndex = 0;
-
-    const parser = new Parser({
+  private createParser(): Parser {
+    return new Parser({
       operators: {
         add: true,
         concatenate: true,
@@ -165,51 +194,90 @@ class FExprProcessor extends AudioWorkletProcessor {
         assignment: true
       }
     });
+  }
 
+  // Parameter names matching FExprDspFn signature
+  private static parameterNames = [
+    // Input accessors x1-x9
+    ...Array.from({ length: 9 }, (_, i) => `x${i + 1}`),
+
+    // Aliases s1-s9
+    ...Array.from({ length: 9 }, (_, i) => `s${i + 1}`),
+
+    // Output accessors y1-y9
+    ...Array.from({ length: 9 }, (_, i) => `y${i + 1}`),
+
+    // Other params
+    'i',
+    't',
+
+    // Control values c1-c9
+    ...Array.from({ length: 9 }, (_, i) => `c${i + 1}`)
+  ];
+
+  // Uses the shared pure function below
+  private static transformExpression = transformFExprExpression;
+
+  private compileExpression(expressionString: string): FExprDspFn | null {
     try {
-      // Transform expression:
-      // 1. $1, $2, etc. -> c1, c2, etc. (control values)
-      // 2. x1[-1], s1[-2], etc. -> x1(-1), s1(-2) (function call syntax for history)
-      // 3. y1[-1] -> y1(-1)
-      // 4. bare x1, s1 (no brackets) -> x1(0), s1(0)
-      // 5. bare s[-1] -> x1(-1), bare s -> x1(0)
-      const transformed = expressionString
-        // Control values: $1 -> c1
-        .replace(/\$(\d+)/g, 'c$1')
-        // Bare s with history: s[-1] -> x1(-1) (must come before other s transformations)
-        .replace(/\bs\[(-?\d+(?:\.\d+)?)\]/g, 'x1($1)')
-        // Input history access: x1[-1] or s1[-1] -> x1(-1) or s1(-1)
-        .replace(/([xs])(\d+)\[(-?\d+(?:\.\d+)?)\]/g, '$1$2($3)')
-        // Output history access: y1[-1] -> y1(-1)
-        .replace(/y(\d+)\[(-?\d+(?:\.\d+)?)\]/g, 'y$1($2)')
-        // Bare x1, s1 without brackets -> x1(0), s1(0) (current sample)
-        // Use negative lookahead to avoid transforming already-converted x1(
-        .replace(/\b([xs])(\d+)\b(?!\s*\()/g, '$1$2(0)')
-        // Bare `s` (not followed by digit or bracket) -> x1(0) for backwards compat with expr~
-        .replace(/\bs\b(?![\d[])/g, 'x1(0)');
-
+      const transformed = FExprProcessor.transformExpression(expressionString);
+      const parser = this.createParser();
       const expr = parser.parse(transformed);
 
-      // Parameter names matching FExprDspFn signature
-      const parameterNames = [
-        // Input accessors x1-x9
-        ...Array.from({ length: 9 }, (_, i) => `x${i + 1}`),
-        // Aliases s1-s9
-        ...Array.from({ length: 9 }, (_, i) => `s${i + 1}`),
-        // Output accessor y1
-        'y1',
-        // Other params
-        'i',
-        't',
-        // Control values c1-c9
-        ...Array.from({ length: 9 }, (_, i) => `c${i + 1}`)
-      ];
-
-      this.evaluator = expr.toJSFunction(parameterNames.join(',')) as FExprDspFn;
+      return expr.toJSFunction(FExprProcessor.parameterNames.join(',')) as FExprDspFn;
     } catch (error) {
       console.error('Failed to compile fexpr~ expression:', error);
-      this.evaluator = null;
+      return null;
     }
+  }
+
+  private resetHistory(outletCount: number): void {
+    for (const history of this.inputHistory) {
+      history.fill(0);
+    }
+
+    this.historyIndex = 0;
+    this.rebuildOutputAccessors(outletCount);
+  }
+
+  /**
+   * Set a single expression (backwards compat, single outlet).
+   */
+  private setExpression(expressionString: string): void {
+    if (!expressionString || expressionString.trim() === '') {
+      this.evaluators = [];
+      return;
+    }
+
+    this.resetHistory(1);
+
+    const fn = this.compileExpression(expressionString);
+
+    this.evaluators = fn ? [fn] : [];
+  }
+
+  /**
+   * Set multiple outlet expressions with shared assignments.
+   */
+  private setExpressions(assignments: string[], outletExpressions: string[]): void {
+    const outletCount = Math.max(1, outletExpressions.length);
+    this.resetHistory(outletCount);
+
+    const prefix = assignments.length > 0 ? assignments.join(';') + ';' : '';
+    const fns: FExprDspFn[] = [];
+
+    for (const outletExpr of outletExpressions) {
+      const fn = this.compileExpression(prefix + outletExpr);
+
+      if (fn) {
+        fns.push(fn);
+      } else {
+        this.evaluators = [];
+        return;
+      }
+    }
+
+    this.evaluators = fns;
   }
 
   private setInletValues(values: number[]): void {
@@ -218,24 +286,40 @@ class FExprProcessor extends AudioWorkletProcessor {
     }
   }
 
-  process(inputs: Float32Array[][], outputs: Float32Array[][]): boolean {
-    const output = outputs[0]?.[0];
-    if (!output) return true;
+  // Dummy accessor that always returns 0 (for unused y slots)
+  private static zeroAccessor = () => 0;
 
-    // Keep alive even without evaluator
-    if (!this.evaluator) {
-      output.fill(0);
+  process(inputs: Float32Array[][], outputs: Float32Array[][]): boolean {
+    // Keep alive even without evaluators
+    if (this.evaluators.length === 0) {
+      for (const output of outputs) {
+        if (output[0]) output[0].fill(0);
+      }
+
       return true;
     }
 
     try {
-      const bufferSize = output.length;
+      const bufferSize = outputs[0]?.[0]?.length ?? 128;
 
       // Snapshot control values once per block
       const args = this.inletArgs;
+
       for (let k = 0; k < 9; k++) {
         args[k] = this.inletValues[k];
       }
+
+      // Build y accessor array: real accessors for existing outlets, zero for the rest
+      const ya = this.outputAccessors;
+      const y1 = ya[0] ?? FExprProcessor.zeroAccessor;
+      const y2 = ya[1] ?? FExprProcessor.zeroAccessor;
+      const y3 = ya[2] ?? FExprProcessor.zeroAccessor;
+      const y4 = ya[3] ?? FExprProcessor.zeroAccessor;
+      const y5 = ya[4] ?? FExprProcessor.zeroAccessor;
+      const y6 = ya[5] ?? FExprProcessor.zeroAccessor;
+      const y7 = ya[6] ?? FExprProcessor.zeroAccessor;
+      const y8 = ya[7] ?? FExprProcessor.zeroAccessor;
+      const y9 = ya[8] ?? FExprProcessor.zeroAccessor;
 
       // Process sample by sample (required for feedback to work correctly)
       for (let i = 0; i < bufferSize; i++) {
@@ -244,67 +328,82 @@ class FExprProcessor extends AudioWorkletProcessor {
         // Store current input samples in history
         for (let inlet = 0; inlet < MAX_SIGNAL_INLETS; inlet++) {
           const sample = inputs[inlet]?.[0]?.[i] ?? 0;
+
           this.inputHistory[inlet][this.historyIndex] = sample;
         }
 
-        try {
-          // Call evaluator with all accessors and values
-          const result = this.evaluator(
-            // x1-x9 accessors
-            this.inputAccessors[0],
-            this.inputAccessors[1],
-            this.inputAccessors[2],
-            this.inputAccessors[3],
-            this.inputAccessors[4],
-            this.inputAccessors[5],
-            this.inputAccessors[6],
-            this.inputAccessors[7],
-            this.inputAccessors[8],
-            // s1-s9 accessors (same as x1-x9)
-            this.inputAccessors[0],
-            this.inputAccessors[1],
-            this.inputAccessors[2],
-            this.inputAccessors[3],
-            this.inputAccessors[4],
-            this.inputAccessors[5],
-            this.inputAccessors[6],
-            this.inputAccessors[7],
-            this.inputAccessors[8],
-            // y1 accessor
-            this.outputAccessor,
-            // i, t
-            i,
-            t,
-            // c1-c9 control values
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8]
-          );
+        // Evaluate each outlet expression
+        for (let outIdx = 0; outIdx < this.evaluators.length; outIdx++) {
+          const outBuf = outputs[outIdx]?.[0];
+          if (!outBuf) continue;
 
-          if (typeof result !== 'number' || isNaN(result)) {
-            output[i] = 0;
-          } else {
-            output[i] = result;
+          try {
+            const result = this.evaluators[outIdx](
+              // x1-x9 accessors
+              this.inputAccessors[0],
+              this.inputAccessors[1],
+              this.inputAccessors[2],
+              this.inputAccessors[3],
+              this.inputAccessors[4],
+              this.inputAccessors[5],
+              this.inputAccessors[6],
+              this.inputAccessors[7],
+              this.inputAccessors[8],
+
+              // s1-s9 accessors (same as x1-x9)
+              this.inputAccessors[0],
+              this.inputAccessors[1],
+              this.inputAccessors[2],
+              this.inputAccessors[3],
+              this.inputAccessors[4],
+              this.inputAccessors[5],
+              this.inputAccessors[6],
+              this.inputAccessors[7],
+              this.inputAccessors[8],
+
+              // y1-y9 output history accessors
+              y1,
+              y2,
+              y3,
+              y4,
+              y5,
+              y6,
+              y7,
+              y8,
+              y9,
+
+              // i, t
+              i,
+              t,
+
+              // c1-c9 control values
+              args[0],
+              args[1],
+              args[2],
+              args[3],
+              args[4],
+              args[5],
+              args[6],
+              args[7],
+              args[8]
+            );
+
+            const value = typeof result === 'number' && !isNaN(result) ? result : 0;
+            outBuf[i] = value;
+
+            // Store in this outlet's history (for y access in next sample)
+            this.outputHistories[outIdx][this.historyIndex] = value;
+          } catch {
+            outBuf[i] = 0;
+            this.outputHistories[outIdx][this.historyIndex] = 0;
           }
-        } catch {
-          output[i] = 0;
         }
 
-        // Store output in history (for y1[-1] access in next sample)
-        this.outputHistory[this.historyIndex] = output[i];
-
-        // Advance history index
+        // Advance history index after all outlets are evaluated
         this.historyIndex = (this.historyIndex + 1) % HISTORY_SIZE;
       }
     } catch (error) {
       console.error('fexpr~ processing error:', error);
-      output.fill(0);
     }
 
     return true;

--- a/ui/src/lib/audio/fexpr-processor.ts
+++ b/ui/src/lib/audio/fexpr-processor.ts
@@ -220,7 +220,9 @@ class FExprProcessor extends AudioWorkletProcessor {
 
   private compileExpression(expressionString: string): FExprDspFn | null {
     try {
-      const transformed = FExprProcessor.transformExpression(expressionString);
+      // Normalize newlines to spaces so multi-line expressions (e.g. ternaries) work
+      const normalized = expressionString.replace(/\n/g, ' ');
+      const transformed = FExprProcessor.transformExpression(normalized);
       const parser = this.createParser();
       const expr = parser.parse(transformed);
 
@@ -242,6 +244,8 @@ class FExprProcessor extends AudioWorkletProcessor {
 
   /**
    * Set a single expression (backwards compat, single outlet).
+   * Newlines are converted to semicolons so expr-eval treats them
+   * as sequential statements (evaluates all, returns last value).
    */
   private setExpression(expressionString: string): void {
     if (!expressionString || expressionString.trim() === '') {
@@ -251,7 +255,8 @@ class FExprProcessor extends AudioWorkletProcessor {
 
     this.resetHistory(1);
 
-    const fn = this.compileExpression(expressionString);
+    const normalized = expressionString.replace(/\n/g, ';');
+    const fn = this.compileExpression(normalized);
 
     this.evaluators = fn ? [fn] : [];
   }

--- a/ui/src/lib/audio/fexpr-transform.test.ts
+++ b/ui/src/lib/audio/fexpr-transform.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { transformFExprExpression } from './fexpr-transform';
+
+describe('transformFExprExpression', () => {
+  it('converts control values: $1 → c1', () => {
+    expect(transformFExprExpression('$1 + $2')).toBe('c1 + c2');
+  });
+
+  it('converts bare s with history: s[-1] → x1(-1)', () => {
+    expect(transformFExprExpression('s[-1]')).toBe('x1(-1)');
+    expect(transformFExprExpression('s[-2.5]')).toBe('x1(-2.5)');
+  });
+
+  it('converts input history access: x1[-1] → x1(-1)', () => {
+    expect(transformFExprExpression('x1[-1]')).toBe('x1(-1)');
+    expect(transformFExprExpression('s1[-2]')).toBe('s1(-2)');
+    expect(transformFExprExpression('x2[-1.5]')).toBe('x2(-1.5)');
+  });
+
+  it('converts output history access: y1[-1] → y1(-1)', () => {
+    expect(transformFExprExpression('y1[-1]')).toBe('y1(-1)');
+    expect(transformFExprExpression('y2[-3]')).toBe('y2(-3)');
+  });
+
+  it('converts bare variables to current sample: x1 → x1(0)', () => {
+    expect(transformFExprExpression('x1 + x2')).toBe('x1(0) + x2(0)');
+    expect(transformFExprExpression('s1 * s2')).toBe('s1(0) * s2(0)');
+  });
+
+  it('converts bare s to x1(0)', () => {
+    expect(transformFExprExpression('s * 2')).toBe('x1(0) * 2');
+  });
+
+  it('does not double-convert already-converted accessors', () => {
+    // x1[-1] should become x1(-1), not x1(-1)(0)
+    expect(transformFExprExpression('x1[-1] + x1')).toBe('x1(-1) + x1(0)');
+  });
+
+  it('handles a full IIR filter expression', () => {
+    const input = 'x1 * 0.1 + y1[-1] * 0.9';
+    const expected = 'x1(0) * 0.1 + y1(-1) * 0.9';
+
+    expect(transformFExprExpression(input)).toBe(expected);
+  });
+
+  it('handles multi-outlet with cross-outlet y references', () => {
+    expect(transformFExprExpression('y2[-1] * 0.5')).toBe('y2(-1) * 0.5');
+  });
+});

--- a/ui/src/lib/audio/fexpr-transform.ts
+++ b/ui/src/lib/audio/fexpr-transform.ts
@@ -1,0 +1,26 @@
+/**
+ * Transform fexpr~ expression syntax to expr-eval compatible format.
+ *
+ * Conversions:
+ * - $1, $2 → c1, c2 (control values)
+ * - s[-1] → x1(-1) (bare s with history)
+ * - x1[-1], s1[-2] → x1(-1), s1(-2) (function call syntax)
+ * - y1[-1] → y1(-1) (output history)
+ * - bare x1, s1 → x1(0), s1(0) (current sample)
+ * - bare s → x1(0) (backwards compat)
+ */
+export const transformFExprExpression = (expressionString: string): string =>
+  expressionString
+    // Control values: $1 -> c1
+    .replace(/\$(\d+)/g, 'c$1')
+    // Bare s with history: s[-1] -> x1(-1) (must come before other s transformations)
+    .replace(/\bs\[(-?\d+(?:\.\d+)?)\]/g, 'x1($1)')
+    // Input history access: x1[-1] or s1[-1] -> x1(-1) or s1(-1)
+    .replace(/([xs])(\d+)\[(-?\d+(?:\.\d+)?)\]/g, '$1$2($3)')
+    // Output history access: y1[-1] -> y1(-1)
+    .replace(/y(\d+)\[(-?\d+(?:\.\d+)?)\]/g, 'y$1($2)')
+    // Bare x1, s1 without brackets -> x1(0), s1(0) (current sample)
+    // Use negative lookahead to avoid transforming already-converted x1(
+    .replace(/\b([xs])(\d+)\b(?!\s*\()/g, '$1$2(0)')
+    // Bare `s` (not followed by digit or bracket) -> x1(0) for backwards compat with expr~
+    .replace(/\bs\b(?![\d[])/g, 'x1(0)');

--- a/ui/src/lib/audio/v2/nodes/ExprNode.ts
+++ b/ui/src/lib/audio/v2/nodes/ExprNode.ts
@@ -2,6 +2,7 @@ import type { AudioNodeV2, AudioNodeGroup } from '../interfaces/audio-nodes';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 import { logger } from '$lib/utils/logger';
 import { handleToPortIndex } from '$lib/utils/get-edge-types';
+import { parseMultiOutletExpressions } from '$lib/utils/expr-parser';
 import { match, P } from 'ts-pattern';
 import workletUrl from '../../../audio/expression-processor?worker&url';
 
@@ -59,10 +60,18 @@ export class ExprNode implements AudioNodeV2 {
 
     const [, expression] = params as [unknown, string];
 
-    await this.createWorklet(1);
-
     if (expression) {
-      this.send('expression', expression);
+      const parsed = parseMultiOutletExpressions(expression);
+
+      await this.createWorklet(parsed.outletCount);
+
+      this.workletNode?.port.postMessage({
+        type: 'set-expressions',
+        assignments: parsed.assignments,
+        outletExpressions: parsed.outletExpressions
+      });
+    } else {
+      await this.createWorklet(1);
     }
   }
 

--- a/ui/src/lib/audio/v2/nodes/ExprNode.ts
+++ b/ui/src/lib/audio/v2/nodes/ExprNode.ts
@@ -12,6 +12,10 @@ const MAX_SIGNAL_INLETS = 9;
  * ExprNode implements the expr~ (expression evaluator) audio node.
  * Evaluates mathematical expressions on audio samples.
  * Supports multiple outlets via semicolon-separated expressions.
+ *
+ * audioNode IS the AudioWorkletNode — no intermediate gain node.
+ * This ensures AudioService.updateEdges() properly disconnects all
+ * outgoing connections via audioNode.disconnect().
  */
 export class ExprNode implements AudioNodeV2 {
   static type = 'expr~';
@@ -38,21 +42,20 @@ export class ExprNode implements AudioNodeV2 {
     { name: 'out', type: 'signal', description: 'Expression result as audio output' }
   ];
 
-  // Output gain
-  audioNode: GainNode;
+  audioNode: AudioNode | null = null;
 
   readonly nodeId: string;
 
-  private workletNode: AudioWorkletNode | null = null;
   private audioContext: AudioContext;
   private currentOutletCount: number = 1;
 
   constructor(nodeId: string, audioContext: AudioContext) {
     this.nodeId = nodeId;
     this.audioContext = audioContext;
-    // Create gain node immediately for connections
-    this.audioNode = audioContext.createGain();
-    this.audioNode.gain.value = 1.0;
+  }
+
+  private get port(): MessagePort | undefined {
+    return (this.audioNode as AudioWorkletNode)?.port;
   }
 
   async create(params: unknown[]): Promise<void> {
@@ -65,7 +68,7 @@ export class ExprNode implements AudioNodeV2 {
 
       await this.createWorklet(parsed.outletCount);
 
-      this.workletNode?.port.postMessage({
+      this.port?.postMessage({
         type: 'set-expressions',
         assignments: parsed.assignments,
         outletExpressions: parsed.outletExpressions
@@ -76,22 +79,16 @@ export class ExprNode implements AudioNodeV2 {
   }
 
   private async createWorklet(outletCount: number): Promise<void> {
-    // Disconnect and clean up existing worklet
-    if (this.workletNode) {
-      this.workletNode.disconnect();
-      this.workletNode = null;
+    if (this.audioNode) {
+      this.audioNode.disconnect();
+      this.audioNode = null;
     }
 
     try {
-      this.workletNode = new AudioWorkletNode(this.audioContext, 'expression-processor', {
+      this.audioNode = new AudioWorkletNode(this.audioContext, 'expression-processor', {
         numberOfInputs: MAX_SIGNAL_INLETS,
         numberOfOutputs: outletCount
       });
-
-      // For single outlet, connect worklet directly to gain output.
-      // For multi-outlet, the `connect` method handles per-output routing,
-      // so we only connect output 0 to the gain node as a default.
-      this.workletNode.connect(this.audioNode, 0);
 
       this.currentOutletCount = outletCount;
     } catch (error) {
@@ -102,7 +99,7 @@ export class ExprNode implements AudioNodeV2 {
   async send(key: string, msg: unknown): Promise<void> {
     await this.ensureModule();
 
-    const port = this.workletNode?.port;
+    const port = this.port;
 
     if (!port) {
       logger.warn('cannot send message to expr~ as worklet port is missing', { key, msg, port });
@@ -123,7 +120,7 @@ export class ExprNode implements AudioNodeV2 {
         // Recreate worklet if outlet count changed
         if (outletCount !== this.currentOutletCount) {
           this.createWorklet(outletCount).then(() => {
-            this.workletNode?.port.postMessage({
+            this.port?.postMessage({
               type: 'set-expressions',
               assignments,
               outletExpressions
@@ -140,7 +137,7 @@ export class ExprNode implements AudioNodeV2 {
 
   /**
    * Handle outgoing connections - route from correct worklet output based on source handle.
-   * Handles: audio-out (default to output 0), audio-out-0, audio-out-1, etc.
+   * Handles: audio-out-0, audio-out-1, etc.
    */
   connect(
     target: AudioNodeV2,
@@ -148,7 +145,7 @@ export class ExprNode implements AudioNodeV2 {
     sourceHandle?: string,
     targetHandle?: string
   ): void {
-    if (!this.workletNode || !target.audioNode) return;
+    if (!this.audioNode || !target.audioNode) return;
 
     const outputIndexRaw = sourceHandle ? handleToPortIndex(sourceHandle) : null;
     const outputIndex = outputIndexRaw !== null && !isNaN(outputIndexRaw) ? outputIndexRaw : 0;
@@ -160,12 +157,12 @@ export class ExprNode implements AudioNodeV2 {
       const inputIndex = handleToPortIndex(targetHandle);
 
       if (inputIndex !== null && !isNaN(inputIndex)) {
-        this.workletNode.connect(target.audioNode, outputIndex, inputIndex);
+        this.audioNode.connect(target.audioNode, outputIndex, inputIndex);
         return;
       }
     }
 
-    this.workletNode.connect(target.audioNode, outputIndex, 0);
+    this.audioNode.connect(target.audioNode, outputIndex, 0);
   }
 
   /**
@@ -180,7 +177,7 @@ export class ExprNode implements AudioNodeV2 {
   ): Promise<void> {
     await this.ensureModule();
 
-    if (!this.workletNode || !source.audioNode) return;
+    if (!this.audioNode || !source.audioNode) return;
 
     // Parse input index from target handle (e.g., "audio-in-2" -> 2)
     let inputIndex = 0;
@@ -194,7 +191,7 @@ export class ExprNode implements AudioNodeV2 {
     }
 
     // Connect source to the correct worklet input
-    source.audioNode.connect(this.workletNode, 0, inputIndex);
+    source.audioNode.connect(this.audioNode, 0, inputIndex);
   }
 
   async ensureModule(): Promise<void> {
@@ -202,8 +199,7 @@ export class ExprNode implements AudioNodeV2 {
   }
 
   destroy(): void {
-    this.workletNode?.disconnect();
-    this.audioNode.disconnect();
+    this.audioNode?.disconnect();
   }
 
   private static moduleReady = false;

--- a/ui/src/lib/audio/v2/nodes/ExprNode.ts
+++ b/ui/src/lib/audio/v2/nodes/ExprNode.ts
@@ -141,7 +141,8 @@ export class ExprNode implements AudioNodeV2 {
   ): void {
     if (!this.workletNode || !target.audioNode) return;
 
-    const outputIndex = sourceHandle ? (handleToPortIndex(sourceHandle) ?? 0) : 0;
+    const outputIndexRaw = sourceHandle ? handleToPortIndex(sourceHandle) : null;
+    const outputIndex = outputIndexRaw !== null && !isNaN(outputIndexRaw) ? outputIndexRaw : 0;
 
     // Skip if output index exceeds current outlet count (stale edge from before outlet reduction)
     if (outputIndex >= this.currentOutletCount) return;

--- a/ui/src/lib/audio/v2/nodes/ExprNode.ts
+++ b/ui/src/lib/audio/v2/nodes/ExprNode.ts
@@ -1,6 +1,7 @@
 import type { AudioNodeV2, AudioNodeGroup } from '../interfaces/audio-nodes';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 import { logger } from '$lib/utils/logger';
+import { handleToPortIndex } from '$lib/utils/get-edge-types';
 import { match, P } from 'ts-pattern';
 import workletUrl from '../../../audio/expression-processor?worker&url';
 
@@ -9,6 +10,7 @@ const MAX_SIGNAL_INLETS = 9;
 /**
  * ExprNode implements the expr~ (expression evaluator) audio node.
  * Evaluates mathematical expressions on audio samples.
+ * Supports multiple outlets via semicolon-separated expressions.
  */
 export class ExprNode implements AudioNodeV2 {
   static type = 'expr~';
@@ -42,6 +44,7 @@ export class ExprNode implements AudioNodeV2 {
 
   private workletNode: AudioWorkletNode | null = null;
   private audioContext: AudioContext;
+  private currentOutletCount: number = 1;
 
   constructor(nodeId: string, audioContext: AudioContext) {
     this.nodeId = nodeId;
@@ -56,16 +59,32 @@ export class ExprNode implements AudioNodeV2 {
 
     const [, expression] = params as [unknown, string];
 
+    await this.createWorklet(1);
+
+    if (expression) {
+      this.send('expression', expression);
+    }
+  }
+
+  private async createWorklet(outletCount: number): Promise<void> {
+    // Disconnect and clean up existing worklet
+    if (this.workletNode) {
+      this.workletNode.disconnect();
+      this.workletNode = null;
+    }
+
     try {
       this.workletNode = new AudioWorkletNode(this.audioContext, 'expression-processor', {
         numberOfInputs: MAX_SIGNAL_INLETS,
-        numberOfOutputs: 1
+        numberOfOutputs: outletCount
       });
-      this.workletNode.connect(this.audioNode);
 
-      if (expression) {
-        this.send('expression', expression);
-      }
+      // For single outlet, connect worklet directly to gain output.
+      // For multi-outlet, the `connect` method handles per-output routing,
+      // so we only connect output 0 to the gain node as a default.
+      this.workletNode.connect(this.audioNode, 0);
+
+      this.currentOutletCount = outletCount;
     } catch (error) {
       logger.error('Failed to create expression node:', error);
     }
@@ -85,9 +104,58 @@ export class ExprNode implements AudioNodeV2 {
       .with(['expression', P.string], ([, expression]) => {
         port.postMessage({ type: 'set-expression', expression });
       })
+      .with(['expressions', P.select()], (data) => {
+        const { assignments, outletExpressions, outletCount } = data as {
+          assignments: string[];
+          outletExpressions: string[];
+          outletCount: number;
+        };
+
+        // Recreate worklet if outlet count changed
+        if (outletCount !== this.currentOutletCount) {
+          this.createWorklet(outletCount).then(() => {
+            this.workletNode?.port.postMessage({
+              type: 'set-expressions',
+              assignments,
+              outletExpressions
+            });
+          });
+        } else {
+          port.postMessage({ type: 'set-expressions', assignments, outletExpressions });
+        }
+      })
       .with(['inletValues', P.array(P.number)], ([, values]) => {
         port.postMessage({ type: 'set-inlet-values', values: Array.from(values) });
       });
+  }
+
+  /**
+   * Handle outgoing connections - route from correct worklet output based on source handle.
+   * Handles: audio-out (default to output 0), audio-out-0, audio-out-1, etc.
+   */
+  connect(
+    target: AudioNodeV2,
+    _paramName?: string,
+    sourceHandle?: string,
+    targetHandle?: string
+  ): void {
+    if (!this.workletNode || !target.audioNode) return;
+
+    const outputIndex = sourceHandle ? (handleToPortIndex(sourceHandle) ?? 0) : 0;
+
+    // Skip if output index exceeds current outlet count (stale edge from before outlet reduction)
+    if (outputIndex >= this.currentOutletCount) return;
+
+    if (targetHandle) {
+      const inputIndex = handleToPortIndex(targetHandle);
+
+      if (inputIndex !== null && !isNaN(inputIndex)) {
+        this.workletNode.connect(target.audioNode, outputIndex, inputIndex);
+        return;
+      }
+    }
+
+    this.workletNode.connect(target.audioNode, outputIndex, 0);
   }
 
   /**
@@ -106,15 +174,16 @@ export class ExprNode implements AudioNodeV2 {
 
     // Parse input index from target handle (e.g., "audio-in-2" -> 2)
     let inputIndex = 0;
+
     if (targetHandle) {
       const indexMatch = targetHandle.match(/audio-in-(\d+)/);
+
       if (indexMatch) {
         inputIndex = parseInt(indexMatch[1], 10);
       }
     }
 
     // Connect source to the correct worklet input
-    // connect(destination, outputIndex, inputIndex)
     source.audioNode.connect(this.workletNode, 0, inputIndex);
   }
 

--- a/ui/src/lib/audio/v2/nodes/FExprNode.ts
+++ b/ui/src/lib/audio/v2/nodes/FExprNode.ts
@@ -128,7 +128,8 @@ export class FExprNode implements AudioNodeV2 {
   ): void {
     if (!this.workletNode || !target.audioNode) return;
 
-    const outputIndex = sourceHandle ? (handleToPortIndex(sourceHandle) ?? 0) : 0;
+    const outputIndexRaw = sourceHandle ? handleToPortIndex(sourceHandle) : null;
+    const outputIndex = outputIndexRaw !== null && !isNaN(outputIndexRaw) ? outputIndexRaw : 0;
 
     // Skip if output index exceeds current outlet count (stale edge)
     if (outputIndex >= this.currentOutletCount) return;

--- a/ui/src/lib/audio/v2/nodes/FExprNode.ts
+++ b/ui/src/lib/audio/v2/nodes/FExprNode.ts
@@ -13,6 +13,10 @@ const MAX_SIGNAL_INLETS = 9;
  * Evaluates mathematical expressions sample-by-sample with access to
  * previous input and output samples for building FIR/IIR filters.
  * Supports multiple outlets via semicolon-separated expressions.
+ *
+ * audioNode IS the AudioWorkletNode — no intermediate gain node.
+ * This ensures AudioService.updateEdges() properly disconnects all
+ * outgoing connections via audioNode.disconnect().
  */
 export class FExprNode implements AudioNodeV2 {
   static type = 'fexpr~';
@@ -32,21 +36,20 @@ export class FExprNode implements AudioNodeV2 {
     { name: 'out', type: 'signal', description: 'Expression result as audio output' }
   ];
 
-  // Output gain
-  audioNode: GainNode;
+  audioNode: AudioNode | null = null;
 
   readonly nodeId: string;
 
-  private workletNode: AudioWorkletNode | null = null;
   private audioContext: AudioContext;
   private currentOutletCount: number = 1;
 
   constructor(nodeId: string, audioContext: AudioContext) {
     this.nodeId = nodeId;
     this.audioContext = audioContext;
-    // Create gain node immediately for connections
-    this.audioNode = audioContext.createGain();
-    this.audioNode.gain.value = 1.0;
+  }
+
+  private get port(): MessagePort | undefined {
+    return (this.audioNode as AudioWorkletNode)?.port;
   }
 
   async create(params: unknown[]): Promise<void> {
@@ -59,7 +62,7 @@ export class FExprNode implements AudioNodeV2 {
 
       await this.createWorklet(parsed.outletCount);
 
-      this.workletNode?.port.postMessage({
+      this.port?.postMessage({
         type: 'set-expressions',
         assignments: parsed.assignments,
         outletExpressions: parsed.outletExpressions
@@ -70,18 +73,17 @@ export class FExprNode implements AudioNodeV2 {
   }
 
   private async createWorklet(outletCount: number): Promise<void> {
-    if (this.workletNode) {
-      this.workletNode.disconnect();
-      this.workletNode = null;
+    if (this.audioNode) {
+      this.audioNode.disconnect();
+      this.audioNode = null;
     }
 
     try {
-      this.workletNode = new AudioWorkletNode(this.audioContext, 'fexpr-processor', {
+      this.audioNode = new AudioWorkletNode(this.audioContext, 'fexpr-processor', {
         numberOfInputs: MAX_SIGNAL_INLETS,
         numberOfOutputs: outletCount
       });
 
-      this.workletNode.connect(this.audioNode, 0);
       this.currentOutletCount = outletCount;
     } catch (error) {
       logger.error('Failed to create fexpr~ node:', error);
@@ -91,7 +93,7 @@ export class FExprNode implements AudioNodeV2 {
   async send(key: string, msg: unknown): Promise<void> {
     await this.ensureModule();
 
-    const port = this.workletNode?.port;
+    const port = this.port;
 
     if (!port) {
       logger.warn('cannot send message to fexpr~ as worklet port is missing', { key, msg, port });
@@ -111,7 +113,7 @@ export class FExprNode implements AudioNodeV2 {
 
         if (outletCount !== this.currentOutletCount) {
           this.createWorklet(outletCount).then(() => {
-            this.workletNode?.port.postMessage({
+            this.port?.postMessage({
               type: 'set-expressions',
               assignments,
               outletExpressions
@@ -135,7 +137,7 @@ export class FExprNode implements AudioNodeV2 {
     sourceHandle?: string,
     targetHandle?: string
   ): void {
-    if (!this.workletNode || !target.audioNode) return;
+    if (!this.audioNode || !target.audioNode) return;
 
     const outputIndexRaw = sourceHandle ? handleToPortIndex(sourceHandle) : null;
     const outputIndex = outputIndexRaw !== null && !isNaN(outputIndexRaw) ? outputIndexRaw : 0;
@@ -147,12 +149,12 @@ export class FExprNode implements AudioNodeV2 {
       const inputIndex = handleToPortIndex(targetHandle);
 
       if (inputIndex !== null && !isNaN(inputIndex)) {
-        this.workletNode.connect(target.audioNode, outputIndex, inputIndex);
+        this.audioNode.connect(target.audioNode, outputIndex, inputIndex);
         return;
       }
     }
 
-    this.workletNode.connect(target.audioNode, outputIndex, 0);
+    this.audioNode.connect(target.audioNode, outputIndex, 0);
   }
 
   /**
@@ -166,7 +168,7 @@ export class FExprNode implements AudioNodeV2 {
   ): Promise<void> {
     await this.ensureModule();
 
-    if (!this.workletNode || !source.audioNode) return;
+    if (!this.audioNode || !source.audioNode) return;
 
     let inputIndex = 0;
 
@@ -178,7 +180,7 @@ export class FExprNode implements AudioNodeV2 {
       }
     }
 
-    source.audioNode.connect(this.workletNode, 0, inputIndex);
+    source.audioNode.connect(this.audioNode, 0, inputIndex);
   }
 
   async ensureModule(): Promise<void> {
@@ -186,8 +188,7 @@ export class FExprNode implements AudioNodeV2 {
   }
 
   destroy(): void {
-    this.workletNode?.disconnect();
-    this.audioNode.disconnect();
+    this.audioNode?.disconnect();
   }
 
   private static moduleReady = false;

--- a/ui/src/lib/audio/v2/nodes/FExprNode.ts
+++ b/ui/src/lib/audio/v2/nodes/FExprNode.ts
@@ -1,6 +1,7 @@
 import type { AudioNodeV2, AudioNodeGroup } from '../interfaces/audio-nodes';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 import { logger } from '$lib/utils/logger';
+import { handleToPortIndex } from '$lib/utils/get-edge-types';
 import { match, P } from 'ts-pattern';
 import workletUrl from '../../../audio/fexpr-processor?worker&url';
 
@@ -10,6 +11,7 @@ const MAX_SIGNAL_INLETS = 9;
  * FExprNode implements the fexpr~ (filter expression) audio node.
  * Evaluates mathematical expressions sample-by-sample with access to
  * previous input and output samples for building FIR/IIR filters.
+ * Supports multiple outlets via semicolon-separated expressions.
  */
 export class FExprNode implements AudioNodeV2 {
   static type = 'fexpr~';
@@ -36,6 +38,7 @@ export class FExprNode implements AudioNodeV2 {
 
   private workletNode: AudioWorkletNode | null = null;
   private audioContext: AudioContext;
+  private currentOutletCount: number = 1;
 
   constructor(nodeId: string, audioContext: AudioContext) {
     this.nodeId = nodeId;
@@ -50,16 +53,27 @@ export class FExprNode implements AudioNodeV2 {
 
     const [, expression] = params as [unknown, string];
 
+    await this.createWorklet(1);
+
+    if (expression) {
+      this.send('expression', expression);
+    }
+  }
+
+  private async createWorklet(outletCount: number): Promise<void> {
+    if (this.workletNode) {
+      this.workletNode.disconnect();
+      this.workletNode = null;
+    }
+
     try {
       this.workletNode = new AudioWorkletNode(this.audioContext, 'fexpr-processor', {
         numberOfInputs: MAX_SIGNAL_INLETS,
-        numberOfOutputs: 1
+        numberOfOutputs: outletCount
       });
-      this.workletNode.connect(this.audioNode);
 
-      if (expression) {
-        this.send('expression', expression);
-      }
+      this.workletNode.connect(this.audioNode, 0);
+      this.currentOutletCount = outletCount;
     } catch (error) {
       logger.error('Failed to create fexpr~ node:', error);
     }
@@ -79,14 +93,60 @@ export class FExprNode implements AudioNodeV2 {
       .with(['expression', P.string], ([, expression]) => {
         port.postMessage({ type: 'set-expression', expression });
       })
+      .with(['expressions', P.select()], (data) => {
+        const { assignments, outletExpressions, outletCount } = data as {
+          assignments: string[];
+          outletExpressions: string[];
+          outletCount: number;
+        };
+
+        if (outletCount !== this.currentOutletCount) {
+          this.createWorklet(outletCount).then(() => {
+            this.workletNode?.port.postMessage({
+              type: 'set-expressions',
+              assignments,
+              outletExpressions
+            });
+          });
+        } else {
+          port.postMessage({ type: 'set-expressions', assignments, outletExpressions });
+        }
+      })
       .with(['inletValues', P.array(P.number)], ([, values]) => {
         port.postMessage({ type: 'set-inlet-values', values: Array.from(values) });
       });
   }
 
   /**
+   * Handle outgoing connections - route from correct worklet output based on source handle.
+   */
+  connect(
+    target: AudioNodeV2,
+    _paramName?: string,
+    sourceHandle?: string,
+    targetHandle?: string
+  ): void {
+    if (!this.workletNode || !target.audioNode) return;
+
+    const outputIndex = sourceHandle ? (handleToPortIndex(sourceHandle) ?? 0) : 0;
+
+    // Skip if output index exceeds current outlet count (stale edge)
+    if (outputIndex >= this.currentOutletCount) return;
+
+    if (targetHandle) {
+      const inputIndex = handleToPortIndex(targetHandle);
+
+      if (inputIndex !== null && !isNaN(inputIndex)) {
+        this.workletNode.connect(target.audioNode, outputIndex, inputIndex);
+        return;
+      }
+    }
+
+    this.workletNode.connect(target.audioNode, outputIndex, 0);
+  }
+
+  /**
    * Handle incoming connections - route to correct worklet input based on handle.
-   * Handles: audio-in (default to input 0), audio-in-0, audio-in-1, etc.
    */
   async connectFrom(
     source: AudioNodeV2,
@@ -98,16 +158,16 @@ export class FExprNode implements AudioNodeV2 {
 
     if (!this.workletNode || !source.audioNode) return;
 
-    // Parse input index from target handle (e.g., "audio-in-2" -> 2)
     let inputIndex = 0;
+
     if (targetHandle) {
       const indexMatch = targetHandle.match(/audio-in-(\d+)/);
+
       if (indexMatch) {
         inputIndex = parseInt(indexMatch[1], 10);
       }
     }
 
-    // Connect source to the correct worklet input
     source.audioNode.connect(this.workletNode, 0, inputIndex);
   }
 

--- a/ui/src/lib/audio/v2/nodes/FExprNode.ts
+++ b/ui/src/lib/audio/v2/nodes/FExprNode.ts
@@ -2,6 +2,7 @@ import type { AudioNodeV2, AudioNodeGroup } from '../interfaces/audio-nodes';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 import { logger } from '$lib/utils/logger';
 import { handleToPortIndex } from '$lib/utils/get-edge-types';
+import { parseMultiOutletExpressions } from '$lib/utils/expr-parser';
 import { match, P } from 'ts-pattern';
 import workletUrl from '../../../audio/fexpr-processor?worker&url';
 
@@ -53,10 +54,18 @@ export class FExprNode implements AudioNodeV2 {
 
     const [, expression] = params as [unknown, string];
 
-    await this.createWorklet(1);
-
     if (expression) {
-      this.send('expression', expression);
+      const parsed = parseMultiOutletExpressions(expression);
+
+      await this.createWorklet(parsed.outletCount);
+
+      this.workletNode?.port.postMessage({
+        type: 'set-expressions',
+        assignments: parsed.assignments,
+        outletExpressions: parsed.outletExpressions
+      });
+    } else {
+      await this.createWorklet(1);
     }
   }
 

--- a/ui/src/lib/components/nodes/AudioExprNode.svelte
+++ b/ui/src/lib/components/nodes/AudioExprNode.svelte
@@ -6,8 +6,13 @@
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { match, P } from 'ts-pattern';
   import { AudioService } from '$lib/audio/v2/AudioService';
-  import { parseInletCount, parseSignalInletCount } from '$lib/utils/expr-parser';
+  import {
+    parseInletCount,
+    parseSignalInletCount,
+    parseMultiOutletExpressions
+  } from '$lib/utils/expr-parser';
   import CommonExprLayout from './CommonExprLayout.svelte';
+  import { removeExcessAudioOutletEdges } from './outlet-edges';
 
   let {
     id: nodeId,
@@ -26,7 +31,7 @@
   let audioService = AudioService.getInstance();
   let layoutRef = $state<any>();
 
-  const { updateNodeData } = useSvelteFlow();
+  const { updateNodeData, getEdges, deleteElements } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
 
   // Control inlet count ($1, $2, etc.)
@@ -41,6 +46,18 @@
     if (!data.expr.trim()) return 1; // Default to 1 signal inlet
 
     return Math.max(1, parseSignalInletCount(data.expr.trim()));
+  });
+
+  // Outlet count from multi-outlet expressions
+  const outletCount = $derived.by(() => {
+    if (!data.expr.trim()) return 1;
+
+    return parseMultiOutletExpressions(data.expr.trim()).outletCount;
+  });
+
+  // Remove stale edges when outlet count decreases
+  $effect(() => {
+    removeExcessAudioOutletEdges(nodeId, outletCount, getEdges, deleteElements);
   });
 
   const handleMessage: MessageCallbackFn = (message, meta) => {
@@ -73,7 +90,14 @@
   }
 
   function handleRun() {
-    updateAudioExpression(data.expr);
+    const parsed = parseMultiOutletExpressions(data.expr || '');
+
+    // Send multi-outlet expressions to audio node (triggers worklet recreation if outlet count changed)
+    audioService.send(nodeId, 'expressions', {
+      assignments: parsed.assignments,
+      outletExpressions: parsed.outletExpressions,
+      outletCount: parsed.outletCount
+    });
 
     // Update control inlet count when expression changes
     const newControlInletCount = parseInletCount(data.expr || '');
@@ -89,7 +113,7 @@
       updateAudioInletValues(inletValues);
     }
 
-    // Notify xyflow about handle changes (signal inlets may have changed)
+    // Notify xyflow about handle changes (signal inlets or outlets may have changed)
     updateNodeInternals(nodeId);
   }
 
@@ -150,15 +174,19 @@
 {/snippet}
 
 {#snippet audioOutlets()}
-  <!-- Audio output -->
-  <TypedHandle
-    port="outlet"
-    spec={{ handleType: 'audio' }}
-    title="Audio Output"
-    total={1}
-    index={0}
-    {nodeId}
-  />
+  {#each Array.from({ length: outletCount }) as _, index}
+    <TypedHandle
+      port="outlet"
+      spec={{
+        handleType: 'audio',
+        handleId: outletCount === 1 && index === 0 ? undefined : index
+      }}
+      title={outletCount > 1 ? `Out ${index + 1}` : 'Audio Output'}
+      total={outletCount}
+      {index}
+      {nodeId}
+    />
+  {/each}
 {/snippet}
 
 <CommonExprLayout

--- a/ui/src/lib/components/nodes/AudioExprNode.svelte
+++ b/ui/src/lib/components/nodes/AudioExprNode.svelte
@@ -177,10 +177,7 @@
   {#each Array.from({ length: outletCount }) as _, index}
     <TypedHandle
       port="outlet"
-      spec={{
-        handleType: 'audio',
-        handleId: outletCount === 1 && index === 0 ? undefined : index
-      }}
+      spec={{ handleType: 'audio', handleId: index }}
       title={outletCount > 1 ? `Out ${index + 1}` : 'Audio Output'}
       total={outletCount}
       {index}

--- a/ui/src/lib/components/nodes/AudioFExprNode.svelte
+++ b/ui/src/lib/components/nodes/AudioFExprNode.svelte
@@ -6,8 +6,13 @@
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { match, P } from 'ts-pattern';
   import { AudioService } from '$lib/audio/v2/AudioService';
-  import { parseInletCount, parseFExprSignalInletCount } from '$lib/utils/expr-parser';
+  import {
+    parseInletCount,
+    parseFExprSignalInletCount,
+    parseMultiOutletExpressions
+  } from '$lib/utils/expr-parser';
   import CommonExprLayout from './CommonExprLayout.svelte';
+  import { removeExcessAudioOutletEdges } from './outlet-edges';
 
   let {
     id: nodeId,
@@ -26,7 +31,7 @@
   let audioService = AudioService.getInstance();
   let layoutRef = $state<any>();
 
-  const { updateNodeData } = useSvelteFlow();
+  const { updateNodeData, getEdges, deleteElements } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
 
   // Control inlet count ($1, $2, etc.)
@@ -41,6 +46,18 @@
     if (!data.expr.trim()) return 1; // Default to 1 signal inlet
 
     return Math.max(1, parseFExprSignalInletCount(data.expr.trim()));
+  });
+
+  // Outlet count from multi-outlet expressions
+  const outletCount = $derived.by(() => {
+    if (!data.expr.trim()) return 1;
+
+    return parseMultiOutletExpressions(data.expr.trim()).outletCount;
+  });
+
+  // Remove stale edges when outlet count decreases
+  $effect(() => {
+    removeExcessAudioOutletEdges(nodeId, outletCount, getEdges, deleteElements);
   });
 
   const handleMessage: MessageCallbackFn = (message, meta) => {
@@ -73,7 +90,14 @@
   }
 
   function handleRun() {
-    updateAudioExpression(data.expr);
+    const parsed = parseMultiOutletExpressions(data.expr || '');
+
+    // Send multi-outlet expressions to audio node (triggers worklet recreation if outlet count changed)
+    audioService.send(nodeId, 'expressions', {
+      assignments: parsed.assignments,
+      outletExpressions: parsed.outletExpressions,
+      outletCount: parsed.outletCount
+    });
 
     // Update control inlet count when expression changes
     const newControlInletCount = parseInletCount(data.expr || '');
@@ -89,7 +113,7 @@
       updateAudioInletValues(inletValues);
     }
 
-    // Notify xyflow about handle changes (signal inlets may have changed)
+    // Notify xyflow about handle changes (signal inlets or outlets may have changed)
     updateNodeInternals(nodeId);
   }
 
@@ -150,15 +174,19 @@
 {/snippet}
 
 {#snippet audioOutlets()}
-  <!-- Audio output -->
-  <TypedHandle
-    port="outlet"
-    spec={{ handleType: 'audio' }}
-    title="Audio Output"
-    total={1}
-    index={0}
-    {nodeId}
-  />
+  {#each Array.from({ length: outletCount }) as _, index}
+    <TypedHandle
+      port="outlet"
+      spec={{
+        handleType: 'audio',
+        handleId: outletCount === 1 && index === 0 ? undefined : index
+      }}
+      title={outletCount > 1 ? `Out ${index + 1}` : 'Audio Output'}
+      total={outletCount}
+      {index}
+      {nodeId}
+    />
+  {/each}
 {/snippet}
 
 <CommonExprLayout

--- a/ui/src/lib/components/nodes/AudioFExprNode.svelte
+++ b/ui/src/lib/components/nodes/AudioFExprNode.svelte
@@ -177,10 +177,7 @@
   {#each Array.from({ length: outletCount }) as _, index}
     <TypedHandle
       port="outlet"
-      spec={{
-        handleType: 'audio',
-        handleId: outletCount === 1 && index === 0 ? undefined : index
-      }}
+      spec={{ handleType: 'audio', handleId: index }}
       title={outletCount > 1 ? `Out ${index + 1}` : 'Audio Output'}
       total={outletCount}
       {index}

--- a/ui/src/lib/components/nodes/ExprNode.svelte
+++ b/ui/src/lib/components/nodes/ExprNode.svelte
@@ -15,6 +15,7 @@
   } from '$lib/utils/expr-parser';
   import CommonExprLayout from './CommonExprLayout.svelte';
   import { createCustomConsole } from '$lib/utils/createCustomConsole';
+  import { removeExcessMessageOutletEdges } from './outlet-edges';
 
   let {
     id: nodeId,
@@ -26,7 +27,7 @@
     selected: boolean;
   } = $props();
 
-  const { updateNodeData } = useSvelteFlow();
+  const { updateNodeData, getEdges, deleteElements } = useSvelteFlow();
 
   let isEditing = $state(!data.expr); // Start in editing mode if no expression
   let expr = $state(data.expr || ''); // Active expression being evaluated
@@ -52,6 +53,11 @@
   });
 
   const outletCount = $derived(parseOutletCount(expr));
+
+  // Remove stale edges when outlet count decreases
+  $effect(() => {
+    removeExcessMessageOutletEdges(nodeId, outletCount, getEdges, deleteElements);
+  });
 
   // Update eval result when expression changes
   $effect(() => {

--- a/ui/src/lib/components/nodes/outlet-edges.ts
+++ b/ui/src/lib/components/nodes/outlet-edges.ts
@@ -24,7 +24,15 @@ export const removeExcessMessageOutletEdges = (
   outletCount: number,
   getEdges: () => Edge[],
   deleteElements: (params: { edges: Edge[] }) => void
-) => removeExcessOutletEdges(nodeId, outletCount, /message-out-(\d+)/, getEdges, deleteElements);
+) =>
+  removeExcessOutletEdges(
+    nodeId,
+    outletCount,
+    /message-out-(\d+)/,
+    getEdges,
+    deleteElements,
+    'message-out'
+  );
 
 /**
  * Removes outlet edges whose audio-out-N index is >= outletCount.
@@ -37,17 +45,30 @@ export const removeExcessAudioOutletEdges = (
   outletCount: number,
   getEdges: () => Edge[],
   deleteElements: (params: { edges: Edge[] }) => void
-) => removeExcessOutletEdges(nodeId, outletCount, /audio-out-(\d+)/, getEdges, deleteElements);
+) =>
+  removeExcessOutletEdges(
+    nodeId,
+    outletCount,
+    /audio-out-(\d+)/,
+    getEdges,
+    deleteElements,
+    'audio-out'
+  );
 
 function removeExcessOutletEdges(
   nodeId: string,
   maxCount: number,
   handlePattern: RegExp,
   getEdges: () => Edge[],
-  deleteElements: (params: { edges: Edge[] }) => void
+  deleteElements: (params: { edges: Edge[] }) => void,
+  /** Also remove edges with bare (non-indexed) handles like "audio-out" */
+  bareHandle?: string
 ) {
   const excess = getEdges().filter((edge) => {
     if (edge.source !== nodeId) return false;
+
+    // Remove bare-handle edges (e.g. "audio-out" when node now uses "audio-out-0")
+    if (bareHandle && edge.sourceHandle === bareHandle) return true;
 
     const match = edge.sourceHandle?.match(handlePattern);
 

--- a/ui/src/lib/components/nodes/outlet-edges.ts
+++ b/ui/src/lib/components/nodes/outlet-edges.ts
@@ -14,12 +14,6 @@ export const removeExcessVideoOutletEdges = (
 ) => removeExcessOutletEdges(nodeId, mrtCount, /video-out-(\d+)/, getEdges, deleteElements);
 
 /**
- * Removes outlet edges whose audio-out-N index is >= outletCount.
- *
- * Call this whenever an audio node's outlet count decreases
- * so dangling edges are cleaned up.
- */
-/**
  * Removes outlet edges whose message-out-N index is >= outletCount.
  *
  * Call this whenever a message node's outlet count decreases
@@ -32,6 +26,12 @@ export const removeExcessMessageOutletEdges = (
   deleteElements: (params: { edges: Edge[] }) => void
 ) => removeExcessOutletEdges(nodeId, outletCount, /message-out-(\d+)/, getEdges, deleteElements);
 
+/**
+ * Removes outlet edges whose audio-out-N index is >= outletCount.
+ *
+ * Call this whenever an audio node's outlet count decreases
+ * so dangling edges are cleaned up.
+ */
 export const removeExcessAudioOutletEdges = (
   nodeId: string,
   outletCount: number,

--- a/ui/src/lib/components/nodes/outlet-edges.ts
+++ b/ui/src/lib/components/nodes/outlet-edges.ts
@@ -6,18 +6,52 @@ import type { Edge } from '@xyflow/svelte';
  * Call this whenever a video node's outlet count decreases
  * so dangling edges are cleaned up.
  */
-export function removeExcessVideoOutletEdges(
+export const removeExcessVideoOutletEdges = (
   nodeId: string,
   mrtCount: number,
+  getEdges: () => Edge[],
+  deleteElements: (params: { edges: Edge[] }) => void
+) => removeExcessOutletEdges(nodeId, mrtCount, /video-out-(\d+)/, getEdges, deleteElements);
+
+/**
+ * Removes outlet edges whose audio-out-N index is >= outletCount.
+ *
+ * Call this whenever an audio node's outlet count decreases
+ * so dangling edges are cleaned up.
+ */
+/**
+ * Removes outlet edges whose message-out-N index is >= outletCount.
+ *
+ * Call this whenever a message node's outlet count decreases
+ * so dangling edges are cleaned up.
+ */
+export const removeExcessMessageOutletEdges = (
+  nodeId: string,
+  outletCount: number,
+  getEdges: () => Edge[],
+  deleteElements: (params: { edges: Edge[] }) => void
+) => removeExcessOutletEdges(nodeId, outletCount, /message-out-(\d+)/, getEdges, deleteElements);
+
+export const removeExcessAudioOutletEdges = (
+  nodeId: string,
+  outletCount: number,
+  getEdges: () => Edge[],
+  deleteElements: (params: { edges: Edge[] }) => void
+) => removeExcessOutletEdges(nodeId, outletCount, /audio-out-(\d+)/, getEdges, deleteElements);
+
+function removeExcessOutletEdges(
+  nodeId: string,
+  maxCount: number,
+  handlePattern: RegExp,
   getEdges: () => Edge[],
   deleteElements: (params: { edges: Edge[] }) => void
 ) {
   const excess = getEdges().filter((edge) => {
     if (edge.source !== nodeId) return false;
 
-    const match = edge.sourceHandle?.match(/video-out-(\d+)/);
+    const match = edge.sourceHandle?.match(handlePattern);
 
-    return match ? parseInt(match[1], 10) >= mrtCount : false;
+    return match ? parseInt(match[1], 10) >= maxCount : false;
   });
 
   if (excess.length > 0) {

--- a/ui/src/lib/utils/expr-parser.test.ts
+++ b/ui/src/lib/utils/expr-parser.test.ts
@@ -41,15 +41,15 @@ describe('parseMultiOutletExpressions', () => {
     expect(result.outletExpressions).toEqual(['$1 + 1', '$1 * 2']);
   });
 
-  it('newline-separated expressions = multiple outlets', () => {
-    const result = parseMultiOutletExpressions('$1 + 1\n$1 * 2');
+  it('newline-only expressions stay as single outlet (newlines are not separators)', () => {
+    const result = parseMultiOutletExpressions('$1 > 20\n  ? "ok"\n  : "no"');
 
-    expect(result.outletCount).toBe(2);
-    expect(result.outletExpressions).toEqual(['$1 + 1', '$1 * 2']);
+    expect(result.outletCount).toBe(1);
+    expect(result.outletExpressions).toHaveLength(1);
   });
 
   it('assignments do not create outlets', () => {
-    const result = parseMultiOutletExpressions('a = $1 * 2\nb = $2 + 3\na + b');
+    const result = parseMultiOutletExpressions('a = $1 * 2; b = $2 + 3; a + b');
 
     expect(result.outletCount).toBe(1);
     expect(result.assignments).toEqual(['a = $1 * 2', 'b = $2 + 3']);

--- a/ui/src/lib/utils/expr-parser.ts
+++ b/ui/src/lib/utils/expr-parser.ts
@@ -181,6 +181,7 @@ export function parseMultiOutletExpressions(expression: string): ParsedExpressio
  */
 export function parseOutletCount(expression: string): number {
   if (!expression.trim()) return 1;
+
   return parseMultiOutletExpressions(expression).outletCount;
 }
 

--- a/ui/src/lib/utils/expr-parser.ts
+++ b/ui/src/lib/utils/expr-parser.ts
@@ -141,11 +141,12 @@ export function isAssignment(statement: string): boolean {
 
 /**
  * Split an expression string into individual statements.
- * Splits on both semicolons and newlines, trims whitespace, and filters empty strings.
+ * Splits on semicolons only — newlines are preserved within expressions
+ * so multi-line expressions (e.g. ternaries) work correctly.
  */
 function splitStatements(expression: string): string[] {
   return expression
-    .split(/[;\n]/)
+    .split(';')
     .map((s) => s.trim())
     .filter(Boolean);
 }
@@ -209,7 +210,7 @@ export function createMultiOutletEvaluator(expression: string): MultiOutletEvalu
 
   try {
     const fns = exprs.map((outletExpr) => {
-      const fullExpr = prefix + outletExpr;
+      const fullExpr = (prefix + outletExpr).replace(/\n/g, ';');
       const renamedParam = fullExpr.replace(/\$(\d+)/g, 'x$1');
       const parsed = parser.parse(renamedParam);
 

--- a/ui/static/content/objects/expr.md
+++ b/ui/static/content/objects/expr.md
@@ -37,32 +37,29 @@ $1[5]
 ## Multiple Outlets
 
 Each non-assignment expression creates its own outlet. Separate expressions with
-semicolons or newlines:
+semicolons:
 
 ```js
 // 2 outlets: sum and product
-$1 + $2;
-$1 * $2
+$1 + $2; $1 * $2
 ```
 
 Use variable assignments to share intermediate values without creating extra
 outlets:
 
 ```js
-a = $1 * 2
-a + 1
-a - 1
-a * 3
 // 3 outlets, variable `a` is shared
+a = $1 * 2; a + 1; a - 1; a * 3
 ```
 
 ## Multi-line Expressions
 
-Create variables using `;` or newlines to separate statements:
+Use newlines for readability — they are treated as whitespace within a single
+expression. Use `;` to separate statements:
 
 ```js
-a = $1 * 2
-b = $2 + 3
+a = $1 * 2;
+b = $2 + 3;
 a + b
 ```
 

--- a/ui/static/content/objects/expr~.md
+++ b/ui/static/content/objects/expr~.md
@@ -80,6 +80,26 @@ s1 * (abs(s2) > 0.1 ? 1 : 0)  // Gate (s2 gates s1)
 s1 * abs(s2)                // Vocoder-style envelope
 ```
 
+## Multiple Outlets
+
+Each non-assignment expression creates its own audio outlet.
+Separate expressions with semicolons or newlines:
+
+```js
+// 2 outlets: dry and wet
+s * 0.7
+s * 0.3
+```
+
+Use variable assignments to share intermediate values:
+
+```js
+a = s * $1
+a + sin(t * 440 * PI * 2) * 0.1
+a - sin(t * 440 * PI * 2) * 0.1
+// 2 outlets with shared variable
+```
+
 ## Dynamic Control Inlets
 
 Create `$1` to `$9` variables for control inlets. Example: `$1 * 440` creates

--- a/ui/static/content/objects/expr~.md
+++ b/ui/static/content/objects/expr~.md
@@ -83,21 +83,18 @@ s1 * abs(s2)                // Vocoder-style envelope
 ## Multiple Outlets
 
 Each non-assignment expression creates its own audio outlet.
-Separate expressions with semicolons or newlines:
+Separate expressions with semicolons:
 
 ```js
 // 2 outlets: dry and wet
-s * 0.7
-s * 0.3
+s * 0.7; s * 0.3
 ```
 
 Use variable assignments to share intermediate values:
 
 ```js
-a = s * $1
-a + sin(t * 440 * PI * 2) * 0.1
-a - sin(t * 440 * PI * 2) * 0.1
 // 2 outlets with shared variable
+a = s * $1; a + sin(t * 440 * PI * 2) * 0.1; a - sin(t * 440 * PI * 2) * 0.1
 ```
 
 ## Dynamic Control Inlets

--- a/ui/static/content/objects/fexpr~.md
+++ b/ui/static/content/objects/fexpr~.md
@@ -103,12 +103,11 @@ x1 + y1[-32] * $1
 
 Each non-assignment expression creates its own audio outlet
 with independent output history. Separate expressions with
-semicolons or newlines:
+semicolons:
 
 ```js
 // 2 outlets: lowpass and highpass from same input
-x1 * 0.1 + y1[-1] * 0.9
-x1 - x1[-1] + y2[-1] * 0.95
+x1 * 0.1 + y1[-1] * 0.9; x1 - x1[-1] + y2[-1] * 0.95
 ```
 
 Each outlet has its own `y` history: `y1[-1]` is outlet 1's

--- a/ui/static/content/objects/fexpr~.md
+++ b/ui/static/content/objects/fexpr~.md
@@ -99,6 +99,23 @@ x1 + x1[-32] * $1
 x1 + y1[-32] * $1
 ```
 
+## Multiple Outlets
+
+Each non-assignment expression creates its own audio outlet
+with independent output history. Separate expressions with
+semicolons or newlines:
+
+```js
+// 2 outlets: lowpass and highpass from same input
+x1 * 0.1 + y1[-1] * 0.9
+x1 - x1[-1] + y2[-1] * 0.95
+```
+
+Each outlet has its own `y` history: `y1[-1]` is outlet 1's
+previous output, `y2[-1]` is outlet 2's, etc. All `y`
+accessors are available to all expressions,
+enabling cross-outlet feedback.
+
 ## Stability Warning
 
 IIR filters can become unstable if feedback coefficients are too high:

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -9,8 +9,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "moduleResolution": "bundler",
-    "types": ["audioworklet"]
+    "moduleResolution": "bundler"
   },
   "exclude": [
     "node_modules/**",

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "types": ["audioworklet"]
   },
   "exclude": [
     "node_modules/**",


### PR DESCRIPTION
## Summary

- Add Pure Data-style multi-outlet support to `expr~`, and `fexpr~`
- Each non-assignment expression separated by semicolons/newlines creates its own outlet
- Assignment statements (`a = $1 * 2`) set variables without creating outlets
- For `fexpr~`, each outlet gets independent output history (`y1[-1]`, `y2[-1]`, etc.) with cross-outlet feedback support

## Changes

- **expr-parser.ts**: `parseMultiOutletExpressions`, `createMultiOutletEvaluator`, `parseOutletCount`
- **expression-processor.ts**: Multi-evaluator array, writes to `outputs[0..N-1]`
- **fexpr-processor.ts**: Multi-evaluator + per-outlet `y` history buffers; extracted `transformFExprExpression` to shared module with tests
- **ExprNode.ts / FExprNode.ts** (audio V2): Dynamic `numberOfOutputs`, worklet recreation on outlet count change, `connect()` for output routing
- **AudioExprNode / AudioFExprNode / ExprNode .svelte**: Dynamic outlet handle rendering, stale edge cleanup
- **outlet-edges.ts**: Added `removeExcessAudioOutletEdges` and `removeExcessMessageOutletEdges`
- **Docs**: Updated expr.md, expr~.md, fexpr~.md with "Multiple Outlets" sections

## Test plan

- [x] Unit tests for `expr-parser` (15 tests) and `fexpr-transform` (9 tests) pass
- [ ] `expr`: type `$1 + 1; $1 * 2`, verify 2 outlets appear, connect downstream and confirm independent values
- [ ] `expr~`: type `s * 0.7; s * 0.3`, verify 2 audio outlets, connect to separate `out~` nodes
- [ ] `fexpr~`: type `x1 * 0.1 + y1[-1] * 0.9; x1 - x1[-1] + y2[-1] * 0.95`, verify cross-outlet feedback works
- [ ] Reducing outlet count removes stale edges without errors
- [ ] Single-expression usage (no semicolons) works identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple expression outlets in expr~ and fexpr~ nodes. Each non-assignment expression now generates a separate audio outlet with independent output history tracking.

* **Documentation**
  * Added documentation explaining multiple outlet functionality, including syntax for declaring outlets and history variable mapping across outlets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->