### PR TITLE
feat(ngea): map midi pitch bend and note on via tuning

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "patchies-web",

--- a/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
+++ b/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
@@ -48,6 +48,7 @@ export const jsRunnerInstructions = `
 - Common MIDI messages:
   - {type: 'noteOn' | 'noteOff', note, velocity, channel}
   - {type: 'controlChange', control, value, channel}
+  - {type: 'pitchBend', value, channel} — value is -1.0 to 1.0 (±2 semitone range)
   - note and velocity is between 0-127
 
 **Named Channels (wireless messaging):**

--- a/ui/src/lib/generated/object-schemas.generated.ts
+++ b/ui/src/lib/generated/object-schemas.generated.ts
@@ -2344,7 +2344,8 @@ export const generatedObjectSchemas: ObjectSchemaRegistry = {
             schema: Type.Object({
               type: Type.Literal('noteOn'),
               note: Type.Number(),
-              velocity: Type.Number()
+              velocity: Type.Number(),
+              channel: Type.Optional(Type.Number())
             }),
             description: 'Trigger pad by MIDI note'
           },
@@ -2352,7 +2353,8 @@ export const generatedObjectSchemas: ObjectSchemaRegistry = {
             schema: Type.Object({
               type: Type.Literal('noteOff'),
               note: Type.Number(),
-              velocity: Type.Number()
+              velocity: Type.Optional(Type.Number()),
+              channel: Type.Optional(Type.Number())
             }),
             description: 'Release pad'
           },

--- a/ui/src/lib/objects/schemas/common.ts
+++ b/ui/src/lib/objects/schemas/common.ts
@@ -26,8 +26,18 @@ export const SetMax = msg('setMax', { value: Type.Number() });
 export const SetDefault = msg('setDefault', { value: Type.Number() });
 export const SetValue = msg('setValue', { value: Type.Number() });
 export const LoadBySrc = msg('load', { src: Type.String() });
-export const NoteOn = msg('noteOn', { note: Type.Number(), velocity: Type.Number() });
-export const NoteOff = msg('noteOff', { note: Type.Number(), velocity: Type.Number() });
+
+export const NoteOn = msg('noteOn', {
+  note: Type.Number(),
+  velocity: Type.Number(),
+  channel: Type.Optional(Type.Number())
+});
+
+export const NoteOff = msg('noteOff', {
+  note: Type.Number(),
+  velocity: Type.Number(),
+  channel: Type.Optional(Type.Number())
+});
 
 /** All common schemas as an array, for building the common message type map. */
 export const COMMON_SCHEMAS = [

--- a/ui/src/lib/objects/schemas/common.ts
+++ b/ui/src/lib/objects/schemas/common.ts
@@ -35,7 +35,7 @@ export const NoteOn = msg('noteOn', {
 
 export const NoteOff = msg('noteOff', {
   note: Type.Number(),
-  velocity: Type.Number(),
+  velocity: Type.Optional(Type.Number()),
   channel: Type.Optional(Type.Number())
 });
 

--- a/ui/src/objects/ngea/components/NgeaNode.svelte
+++ b/ui/src/objects/ngea/components/NgeaNode.svelte
@@ -83,36 +83,42 @@
     );
   }
 
-  function sendMidiGong(note: number, velocity: number, channel = 0, isNoteOn?: boolean): void {
+  function sendMidiGong(note: number, velocity: number, channel: number, isNoteOn: boolean): void {
     if (!currentTuning) return;
 
-    const gongIndex = note % gongCount;
-    const gong = currentTuning.data[gongIndex];
-    if (!gong) return;
-
-    const freq = gong.freq;
-    const exactMidi = 69 + 12 * Math.log2(freq / 440);
-    const baseNote = Math.round(exactMidi);
-    const centsDeviation = (exactMidi - baseNote) * 100;
-    const bendValue = Math.max(-1, Math.min(1, centsDeviation / 200));
-
     if (isNoteOn) {
-      activeNotes.set(note, { baseNote, channel, frequency: freq });
+      const gongIndex = note % gongCount;
+      const gong = currentTuning.data[gongIndex];
+      if (!gong) return;
 
+      const freq = gong.freq;
+      const exactMidi = 69 + 12 * Math.log2(freq / 440);
+      const baseNote = Math.round(exactMidi);
+      const centsDeviation = (exactMidi - baseNote) * 100;
+      const bendValue = Math.max(-1, Math.min(1, centsDeviation / 200));
+
+      activeNotes.set(note, { baseNote, channel, frequency: freq });
       messageContext?.send(
         { type: 'pitchBend', value: bendValue, channel, frequency: freq },
         { to: 0 }
       );
-
       messageContext?.send(
         { type: 'noteOn', note: baseNote, velocity, channel, frequency: freq },
         { to: 0 }
       );
     } else {
-      activeNotes.delete(note);
+      const stored = activeNotes.get(note);
+      if (!stored) return;
 
+      activeNotes.delete(note);
       messageContext?.send(
-        { type: 'noteOff', note: baseNote, velocity, channel, frequency: freq },
+        {
+          type: 'noteOff',
+          note: stored.baseNote,
+          velocity,
+          channel: stored.channel,
+          frequency: stored.frequency
+        },
         { to: 0 }
       );
     }

--- a/ui/src/objects/ngea/components/NgeaNode.svelte
+++ b/ui/src/objects/ngea/components/NgeaNode.svelte
@@ -27,7 +27,7 @@
   let tunings = $state<NgeaTuning[]>([]);
 
   type ActiveNote = { baseNote: number; channel: number; frequency: number };
-  const activeNotes = new SvelteMap<number, ActiveNote>();
+  const activeNotes = new SvelteMap<string, ActiveNote>();
 
   function flushActiveNotes(): void {
     for (const { baseNote, channel, frequency } of activeNotes.values()) {
@@ -97,7 +97,7 @@
       const centsDeviation = (exactMidi - baseNote) * 100;
       const bendValue = Math.max(-1, Math.min(1, centsDeviation / 200));
 
-      activeNotes.set(note, { baseNote, channel, frequency: freq });
+      activeNotes.set(`${channel}:${note}`, { baseNote, channel, frequency: freq });
       messageContext?.send(
         { type: 'pitchBend', value: bendValue, channel, frequency: freq },
         { to: 0 }
@@ -107,10 +107,10 @@
         { to: 0 }
       );
     } else {
-      const stored = activeNotes.get(note);
+      const stored = activeNotes.get(`${channel}:${note}`);
       if (!stored) return;
 
-      activeNotes.delete(note);
+      activeNotes.delete(`${channel}:${note}`);
       messageContext?.send(
         {
           type: 'noteOff',
@@ -130,7 +130,7 @@
         sendGong(currentIndex);
       })
       .with(messages.noteOn, ({ note, velocity, channel }) => {
-        sendMidiGong(note, velocity ?? 0, channel ?? 0, true);
+        sendMidiGong(note, velocity ?? 64, channel ?? 0, true);
       })
       .with(messages.noteOff, ({ note, velocity, channel }) => {
         sendMidiGong(note, velocity ?? 0, channel ?? 0, false);

--- a/ui/src/objects/ngea/components/NgeaNode.svelte
+++ b/ui/src/objects/ngea/components/NgeaNode.svelte
@@ -8,6 +8,8 @@
   import { ngeaSchema } from '../schema';
   import type { NgeaTuning } from '../data';
   import { ChevronDown, Info, X } from '@lucide/svelte/icons';
+  import { SvelteMap } from 'svelte/reactivity';
+  import { messages } from '$lib/objects/schemas';
 
   let {
     id: nodeId,
@@ -24,6 +26,20 @@
   let messageContext: MessageContext;
   let tunings = $state<NgeaTuning[]>([]);
 
+  type ActiveNote = { baseNote: number; channel: number; frequency: number };
+  const activeNotes = new SvelteMap<number, ActiveNote>();
+
+  function flushActiveNotes(): void {
+    for (const { baseNote, channel, frequency } of activeNotes.values()) {
+      messageContext?.send(
+        { type: 'noteOff', note: baseNote, velocity: 0, channel, frequency },
+        { to: 0 }
+      );
+    }
+
+    activeNotes.clear();
+  }
+
   const findTuning = (query: string) => {
     const q = query.toLowerCase();
     return tunings.find((t) => t.title.toLowerCase().includes(q));
@@ -36,34 +52,70 @@
   const currentTuning = $derived(findTuning(currentTuningTitle) ?? tunings[0]);
   const gongCount = $derived(currentTuning?.data.length ?? 0);
 
-  function sendGong(index: number): void {
+  function sendGong(index: number, includeScale = false): void {
     if (!currentTuning) return;
 
     const gong = currentTuning.data[index];
     if (!gong) return;
 
-    messageContext?.send(
-      {
-        type: 'gong',
-        index,
-        id: gong.id,
-        freq: gong.freq,
-        cents: gong.cents,
-        accumulate: gong.accumulate
-      },
-      { to: 0 }
-    );
+    const base = {
+      type: 'gong' as const,
+      index,
+      id: gong.id,
+      freq: gong.freq,
+      cents: gong.cents,
+      accumulate: gong.accumulate
+    };
 
     messageContext?.send(
-      {
-        type: 'scale',
-        name: currentTuning.title,
-        location: currentTuning.location,
-        freqs: currentTuning.data.map((g) => g.freq),
-        cents: currentTuning.data.map((g) => g.accumulate)
-      },
-      { to: 1 }
+      includeScale
+        ? {
+            ...base,
+            scale: {
+              name: currentTuning.title,
+              location: currentTuning.location,
+              freqs: currentTuning.data.map((g) => g.freq),
+              cents: currentTuning.data.map((g) => g.accumulate)
+            }
+          }
+        : base,
+      { to: 0 }
     );
+  }
+
+  function sendMidiGong(note: number, velocity: number, channel = 0, isNoteOn?: boolean): void {
+    if (!currentTuning) return;
+
+    const gongIndex = note % gongCount;
+    const gong = currentTuning.data[gongIndex];
+    if (!gong) return;
+
+    const freq = gong.freq;
+    const exactMidi = 69 + 12 * Math.log2(freq / 440);
+    const baseNote = Math.round(exactMidi);
+    const centsDeviation = (exactMidi - baseNote) * 100;
+    const bendValue = Math.max(-1, Math.min(1, centsDeviation / 200));
+
+    if (isNoteOn) {
+      activeNotes.set(note, { baseNote, channel, frequency: freq });
+
+      messageContext?.send(
+        { type: 'pitchBend', value: bendValue, channel, frequency: freq },
+        { to: 0 }
+      );
+
+      messageContext?.send(
+        { type: 'noteOn', note: baseNote, velocity, channel, frequency: freq },
+        { to: 0 }
+      );
+    } else {
+      activeNotes.delete(note);
+
+      messageContext?.send(
+        { type: 'noteOff', note: baseNote, velocity, channel, frequency: freq },
+        { to: 0 }
+      );
+    }
   }
 
   const handleMessage: MessageCallbackFn = (message) => {
@@ -71,16 +123,23 @@
       .with({ type: 'bang' }, () => {
         sendGong(currentIndex);
       })
+      .with(messages.noteOn, ({ note, velocity, channel }) => {
+        sendMidiGong(note, velocity, channel, true);
+      })
+      .with(messages.noteOff, ({ note, velocity, channel }) => {
+        sendMidiGong(note, velocity, channel, false);
+      })
       .with(P.number, (index) => {
         const normIndex = Math.max(0, Math.min(Math.floor(index), gongCount - 1));
 
         updateNodeData(nodeId, { ...data, index: normIndex });
-        sendGong(normIndex);
+        sendGong(normIndex, true);
       })
       .with(P.string, (value) => {
         const found = findTuning(value);
 
         if (found) {
+          flushActiveNotes();
           updateNodeData(nodeId, { ...data, tuning: found.title, index: 0 });
         }
       })
@@ -97,12 +156,14 @@
   });
 
   onDestroy(() => {
+    flushActiveNotes();
     messageContext?.queue.removeCallback(handleMessage);
     messageContext?.destroy();
   });
 
   function onTuningChange(e: Event) {
     const title = (e.target as HTMLSelectElement).value;
+    flushActiveNotes();
     updateNodeData(nodeId, { ...data, tuning: title, index: 0 });
   }
 
@@ -139,23 +200,13 @@
     {nodeId}
   />
 
-  <!-- Gong outlet -->
+  <!-- Output -->
   <TypedHandle
     port="outlet"
     spec={ngeaSchema.outlets[0].handle!}
-    title="gong data"
-    total={2}
+    title="gong / midi out"
+    total={1}
     index={0}
-    {nodeId}
-  />
-
-  <!-- Scale outlet -->
-  <TypedHandle
-    port="outlet"
-    spec={ngeaSchema.outlets[1].handle!}
-    title="scale"
-    total={2}
-    index={1}
     {nodeId}
   />
 

--- a/ui/src/objects/ngea/components/NgeaNode.svelte
+++ b/ui/src/objects/ngea/components/NgeaNode.svelte
@@ -130,10 +130,10 @@
         sendGong(currentIndex);
       })
       .with(messages.noteOn, ({ note, velocity, channel }) => {
-        sendMidiGong(note, velocity, channel, true);
+        sendMidiGong(note, velocity ?? 0, channel ?? 0, true);
       })
       .with(messages.noteOff, ({ note, velocity, channel }) => {
-        sendMidiGong(note, velocity, channel, false);
+        sendMidiGong(note, velocity ?? 0, channel ?? 0, false);
       })
       .with(P.number, (index) => {
         const normIndex = Math.max(0, Math.min(Math.floor(index), gongCount - 1));

--- a/ui/src/objects/ngea/prompts.ts
+++ b/ui/src/objects/ngea/prompts.ts
@@ -16,14 +16,20 @@ export const ngeaPrompt = `## ngea Object Instructions
 
 The ngea object provides real-world microtonal tuning data from the Network Gong Ensemble Archive (NGEA) — Southeast Asian gong ensembles from Thailand, Cambodia, Indonesia, Philippines, Myanmar, and Vietnam.
 
-**Outlets:**
-- Outlet 0 (gong): \`{ type: 'gong', index, id, freq, cents, accumulate }\` — triggered by index input
-- Outlet 1 (scale): \`{ type: 'scale', name, location, freqs[], cents[] }\` — triggered by bang
+**Single outlet — output type mirrors input type:**
 
-**Inlet messages:**
-- Number: output gong data at that index (0-based)
-- \`{ type: 'bang' }\`: output current gong data
-- String: switch to a named tuning (partial match, e.g. \`'Khong'\` matches \`'Khong Wong Yai'\`)
+- \`bang\` → \`{ type: 'gong', index, id, freq, cents, accumulate }\`
+- \`number\` → same as bang, plus \`scale: { name, location, freqs[], cents[] }\` attached
+- \`string\` → switches tuning (partial match, e.g. \`'Khong'\` matches \`'Khong Wong Yai'\`), no output
+- \`{ type: 'noteOn', note, velocity, channel }\` → emits \`{ type: 'pitchBend', value, channel, frequency }\` then \`{ type: 'noteOn', note, velocity, channel, frequency }\`
+- \`{ type: 'noteOff', note, velocity, channel }\` → emits \`{ type: 'noteOff', note, velocity, channel, frequency }\`
+
+MIDI note numbers are mapped to gongs via \`note % gongCount\`. The pitch bend value is -1.0 to 1.0 (±2 semitone range). Active notes are tracked — switching tunings sends noteOff for all held notes first.
+
+**MIDI microtuning example:**
+\`\`\`
+midi.in → ngea → midi.out
+\`\`\`
 
 **Strudel integration — use single quotes for the name:**
 

--- a/ui/src/objects/ngea/schema.ts
+++ b/ui/src/objects/ngea/schema.ts
@@ -1,7 +1,7 @@
 import { Type } from '@sinclair/typebox';
 
 import type { ObjectSchema } from '$lib/objects/schemas/types';
-import { Bang } from '$lib/objects/schemas/common';
+import { Bang, NoteOn, NoteOff } from '$lib/objects/schemas/common';
 
 const ScaleField = Type.Object({
   name: Type.String(),
@@ -31,21 +31,11 @@ export const ngeaSchema: ObjectSchema = {
         { schema: Bang, description: 'Output gong at current index' },
         { schema: Type.String(), description: 'Switch to a named tuning (partial match)' },
         {
-          schema: Type.Object({
-            type: Type.Literal('noteOn'),
-            note: Type.Number(),
-            velocity: Type.Number(),
-            channel: Type.Number()
-          }),
+          schema: NoteOn,
           description: 'MIDI noteOn — maps note to gong, outputs pitchBend + noteOn'
         },
         {
-          schema: Type.Object({
-            type: Type.Literal('noteOff'),
-            note: Type.Number(),
-            velocity: Type.Number(),
-            channel: Type.Number()
-          }),
+          schema: NoteOff,
           description: 'MIDI noteOff — outputs tuned noteOff with frequency'
         }
       ]

--- a/ui/src/objects/ngea/schema.ts
+++ b/ui/src/objects/ngea/schema.ts
@@ -3,6 +3,13 @@ import { Type } from '@sinclair/typebox';
 import type { ObjectSchema } from '$lib/objects/schemas/types';
 import { Bang } from '$lib/objects/schemas/common';
 
+const ScaleField = Type.Object({
+  name: Type.String(),
+  location: Type.String(),
+  freqs: Type.Array(Type.Number()),
+  cents: Type.Array(Type.Number())
+});
+
 /**
  * Schema for the ngea (Network Gong Ensemble Archive) object.
  * Provides real-world microtonal tuning data from Southeast Asian gong ensembles.
@@ -14,19 +21,40 @@ export const ngeaSchema: ObjectSchema = {
   inlets: [
     {
       id: 'index',
-      description: 'Gong index (0-based) or bang to output current; set tuning name',
+      description: 'Gong index, bang, tuning name, or MIDI note',
       handle: { handleType: 'message' },
       messages: [
-        { schema: Type.Number(), description: 'Output gong data at this index (0-based)' },
-        { schema: Bang, description: 'Output gong data at current index' },
-        { schema: Type.String(), description: 'Switch to a named tuning (partial match)' }
+        {
+          schema: Type.Number(),
+          description: 'Output gong at this index (0-based), includes scale'
+        },
+        { schema: Bang, description: 'Output gong at current index' },
+        { schema: Type.String(), description: 'Switch to a named tuning (partial match)' },
+        {
+          schema: Type.Object({
+            type: Type.Literal('noteOn'),
+            note: Type.Number(),
+            velocity: Type.Number(),
+            channel: Type.Number()
+          }),
+          description: 'MIDI noteOn — maps note to gong, outputs pitchBend + noteOn'
+        },
+        {
+          schema: Type.Object({
+            type: Type.Literal('noteOff'),
+            note: Type.Number(),
+            velocity: Type.Number(),
+            channel: Type.Number()
+          }),
+          description: 'MIDI noteOff — outputs tuned noteOff with frequency'
+        }
       ]
     }
   ],
   outlets: [
     {
-      id: 'gong',
-      description: 'Gong data for the triggered index',
+      id: 'out',
+      description: 'Gong data (bang/number input) or tuned MIDI (noteOn/noteOff input)',
       handle: { handleType: 'message', handleId: 0 },
       messages: [
         {
@@ -38,28 +66,52 @@ export const ngeaSchema: ObjectSchema = {
             cents: Type.Number(),
             accumulate: Type.Number()
           }),
-          description:
-            'Gong data: index, id, freq (Hz), cents interval, accumulate (cents from root)'
-        }
-      ]
-    },
-    {
-      id: 'scale',
-      description: 'Full tuning scale info (bang on inlet to trigger)',
-      handle: { handleType: 'message', handleId: 1 },
-      messages: [
+          description: 'Gong data (bang): index, id, freq (Hz), cents, accumulate'
+        },
         {
           schema: Type.Object({
-            type: Type.Literal('scale'),
-            name: Type.String(),
-            location: Type.String(),
-            freqs: Type.Array(Type.Number()),
-            cents: Type.Array(Type.Number())
+            type: Type.Literal('gong'),
+            index: Type.Number(),
+            id: Type.String(),
+            freq: Type.Number(),
+            cents: Type.Number(),
+            accumulate: Type.Number(),
+            scale: ScaleField
           }),
-          description: 'Scale info: name, location, freqs[], cents[]'
+          description: 'Gong data (number): same as above, plus full scale info'
+        },
+        {
+          schema: Type.Object({
+            type: Type.Literal('pitchBend'),
+            value: Type.Number(),
+            channel: Type.Number(),
+            frequency: Type.Number()
+          }),
+          description:
+            'Pitch bend to reach exact gong frequency (-1.0 to 1.0, ±2 semitone range, sent before noteOn)'
+        },
+        {
+          schema: Type.Object({
+            type: Type.Literal('noteOn'),
+            note: Type.Number(),
+            velocity: Type.Number(),
+            channel: Type.Number(),
+            frequency: Type.Number()
+          }),
+          description: 'MIDI noteOn at nearest semitone with frequency metadata'
+        },
+        {
+          schema: Type.Object({
+            type: Type.Literal('noteOff'),
+            note: Type.Number(),
+            velocity: Type.Number(),
+            channel: Type.Number(),
+            frequency: Type.Number()
+          }),
+          description: 'MIDI noteOff with frequency metadata'
         }
       ]
     }
   ],
-  tags: ['music', 'tuning', 'microtonal', 'gong', 'world', 'frequency', 'scale']
+  tags: ['music', 'tuning', 'microtonal', 'gong', 'world', 'frequency', 'scale', 'midi']
 };

--- a/ui/static/content/objects/ngea.md
+++ b/ui/static/content/objects/ngea.md
@@ -8,11 +8,32 @@ Licensed CC BY-SA 4.0.
 
 ## Usage
 
-Select a tuning from the dropdown.
+Select a tuning from the dropdown. The outlet type mirrors what you send in.
 
-Send a **number** (0-based gong index) to outlet 0 to get that gong's data.
+**bang** → `{type: 'gong', index, id, freq, cents, accumulate}`
 
-Send a **bang** to get the current gong. Outlet 1 emits the full scale when banged.
+**number** → same as bang, plus `scale: {name, location, freqs[], cents[]}` attached
+
+**string** → switches to the named tuning (partial, case-insensitive match), no output
+
+**noteOn** → emits `pitchBend` then `noteOn`, both with `frequency` field. Note is mapped to a gong via `note % gongCount`, then pitch-bent to the exact microtonal frequency (±2 semitone bend range).
+
+**noteOff** → emits `noteOff` with `frequency` field
+
+## MIDI Microtuning
+
+Wire a [midi.in](/docs/objects/midi.in) node into ngea to retune a MIDI controller to any
+Southeast Asian gong ensemble tuning. Wire the output to [midi.out](/docs/objects/midi.out)
+to hear the result on a synth:
+
+```
+midi.in → ngea → midi.out
+```
+
+Each incoming MIDI note is mapped to a gong (`note % gongCount`), then
+a `pitchBend` message is emitted before the `noteOn` to bend the synth to
+the exact frequency. The bend value is normalized to -1.0–1.0 assuming a ±2
+semitone range — match this in your synth's pitch bend range setting.
 
 ## Strudel Integration
 
@@ -35,6 +56,8 @@ Names are partial, case-insensitive matches against the tuning title
 
 ## See Also
 
+- [midi.in](/docs/objects/midi.in) — source of MIDI notes to retune
+- [midi.out](/docs/objects/midi.out) — send retuned MIDI to a synth
 - [osc~](/docs/objects/osc~) — connect gong freqs to an oscillator
 - [strudel](/docs/objects/strudel) — sequence gongs with Strudel patterns
 - [metro](/docs/objects/metro) — clock to step through gong indices

--- a/ui/static/content/objects/ngea.md
+++ b/ui/static/content/objects/ngea.md
@@ -23,17 +23,26 @@ Select a tuning from the dropdown. The outlet type mirrors what you send in.
 ## MIDI Microtuning
 
 Wire a [midi.in](/docs/objects/midi.in) node into ngea to retune a MIDI controller to any
-Southeast Asian gong ensemble tuning. Wire the output to [midi.out](/docs/objects/midi.out)
-to hear the result on a synth:
+Southeast Asian gong ensemble tuning.
+
+Each incoming MIDI note is mapped to a gong (`note % gongCount`), then
+a `pitchBend` message is emitted before the `noteOn` to bend to the exact
+microtonal frequency. The bend value is -1.0–1.0 assuming a ±2 semitone range.
+
+**To hear it in Patchies** — use the built-in **poly-synth-midi** preset
+(from [tone~](/docs/objects/tone~)). It handles `pitchBend` correctly and
+is the easiest way to audition any MIDI microtuning:
+
+```
+midi.in → ngea → tone~ (poly-synth-midi preset)
+```
+
+**To send to your DAW** — wire to [midi.out](/docs/objects/midi.out) instead.
+Set your synth's pitch bend range to ±2 semitones to match:
 
 ```
 midi.in → ngea → midi.out
 ```
-
-Each incoming MIDI note is mapped to a gong (`note % gongCount`), then
-a `pitchBend` message is emitted before the `noteOn` to bend the synth to
-the exact frequency. The bend value is normalized to -1.0–1.0 assuming a ±2
-semitone range — match this in your synth's pitch bend range setting.
 
 ## Strudel Integration
 

--- a/ui/static/content/objects/tone~.md
+++ b/ui/static/content/objects/tone~.md
@@ -71,7 +71,7 @@ onCleanup(() => inputNode.disconnect(outputNode));
 
 ## Presets
 
-- `poly-synth.tone`: Polyphonic synthesizer with chord sequences
+- `poly-synth-midi.tone`: Polyphonic synthesizer with chord sequences
 - `lowpass.tone`: Low pass filter
 - `tone>`: Direct input to output
 


### PR DESCRIPTION
Maps the MIDI note on and pitch bend like what Leimma (https://isartum.net/leimma) did. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NGEA object now accepts MIDI note on/off input for real-time microtuning
  * Added pitch-bend output for precise microtonal frequency adjustments (±2 semitone range)
  * Consolidated gong and scale output into unified outlet

* **Documentation**
  * Updated NGEA documentation with MIDI microtuning workflow examples
  * Extended MIDI message schemas with optional channel support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->