### PR TITLE
Add more texture operator GLSL presets

### DIFF
--- a/docs/design-docs/specs/135-glsl-top-presets.md
+++ b/docs/design-docs/specs/135-glsl-top-presets.md
@@ -55,25 +55,24 @@ renamed to title-case names, except starter presets that end with `>`.
 
 ### Sweet 16 Inspired Presets
 
-| Preset           | Inputs                     | Parameters                                         | Notes                                                                   |
-| ---------------- | -------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------- |
-| `Linear Ramp`    | none                       | colors, angle, offset                              | Directional linear color ramp.                                          |
-| `Radial Ramp`    | none                       | colors, center, radius, offset                     | Radial color ramp from a center point.                                  |
-| `Circular Ramp`  | none                       | colors, center, angle, offset                      | Angular color ramp around a center point.                               |
-| `Constant`       | none                       | color, alpha                                       | Constant color generator.                                               |
-| `Level`          | `source`                   | black, white, gamma, brightness, contrast, opacity | Color correction and range remapping.                                   |
-| `Transform`      | `source`                   | translate, scale, rotate, repeat mode              | UV-space transform for image placement and tiling.                      |
-| `Overlay`        | `background`, `foreground` | opacity                                            | Alpha-composite foreground over background.                             |
-| `Mix`            | `a`, `b`                   | mix                                                | Crossfade between two inputs.                                           |
-| `Multiply`       | `a`, `b`                   | opacity                                            | Dedicated common composite mode.                                        |
-| `Blur`           | `source`                   | radius                                             | Single-pass practical 2D blur; avoid expensive large kernels.           |
-| `Crop`           | `source`                   | min, max, feather                                  | Window/crop the input and output transparent pixels outside the region. |
-| `Reorder`        | `source`                   | channel selectors, invert alpha                    | Channel swizzle and alpha/luma utility.                                 |
-| `Displace`       | `source`, `displacement`   | amount, center, channels                           | Warp one texture with another texture.                                  |
-| `Edge`           | `source`                   | strength, threshold, mode                          | Sobel-style edge detection.                                             |
-| `Noise`          | none                       | scale, speed, contrast, colors                     | Procedural animated noise generator.                                    |
-| `Noise Displace` | `source`                   | scale, speed, amount, direction                    | Uses procedural noise to warp an input texture.                         |
-| `Feedback`       | `source`, `feedback`       | feedback amount, decay, blend, transform           | Accumulate current input with manually wired previous-frame feedback.   |
+| Preset           | Inputs                   | Parameters                                         | Notes                                                                   |
+| ---------------- | ------------------------ | -------------------------------------------------- | ----------------------------------------------------------------------- |
+| `Linear Ramp`    | none                     | colors, angle, offset                              | Directional linear color ramp.                                          |
+| `Radial Ramp`    | none                     | colors, center, radius, offset                     | Radial color ramp from a center point.                                  |
+| `Circular Ramp`  | none                     | colors, center, angle, offset                      | Angular color ramp around a center point.                               |
+| `Constant`       | none                     | color, alpha                                       | Constant color generator.                                               |
+| `Level`          | `source`                 | black, white, gamma, brightness, contrast, opacity | Color correction and range remapping.                                   |
+| `Transform`      | `source`                 | translate, scale, rotate, repeat mode              | UV-space transform for image placement and tiling.                      |
+| `Mix`            | `a`, `b`                 | mix                                                | Crossfade between two inputs.                                           |
+| `Multiply`       | `a`, `b`                 | opacity                                            | Dedicated common composite mode.                                        |
+| `Blur`           | `source`                 | radius                                             | Single-pass practical 2D blur; avoid expensive large kernels.           |
+| `Crop`           | `source`                 | min, max, feather                                  | Window/crop the input and output transparent pixels outside the region. |
+| `Reorder`        | `source`                 | channel selectors, invert alpha                    | Channel swizzle and alpha/luma utility.                                 |
+| `Displace`       | `source`, `displacement` | amount, center, channels                           | Warp one texture with another texture.                                  |
+| `Edge`           | `source`                 | strength, threshold, mode                          | Sobel-style edge detection.                                             |
+| `Noise`          | none                     | scale, speed, contrast, colors                     | Procedural animated noise generator.                                    |
+| `Noise Displace` | `source`                 | scale, speed, amount, direction                    | Uses procedural noise to warp an input texture.                         |
+| `Feedback`       | `source`, `feedback`     | feedback amount, decay, blend, transform           | Accumulate current input with manually wired previous-frame feedback.   |
 
 ### Out of Scope Sweet 16 Items
 
@@ -157,7 +156,6 @@ Rename existing GLSL operator presets to title-case keys:
 | Current key   | New key    |
 | ------------- | ---------- |
 | `mix.gl`      | `Mix`      |
-| `overlay.gl`  | `Overlay`  |
 | `solid.gl`    | `Constant` |
 | `switcher.gl` | `Switcher` |
 
@@ -178,8 +176,8 @@ unless they are moved into a separate cleanup pass.
 2. Register the presets from `ui/src/lib/presets/builtin/glsl/index.ts` using
    clean title-case keys.
 3. Update the **GLSL Operators** pack in `ui/src/lib/extensions/preset-packs.ts`.
-4. Rename existing GLSL operator keys: `mix.gl` to `Mix`, `overlay.gl` to
-   `Overlay`, `solid.gl` to `Constant`, and `switcher.gl` to `Switcher`.
+4. Rename existing GLSL operator keys: `mix.gl` to `Mix`, `solid.gl` to
+   `Constant`, and `switcher.gl` to `Switcher`.
 5. Leave `glsl>`, `regl>`, `swgl>`, and `three>` unchanged.
 6. Use clean preset keys and `@title` directives for TOP-style names.
 7. Update `ui/static/content/objects/glsl.md` to mention the expanded TOP-style

--- a/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
+++ b/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
@@ -159,6 +159,9 @@ moving on.
 5. `Convolve`: add to **Texture Filters** with named 3x3 kernels instead of
    editable matrix fields. Expose practical kernels such as sharpen, edge,
    outline, box blur, and gaussian-ish blur, plus strength and bias controls.
+6. `Math`: add to **Texture Composite** as a compact two-input arithmetic
+   utility. Keep explicit `Add`, `Subtract`, and `Difference` presets for common
+   cases, but offer `Math` for selectable per-pixel operations.
 
 ## Better With REGL
 

--- a/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
+++ b/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
@@ -156,6 +156,9 @@ moving on.
    named texture inputs: `redSource`, `greenSource`, `blueSource`, and
    `alphaSource`. Each output channel gets a selector for Luma/R/G/B/A from its
    matching input.
+5. `Convolve`: add to **Texture Filters** with named 3x3 kernels instead of
+   editable matrix fields. Expose practical kernels such as sharpen, edge,
+   outline, box blur, and gaussian-ish blur, plus strength and bias controls.
 
 ## Better With REGL
 

--- a/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
+++ b/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
@@ -152,6 +152,10 @@ moving on.
 3. `Luma Level`: add to **Texture Color** as a luminance-only level utility.
    Adjust the source luma curve and reapply it to RGB as a ratio so hue is
    mostly preserved.
+4. `Pack`: add to **Texture Color** as a channel-packing utility with four
+   named texture inputs: `redSource`, `greenSource`, `blueSource`, and
+   `alphaSource`. Each output channel gets a selector for Luma/R/G/B/A from its
+   matching input.
 
 ## Better With REGL
 

--- a/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
+++ b/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
@@ -35,7 +35,6 @@ The current GLSL Operators pack already covers:
 
 - `Constant`
 - `Mix`
-- `Overlay`
 - `Switcher`
 - `Linear Ramp`
 - `Radial Ramp`
@@ -64,15 +63,15 @@ mix `glsl`, `regl`, `swgl`, or `three` presets when that gives the best result.
 
 Recommended user-facing packs:
 
-| Pack                        | Purpose                                      | Likely Presets                                                        |
-| --------------------------- | -------------------------------------------- | --------------------------------------------------------------------- |
-| **Texture Generators**      | Start a visual chain from procedural content | `Constant`, `Linear Ramp`, `Radial Ramp`, `Circular Ramp`, `Noise`    |
-| **Texture Composite**       | Combine multiple textures                    | `Mix`, `Overlay`, `Multiply`, `Add`, `Subtract`, `Difference`, `Over` |
-| **Texture Color**           | Color correction and color-space utilities   | `Level`, `HSV Adjust`, `Monochrome`, `Channel Mix`, `Remap`           |
-| **Texture Masks & Keys**    | Build and apply alpha/matte textures         | `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`, `Matte`             |
-| **Texture Transform**       | Move, fit, repeat, and distort textures      | `Transform`, `Crop`, `Fit`, `Flip`, `Mirror`, `Tile`, `Lens Distort`  |
-| **Texture Filters**         | Image-processing effects                     | `Blur`, `Edge`, `Emboss`, `Slope`, `Normal Map`, `Tone Map`           |
-| **Texture Feedback & Data** | Feedback, history, and render-pipeline tools | `Feedback`, future `regl` presets such as `Bloom`, `Cache`            |
+| Pack                        | Purpose                                      | Likely Presets                                                          |
+| --------------------------- | -------------------------------------------- | ----------------------------------------------------------------------- |
+| **Texture Generators**      | Start a visual chain from procedural content | `Constant`, `Linear Ramp`, `Radial Ramp`, `Circular Ramp`, `Noise`      |
+| **Texture Composite**       | Combine multiple textures                    | `Mix`, `Multiply`, `Add`, `Subtract`, `Difference`, `Composite`, `Over` |
+| **Texture Color**           | Color correction and color-space utilities   | `Level`, `HSV Adjust`, `Monochrome`, `Channel Mix`, `Remap`             |
+| **Texture Masks & Keys**    | Build and apply alpha/matte textures         | `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`, `Matte`               |
+| **Texture Transform**       | Move, fit, repeat, and distort textures      | `Transform`, `Crop`, `Fit`, `Flip`, `Mirror`, `Tile`, `Lens Distort`    |
+| **Texture Filters**         | Image-processing effects                     | `Blur`, `Edge`, `Emboss`, `Slope`, `Normal Map`, `Tone Map`             |
+| **Texture Feedback & Data** | Feedback, history, and render-pipeline tools | `Feedback`, future `regl` presets such as `Bloom`, `Cache`              |
 
 The existing **GLSL Operators** pack can remain during the first migration, but
 new work should move toward these task-based packs. Presets should still be
@@ -187,7 +186,7 @@ Presets:
 Pack target: **Texture Composite**.
 
 This group gives users clearer texture-combination tools and avoids forcing all
-blend workflows through `Mix`, `Overlay`, or `Multiply`.
+blend workflows through `Mix` or `Multiply`.
 
 ### Group 2 — Keying And Masks
 

--- a/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
+++ b/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
@@ -63,15 +63,14 @@ mix `glsl`, `regl`, `swgl`, or `three` presets when that gives the best result.
 
 Recommended user-facing packs:
 
-| Pack                        | Purpose                                      | Likely Presets                                                          |
-| --------------------------- | -------------------------------------------- | ----------------------------------------------------------------------- |
-| **Texture Generators**      | Start a visual chain from procedural content | `Constant`, `Linear Ramp`, `Radial Ramp`, `Circular Ramp`, `Noise`      |
-| **Texture Composite**       | Combine multiple textures                    | `Mix`, `Multiply`, `Add`, `Subtract`, `Difference`, `Composite`, `Over` |
-| **Texture Color**           | Color correction and color-space utilities   | `Level`, `HSV Adjust`, `Monochrome`, `Channel Mix`, `Remap`             |
-| **Texture Masks & Keys**    | Build and apply alpha/matte textures         | `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`, `Matte`               |
-| **Texture Transform**       | Move, fit, repeat, and distort textures      | `Transform`, `Crop`, `Fit`, `Flip`, `Mirror`, `Tile`, `Lens Distort`    |
-| **Texture Filters**         | Image-processing effects                     | `Blur`, `Edge`, `Emboss`, `Slope`, `Normal Map`, `Tone Map`             |
-| **Texture Feedback & Data** | Feedback, history, and render-pipeline tools | `Feedback`, future `regl` presets such as `Bloom`, `Cache`              |
+| Pack                     | Purpose                                      | Likely Presets                                                                      |
+| ------------------------ | -------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **Texture Generators**   | Start a visual chain from procedural content | `Constant`, `Linear Ramp`, `Radial Ramp`, `Circular Ramp`, `Noise`                  |
+| **Texture Composite**    | Combine multiple textures                    | `Mix`, `Multiply`, `Add`, `Subtract`, `Difference`, `Composite`, `Over`, `Feedback` |
+| **Texture Color**        | Color correction and color-space utilities   | `Level`, `HSV Adjust`, `Monochrome`, `Channel Mix`, `Remap`                         |
+| **Texture Masks & Keys** | Build and apply alpha/matte textures         | `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`, `Matte`                           |
+| **Texture Transform**    | Move, fit, repeat, and distort textures      | `Transform`, `Crop`, `Fit`, `Flip`, `Mirror`, `Tile`, `Lens Distort`                |
+| **Texture Filters**      | Image-processing effects                     | `Blur`, `Edge`, `Emboss`, `Slope`, `Normal Map`, `Tone Map`                         |
 
 The existing **GLSL Operators** pack can remain during the first migration, but
 new work should move toward these task-based packs. Presets should still be

--- a/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
+++ b/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
@@ -149,6 +149,9 @@ moving on.
    amount is gated by source luminance. Let users target bright or dark regions
    so the preset can produce glow-like smearing without requiring a multi-pass
    bloom pipeline.
+3. `Luma Level`: add to **Texture Color** as a luminance-only level utility.
+   Adjust the source luma curve and reapply it to RGB as a ratio so hue is
+   mostly preserved.
 
 ## Better With REGL
 

--- a/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
+++ b/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
@@ -136,6 +136,16 @@ more niche, overlapping, or awkward to expose through compact settings.
 | `Select`        | multiple textures | Numeric selector over sampler inputs         | Mostly covered by `Switcher`.                               |
 | `Switch`        | multiple textures | Same as `Select` with a different name       | Existing `Switcher` already handles the common case.        |
 
+### GLSL Possible Implementation Order
+
+Work through these one-by-one so each preset gets a compact, tested UX before
+moving on.
+
+1. `Anti Alias`: add to **Texture Filters** as a mask/edge cleanup filter for
+   generated shapes and threshold-style alpha textures. Keep the scope narrow:
+   it smooths a selected channel into alpha and is not a replacement for true
+   multisample anti-aliasing.
+
 ## Better With REGL
 
 These are possible in Patchies, but `regl` is the better target because it gives

--- a/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
+++ b/docs/design-docs/specs/136-glsl-top-preset-roadmap.md
@@ -145,6 +145,10 @@ moving on.
    generated shapes and threshold-style alpha textures. Keep the scope narrow:
    it smooths a selected channel into alpha and is not a replacement for true
    multisample anti-aliasing.
+2. `Luma Blur`: add to **Texture Filters** as a single-pass blur whose blend
+   amount is gated by source luminance. Let users target bright or dark regions
+   so the preset can produce glow-like smearing without requiring a multi-pass
+   bloom pipeline.
 
 ## Better With REGL
 

--- a/docs/design-docs/specs/137-final-output-alpha.md
+++ b/docs/design-docs/specs/137-final-output-alpha.md
@@ -1,0 +1,37 @@
+# 137. Final Output Alpha
+
+## Problem
+
+Node previews preserve alpha because they read node FBO pixels into `ImageData`, then create an `ImageBitmap` from a 2D canvas. The background output path is different: it blits the selected FBO into the worker's WebGL drawing buffer and transfers that canvas with `transferToImageBitmap()`.
+
+The worker WebGL context used browser defaults, including `premultipliedAlpha: true`. Patchies render nodes output straight alpha from shaders and FBOs. When straight-alpha pixels are presented through a premultiplied-alpha drawing buffer, feathered edges can look solid because RGB is interpreted as already multiplied by alpha.
+
+## Design
+
+Create the worker WebGL context with explicit alpha settings:
+
+- `alpha: true` so the drawing buffer has an alpha channel.
+- `premultipliedAlpha: false` because Patchies FBO content is straight alpha.
+
+The final blit still uses the existing GPU path:
+
+```typescript
+gl.bindFramebuffer(gl.READ_FRAMEBUFFER, sourceFbo);
+gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
+gl.blitFramebuffer(...);
+```
+
+This keeps output transfer zero-copy while making the background path match preview semantics.
+
+## Files affected
+
+| File                                   | Change                                      |
+| -------------------------------------- | ------------------------------------------- |
+| `src/workers/rendering/fboRenderer.ts` | Use explicit straight-alpha WebGL settings. |
+
+## What does NOT change
+
+- Preview readback behavior.
+- FBO formats or node renderers.
+- Background cover-mode crop behavior.
+- Output routing to background or secondary screen.

--- a/docs/design-docs/specs/59-preset-packs.md
+++ b/docs/design-docs/specs/59-preset-packs.md
@@ -21,6 +21,8 @@ Key principles:
 - "Starter Presets" enabled by default for new users
 - Some presets are **object companions** - lightweight starter presets that appear automatically
   when their object is enabled because the locked Starter Presets pack is enabled by default
+- Built-in preset browsers group presets by preset pack name, not by object type. For example,
+  **Texture Generators** contains `Circle` and `Radial Ramp`.
 
 ## Data Model
 
@@ -158,6 +160,20 @@ When an Object Pack is disabled after a Preset Pack is installed:
 
 This is consistent with how object filtering already works and avoids surprising the user.
 
+## Browser Grouping
+
+Built-in presets should use preset pack names as their visible folders/categories:
+
+- Sidebar Preset Tree: `Built-in > Texture Generators > Circle`
+- Object Browser preset categories: `Texture Generators`, `Texture Composite`, `Canvas Widgets`, etc.
+- Search result locations and autocomplete descriptions should use the same pack folder path
+
+User libraries keep their manually-created folder paths. Only the readonly built-in catalog is
+derived from `BUILT_IN_PRESET_PACKS`.
+
+Every built-in preset must be assigned to exactly one preset pack. Pack definitions must not point
+at missing preset names.
+
 ## UI Design
 
 ### Packs Tab Layout
@@ -209,6 +225,7 @@ This is consistent with how object filtering already works and avoids surprising
 1. Update `ObjectBrowserModal.svelte` - filter presets by `enabledPresets`
 2. Update `QuickInsertObjectMenu.svelte` - filter preset suggestions
 3. Update `PresetTreeView.svelte` - filter visible presets in sidebar
+4. Group built-in preset folders/categories by preset pack name instead of preset object type
 
 ### Phase 3: UI Updates
 
@@ -227,13 +244,15 @@ This is consistent with how object filtering already works and avoids surprising
 
 ## Key Files to Modify
 
-| File                                                            | Changes                                                 |
-| --------------------------------------------------------------- | ------------------------------------------------------- |
-| `src/stores/extensions.store.ts`                                | Add PresetPack interface, BUILT_IN_PRESET_PACKS, stores |
-| `src/lib/components/sidebar/ExtensionsView.svelte`              | Add Preset Packs section                                |
-| `src/lib/components/object-browser/ObjectBrowserModal.svelte`   | Filter presets by enabledPresets                        |
-| `src/lib/components/insert-object/QuickInsertObjectMenu.svelte` | Filter preset suggestions                               |
-| `src/lib/components/sidebar/PresetTreeView.svelte`              | Filter visible presets                                  |
+| File                                                            | Changes                                                  |
+| --------------------------------------------------------------- | -------------------------------------------------------- |
+| `src/stores/extensions.store.ts`                                | Add PresetPack interface, BUILT_IN_PRESET_PACKS, stores  |
+| `src/lib/components/sidebar/ExtensionsView.svelte`              | Add Preset Packs section                                 |
+| `src/lib/components/object-browser/ObjectBrowserModal.svelte`   | Filter presets by enabledPresets                         |
+| `src/lib/components/insert-object/QuickInsertObjectMenu.svelte` | Filter preset suggestions                                |
+| `src/lib/components/sidebar/PresetTreeView.svelte`              | Filter visible presets                                   |
+| `src/stores/preset-library.store.ts`                            | Build readonly built-in library from preset pack folders |
+| `src/lib/extensions/preset-pack-index.ts`                       | Map built-in presets to their preset pack metadata       |
 
 ## Verification Plan
 
@@ -243,6 +262,7 @@ This is consistent with how object filtering already works and avoids surprising
 4. Refresh page → verify settings persist
 5. Quick Insert (Enter) → verify only enabled presets appear
 6. Sidebar Preset Tree → verify filtering works
+7. Built-in preset tree → verify `Circle` appears under `Texture Generators`, not `glsl`
 
 ## Future Considerations
 

--- a/docs/design-docs/specs/59-preset-packs.md
+++ b/docs/design-docs/specs/59-preset-packs.md
@@ -19,6 +19,8 @@ Key principles:
 - Preset packs are **mutually exclusive** - each preset belongs to one pack
 - Preset packs depend on Object Packs - only visible if required objects are enabled
 - "Starter Presets" enabled by default for new users
+- Some presets are **object companions** - lightweight starter presets that appear automatically
+  when their object is enabled because the locked Starter Presets pack is enabled by default
 
 ## Data Model
 
@@ -27,12 +29,12 @@ Key principles:
 ```ts
 // Add to src/stores/extensions.store.ts
 interface PresetPack {
-  id: string;                    // 'starter', 'midi', 'audio-synthesis'
-  name: string;                  // 'Starter Presets'
-  description: string;           // 'Essential presets for getting started'
-  icon: string;                  // Lucide icon name
-  requiredObjects: string[];     // Object types needed (filters pack visibility)
-  presets: string[];             // Preset names to enable (e.g., 'logger.js', 'add.hydra')
+  id: string; // 'starter', 'midi', 'audio-synthesis'
+  name: string; // 'Starter Presets'
+  description: string; // 'Essential presets for getting started'
+  icon: string; // Lucide icon name
+  requiredObjects: string[]; // Object types needed (filters pack visibility)
+  presets: string[]; // Preset names to enable (e.g., 'logger.js', 'add.hydra')
 }
 ```
 
@@ -40,10 +42,12 @@ interface PresetPack {
 
 ```ts
 // Extend extensions.store.ts
-const PRESET_STORAGE_KEY = 'patchies:enabled-preset-packs';
-const DEFAULT_ENABLED_PRESET_PACKS = ['starter'];
+const PRESET_STORAGE_KEY = "patchies:enabled-preset-packs";
+const DEFAULT_ENABLED_PRESET_PACKS = ["starter"];
 
-export const enabledPresetPackIds = writable<string[]>(getInitialEnabledPresetPacks());
+export const enabledPresetPackIds = writable<string[]>(
+  getInitialEnabledPresetPacks(),
+);
 
 // Derived: visible presets based on enabled preset packs + enabled objects
 export const enabledPresets = derived(
@@ -52,11 +56,15 @@ export const enabledPresets = derived(
     const presets = new Set<string>();
 
     for (const packId of $enabledPresetPackIds) {
-      const pack = BUILT_IN_PRESET_PACKS.find(p => p.id === packId);
+      const pack = BUILT_IN_PRESET_PACKS.find((p) => p.id === packId);
       if (!pack) continue;
 
-      // Only include if required objects are enabled
-      const hasRequiredObjects = pack.requiredObjects.every(obj => $enabledObjects.has(obj));
+      // Packs without requirements are always active.
+      // Otherwise include if at least one required object is enabled.
+      // Individual preset UI still filters by each preset's object type.
+      const hasRequiredObjects =
+        pack.requiredObjects.length === 0 ||
+        pack.requiredObjects.some((obj) => $enabledObjects.has(obj));
       if (!hasRequiredObjects) continue;
 
       for (const preset of pack.presets) {
@@ -65,30 +73,45 @@ export const enabledPresets = derived(
     }
 
     return presets;
-  }
+  },
 );
 ```
 
 ## Proposed Built-in Preset Packs
 
-| Pack | Description | Required Objects | Presets |
-|------|-------------|------------------|---------|
-| **Starter Presets** | Essential presets for getting started | js, hydra | logger.js, add.hydra, add-fft.hydra |
-| **MIDI Presets** | MIDI routing and control | js, midi.in | midi-adsr.js, midi-control-router.js, virtual-midi-keyboard.canvas |
-| **Audio Synthesis** | Sound design utilities | js, osc~ | sawtooth-harmonics.js, waveshaper-distortion.js |
-| **Animation** | Frame-based animation helpers | js, p5 | bang-every-frame.js, frame-counter.js, interval.js |
-| **Livecoding Examples** | Example patches for livecoding | strudel, hydra, orca | (various strudel/orca presets) |
-| **Canvas Widgets** | Interactive canvas components | canvas.dom | xy-pad.canvas, hsla-picker.canvas, rgba-picker.canvas, plotter.canvas |
+| Pack                    | Description                             | Required Objects     | Presets                                                               |
+| ----------------------- | --------------------------------------- | -------------------- | --------------------------------------------------------------------- |
+| **Starter Presets**     | Essential presets and object companions | none                 | logger.js, glsl>, hydra>, regl>, swgl>, three>                        |
+| **MIDI Presets**        | MIDI routing and control                | js, midi.in          | midi-adsr.js, midi-control-router.js, virtual-midi-keyboard.canvas    |
+| **Audio Synthesis**     | Sound design utilities                  | js, osc~             | sawtooth-harmonics.js, waveshaper-distortion.js                       |
+| **Animation**           | Frame-based animation helpers           | js, p5               | bang-every-frame.js, frame-counter.js, interval.js                    |
+| **Livecoding Examples** | Example patches for livecoding          | strudel, hydra, orca | (various strudel/orca presets)                                        |
+| **Canvas Widgets**      | Interactive canvas components           | canvas.dom           | xy-pad.canvas, hsla-picker.canvas, rgba-picker.canvas, plotter.canvas |
 
 ### Preset Assignment (Draft)
 
 **Starter Presets:**
 
 - logger.js (debugging)
-- add.hydra (common pattern)
-- add-fft.hydra (audio-reactive)
-- pipe-msg.js (utility)
-- delay.js (utility)
+- glsl> (object companion preset for `glsl`)
+- hydra> (object companion preset for `hydra`)
+- regl> (object companion preset for `regl`)
+- swgl> (object companion preset for `swgl`)
+- three> (object companion preset for `three`)
+
+Object companion presets belong only to Starter Presets. They are visible when both of these are
+true:
+
+1. Starter Presets is enabled, which it is by default and locked for baseline visibility
+2. The companion preset's object type is enabled by an object pack
+
+Starter Presets has no pack-level object requirements so it never shows a "Requires ..." warning.
+Availability is decided per preset when object browser/autocomplete surfaces filter by each preset's
+object type.
+
+For example, enabling the Video Synths object pack makes `glsl>`, `hydra>`, `regl>`, `swgl>`, and
+`three>` visible without requiring the user to also enable a GLSL, Hydra, REGL, SwissGL, or Three.js
+preset pack. Larger visual effect libraries remain in their own opt-in preset packs.
 
 **MIDI Presets:**
 
@@ -204,13 +227,13 @@ This is consistent with how object filtering already works and avoids surprising
 
 ## Key Files to Modify
 
-| File | Changes |
-|------|---------|
-| `src/stores/extensions.store.ts` | Add PresetPack interface, BUILT_IN_PRESET_PACKS, stores |
-| `src/lib/components/sidebar/ExtensionsView.svelte` | Add Preset Packs section |
-| `src/lib/components/object-browser/ObjectBrowserModal.svelte` | Filter presets by enabledPresets |
-| `src/lib/components/insert-object/QuickInsertObjectMenu.svelte` | Filter preset suggestions |
-| `src/lib/components/sidebar/PresetTreeView.svelte` | Filter visible presets |
+| File                                                            | Changes                                                 |
+| --------------------------------------------------------------- | ------------------------------------------------------- |
+| `src/stores/extensions.store.ts`                                | Add PresetPack interface, BUILT_IN_PRESET_PACKS, stores |
+| `src/lib/components/sidebar/ExtensionsView.svelte`              | Add Preset Packs section                                |
+| `src/lib/components/object-browser/ObjectBrowserModal.svelte`   | Filter presets by enabledPresets                        |
+| `src/lib/components/insert-object/QuickInsertObjectMenu.svelte` | Filter preset suggestions                               |
+| `src/lib/components/sidebar/PresetTreeView.svelte`              | Filter visible presets                                  |
 
 ## Verification Plan
 

--- a/ui/src/lib/components/object-browser/ObjectBrowserModal.svelte
+++ b/ui/src/lib/components/object-browser/ObjectBrowserModal.svelte
@@ -38,6 +38,7 @@
   import { sortFuseResultsWithPrefixPriority } from '$lib/utils/sort-fuse-results';
   import { isSidebarOpen, sidebarView, selectedNodeInfo } from '../../../stores/ui.store';
   import { getPackIcon } from '$lib/extensions/pack-icons';
+  import { getBuiltInPresetPackByPresetName } from '$lib/extensions/preset-pack-index';
   import { formatPresetLocation } from '$lib/presets/preset-utils';
   import DisabledObjectSuggestion from './DisabledObjectSuggestion.svelte';
   import ExtensionPackCard from '../sidebar/ExtensionPackCard.svelte';
@@ -109,14 +110,18 @@
         continue;
       }
 
+      const presetPack =
+        libraryName === 'Built-in' ? getBuiltInPresetPackByPresetName(preset.name) : undefined;
       const typeFolder = path.length > 2 ? path[1] : preset.type;
       const categoryKey =
-        libraryName === 'Built-in' ? typeFolder : formatPresetLocation(flatPreset);
+        libraryName === 'Built-in'
+          ? (presetPack?.name ?? typeFolder)
+          : formatPresetLocation(flatPreset);
 
       if (!presetsByCategory.has(categoryKey)) {
         presetsByCategory.set(categoryKey, []);
         const pack = BUILT_IN_PACKS.find((p) => p.objects.includes(preset.type));
-        categoryIconMap.set(categoryKey, pack?.icon || 'Package');
+        categoryIconMap.set(categoryKey, presetPack?.icon ?? pack?.icon ?? 'Package');
       }
 
       presetsByCategory.get(categoryKey)!.push({
@@ -131,7 +136,15 @@
       presets.sort((a, b) => a.name.localeCompare(b.name));
     }
 
-    const sortedCategories = Array.from(presetsByCategory.keys()).sort();
+    const presetPackOrder = new Map(BUILT_IN_PRESET_PACKS.map((pack, index) => [pack.name, index]));
+    const sortedCategories = Array.from(presetsByCategory.keys()).sort((a, b) => {
+      const aOrder = presetPackOrder.get(a) ?? Number.MAX_SAFE_INTEGER;
+      const bOrder = presetPackOrder.get(b) ?? Number.MAX_SAFE_INTEGER;
+
+      if (aOrder !== bOrder) return aOrder - bOrder;
+
+      return a.localeCompare(b);
+    });
 
     return sortedCategories.map((category) => ({
       title: category,

--- a/ui/src/lib/extensions/preset-pack-availability.ts
+++ b/ui/src/lib/extensions/preset-pack-availability.ts
@@ -1,0 +1,8 @@
+export function isPresetPackAvailableForObjects(
+  requiredObjects: string[],
+  enabledObjects: Set<string>
+): boolean {
+  if (requiredObjects.length === 0) return true;
+
+  return requiredObjects.some((objectName) => enabledObjects.has(objectName));
+}

--- a/ui/src/lib/extensions/preset-pack-index.ts
+++ b/ui/src/lib/extensions/preset-pack-index.ts
@@ -1,0 +1,33 @@
+import type { LegacyPresetsRecord, Preset, PresetFolder } from '$lib/presets/types';
+
+import { BUILT_IN_PRESET_PACKS } from './preset-packs';
+
+export function getBuiltInPresetPackByPresetName(presetName: string) {
+  return BUILT_IN_PRESET_PACKS.find((pack) => pack.presets.includes(presetName));
+}
+
+export function buildBuiltInPresetPackFolders(presets: LegacyPresetsRecord): PresetFolder {
+  const result: PresetFolder = {};
+
+  for (const pack of BUILT_IN_PRESET_PACKS) {
+    const folder: PresetFolder = {};
+
+    for (const presetName of pack.presets) {
+      const preset = presets[presetName];
+      if (!preset) continue;
+
+      folder[presetName] = {
+        name: presetName,
+        description: preset.description,
+        type: preset.type,
+        data: preset.data
+      } satisfies Preset;
+    }
+
+    if (Object.keys(folder).length > 0) {
+      result[pack.name] = folder;
+    }
+  }
+
+  return result;
+}

--- a/ui/src/lib/extensions/preset-packs.test.ts
+++ b/ui/src/lib/extensions/preset-packs.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'vitest';
+
+import { BUILT_IN_PACKS } from './object-packs';
+import { isPresetPackAvailableForObjects } from './preset-pack-availability';
+import { BUILT_IN_PRESET_PACKS } from './preset-packs';
+
+const companionPresetNames = ['glsl>', 'hydra>', 'regl>', 'swgl>', 'three>'];
+
+describe('built-in preset packs', () => {
+  test('keeps object companion presets in the locked starter pack', () => {
+    const starterPack = BUILT_IN_PRESET_PACKS.find((pack) => pack.id === 'starters');
+
+    expect(starterPack?.presets).toEqual(expect.arrayContaining(companionPresetNames));
+  });
+
+  test('does not require objects for the starter preset pack', () => {
+    const starterPack = BUILT_IN_PRESET_PACKS.find((pack) => pack.id === 'starters');
+
+    expect(starterPack?.requiredObjects).toEqual([]);
+  });
+
+  test('treats preset packs without required objects as enabled', () => {
+    const isAvailable = isPresetPackAvailableForObjects([], new Set());
+
+    expect(isAvailable).toBe(true);
+  });
+
+  test('does not list preset names as required objects', () => {
+    const knownObjects = new Set(BUILT_IN_PACKS.flatMap((pack) => pack.objects));
+    const unknownRequiredObjects = BUILT_IN_PRESET_PACKS.flatMap((pack) =>
+      pack.requiredObjects
+        .filter((objectName) => !knownObjects.has(objectName))
+        .map((objectName) => ({ packId: pack.id, objectName }))
+    );
+
+    expect(unknownRequiredObjects).toEqual([]);
+  });
+
+  test('assigns each companion preset to exactly one pack', () => {
+    const assignments = companionPresetNames.map((presetName) => ({
+      presetName,
+      packIds: BUILT_IN_PRESET_PACKS.filter((pack) => pack.presets.includes(presetName)).map(
+        (pack) => pack.id
+      )
+    }));
+
+    expect(assignments).toEqual(
+      companionPresetNames.map((presetName) => ({ presetName, packIds: ['starters'] }))
+    );
+  });
+
+  test('does not include empty preset packs', () => {
+    const emptyPackIds = BUILT_IN_PRESET_PACKS.filter((pack) => pack.presets.length === 0).map(
+      (pack) => pack.id
+    );
+
+    expect(emptyPackIds).toEqual([]);
+  });
+});

--- a/ui/src/lib/extensions/preset-packs.test.ts
+++ b/ui/src/lib/extensions/preset-packs.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from 'vitest';
 
 import { BUILT_IN_PACKS } from './object-packs';
 import { isPresetPackAvailableForObjects } from './preset-pack-availability';
+import { buildBuiltInPresetPackFolders } from './preset-pack-index';
 import { BUILT_IN_PRESET_PACKS, OBJECT_PIPE_PRESETS } from './preset-packs';
+import { BUILTIN_PRESETS } from '$lib/presets/builtin';
+import { isPreset } from '$lib/presets/preset-utils';
 
 describe('built-in preset packs', () => {
   test('keeps object companion presets in the locked starter pack', () => {
@@ -53,5 +56,43 @@ describe('built-in preset packs', () => {
     );
 
     expect(emptyPackIds).toEqual([]);
+  });
+
+  test('assigns every built-in preset to exactly one preset pack', () => {
+    const assignmentCounts = new Map<string, number>();
+
+    for (const pack of BUILT_IN_PRESET_PACKS) {
+      for (const presetName of pack.presets) {
+        assignmentCounts.set(presetName, (assignmentCounts.get(presetName) ?? 0) + 1);
+      }
+    }
+
+    const unassignedPresetNames = Object.keys(BUILTIN_PRESETS).filter(
+      (presetName) => !assignmentCounts.has(presetName)
+    );
+    const duplicatePresetNames = Array.from(assignmentCounts.entries())
+      .filter(([, count]) => count !== 1)
+      .map(([presetName]) => presetName);
+    const missingPresetNames = Array.from(assignmentCounts.keys()).filter(
+      (presetName) => !(presetName in BUILTIN_PRESETS)
+    );
+
+    expect(unassignedPresetNames).toEqual([]);
+    expect(duplicatePresetNames).toEqual([]);
+    expect(missingPresetNames).toEqual([]);
+  });
+
+  test('groups built-in preset folders by preset pack name', () => {
+    const folders = buildBuiltInPresetPackFolders(BUILTIN_PRESETS);
+    const textureGenerators = folders['Texture Generators'];
+
+    expect(textureGenerators).toBeDefined();
+    if (!textureGenerators || isPreset(textureGenerators)) {
+      throw new Error('Expected Texture Generators to be a preset folder');
+    }
+
+    expect(isPreset(textureGenerators['Circle'])).toBe(true);
+    expect(isPreset(textureGenerators['Radial Ramp'])).toBe(true);
+    expect(folders.glsl).toBeUndefined();
   });
 });

--- a/ui/src/lib/extensions/preset-packs.test.ts
+++ b/ui/src/lib/extensions/preset-packs.test.ts
@@ -2,15 +2,13 @@ import { describe, expect, test } from 'vitest';
 
 import { BUILT_IN_PACKS } from './object-packs';
 import { isPresetPackAvailableForObjects } from './preset-pack-availability';
-import { BUILT_IN_PRESET_PACKS } from './preset-packs';
-
-const companionPresetNames = ['glsl>', 'hydra>', 'regl>', 'swgl>', 'three>'];
+import { BUILT_IN_PRESET_PACKS, OBJECT_PIPE_PRESETS } from './preset-packs';
 
 describe('built-in preset packs', () => {
   test('keeps object companion presets in the locked starter pack', () => {
     const starterPack = BUILT_IN_PRESET_PACKS.find((pack) => pack.id === 'starters');
 
-    expect(starterPack?.presets).toEqual(expect.arrayContaining(companionPresetNames));
+    expect(starterPack?.presets).toEqual(expect.arrayContaining(OBJECT_PIPE_PRESETS));
   });
 
   test('does not require objects for the starter preset pack', () => {
@@ -37,7 +35,7 @@ describe('built-in preset packs', () => {
   });
 
   test('assigns each companion preset to exactly one pack', () => {
-    const assignments = companionPresetNames.map((presetName) => ({
+    const assignments = OBJECT_PIPE_PRESETS.map((presetName) => ({
       presetName,
       packIds: BUILT_IN_PRESET_PACKS.filter((pack) => pack.presets.includes(presetName)).map(
         (pack) => pack.id
@@ -45,7 +43,7 @@ describe('built-in preset packs', () => {
     }));
 
     expect(assignments).toEqual(
-      companionPresetNames.map((presetName) => ({ presetName, packIds: ['starters'] }))
+      OBJECT_PIPE_PRESETS.map((presetName) => ({ presetName, packIds: ['starters'] }))
     );
   });
 

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -76,7 +76,19 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'Color correction and channel utilities',
     icon: 'Palette',
     requiredObjects: ['glsl'],
-    presets: ['Level', 'Reorder']
+    presets: [
+      'Level',
+      'HSV Adjust',
+      'Monochrome',
+      'Channel Mix',
+      'Limit',
+      'Remap',
+      'Lookup',
+      'RGB to HSV',
+      'HSV to RGB',
+      'Tone Map',
+      'Reorder'
+    ]
   },
   {
     id: 'texture-masks-keys',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -50,7 +50,16 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'Procedural sources for starting visual chains',
     icon: 'Shapes',
     requiredObjects: ['glsl'],
-    presets: ['Constant', 'Linear Ramp', 'Radial Ramp', 'Circular Ramp', 'Noise']
+    presets: [
+      'Constant',
+      'Linear Ramp',
+      'Radial Ramp',
+      'Circular Ramp',
+      'Noise',
+      'Circle',
+      'Rectangle',
+      'Cross'
+    ]
   },
   {
     id: 'texture-composite',
@@ -122,7 +131,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'Image-processing effects for texture chains',
     icon: 'SlidersHorizontal',
     requiredObjects: ['glsl'],
-    presets: ['Blur', 'Edge']
+    presets: ['Blur', 'Edge', 'Emboss', 'Slope', 'Normal Map']
   },
   {
     id: 'texture-feedback-data',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -29,6 +29,14 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     ]
   },
   {
+    id: 'visual-starters',
+    name: 'Visual Starters',
+    description: 'Starter templates for GPU visual nodes',
+    icon: 'Code',
+    requiredObjects: ['hydra>', 'glsl', 'regl', 'swgl', 'three'],
+    presets: ['hydra>', 'glsl>', 'regl>', 'swgl>', 'three>']
+  },
+  {
     id: 'hydra-operators',
     name: 'Hydra Operators',
     description: 'Video operators built with Hydra',
@@ -37,35 +45,52 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     presets: ['hydra>', 'add.hydra', 'diff.hydra', 'sub.hydra', 'blend.hydra', 'mask.hydra']
   },
   {
-    id: 'glsl-presets',
-    name: 'GLSL Operators',
-    description: 'Video operators built with GLSL',
+    id: 'texture-generators',
+    name: 'Texture Generators',
+    description: 'Procedural sources for starting visual chains',
     icon: 'Shapes',
-    requiredObjects: ['glsl', 'regl', 'swgl', 'three'],
-    presets: [
-      'glsl>',
-      'Mix',
-      'Overlay',
-      'Switcher',
-      'Constant',
-      'Linear Ramp',
-      'Radial Ramp',
-      'Circular Ramp',
-      'Level',
-      'Transform',
-      'Multiply',
-      'Blur',
-      'Crop',
-      'Reorder',
-      'Displace',
-      'Edge',
-      'Noise',
-      'Noise Displace',
-      'Feedback',
-      'regl>',
-      'swgl>',
-      'three>'
-    ]
+    requiredObjects: ['glsl'],
+    presets: ['Constant', 'Linear Ramp', 'Radial Ramp', 'Circular Ramp', 'Noise']
+  },
+  {
+    id: 'texture-composite',
+    name: 'Texture Composite',
+    description: 'Combine and switch between multiple textures',
+    icon: 'ArrowRightLeft',
+    requiredObjects: ['glsl'],
+    presets: ['Mix', 'Overlay', 'Multiply', 'Switcher']
+  },
+  {
+    id: 'texture-color',
+    name: 'Texture Color',
+    description: 'Color correction and channel utilities',
+    icon: 'Palette',
+    requiredObjects: ['glsl'],
+    presets: ['Level', 'Reorder']
+  },
+  {
+    id: 'texture-transform',
+    name: 'Texture Transform',
+    description: 'Move, crop, tile, and warp textures',
+    icon: 'Route',
+    requiredObjects: ['glsl'],
+    presets: ['Transform', 'Crop', 'Displace', 'Noise Displace']
+  },
+  {
+    id: 'texture-filters',
+    name: 'Texture Filters',
+    description: 'Image-processing effects for texture chains',
+    icon: 'SlidersHorizontal',
+    requiredObjects: ['glsl'],
+    presets: ['Blur', 'Edge']
+  },
+  {
+    id: 'texture-feedback-data',
+    name: 'Texture Feedback & Data',
+    description: 'Feedback and data-texture visual workflows',
+    icon: 'GitBranch',
+    requiredObjects: ['glsl'],
+    presets: ['Feedback']
   },
   {
     id: 'scripting-demos',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -1,5 +1,7 @@
 import type { PresetPack } from '../../stores/extensions.store';
 
+export const OBJECT_PIPE_PRESETS = ['js>', 'hydra>', 'glsl>', 'regl>', 'swgl>', 'three>', 'tone>'];
+
 /**
  * Built-in preset packs organized by use-case
  * Each preset belongs to exactly one pack (mutually exclusive)
@@ -11,7 +13,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'Essentials for getting started',
     icon: 'Boxes',
     requiredObjects: [],
-    presets: ['logger.js', 'glsl>', 'hydra>', 'regl>', 'swgl>', 'three>']
+    presets: ['logger.js', ...OBJECT_PIPE_PRESETS]
   },
   {
     id: 'canvas-widgets',
@@ -132,7 +134,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'JS scripts for control flow',
     icon: 'Code',
     requiredObjects: ['js'],
-    presets: ['js>', 'delay.js']
+    presets: ['delay.js']
   },
   {
     id: 'iframe-widgets',
@@ -250,7 +252,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'Audio synthesis with Tone.js',
     icon: 'AudioLines',
     requiredObjects: ['tone~'],
-    presets: ['poly-synth-midi.tone', 'tone>', 'reverb.tone', 'lowpass.tone']
+    presets: ['poly-synth-midi.tone', 'reverb.tone', 'lowpass.tone']
   },
   {
     id: 'asm-examples',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -129,7 +129,16 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'Image-processing effects for texture chains',
     icon: 'SlidersHorizontal',
     requiredObjects: ['glsl'],
-    presets: ['Blur', 'Luma Blur', 'Edge', 'Anti Alias', 'Emboss', 'Slope', 'Normal Map']
+    presets: [
+      'Blur',
+      'Luma Blur',
+      'Convolve',
+      'Edge',
+      'Anti Alias',
+      'Emboss',
+      'Slope',
+      'Normal Map'
+    ]
   },
   {
     id: 'scripting-demos',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -68,6 +68,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
       'Add',
       'Subtract',
       'Difference',
+      'Math',
       'Composite',
       'Over',
       'Under',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -83,6 +83,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     requiredObjects: ['glsl'],
     presets: [
       'Level',
+      'Luma Level',
       'HSV Adjust',
       'Monochrome',
       'Channel Mix',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -27,7 +27,8 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
       'rgba.picker',
       'plotter.canvas',
       'particle.canvas',
-      'midi.keyboard'
+      'midi.keyboard',
+      'fractal-tree.canvas'
     ]
   },
   {
@@ -126,7 +127,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'Image-processing effects for texture chains',
     icon: 'SlidersHorizontal',
     requiredObjects: ['glsl'],
-    presets: ['Blur', 'Edge', 'Emboss', 'Slope', 'Normal Map']
+    presets: ['Blur', 'Edge', 'Anti Alias', 'Emboss', 'Slope', 'Normal Map']
   },
   {
     id: 'scripting-demos',
@@ -141,8 +142,8 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     name: 'Iframe Widgets',
     description: 'Useful widgets made with iframes',
     icon: 'Layout',
-    requiredObjects: ['iframe'],
-    presets: ['youtube.iframe']
+    requiredObjects: ['iframe', 'dom'],
+    presets: ['youtube.iframe', 'bitmaprenderer']
   },
   {
     id: 'midi',
@@ -190,8 +191,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
       'rms.p5',
       'rms-wide.p5',
       'FFT Frequency GL',
-      'FFT Waveform GL',
-      'fft.js'
+      'FFT Waveform GL'
     ]
   },
   {
@@ -343,5 +343,13 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
       'floatbeat.beat',
       'ice-age.beat'
     ]
+  },
+  {
+    id: 'ai-prompt-presets',
+    name: 'AI Prompt Presets',
+    description: 'Prompt templates for AI objects',
+    icon: 'Brain',
+    requiredObjects: ['ai.txt'],
+    presets: ['music-from-image.prompt']
   }
 ];

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -10,8 +10,8 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     name: 'Starter Presets',
     description: 'Essentials for getting started',
     icon: 'Boxes',
-    requiredObjects: ['js'],
-    presets: ['logger.js']
+    requiredObjects: [],
+    presets: ['logger.js', 'glsl>', 'hydra>', 'regl>', 'swgl>', 'three>']
   },
   {
     id: 'canvas-widgets',
@@ -29,20 +29,12 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     ]
   },
   {
-    id: 'visual-starters',
-    name: 'Visual Starters',
-    description: 'Starter templates for GPU visual nodes',
-    icon: 'Code',
-    requiredObjects: ['hydra>', 'glsl', 'regl', 'swgl', 'three'],
-    presets: ['hydra>', 'glsl>', 'regl>', 'swgl>', 'three>']
-  },
-  {
     id: 'hydra-operators',
     name: 'Hydra Operators',
     description: 'Video operators built with Hydra',
     icon: 'Palette',
     requiredObjects: ['hydra'],
-    presets: ['hydra>', 'add.hydra', 'diff.hydra', 'sub.hydra', 'blend.hydra', 'mask.hydra']
+    presets: ['add.hydra', 'diff.hydra', 'sub.hydra', 'blend.hydra', 'mask.hydra']
   },
   {
     id: 'texture-generators',
@@ -76,6 +68,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
       'Composite',
       'Over',
       'Under',
+      'Feedback',
       'Switcher'
     ]
   },
@@ -132,14 +125,6 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     icon: 'SlidersHorizontal',
     requiredObjects: ['glsl'],
     presets: ['Blur', 'Edge', 'Emboss', 'Slope', 'Normal Map']
-  },
-  {
-    id: 'texture-feedback-data',
-    name: 'Texture Feedback & Data',
-    description: 'Feedback and data-texture visual workflows',
-    icon: 'GitBranch',
-    requiredObjects: ['glsl'],
-    presets: ['Feedback']
   },
   {
     id: 'scripting-demos',
@@ -243,13 +228,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: '3D graphics with Three.js',
     icon: 'Box',
     requiredObjects: ['three', 'glsl'],
-    presets: [
-      'three>',
-      'video-cube.three',
-      'video-torus.three',
-      'video-sphere.three',
-      'crate.three'
-    ]
+    presets: ['video-cube.three', 'video-torus.three', 'video-sphere.three', 'crate.three']
   },
   {
     id: 'gpu-geometry',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -58,7 +58,17 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'Combine and switch between multiple textures',
     icon: 'ArrowRightLeft',
     requiredObjects: ['glsl'],
-    presets: ['Mix', 'Overlay', 'Multiply', 'Switcher']
+    presets: [
+      'Mix',
+      'Multiply',
+      'Add',
+      'Subtract',
+      'Difference',
+      'Composite',
+      'Over',
+      'Under',
+      'Switcher'
+    ]
   },
   {
     id: 'texture-color',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -104,7 +104,17 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'Move, crop, tile, and warp textures',
     icon: 'Route',
     requiredObjects: ['glsl'],
-    presets: ['Transform', 'Crop', 'Displace', 'Noise Displace']
+    presets: [
+      'Transform',
+      'Crop',
+      'Fit',
+      'Flip',
+      'Mirror',
+      'Tile',
+      'Lens Distort',
+      'Displace',
+      'Noise Displace'
+    ]
   },
   {
     id: 'texture-filters',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -87,6 +87,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
       'HSV Adjust',
       'Monochrome',
       'Channel Mix',
+      'Pack',
       'Limit',
       'Remap',
       'Lookup',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -127,7 +127,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'Image-processing effects for texture chains',
     icon: 'SlidersHorizontal',
     requiredObjects: ['glsl'],
-    presets: ['Blur', 'Edge', 'Anti Alias', 'Emboss', 'Slope', 'Normal Map']
+    presets: ['Blur', 'Luma Blur', 'Edge', 'Anti Alias', 'Emboss', 'Slope', 'Normal Map']
   },
   {
     id: 'scripting-demos',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -79,6 +79,14 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     presets: ['Level', 'Reorder']
   },
   {
+    id: 'texture-masks-keys',
+    name: 'Texture Masks & Keys',
+    description: 'Build and apply alpha and matte textures',
+    icon: 'Eye',
+    requiredObjects: ['glsl'],
+    presets: ['Threshold', 'Chroma Key', 'RGB Key', 'Luma Key', 'Matte']
+  },
+  {
     id: 'texture-transform',
     name: 'Texture Transform',
     description: 'Move, crop, tile, and warp textures',

--- a/ui/src/lib/presets/builtin/glsl/add.ts
+++ b/ui/src/lib/presets/builtin/glsl/add.ts
@@ -1,0 +1,25 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Add
+// @primaryButton settings
+// @param opacity 1.0 0.0 1.0 0.001 "Opacity"
+// @param clampOutput true "Clamp Output"
+
+uniform sampler2D a;
+uniform sampler2D b;
+uniform float opacity;
+uniform bool clampOutput;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 ca = texture(a, uv);
+  vec4 cb = texture(b, uv);
+  vec4 added = vec4(ca.rgb + cb.rgb * opacity, max(ca.a, cb.a * opacity));
+
+  fragColor = clampOutput ? clamp(added, 0.0, 1.0) : added;
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Add two textures with opacity and optional clamping.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/anti-alias.ts
+++ b/ui/src/lib/presets/builtin/glsl/anti-alias.ts
@@ -1,0 +1,55 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Anti Alias
+// @primaryButton settings
+// @param channel 4 (0: Luma, 1: Red, 2: Green, 3: Blue, 4: Alpha) "Channel"
+// @param threshold 0.5 0.0 1.0 0.001 "Threshold"
+// @param softness 0.05 0.0 0.5 0.001 "Softness"
+// @param radius 1.0 0.0 4.0 0.001 "Radius"
+// @param amount 1.0 0.0 1.0 0.001 "Amount"
+
+uniform sampler2D source;
+uniform float channel;
+uniform float threshold;
+uniform float softness;
+uniform float radius;
+uniform float amount;
+
+float sampleChannel(vec2 p) {
+  vec4 color = texture(source, p);
+  if (channel < 0.5) return dot(color.rgb, vec3(0.299, 0.587, 0.114));
+  if (channel < 1.5) return color.r;
+  if (channel < 2.5) return color.g;
+  if (channel < 3.5) return color.b;
+  return color.a;
+}
+
+float coverage(vec2 p) {
+  float value = sampleChannel(p);
+  return smoothstep(threshold - softness, threshold + softness, value);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 px = radius / iResolution.xy;
+  vec4 sourceColor = texture(source, uv);
+
+  float smoothed = coverage(uv) * 0.28;
+  smoothed += coverage(uv + vec2(px.x, 0.0)) * 0.12;
+  smoothed += coverage(uv - vec2(px.x, 0.0)) * 0.12;
+  smoothed += coverage(uv + vec2(0.0, px.y)) * 0.12;
+  smoothed += coverage(uv - vec2(0.0, px.y)) * 0.12;
+  smoothed += coverage(uv + vec2(px.x, px.y)) * 0.06;
+  smoothed += coverage(uv - vec2(px.x, px.y)) * 0.06;
+  smoothed += coverage(uv + vec2(px.x, -px.y)) * 0.06;
+  smoothed += coverage(uv + vec2(-px.x, px.y)) * 0.06;
+
+  float original = coverage(uv);
+  float alpha = mix(original, smoothed, amount);
+  fragColor = vec4(sourceColor.rgb, alpha);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Smooth hard mask edges from a selected source channel.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/channel-mix.ts
+++ b/ui/src/lib/presets/builtin/glsl/channel-mix.ts
@@ -1,0 +1,43 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Channel Mix
+// @primaryButton settings
+// @param rr 1.0 -2.0 2.0 0.001 "Red <- Red"
+// @param rg 0.0 -2.0 2.0 0.001 "Red <- Green"
+// @param rb 0.0 -2.0 2.0 0.001 "Red <- Blue"
+// @param gr 0.0 -2.0 2.0 0.001 "Green <- Red"
+// @param gg 1.0 -2.0 2.0 0.001 "Green <- Green"
+// @param gb 0.0 -2.0 2.0 0.001 "Green <- Blue"
+// @param br 0.0 -2.0 2.0 0.001 "Blue <- Red"
+// @param bg 0.0 -2.0 2.0 0.001 "Blue <- Green"
+// @param bb 1.0 -2.0 2.0 0.001 "Blue <- Blue"
+// @param opacity 1.0 0.0 1.0 0.001 "Opacity"
+
+uniform sampler2D source;
+uniform float rr;
+uniform float rg;
+uniform float rb;
+uniform float gr;
+uniform float gg;
+uniform float gb;
+uniform float br;
+uniform float bg;
+uniform float bb;
+uniform float opacity;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  mat3 matrix = mat3(
+    rr, gr, br,
+    rg, gg, bg,
+    rb, gb, bb
+  );
+  vec3 mixed = matrix * color.rgb;
+  fragColor = vec4(mix(color.rgb, mixed, opacity), color.a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Mix RGB channels with a 3x3 color matrix.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/chroma-key.ts
+++ b/ui/src/lib/presets/builtin/glsl/chroma-key.ts
@@ -1,0 +1,32 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Chroma Key
+// @primaryButton settings
+// @param keyColor color #00ff00 "Key Color"
+// @param tolerance 0.25 0.0 1.0 0.001 "Tolerance"
+// @param softness 0.08 0.0 0.5 0.001 "Softness"
+// @param spill 0.5 0.0 1.0 0.001 "Spill"
+
+uniform sampler2D source;
+uniform vec3 keyColor;
+uniform float tolerance;
+uniform float softness;
+uniform float spill;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  float distanceToKey = distance(color.rgb, keyColor);
+  float alpha = smoothstep(tolerance, tolerance + softness, distanceToKey);
+
+  vec3 keyAxis = normalize(max(keyColor, vec3(0.001)));
+  float keyAmount = dot(color.rgb, keyAxis);
+  vec3 neutralized = color.rgb - keyAxis * keyAmount * (1.0 - alpha) * spill;
+
+  fragColor = vec4(max(neutralized, 0.0), color.a * alpha);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Key out a chosen chroma color with tolerance, softness, and spill control.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/chroma-key.ts
+++ b/ui/src/lib/presets/builtin/glsl/chroma-key.ts
@@ -16,7 +16,9 @@ uniform float spill;
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   vec4 color = texture(source, uv);
   float distanceToKey = distance(color.rgb, keyColor);
-  float alpha = smoothstep(tolerance, tolerance + softness, distanceToKey);
+  float alpha = softness <= 0.0
+    ? step(tolerance, distanceToKey)
+    : smoothstep(tolerance, tolerance + softness, distanceToKey);
 
   vec3 keyAxis = normalize(max(keyColor, vec3(0.001)));
   float keyAmount = dot(color.rgb, keyAxis);

--- a/ui/src/lib/presets/builtin/glsl/circle.ts
+++ b/ui/src/lib/presets/builtin/glsl/circle.ts
@@ -1,0 +1,32 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Circle
+// @primaryButton settings
+// @param centerX 0.5 0.0 1.0 0.001 "Center X"
+// @param centerY 0.5 0.0 1.0 0.001 "Center Y"
+// @param radius 0.3 0.0 1.0 0.001 "Radius"
+// @param feather 0.02 0.0 0.5 0.001 "Feather"
+// @param color color #ffffff "Color"
+// @param alpha 1.0 0.0 1.0 0.001 "Alpha"
+
+uniform float centerX;
+uniform float centerY;
+uniform float radius;
+uniform float feather;
+uniform vec3 color;
+uniform float alpha;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 aspect = vec2(iResolution.x / max(iResolution.y, 0.0001), 1.0);
+  vec2 p = (uv - vec2(centerX, centerY)) * aspect;
+  float dist = length(p);
+  float mask = 1.0 - smoothstep(radius, radius + feather, dist);
+
+  fragColor = vec4(color, alpha * mask);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Generate a feathered circle shape with useful alpha output.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/composite.ts
+++ b/ui/src/lib/presets/builtin/glsl/composite.ts
@@ -1,0 +1,46 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Composite
+// @primaryButton settings
+// @param mode 0 (0: Over, 1: Add, 2: Multiply, 3: Screen, 4: Difference, 5: Overlay) "Mode"
+// @param opacity 1.0 0.0 1.0 0.001 "Opacity"
+
+uniform sampler2D background;
+uniform sampler2D foreground;
+uniform float mode;
+uniform float opacity;
+
+vec3 blendOverlay(vec3 bg, vec3 fg) {
+  vec3 low = 2.0 * bg * fg;
+  vec3 high = 1.0 - 2.0 * (1.0 - bg) * (1.0 - fg);
+  return mix(low, high, step(0.5, bg));
+}
+
+vec4 over(vec4 bg, vec4 fg) {
+  float alpha = clamp(fg.a * opacity, 0.0, 1.0);
+  float outAlpha = alpha + bg.a * (1.0 - alpha);
+  vec3 rgb = (fg.rgb * alpha + bg.rgb * bg.a * (1.0 - alpha)) / max(outAlpha, 0.0001);
+  return vec4(rgb, outAlpha);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 bg = texture(background, uv);
+  vec4 fg = texture(foreground, uv);
+
+  vec3 blended = fg.rgb;
+  if (mode > 0.5 && mode < 1.5) blended = bg.rgb + fg.rgb;
+  if (mode >= 1.5 && mode < 2.5) blended = bg.rgb * fg.rgb;
+  if (mode >= 2.5 && mode < 3.5) blended = 1.0 - (1.0 - bg.rgb) * (1.0 - fg.rgb);
+  if (mode >= 3.5 && mode < 4.5) blended = abs(bg.rgb - fg.rgb);
+  if (mode >= 4.5) blended = blendOverlay(bg.rgb, fg.rgb);
+
+  vec4 composite = vec4(clamp(blended, 0.0, 1.0), max(bg.a, fg.a * opacity));
+  vec4 blendedComposite = mix(bg, composite, fg.a * opacity);
+  fragColor = mode < 0.5 ? over(bg, fg) : blendedComposite;
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Composite a foreground over a background with common blend modes.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/composite.ts
+++ b/ui/src/lib/presets/builtin/glsl/composite.ts
@@ -17,7 +17,7 @@ vec3 blendOverlay(vec3 bg, vec3 fg) {
 }
 
 vec4 over(vec4 bg, vec4 fg) {
-  float alpha = clamp(fg.a * opacity, 0.0, 1.0);
+  float alpha = clamp(fg.a, 0.0, 1.0);
   float outAlpha = alpha + bg.a * (1.0 - alpha);
   vec3 rgb = (fg.rgb * alpha + bg.rgb * bg.a * (1.0 - alpha)) / max(outAlpha, 0.0001);
   return vec4(rgb, outAlpha);
@@ -34,9 +34,10 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   if (mode >= 3.5 && mode < 4.5) blended = abs(bg.rgb - fg.rgb);
   if (mode >= 4.5) blended = blendOverlay(bg.rgb, fg.rgb);
 
-  vec4 composite = vec4(clamp(blended, 0.0, 1.0), max(bg.a, fg.a * opacity));
-  vec4 blendedComposite = mix(bg, composite, fg.a * opacity);
-  fragColor = mode < 0.5 ? over(bg, fg) : blendedComposite;
+  vec4 foregroundWithOpacity = vec4(fg.rgb, fg.a * opacity);
+  vec4 blendedForeground = vec4(clamp(blended, 0.0, 1.0), fg.a * opacity);
+  vec4 blendedComposite = over(bg, blendedForeground);
+  fragColor = mode < 0.5 ? over(bg, foregroundWithOpacity) : blendedComposite;
 }`;
 
 export const preset: GLSLPreset = {

--- a/ui/src/lib/presets/builtin/glsl/convolve.ts
+++ b/ui/src/lib/presets/builtin/glsl/convolve.ts
@@ -1,0 +1,96 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Convolve
+// @primaryButton settings
+// @param kernel 0 (0: Sharpen, 1: Edge, 2: Outline, 3: Box Blur, 4: Gaussian Blur, 5: Emboss) "Kernel"
+// @param strength 1.0 0.0 5.0 0.001 "Strength"
+// @param bias 0.0 -1.0 1.0 0.001 "Bias"
+// @param pixelScale 1.0 0.25 8.0 0.001 "Pixel Scale"
+// @param monochrome false "Monochrome"
+
+uniform sampler2D source;
+uniform float kernel;
+uniform float strength;
+uniform float bias;
+uniform float pixelScale;
+uniform bool monochrome;
+
+float luma(vec3 color) {
+  return dot(color, vec3(0.299, 0.587, 0.114));
+}
+
+mat3 kernelMatrix() {
+  if (kernel < 0.5) {
+    return mat3(
+       0.0, -1.0,  0.0,
+      -1.0,  5.0, -1.0,
+       0.0, -1.0,  0.0
+    );
+  }
+  if (kernel < 1.5) {
+    return mat3(
+      -1.0, -1.0, -1.0,
+      -1.0,  8.0, -1.0,
+      -1.0, -1.0, -1.0
+    );
+  }
+  if (kernel < 2.5) {
+    return mat3(
+       1.0,  1.0,  1.0,
+       1.0, -8.0,  1.0,
+       1.0,  1.0,  1.0
+    );
+  }
+  if (kernel < 3.5) {
+    return mat3(
+      1.0 / 9.0, 1.0 / 9.0, 1.0 / 9.0,
+      1.0 / 9.0, 1.0 / 9.0, 1.0 / 9.0,
+      1.0 / 9.0, 1.0 / 9.0, 1.0 / 9.0
+    );
+  }
+  if (kernel < 4.5) {
+    return mat3(
+      1.0 / 16.0, 2.0 / 16.0, 1.0 / 16.0,
+      2.0 / 16.0, 4.0 / 16.0, 2.0 / 16.0,
+      1.0 / 16.0, 2.0 / 16.0, 1.0 / 16.0
+    );
+  }
+  return mat3(
+    -2.0, -1.0,  0.0,
+    -1.0,  1.0,  1.0,
+     0.0,  1.0,  2.0
+  );
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 px = pixelScale / iResolution.xy;
+  mat3 k = kernelMatrix();
+
+  vec4 c00 = texture(source, uv + px * vec2(-1.0, -1.0));
+  vec4 c10 = texture(source, uv + px * vec2( 0.0, -1.0));
+  vec4 c20 = texture(source, uv + px * vec2( 1.0, -1.0));
+  vec4 c01 = texture(source, uv + px * vec2(-1.0,  0.0));
+  vec4 c11 = texture(source, uv);
+  vec4 c21 = texture(source, uv + px * vec2( 1.0,  0.0));
+  vec4 c02 = texture(source, uv + px * vec2(-1.0,  1.0));
+  vec4 c12 = texture(source, uv + px * vec2( 0.0,  1.0));
+  vec4 c22 = texture(source, uv + px * vec2( 1.0,  1.0));
+
+  vec4 convolved =
+    c00 * k[0][0] + c10 * k[1][0] + c20 * k[2][0] +
+    c01 * k[0][1] + c11 * k[1][1] + c21 * k[2][1] +
+    c02 * k[0][2] + c12 * k[1][2] + c22 * k[2][2];
+
+  vec3 rgb = convolved.rgb + bias;
+  if (monochrome) {
+    rgb = vec3(luma(rgb));
+  }
+
+  fragColor = vec4(mix(c11.rgb, rgb, strength), c11.a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Apply a named 3x3 convolution kernel to a source texture.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/cross.ts
+++ b/ui/src/lib/presets/builtin/glsl/cross.ts
@@ -1,0 +1,51 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Cross
+// @primaryButton settings
+// @param centerX 0.5 0.0 1.0 0.001 "Center X"
+// @param centerY 0.5 0.0 1.0 0.001 "Center Y"
+// @param size 0.65 0.0 1.5 0.001 "Size"
+// @param thickness 0.08 0.0 0.5 0.001 "Thickness"
+// @param rotation 0.0 -3.1416 3.1416 0.001 "Rotation"
+// @param feather 0.02 0.0 0.5 0.001 "Feather"
+// @param color color #ffffff "Color"
+// @param alpha 1.0 0.0 1.0 0.001 "Alpha"
+
+uniform float centerX;
+uniform float centerY;
+uniform float size;
+uniform float thickness;
+uniform float rotation;
+uniform float feather;
+uniform vec3 color;
+uniform float alpha;
+
+float boxMask(vec2 p, vec2 halfSize, float softness) {
+  vec2 d = abs(p) - halfSize;
+  float outside = length(max(d, 0.0));
+  float inside = min(max(d.x, d.y), 0.0);
+  float dist = outside + inside;
+  return 1.0 - smoothstep(0.0, softness, dist);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 aspect = vec2(iResolution.x / max(iResolution.y, 0.0001), 1.0);
+  vec2 p = (uv - vec2(centerX, centerY)) * aspect;
+  float c = cos(rotation);
+  float s = sin(rotation);
+  p = mat2(c, -s, s, c) * p;
+
+  float halfLength = size * 0.5;
+  float halfThickness = thickness * 0.5;
+  float horizontal = boxMask(p, vec2(halfLength * aspect.x, halfThickness), feather);
+  float vertical = boxMask(p, vec2(halfThickness * aspect.x, halfLength), feather);
+  float mask = max(horizontal, vertical);
+
+  fragColor = vec4(color, alpha * mask);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Generate a feathered cross shape for masks and calibration visuals.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/difference.ts
+++ b/ui/src/lib/presets/builtin/glsl/difference.ts
@@ -1,0 +1,31 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Difference
+// @primaryButton settings
+// @param opacity 1.0 0.0 1.0 0.001 "Opacity"
+// @param monochrome false "Monochrome"
+
+uniform sampler2D a;
+uniform sampler2D b;
+uniform float opacity;
+uniform bool monochrome;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 ca = texture(a, uv);
+  vec4 cb = texture(b, uv);
+  vec3 diff = abs(ca.rgb - cb.rgb);
+
+  if (monochrome) {
+    float luma = dot(diff, vec3(0.299, 0.587, 0.114));
+    diff = vec3(luma);
+  }
+
+  vec4 difference = vec4(diff, max(ca.a, cb.a));
+  fragColor = mix(ca, difference, opacity);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Show the absolute difference between two textures.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/emboss.ts
+++ b/ui/src/lib/presets/builtin/glsl/emboss.ts
@@ -1,0 +1,41 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Emboss
+// @primaryButton settings
+// @param strength 1.0 0.0 5.0 0.001 "Strength"
+// @param angle 0.7854 -3.1416 3.1416 0.001 "Angle"
+// @param distance 1.0 0.25 8.0 0.001 "Distance"
+// @param bias 0.5 0.0 1.0 0.001 "Bias"
+// @param monochrome false "Monochrome"
+
+uniform sampler2D source;
+uniform float strength;
+uniform float angle;
+uniform float distance;
+uniform float bias;
+uniform bool monochrome;
+
+float luma(vec3 color) {
+  return dot(color, vec3(0.299, 0.587, 0.114));
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 direction = vec2(cos(angle), sin(angle)) * distance / iResolution.xy;
+  vec4 forward = texture(source, uv + direction);
+  vec4 backward = texture(source, uv - direction);
+  vec4 sourceColor = texture(source, uv);
+  vec3 embossed = (forward.rgb - backward.rgb) * strength + bias;
+
+  if (monochrome) {
+    float value = (luma(forward.rgb) - luma(backward.rgb)) * strength + bias;
+    embossed = vec3(value);
+  }
+
+  fragColor = vec4(clamp(embossed, 0.0, 1.0), sourceColor.a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Emboss a source texture by comparing neighboring samples.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/fit.ts
+++ b/ui/src/lib/presets/builtin/glsl/fit.ts
@@ -1,0 +1,43 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Fit
+// @primaryButton settings
+// @param mode 0 (0: Contain, 1: Cover, 2: Stretch) "Mode"
+// @param inputAspect 1.7778 0.1 4.0 0.0001 "Input Aspect"
+// @param background color #000000 "Background"
+// @param backgroundAlpha 0.0 0.0 1.0 0.001 "Background Alpha"
+
+uniform sampler2D source;
+uniform float mode;
+uniform float inputAspect;
+uniform vec3 background;
+uniform float backgroundAlpha;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  float outputAspect = iResolution.x / max(iResolution.y, 0.0001);
+  float sourceAspect = max(inputAspect, 0.0001);
+  vec2 p = uv;
+
+  if (mode < 1.5) {
+    if (mode < 0.5) {
+      vec2 displayScale = sourceAspect > outputAspect
+        ? vec2(1.0, outputAspect / sourceAspect)
+        : vec2(sourceAspect / outputAspect, 1.0);
+      p = (uv - 0.5) / displayScale + 0.5;
+    } else {
+      vec2 sampleScale = sourceAspect > outputAspect
+        ? vec2(outputAspect / sourceAspect, 1.0)
+        : vec2(1.0, sourceAspect / outputAspect);
+      p = (uv - 0.5) * sampleScale + 0.5;
+    }
+  }
+
+  bool inside = p.x >= 0.0 && p.y >= 0.0 && p.x <= 1.0 && p.y <= 1.0;
+  fragColor = inside ? texture(source, p) : vec4(background, backgroundAlpha);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Fit, cover, or stretch a source texture to the output aspect.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/flip.ts
+++ b/ui/src/lib/presets/builtin/glsl/flip.ts
@@ -1,0 +1,24 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Flip
+// @primaryButton settings
+// @param horizontal true "Horizontal"
+// @param vertical false "Vertical"
+
+uniform sampler2D source;
+uniform bool horizontal;
+uniform bool vertical;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 p = uv;
+  if (horizontal) p.x = 1.0 - p.x;
+  if (vertical) p.y = 1.0 - p.y;
+
+  fragColor = texture(source, p);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Flip a source texture horizontally and/or vertically.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/hsv-adjust.ts
+++ b/ui/src/lib/presets/builtin/glsl/hsv-adjust.ts
@@ -1,0 +1,45 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title HSV Adjust
+// @primaryButton settings
+// @param hue 0.0 -1.0 1.0 0.001 "Hue"
+// @param saturation 1.0 0.0 3.0 0.001 "Saturation"
+// @param value 1.0 0.0 3.0 0.001 "Value"
+// @param amount 1.0 0.0 1.0 0.001 "Amount"
+
+uniform sampler2D source;
+uniform float hue;
+uniform float saturation;
+uniform float value;
+uniform float amount;
+
+vec3 rgb2hsv(vec3 c) {
+  vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+  vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+  vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+  float d = q.x - min(q.w, q.y);
+  float e = 0.0000001;
+  return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+vec3 hsv2rgb(vec3 c) {
+  vec3 p = abs(fract(c.xxx + vec3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0);
+  return c.z * mix(vec3(1.0), clamp(p - 1.0, 0.0, 1.0), c.y);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  vec3 hsv = rgb2hsv(color.rgb);
+  hsv.x = fract(hsv.x + hue);
+  hsv.y = clamp(hsv.y * saturation, 0.0, 1.0);
+  hsv.z = max(hsv.z * value, 0.0);
+  vec3 adjusted = hsv2rgb(hsv);
+
+  fragColor = vec4(mix(color.rgb, adjusted, amount), color.a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Adjust hue, saturation, and value for a source texture.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/hsv-to-rgb.ts
+++ b/ui/src/lib/presets/builtin/glsl/hsv-to-rgb.ts
@@ -1,0 +1,21 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title HSV to RGB
+
+uniform sampler2D source;
+
+vec3 hsv2rgb(vec3 c) {
+  vec3 p = abs(fract(c.xxx + vec3(0.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - 3.0);
+  return c.z * mix(vec3(1.0), clamp(p - 1.0, 0.0, 1.0), c.y);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  fragColor = vec4(hsv2rgb(color.rgb), color.a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Convert HSV texture values stored in RGB channels back to RGB.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/index.ts
+++ b/ui/src/lib/presets/builtin/glsl/index.ts
@@ -6,21 +6,26 @@ import { preset as preset4 } from './radial-ramp';
 import { preset as preset5 } from './circular-ramp';
 import { preset as preset6 } from './level';
 import { preset as preset7 } from './transform';
-import { preset as preset8 } from './overlay';
-import { preset as preset9 } from './multiply';
-import { preset as preset10 } from './blur';
-import { preset as preset11 } from './crop';
-import { preset as preset12 } from './reorder';
-import { preset as preset13 } from './displace';
-import { preset as preset14 } from './edge';
-import { preset as preset15 } from './noise';
-import { preset as preset16 } from './noise-displace';
-import { preset as preset17 } from './feedback';
-import { preset as preset18 } from './fft-frequency';
-import { preset as preset19 } from './fft-waveform';
-import { preset as preset20 } from './switcher';
-import { preset as preset21 } from './position-field';
-import { preset as preset22 } from './torus-position-field';
+import { preset as preset8 } from './multiply';
+import { preset as preset9 } from './blur';
+import { preset as preset10 } from './crop';
+import { preset as preset11 } from './reorder';
+import { preset as preset12 } from './displace';
+import { preset as preset13 } from './edge';
+import { preset as preset14 } from './noise';
+import { preset as preset15 } from './noise-displace';
+import { preset as preset16 } from './feedback';
+import { preset as preset17 } from './fft-frequency';
+import { preset as preset18 } from './fft-waveform';
+import { preset as preset19 } from './switcher';
+import { preset as preset20 } from './position-field';
+import { preset as preset21 } from './torus-position-field';
+import { preset as preset22 } from './add';
+import { preset as preset23 } from './subtract';
+import { preset as preset24 } from './difference';
+import { preset as preset25 } from './composite';
+import { preset as preset26 } from './over';
+import { preset as preset27 } from './under';
 import type { GLSLPreset } from './types';
 
 export const GLSL_PRESETS: Record<string, GLSLPreset> = {
@@ -32,21 +37,26 @@ export const GLSL_PRESETS: Record<string, GLSLPreset> = {
   'Circular Ramp': preset5,
   Level: preset6,
   Transform: preset7,
-  Overlay: preset8,
-  Multiply: preset9,
-  Blur: preset10,
-  Crop: preset11,
-  Reorder: preset12,
-  Displace: preset13,
-  Edge: preset14,
-  Noise: preset15,
-  'Noise Displace': preset16,
-  Feedback: preset17,
-  'FFT Frequency GL': preset18,
-  'FFT Waveform GL': preset19,
-  Switcher: preset20,
-  'Position Field': preset21,
-  'Torus Position Field': preset22
+  Multiply: preset8,
+  Blur: preset9,
+  Crop: preset10,
+  Reorder: preset11,
+  Displace: preset12,
+  Edge: preset13,
+  Noise: preset14,
+  'Noise Displace': preset15,
+  Feedback: preset16,
+  'FFT Frequency GL': preset17,
+  'FFT Waveform GL': preset18,
+  Switcher: preset19,
+  'Position Field': preset20,
+  'Torus Position Field': preset21,
+  Add: preset22,
+  Subtract: preset23,
+  Difference: preset24,
+  Composite: preset25,
+  Over: preset26,
+  Under: preset27
 };
 
 export type { GLSLPreset } from './types';

--- a/ui/src/lib/presets/builtin/glsl/index.ts
+++ b/ui/src/lib/presets/builtin/glsl/index.ts
@@ -51,6 +51,7 @@ import { preset as preset49 } from './cross';
 import { preset as preset50 } from './emboss';
 import { preset as preset51 } from './slope';
 import { preset as preset52 } from './normal-map';
+import { preset as preset53 } from './anti-alias';
 import type { GLSLPreset } from './types';
 
 export const GLSL_PRESETS: Record<string, GLSLPreset> = {
@@ -106,7 +107,8 @@ export const GLSL_PRESETS: Record<string, GLSLPreset> = {
   Cross: preset49,
   Emboss: preset50,
   Slope: preset51,
-  'Normal Map': preset52
+  'Normal Map': preset52,
+  'Anti Alias': preset53
 };
 
 export type { GLSLPreset } from './types';

--- a/ui/src/lib/presets/builtin/glsl/index.ts
+++ b/ui/src/lib/presets/builtin/glsl/index.ts
@@ -55,6 +55,7 @@ import { preset as preset53 } from './anti-alias';
 import { preset as preset54 } from './luma-blur';
 import { preset as preset55 } from './luma-level';
 import { preset as preset56 } from './pack';
+import { preset as preset57 } from './convolve';
 import type { GLSLPreset } from './types';
 
 export const GLSL_PRESETS: Record<string, GLSLPreset> = {
@@ -114,7 +115,8 @@ export const GLSL_PRESETS: Record<string, GLSLPreset> = {
   'Anti Alias': preset53,
   'Luma Blur': preset54,
   'Luma Level': preset55,
-  Pack: preset56
+  Pack: preset56,
+  Convolve: preset57
 };
 
 export type { GLSLPreset } from './types';

--- a/ui/src/lib/presets/builtin/glsl/index.ts
+++ b/ui/src/lib/presets/builtin/glsl/index.ts
@@ -54,6 +54,7 @@ import { preset as preset52 } from './normal-map';
 import { preset as preset53 } from './anti-alias';
 import { preset as preset54 } from './luma-blur';
 import { preset as preset55 } from './luma-level';
+import { preset as preset56 } from './pack';
 import type { GLSLPreset } from './types';
 
 export const GLSL_PRESETS: Record<string, GLSLPreset> = {
@@ -112,7 +113,8 @@ export const GLSL_PRESETS: Record<string, GLSLPreset> = {
   'Normal Map': preset52,
   'Anti Alias': preset53,
   'Luma Blur': preset54,
-  'Luma Level': preset55
+  'Luma Level': preset55,
+  Pack: preset56
 };
 
 export type { GLSLPreset } from './types';

--- a/ui/src/lib/presets/builtin/glsl/index.ts
+++ b/ui/src/lib/presets/builtin/glsl/index.ts
@@ -45,6 +45,12 @@ import { preset as preset43 } from './flip';
 import { preset as preset44 } from './mirror';
 import { preset as preset45 } from './tile';
 import { preset as preset46 } from './lens-distort';
+import { preset as preset47 } from './circle';
+import { preset as preset48 } from './rectangle';
+import { preset as preset49 } from './cross';
+import { preset as preset50 } from './emboss';
+import { preset as preset51 } from './slope';
+import { preset as preset52 } from './normal-map';
 import type { GLSLPreset } from './types';
 
 export const GLSL_PRESETS: Record<string, GLSLPreset> = {
@@ -94,7 +100,13 @@ export const GLSL_PRESETS: Record<string, GLSLPreset> = {
   Flip: preset43,
   Mirror: preset44,
   Tile: preset45,
-  'Lens Distort': preset46
+  'Lens Distort': preset46,
+  Circle: preset47,
+  Rectangle: preset48,
+  Cross: preset49,
+  Emboss: preset50,
+  Slope: preset51,
+  'Normal Map': preset52
 };
 
 export type { GLSLPreset } from './types';

--- a/ui/src/lib/presets/builtin/glsl/index.ts
+++ b/ui/src/lib/presets/builtin/glsl/index.ts
@@ -40,6 +40,11 @@ import { preset as preset38 } from './lookup';
 import { preset as preset39 } from './rgb-to-hsv';
 import { preset as preset40 } from './hsv-to-rgb';
 import { preset as preset41 } from './tone-map';
+import { preset as preset42 } from './fit';
+import { preset as preset43 } from './flip';
+import { preset as preset44 } from './mirror';
+import { preset as preset45 } from './tile';
+import { preset as preset46 } from './lens-distort';
 import type { GLSLPreset } from './types';
 
 export const GLSL_PRESETS: Record<string, GLSLPreset> = {
@@ -84,7 +89,12 @@ export const GLSL_PRESETS: Record<string, GLSLPreset> = {
   Lookup: preset38,
   'RGB to HSV': preset39,
   'HSV to RGB': preset40,
-  'Tone Map': preset41
+  'Tone Map': preset41,
+  Fit: preset42,
+  Flip: preset43,
+  Mirror: preset44,
+  Tile: preset45,
+  'Lens Distort': preset46
 };
 
 export type { GLSLPreset } from './types';

--- a/ui/src/lib/presets/builtin/glsl/index.ts
+++ b/ui/src/lib/presets/builtin/glsl/index.ts
@@ -31,6 +31,15 @@ import { preset as preset29 } from './chroma-key';
 import { preset as preset30 } from './rgb-key';
 import { preset as preset31 } from './luma-key';
 import { preset as preset32 } from './matte';
+import { preset as preset33 } from './hsv-adjust';
+import { preset as preset34 } from './monochrome';
+import { preset as preset35 } from './channel-mix';
+import { preset as preset36 } from './limit';
+import { preset as preset37 } from './remap';
+import { preset as preset38 } from './lookup';
+import { preset as preset39 } from './rgb-to-hsv';
+import { preset as preset40 } from './hsv-to-rgb';
+import { preset as preset41 } from './tone-map';
 import type { GLSLPreset } from './types';
 
 export const GLSL_PRESETS: Record<string, GLSLPreset> = {
@@ -66,7 +75,16 @@ export const GLSL_PRESETS: Record<string, GLSLPreset> = {
   'Chroma Key': preset29,
   'RGB Key': preset30,
   'Luma Key': preset31,
-  Matte: preset32
+  Matte: preset32,
+  'HSV Adjust': preset33,
+  Monochrome: preset34,
+  'Channel Mix': preset35,
+  Limit: preset36,
+  Remap: preset37,
+  Lookup: preset38,
+  'RGB to HSV': preset39,
+  'HSV to RGB': preset40,
+  'Tone Map': preset41
 };
 
 export type { GLSLPreset } from './types';

--- a/ui/src/lib/presets/builtin/glsl/index.ts
+++ b/ui/src/lib/presets/builtin/glsl/index.ts
@@ -52,6 +52,7 @@ import { preset as preset50 } from './emboss';
 import { preset as preset51 } from './slope';
 import { preset as preset52 } from './normal-map';
 import { preset as preset53 } from './anti-alias';
+import { preset as preset54 } from './luma-blur';
 import type { GLSLPreset } from './types';
 
 export const GLSL_PRESETS: Record<string, GLSLPreset> = {
@@ -108,7 +109,8 @@ export const GLSL_PRESETS: Record<string, GLSLPreset> = {
   Emboss: preset50,
   Slope: preset51,
   'Normal Map': preset52,
-  'Anti Alias': preset53
+  'Anti Alias': preset53,
+  'Luma Blur': preset54
 };
 
 export type { GLSLPreset } from './types';

--- a/ui/src/lib/presets/builtin/glsl/index.ts
+++ b/ui/src/lib/presets/builtin/glsl/index.ts
@@ -56,6 +56,7 @@ import { preset as preset54 } from './luma-blur';
 import { preset as preset55 } from './luma-level';
 import { preset as preset56 } from './pack';
 import { preset as preset57 } from './convolve';
+import { preset as preset58 } from './math';
 import type { GLSLPreset } from './types';
 
 export const GLSL_PRESETS: Record<string, GLSLPreset> = {
@@ -116,7 +117,8 @@ export const GLSL_PRESETS: Record<string, GLSLPreset> = {
   'Luma Blur': preset54,
   'Luma Level': preset55,
   Pack: preset56,
-  Convolve: preset57
+  Convolve: preset57,
+  Math: preset58
 };
 
 export type { GLSLPreset } from './types';

--- a/ui/src/lib/presets/builtin/glsl/index.ts
+++ b/ui/src/lib/presets/builtin/glsl/index.ts
@@ -53,6 +53,7 @@ import { preset as preset51 } from './slope';
 import { preset as preset52 } from './normal-map';
 import { preset as preset53 } from './anti-alias';
 import { preset as preset54 } from './luma-blur';
+import { preset as preset55 } from './luma-level';
 import type { GLSLPreset } from './types';
 
 export const GLSL_PRESETS: Record<string, GLSLPreset> = {
@@ -110,7 +111,8 @@ export const GLSL_PRESETS: Record<string, GLSLPreset> = {
   Slope: preset51,
   'Normal Map': preset52,
   'Anti Alias': preset53,
-  'Luma Blur': preset54
+  'Luma Blur': preset54,
+  'Luma Level': preset55
 };
 
 export type { GLSLPreset } from './types';

--- a/ui/src/lib/presets/builtin/glsl/index.ts
+++ b/ui/src/lib/presets/builtin/glsl/index.ts
@@ -26,6 +26,11 @@ import { preset as preset24 } from './difference';
 import { preset as preset25 } from './composite';
 import { preset as preset26 } from './over';
 import { preset as preset27 } from './under';
+import { preset as preset28 } from './threshold';
+import { preset as preset29 } from './chroma-key';
+import { preset as preset30 } from './rgb-key';
+import { preset as preset31 } from './luma-key';
+import { preset as preset32 } from './matte';
 import type { GLSLPreset } from './types';
 
 export const GLSL_PRESETS: Record<string, GLSLPreset> = {
@@ -56,7 +61,12 @@ export const GLSL_PRESETS: Record<string, GLSLPreset> = {
   Difference: preset24,
   Composite: preset25,
   Over: preset26,
-  Under: preset27
+  Under: preset27,
+  Threshold: preset28,
+  'Chroma Key': preset29,
+  'RGB Key': preset30,
+  'Luma Key': preset31,
+  Matte: preset32
 };
 
 export type { GLSLPreset } from './types';

--- a/ui/src/lib/presets/builtin/glsl/lens-distort.ts
+++ b/ui/src/lib/presets/builtin/glsl/lens-distort.ts
@@ -1,0 +1,41 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Lens Distort
+// @primaryButton settings
+// @param amount 0.25 -1.0 1.0 0.001 "Amount"
+// @param centerX 0.5 0.0 1.0 0.001 "Center X"
+// @param centerY 0.5 0.0 1.0 0.001 "Center Y"
+// @param scale 1.0 0.1 2.0 0.001 "Scale"
+// @param chromatic 0.01 0.0 0.1 0.0001 "Chromatic"
+
+uniform sampler2D source;
+uniform float amount;
+uniform float centerX;
+uniform float centerY;
+uniform float scale;
+uniform float chromatic;
+
+vec2 distort(vec2 p, float strength) {
+  vec2 centered = (p - vec2(centerX, centerY)) / max(scale, 0.0001);
+  float r2 = dot(centered, centered);
+  return vec2(centerX, centerY) + centered * (1.0 + strength * r2);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 redUv = distort(uv, amount + chromatic);
+  vec2 greenUv = distort(uv, amount);
+  vec2 blueUv = distort(uv, amount - chromatic);
+
+  float r = texture(source, redUv).r;
+  float g = texture(source, greenUv).g;
+  float b = texture(source, blueUv).b;
+  float a = texture(source, greenUv).a;
+
+  fragColor = vec4(r, g, b, a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Apply barrel or pincushion lens distortion with chromatic offset.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/limit.ts
+++ b/ui/src/lib/presets/builtin/glsl/limit.ts
@@ -1,0 +1,40 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Limit
+// @primaryButton settings
+// @param minValue 0.0 -2.0 2.0 0.001 "Min"
+// @param maxValue 1.0 -2.0 2.0 0.001 "Max"
+// @param mode 0 (0: Clamp, 1: Wrap, 2: Fold) "Mode"
+
+uniform sampler2D source;
+uniform float minValue;
+uniform float maxValue;
+uniform float mode;
+
+vec3 wrapRange(vec3 value, float lo, float hi) {
+  float range = max(hi - lo, 0.0001);
+  return mod(value - lo, range) + lo;
+}
+
+vec3 foldRange(vec3 value, float lo, float hi) {
+  float range = max(hi - lo, 0.0001);
+  vec3 wrapped = mod(value - lo, range * 2.0);
+  return lo + mix(wrapped, range * 2.0 - wrapped, step(range, wrapped));
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  float lo = min(minValue, maxValue);
+  float hi = max(minValue, maxValue);
+  vec3 limited = clamp(color.rgb, lo, hi);
+  if (mode > 0.5 && mode < 1.5) limited = wrapRange(color.rgb, lo, hi);
+  if (mode >= 1.5) limited = foldRange(color.rgb, lo, hi);
+
+  fragColor = vec4(limited, color.a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Clamp, wrap, or fold RGB values into a chosen range.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/lookup.ts
+++ b/ui/src/lib/presets/builtin/glsl/lookup.ts
@@ -1,0 +1,33 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Lookup
+// @primaryButton settings
+// @param channel 0 (0: Luma, 1: Red, 2: Green, 3: Blue, 4: Alpha) "Channel"
+// @param amount 1.0 0.0 1.0 0.001 "Amount"
+
+uniform sampler2D source;
+uniform sampler2D lookup;
+uniform float channel;
+uniform float amount;
+
+float sampleChannel(vec4 color) {
+  if (channel < 0.5) return dot(color.rgb, vec3(0.299, 0.587, 0.114));
+  if (channel < 1.5) return color.r;
+  if (channel < 2.5) return color.g;
+  if (channel < 3.5) return color.b;
+  return color.a;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  float index = clamp(sampleChannel(color), 0.0, 1.0);
+  vec3 lookedUp = texture(lookup, vec2(index, 0.5)).rgb;
+
+  fragColor = vec4(mix(color.rgb, lookedUp, amount), color.a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Map a source channel through a horizontal 1D lookup texture.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/luma-blur.ts
+++ b/ui/src/lib/presets/builtin/glsl/luma-blur.ts
@@ -1,0 +1,58 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Luma Blur
+// @primaryButton settings
+// @param radius 18.0 0.0 80.0 0.001 "Radius"
+// @param threshold 0.55 0.0 1.0 0.001 "Threshold"
+// @param softness 0.2 0.0 1.0 0.001 "Softness"
+// @param amount 1.0 0.0 1.0 0.001 "Amount"
+// @param mode 0 (0: Bright, 1: Dark) "Mode"
+
+uniform sampler2D source;
+uniform float radius;
+uniform float threshold;
+uniform float softness;
+uniform float amount;
+uniform float mode;
+
+float luma(vec3 color) {
+  return dot(color, vec3(0.299, 0.587, 0.114));
+}
+
+vec4 blurSource(vec2 p) {
+  vec2 texel = 1.0 / iResolution.xy;
+  vec2 px = texel * radius;
+  vec2 diagonal = px * 0.70710678;
+
+  vec4 color = texture(source, p) * 0.16;
+  color += texture(source, p + vec2(px.x * 0.5, 0.0)) * 0.10;
+  color += texture(source, p - vec2(px.x * 0.5, 0.0)) * 0.10;
+  color += texture(source, p + vec2(0.0, px.y * 0.5)) * 0.10;
+  color += texture(source, p - vec2(0.0, px.y * 0.5)) * 0.10;
+  color += texture(source, p + diagonal) * 0.06;
+  color += texture(source, p - diagonal) * 0.06;
+  color += texture(source, p + vec2(diagonal.x, -diagonal.y)) * 0.06;
+  color += texture(source, p + vec2(-diagonal.x, diagonal.y)) * 0.06;
+  color += texture(source, p + vec2(px.x * 1.5, 0.0)) * 0.05;
+  color += texture(source, p - vec2(px.x * 1.5, 0.0)) * 0.05;
+  color += texture(source, p + vec2(0.0, px.y * 1.5)) * 0.05;
+  color += texture(source, p - vec2(0.0, px.y * 1.5)) * 0.05;
+  return color;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 sourceColor = texture(source, uv);
+  vec4 blurred = blurSource(uv);
+  float value = luma(sourceColor.rgb);
+  float gate = mode < 0.5
+    ? smoothstep(threshold - softness, threshold + softness, value)
+    : 1.0 - smoothstep(threshold - softness, threshold + softness, value);
+
+  fragColor = mix(sourceColor, blurred, gate * amount);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Blur a source texture selectively by bright or dark luminance regions.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/luma-key.ts
+++ b/ui/src/lib/presets/builtin/glsl/luma-key.ts
@@ -1,0 +1,27 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Luma Key
+// @primaryButton settings
+// @param threshold 0.5 0.0 1.0 0.001 "Threshold"
+// @param softness 0.08 0.0 0.5 0.001 "Softness"
+// @param invert false "Invert"
+
+uniform sampler2D source;
+uniform float threshold;
+uniform float softness;
+uniform bool invert;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  float luma = dot(color.rgb, vec3(0.299, 0.587, 0.114));
+  float mask = smoothstep(threshold - softness, threshold + softness, luma);
+  if (invert) mask = 1.0 - mask;
+
+  fragColor = vec4(color.rgb, color.a * mask);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Create an alpha mask from source luminance.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/luma-key.ts
+++ b/ui/src/lib/presets/builtin/glsl/luma-key.ts
@@ -14,7 +14,9 @@ uniform bool invert;
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   vec4 color = texture(source, uv);
   float luma = dot(color.rgb, vec3(0.299, 0.587, 0.114));
-  float mask = smoothstep(threshold - softness, threshold + softness, luma);
+  float mask = softness <= 0.0
+    ? step(threshold, luma)
+    : smoothstep(threshold - softness, threshold + softness, luma);
   if (invert) mask = 1.0 - mask;
 
   fragColor = vec4(color.rgb, color.a * mask);

--- a/ui/src/lib/presets/builtin/glsl/luma-level.ts
+++ b/ui/src/lib/presets/builtin/glsl/luma-level.ts
@@ -1,0 +1,45 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Luma Level
+// @primaryButton settings
+// @param black 0.0 0.0 1.0 0.001 "Black"
+// @param white 1.0 0.0 1.0 0.001 "White"
+// @param gamma 1.0 0.1 4.0 0.001 "Gamma"
+// @param brightness 0.0 -1.0 1.0 0.001 "Brightness"
+// @param contrast 1.0 0.0 4.0 0.001 "Contrast"
+// @param amount 1.0 0.0 1.0 0.001 "Amount"
+
+uniform sampler2D source;
+uniform float black;
+uniform float white;
+uniform float gamma;
+uniform float brightness;
+uniform float contrast;
+uniform float amount;
+
+float luma(vec3 color) {
+  return dot(color, vec3(0.299, 0.587, 0.114));
+}
+
+float adjustLuma(float value) {
+  float range = max(white - black, 0.0001);
+  float adjusted = clamp((value - black) / range, 0.0, 1.0);
+  adjusted = pow(adjusted, 1.0 / max(gamma, 0.0001));
+  adjusted = (adjusted - 0.5) * contrast + 0.5 + brightness;
+  return clamp(adjusted, 0.0, 1.0);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  float originalLuma = max(luma(color.rgb), 0.0001);
+  float targetLuma = adjustLuma(originalLuma);
+  vec3 adjustedRgb = color.rgb * (targetLuma / originalLuma);
+
+  fragColor = vec4(mix(color.rgb, adjustedRgb, amount), color.a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Adjust luminance levels while mostly preserving source hue.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/math.ts
+++ b/ui/src/lib/presets/builtin/glsl/math.ts
@@ -1,0 +1,45 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Math
+// @primaryButton settings
+// @param operation 0 (0: Add, 1: Subtract, 2: Multiply, 3: Divide, 4: Min, 5: Max, 6: Difference, 7: Average) "Operation"
+// @param opacity 1.0 0.0 1.0 0.001 "Opacity"
+// @param offset 0.0 -1.0 1.0 0.001 "Offset"
+// @param scale 1.0 -4.0 4.0 0.001 "Scale"
+// @param clampOutput true "Clamp Output"
+
+uniform sampler2D a;
+uniform sampler2D b;
+uniform float operation;
+uniform float opacity;
+uniform float offset;
+uniform float scale;
+uniform bool clampOutput;
+
+vec3 mathOp(vec3 ca, vec3 cb) {
+  if (operation < 0.5) return ca + cb;
+  if (operation < 1.5) return ca - cb;
+  if (operation < 2.5) return ca * cb;
+  if (operation < 3.5) return ca / max(cb, vec3(0.0001));
+  if (operation < 4.5) return min(ca, cb);
+  if (operation < 5.5) return max(ca, cb);
+  if (operation < 6.5) return abs(ca - cb);
+  return (ca + cb) * 0.5;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 ca = texture(a, uv);
+  vec4 cb = texture(b, uv);
+  vec3 result = mathOp(ca.rgb, cb.rgb) * scale + offset;
+  vec3 rgb = mix(ca.rgb, result, opacity);
+  float alpha = max(ca.a, cb.a * opacity);
+
+  fragColor = vec4(rgb, alpha);
+  if (clampOutput) fragColor = clamp(fragColor, 0.0, 1.0);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Combine two textures with selectable per-pixel math operations.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/matte.ts
+++ b/ui/src/lib/presets/builtin/glsl/matte.ts
@@ -1,0 +1,31 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Matte
+// @primaryButton settings
+// @param opacity 1.0 0.0 1.0 0.001 "Opacity"
+// @param invert false "Invert"
+// @param premultiply false "Premultiply"
+
+uniform sampler2D source;
+uniform sampler2D matte;
+uniform float opacity;
+uniform bool invert;
+uniform bool premultiply;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  vec4 matteColor = texture(matte, uv);
+  float mask = dot(matteColor.rgb, vec3(0.299, 0.587, 0.114));
+  if (invert) mask = 1.0 - mask;
+
+  color.a *= mask * opacity;
+  if (premultiply) color.rgb *= color.a;
+
+  fragColor = color;
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Apply a grayscale matte texture to the alpha of a source texture.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/mirror.ts
+++ b/ui/src/lib/presets/builtin/glsl/mirror.ts
@@ -12,7 +12,7 @@ uniform float center;
 uniform float blend;
 
 float mirroredCoordinate(float value, float c) {
-  return c - abs(value - c);
+  return 2.0 * c - value;
 }
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {

--- a/ui/src/lib/presets/builtin/glsl/mirror.ts
+++ b/ui/src/lib/presets/builtin/glsl/mirror.ts
@@ -1,0 +1,39 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Mirror
+// @primaryButton settings
+// @param axis 0 (0: Horizontal, 1: Vertical, 2: Both) "Axis"
+// @param center 0.5 0.0 1.0 0.001 "Center"
+// @param blend 0.0 0.0 0.5 0.001 "Blend"
+
+uniform sampler2D source;
+uniform float axis;
+uniform float center;
+uniform float blend;
+
+float mirroredCoordinate(float value, float c) {
+  return c - abs(value - c);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 p = uv;
+  vec2 mirrored = uv;
+
+  if (axis < 0.5 || axis >= 1.5) mirrored.x = mirroredCoordinate(uv.x, center);
+  if (axis >= 0.5) mirrored.y = mirroredCoordinate(uv.y, center);
+
+  vec4 original = texture(source, p);
+  vec4 reflected = texture(source, mirrored);
+
+  float seam = 1.0;
+  if (axis < 0.5 || axis >= 1.5) seam *= smoothstep(0.0, max(blend, 0.0001), abs(uv.x - center));
+  if (axis >= 0.5) seam *= smoothstep(0.0, max(blend, 0.0001), abs(uv.y - center));
+
+  fragColor = mix(original, reflected, seam);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Mirror a source texture around a horizontal, vertical, or two-axis center.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/monochrome.ts
+++ b/ui/src/lib/presets/builtin/glsl/monochrome.ts
@@ -1,0 +1,32 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Monochrome
+// @primaryButton settings
+// @param channel 0 (0: Luma, 1: Red, 2: Green, 3: Blue, 4: Alpha) "Channel"
+// @param tint color #ffffff "Tint"
+// @param amount 1.0 0.0 1.0 0.001 "Amount"
+
+uniform sampler2D source;
+uniform float channel;
+uniform vec3 tint;
+uniform float amount;
+
+float sampleChannel(vec4 color) {
+  if (channel < 0.5) return dot(color.rgb, vec3(0.299, 0.587, 0.114));
+  if (channel < 1.5) return color.r;
+  if (channel < 2.5) return color.g;
+  if (channel < 3.5) return color.b;
+  return color.a;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  vec3 mono = vec3(sampleChannel(color)) * tint;
+  fragColor = vec4(mix(color.rgb, mono, amount), color.a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Convert a texture to monochrome with channel and tint controls.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/normal-map.ts
+++ b/ui/src/lib/presets/builtin/glsl/normal-map.ts
@@ -1,0 +1,39 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Normal Map
+// @primaryButton settings
+// @param strength 4.0 0.0 20.0 0.001 "Strength"
+// @param channel 0 (0: Luma, 1: Red, 2: Green, 3: Blue, 4: Alpha) "Channel"
+// @param invertY false "Invert Y"
+
+uniform sampler2D source;
+uniform float strength;
+uniform float channel;
+uniform bool invertY;
+
+float sampleHeight(vec2 p) {
+  vec4 color = texture(source, p);
+  if (channel < 0.5) return dot(color.rgb, vec3(0.299, 0.587, 0.114));
+  if (channel < 1.5) return color.r;
+  if (channel < 2.5) return color.g;
+  if (channel < 3.5) return color.b;
+  return color.a;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 px = 1.0 / iResolution.xy;
+  float left = sampleHeight(uv - vec2(px.x, 0.0));
+  float right = sampleHeight(uv + vec2(px.x, 0.0));
+  float down = sampleHeight(uv - vec2(0.0, px.y));
+  float up = sampleHeight(uv + vec2(0.0, px.y));
+  float ySign = invertY ? -1.0 : 1.0;
+  vec3 normal = normalize(vec3((left - right) * strength, (down - up) * strength * ySign, 1.0));
+
+  fragColor = vec4(normal * 0.5 + 0.5, 1.0);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Generate an approximate normal map from source height or luma.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/normal-map.ts
+++ b/ui/src/lib/presets/builtin/glsl/normal-map.ts
@@ -21,6 +21,7 @@ float sampleHeight(vec2 p) {
 }
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
   vec2 px = 1.0 / iResolution.xy;
   float left = sampleHeight(uv - vec2(px.x, 0.0));
   float right = sampleHeight(uv + vec2(px.x, 0.0));
@@ -29,7 +30,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   float ySign = invertY ? -1.0 : 1.0;
   vec3 normal = normalize(vec3((left - right) * strength, (down - up) * strength * ySign, 1.0));
 
-  fragColor = vec4(normal * 0.5 + 0.5, 1.0);
+  fragColor = vec4(normal * 0.5 + 0.5, color.a);
 }`;
 
 export const preset: GLSLPreset = {

--- a/ui/src/lib/presets/builtin/glsl/over.ts
+++ b/ui/src/lib/presets/builtin/glsl/over.ts
@@ -1,6 +1,6 @@
 import type { GLSLPreset } from './types';
 
-const code = `// @title Overlay
+const code = `// @title Over
 // @primaryButton settings
 // @param opacity 1.0 0.0 1.0 0.001 "Opacity"
 
@@ -9,19 +9,17 @@ uniform sampler2D foreground;
 uniform float opacity;
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-  vec4 fg = texture(foreground, uv);
   vec4 bg = texture(background, uv);
-  float alpha = fg.a * opacity;
+  vec4 fg = texture(foreground, uv);
+  float alpha = clamp(fg.a * opacity, 0.0, 1.0);
+  float outAlpha = alpha + bg.a * (1.0 - alpha);
+  vec3 rgb = (fg.rgb * alpha + bg.rgb * bg.a * (1.0 - alpha)) / max(outAlpha, 0.0001);
 
-  fragColor = mix(
-    bg,
-    fg,
-    alpha
-  );
+  fragColor = vec4(rgb, outAlpha);
 }`;
 
 export const preset: GLSLPreset = {
   type: 'glsl',
-  description: 'Alpha-composite a foreground input over a background input.',
+  description: 'Place a foreground texture over a background using alpha.',
   data: { code: code.trim() }
 };

--- a/ui/src/lib/presets/builtin/glsl/pack.ts
+++ b/ui/src/lib/presets/builtin/glsl/pack.ts
@@ -1,0 +1,43 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Pack
+// @primaryButton settings
+// @param redChannel 0 (0: Luma, 1: Red, 2: Green, 3: Blue, 4: Alpha) "Red Channel"
+// @param greenChannel 0 (0: Luma, 1: Red, 2: Green, 3: Blue, 4: Alpha) "Green Channel"
+// @param blueChannel 0 (0: Luma, 1: Red, 2: Green, 3: Blue, 4: Alpha) "Blue Channel"
+// @param alphaChannel 4 (0: Luma, 1: Red, 2: Green, 3: Blue, 4: Alpha) "Alpha Channel"
+// @param invertAlpha false "Invert Alpha"
+
+uniform sampler2D redSource;
+uniform sampler2D greenSource;
+uniform sampler2D blueSource;
+uniform sampler2D alphaSource;
+uniform float redChannel;
+uniform float greenChannel;
+uniform float blueChannel;
+uniform float alphaChannel;
+uniform bool invertAlpha;
+
+float readChannel(vec4 color, float channel) {
+  if (channel < 0.5) return dot(color.rgb, vec3(0.299, 0.587, 0.114));
+  if (channel < 1.5) return color.r;
+  if (channel < 2.5) return color.g;
+  if (channel < 3.5) return color.b;
+  return color.a;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  float r = readChannel(texture(redSource, uv), redChannel);
+  float g = readChannel(texture(greenSource, uv), greenChannel);
+  float b = readChannel(texture(blueSource, uv), blueChannel);
+  float a = readChannel(texture(alphaSource, uv), alphaChannel);
+  if (invertAlpha) a = 1.0 - a;
+
+  fragColor = vec4(r, g, b, a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Pack channels from four texture inputs into one RGBA texture.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/passthru.ts
+++ b/ui/src/lib/presets/builtin/glsl/passthru.ts
@@ -8,6 +8,6 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
 export const preset: GLSLPreset = {
   type: 'glsl',
-  description: 'Passthrough shader for processing a video input.',
+  description: 'Pipe video through GLSL shader',
   data: { code: code.trim() }
 };

--- a/ui/src/lib/presets/builtin/glsl/rectangle.ts
+++ b/ui/src/lib/presets/builtin/glsl/rectangle.ts
@@ -1,0 +1,47 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Rectangle
+// @primaryButton settings
+// @param centerX 0.5 0.0 1.0 0.001 "Center X"
+// @param centerY 0.5 0.0 1.0 0.001 "Center Y"
+// @param width 0.6 0.0 1.0 0.001 "Width"
+// @param height 0.35 0.0 1.0 0.001 "Height"
+// @param rotation 0.0 -3.1416 3.1416 0.001 "Rotation"
+// @param feather 0.02 0.0 0.5 0.001 "Feather"
+// @param color color #ffffff "Color"
+// @param alpha 1.0 0.0 1.0 0.001 "Alpha"
+
+uniform float centerX;
+uniform float centerY;
+uniform float width;
+uniform float height;
+uniform float rotation;
+uniform float feather;
+uniform vec3 color;
+uniform float alpha;
+
+float boxMask(vec2 p, vec2 halfSize, float softness) {
+  vec2 d = abs(p) - halfSize;
+  float outside = length(max(d, 0.0));
+  float inside = min(max(d.x, d.y), 0.0);
+  float dist = outside + inside;
+  return 1.0 - smoothstep(0.0, softness, dist);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 aspect = vec2(iResolution.x / max(iResolution.y, 0.0001), 1.0);
+  vec2 p = (uv - vec2(centerX, centerY)) * aspect;
+  float c = cos(rotation);
+  float s = sin(rotation);
+  p = mat2(c, -s, s, c) * p;
+
+  vec2 size = vec2(width, height) * 0.5 * aspect;
+  float mask = boxMask(p, size, feather);
+  fragColor = vec4(color, alpha * mask);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Generate a feathered rectangle shape with rotation and alpha output.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/remap.ts
+++ b/ui/src/lib/presets/builtin/glsl/remap.ts
@@ -1,0 +1,32 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Remap
+// @primaryButton settings
+// @param inMin 0.0 -2.0 2.0 0.001 "Input Min"
+// @param inMax 1.0 -2.0 2.0 0.001 "Input Max"
+// @param outMin 0.0 -2.0 2.0 0.001 "Output Min"
+// @param outMax 1.0 -2.0 2.0 0.001 "Output Max"
+// @param clampOutput true "Clamp Output"
+
+uniform sampler2D source;
+uniform float inMin;
+uniform float inMax;
+uniform float outMin;
+uniform float outMax;
+uniform bool clampOutput;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  float inputRange = max(inMax - inMin, 0.0001);
+  vec3 normalized = (color.rgb - inMin) / inputRange;
+  if (clampOutput) normalized = clamp(normalized, 0.0, 1.0);
+  vec3 remapped = mix(vec3(outMin), vec3(outMax), normalized);
+
+  fragColor = vec4(remapped, color.a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Remap RGB values from one range into another.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/rgb-key.ts
+++ b/ui/src/lib/presets/builtin/glsl/rgb-key.ts
@@ -17,8 +17,12 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   vec4 color = texture(source, uv);
   vec3 lo = min(minColor, maxColor);
   vec3 hi = max(minColor, maxColor);
-  vec3 insideLow = smoothstep(lo - softness, lo + softness, color.rgb);
-  vec3 insideHigh = 1.0 - smoothstep(hi - softness, hi + softness, color.rgb);
+  vec3 insideLow = softness <= 0.0
+    ? step(lo, color.rgb)
+    : smoothstep(lo - softness, lo + softness, color.rgb);
+  vec3 insideHigh = softness <= 0.0
+    ? 1.0 - step(hi, color.rgb)
+    : 1.0 - smoothstep(hi - softness, hi + softness, color.rgb);
   float mask = min(min(insideLow.r * insideHigh.r, insideLow.g * insideHigh.g), insideLow.b * insideHigh.b);
   if (invert) mask = 1.0 - mask;
 

--- a/ui/src/lib/presets/builtin/glsl/rgb-key.ts
+++ b/ui/src/lib/presets/builtin/glsl/rgb-key.ts
@@ -1,0 +1,32 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title RGB Key
+// @primaryButton settings
+// @param minColor color #000000 "Min Color"
+// @param maxColor color #808080 "Max Color"
+// @param softness 0.05 0.0 0.5 0.001 "Softness"
+// @param invert false "Invert"
+
+uniform sampler2D source;
+uniform vec3 minColor;
+uniform vec3 maxColor;
+uniform float softness;
+uniform bool invert;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  vec3 lo = min(minColor, maxColor);
+  vec3 hi = max(minColor, maxColor);
+  vec3 insideLow = smoothstep(lo - softness, lo + softness, color.rgb);
+  vec3 insideHigh = 1.0 - smoothstep(hi - softness, hi + softness, color.rgb);
+  float mask = min(min(insideLow.r * insideHigh.r, insideLow.g * insideHigh.g), insideLow.b * insideHigh.b);
+  if (invert) mask = 1.0 - mask;
+
+  fragColor = vec4(color.rgb, color.a * mask);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Create an alpha mask from an RGB color range.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/rgb-to-hsv.ts
+++ b/ui/src/lib/presets/builtin/glsl/rgb-to-hsv.ts
@@ -1,0 +1,25 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title RGB to HSV
+
+uniform sampler2D source;
+
+vec3 rgb2hsv(vec3 c) {
+  vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+  vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+  vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+  float d = q.x - min(q.w, q.y);
+  float e = 0.0000001;
+  return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  fragColor = vec4(rgb2hsv(color.rgb), color.a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Convert RGB texture values into HSV stored in RGB channels.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/slope.ts
+++ b/ui/src/lib/presets/builtin/glsl/slope.ts
@@ -1,0 +1,45 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Slope
+// @primaryButton settings
+// @param strength 4.0 0.0 20.0 0.001 "Strength"
+// @param channel 0 (0: Luma, 1: Red, 2: Green, 3: Blue, 4: Alpha) "Channel"
+// @param mode 0 (0: Signed RGB, 1: Magnitude, 2: Direction) "Mode"
+
+uniform sampler2D source;
+uniform float strength;
+uniform float channel;
+uniform float mode;
+
+float sampleHeight(vec2 p) {
+  vec4 color = texture(source, p);
+  if (channel < 0.5) return dot(color.rgb, vec3(0.299, 0.587, 0.114));
+  if (channel < 1.5) return color.r;
+  if (channel < 2.5) return color.g;
+  if (channel < 3.5) return color.b;
+  return color.a;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 px = 1.0 / iResolution.xy;
+  float left = sampleHeight(uv - vec2(px.x, 0.0));
+  float right = sampleHeight(uv + vec2(px.x, 0.0));
+  float down = sampleHeight(uv - vec2(0.0, px.y));
+  float up = sampleHeight(uv + vec2(0.0, px.y));
+  vec2 slope = vec2(right - left, up - down) * strength;
+
+  if (mode < 0.5) {
+    fragColor = vec4(slope * 0.5 + 0.5, 0.5, 1.0);
+  } else if (mode < 1.5) {
+    fragColor = vec4(vec3(length(slope)), 1.0);
+  } else {
+    float angle = atan(slope.y, slope.x) / 6.2831853 + 0.5;
+    fragColor = vec4(vec3(angle), 1.0);
+  }
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Visualize image gradients as signed slope, magnitude, or direction.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/subtract.ts
+++ b/ui/src/lib/presets/builtin/glsl/subtract.ts
@@ -1,0 +1,25 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Subtract
+// @primaryButton settings
+// @param opacity 1.0 0.0 1.0 0.001 "Opacity"
+// @param clampOutput true "Clamp Output"
+
+uniform sampler2D a;
+uniform sampler2D b;
+uniform float opacity;
+uniform bool clampOutput;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 ca = texture(a, uv);
+  vec4 cb = texture(b, uv);
+  vec4 subtracted = vec4(ca.rgb - cb.rgb * opacity, ca.a);
+
+  fragColor = clampOutput ? clamp(subtracted, 0.0, 1.0) : subtracted;
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Subtract one texture from another with opacity and optional clamping.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/threshold.ts
+++ b/ui/src/lib/presets/builtin/glsl/threshold.ts
@@ -1,0 +1,37 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Threshold
+// @primaryButton settings
+// @param threshold 0.5 0.0 1.0 0.001 "Threshold"
+// @param softness 0.02 0.0 0.5 0.001 "Softness"
+// @param channel 0 (0: Luma, 1: Red, 2: Green, 3: Blue, 4: Alpha) "Channel"
+// @param invert false "Invert"
+
+uniform sampler2D source;
+uniform float threshold;
+uniform float softness;
+uniform float channel;
+uniform bool invert;
+
+float sampleChannel(vec4 color) {
+  if (channel < 0.5) return dot(color.rgb, vec3(0.299, 0.587, 0.114));
+  if (channel < 1.5) return color.r;
+  if (channel < 2.5) return color.g;
+  if (channel < 3.5) return color.b;
+  return color.a;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  float value = sampleChannel(color);
+  float mask = smoothstep(threshold - softness, threshold + softness, value);
+  if (invert) mask = 1.0 - mask;
+
+  fragColor = vec4(color.rgb, color.a * mask);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Create an alpha mask from a thresholded texture channel.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/tile.ts
+++ b/ui/src/lib/presets/builtin/glsl/tile.ts
@@ -1,0 +1,34 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Tile
+// @primaryButton settings
+// @param repeatX 2.0 1.0 16.0 0.001 "Repeat X"
+// @param repeatY 2.0 1.0 16.0 0.001 "Repeat Y"
+// @param offsetX 0.0 -1.0 1.0 0.001 "Offset X"
+// @param offsetY 0.0 -1.0 1.0 0.001 "Offset Y"
+// @param mirror false "Mirror"
+
+uniform sampler2D source;
+uniform float repeatX;
+uniform float repeatY;
+uniform float offsetX;
+uniform float offsetY;
+uniform bool mirror;
+
+vec2 mirrorRepeat(vec2 p) {
+  vec2 f = fract(p);
+  vec2 tile = mod(floor(p), 2.0);
+  return mix(f, 1.0 - f, tile);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 p = uv * vec2(repeatX, repeatY) + vec2(offsetX, offsetY);
+  vec2 sampleUv = mirror ? mirrorRepeat(p) : fract(p);
+  fragColor = texture(source, sampleUv);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Repeat a source texture with offset and optional mirror tiling.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/tone-map.ts
+++ b/ui/src/lib/presets/builtin/glsl/tone-map.ts
@@ -1,0 +1,45 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Tone Map
+// @primaryButton settings
+// @param exposure 1.0 0.0 8.0 0.001 "Exposure"
+// @param gamma 2.2 0.1 4.0 0.001 "Gamma"
+// @param whitePoint 1.0 0.1 16.0 0.001 "White Point"
+// @param curve 0 (0: Reinhard, 1: ACES, 2: Filmic) "Curve"
+
+uniform sampler2D source;
+uniform float exposure;
+uniform float gamma;
+uniform float whitePoint;
+uniform float curve;
+
+vec3 aces(vec3 x) {
+  const float a = 2.51;
+  const float b = 0.03;
+  const float c = 2.43;
+  const float d = 0.59;
+  const float e = 0.14;
+  return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
+}
+
+vec3 filmic(vec3 x) {
+  x = max(vec3(0.0), x - 0.004);
+  return (x * (6.2 * x + 0.5)) / (x * (6.2 * x + 1.7) + 0.06);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 color = texture(source, uv);
+  vec3 hdr = max(color.rgb * exposure, 0.0);
+  vec3 mapped = hdr / (hdr + vec3(max(whitePoint, 0.0001)));
+  if (curve > 0.5 && curve < 1.5) mapped = aces(hdr / max(whitePoint, 0.0001));
+  if (curve >= 1.5) mapped = filmic(hdr / max(whitePoint, 0.0001));
+  mapped = pow(max(mapped, 0.0), vec3(1.0 / max(gamma, 0.0001)));
+
+  fragColor = vec4(mapped, color.a);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Tone-map bright or float texture values with exposure and curve controls.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/glsl/under.ts
+++ b/ui/src/lib/presets/builtin/glsl/under.ts
@@ -1,0 +1,26 @@
+import type { GLSLPreset } from './types';
+
+const code = `// @title Under
+// @primaryButton settings
+// @param opacity 1.0 0.0 1.0 0.001 "Opacity"
+
+uniform sampler2D foreground;
+uniform sampler2D background;
+uniform float opacity;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec4 fg = texture(foreground, uv);
+  vec4 bg = texture(background, uv);
+  fg.a *= opacity;
+
+  float outAlpha = bg.a + fg.a * (1.0 - bg.a);
+  vec3 rgb = (bg.rgb * bg.a + fg.rgb * fg.a * (1.0 - bg.a)) / max(outAlpha, 0.0001);
+
+  fragColor = vec4(rgb, outAlpha);
+}`;
+
+export const preset: GLSLPreset = {
+  type: 'glsl',
+  description: 'Place a foreground texture under a background using alpha.',
+  data: { code: code.trim() }
+};

--- a/ui/src/lib/presets/builtin/hydra.presets.ts
+++ b/ui/src/lib/presets/builtin/hydra.presets.ts
@@ -91,9 +91,13 @@ const defaultsOneVideoIn: HydraNodeData = {
 
 const defaultsTwoVideoIn: HydraNodeData = { ...defaultsOneVideoIn, videoInletCount: 2 };
 
-export const HYDRA_PRESETS: Record<string, { type: string; data: HydraNodeData }> = {
+export const HYDRA_PRESETS: Record<
+  string,
+  { type: string; description?: string; data: HydraNodeData }
+> = {
   'hydra>': {
     type: 'hydra',
+    description: 'Pipe video through Hydra',
     data: { ...defaultsOneVideoIn, code: PIPE.trim() }
   },
   'add.hydra': {

--- a/ui/src/lib/presets/builtin/js.presets.ts
+++ b/ui/src/lib/presets/builtin/js.presets.ts
@@ -81,7 +81,11 @@ send(curve)`;
 
 export const JS_PRESETS: Record<
   string,
-  { type: string; data: { code: string; showConsole?: boolean; runOnMount?: boolean } }
+  {
+    type: string;
+    description?: string;
+    data: { code: string; showConsole?: boolean; runOnMount?: boolean };
+  }
 > = {
   'logger.js': {
     type: 'js',
@@ -117,6 +121,7 @@ export const JS_PRESETS: Record<
   },
   'js>': {
     type: 'js',
+    description: 'Pipe messages through JavaScript',
     data: { code: PIPE_MESSAGE_JS, showConsole: false, runOnMount: true }
   }
 };

--- a/ui/src/lib/presets/builtin/tone.preset.ts
+++ b/ui/src/lib/presets/builtin/tone.preset.ts
@@ -71,6 +71,7 @@ export const TONE_JS_PRESETS = {
   },
   'tone>': {
     type: 'tone~',
+    description: 'Pipe audio through Tone.js',
     data: { code: PIPE_JS, messageInletCount: 0 }
   },
   'reverb.tone': {

--- a/ui/src/stores/extensions.store.ts
+++ b/ui/src/stores/extensions.store.ts
@@ -24,6 +24,7 @@ export { BUILT_IN_PRESET_PACKS } from '$lib/extensions/preset-packs';
 
 // Import for internal use
 import { BUILT_IN_PACKS } from '$lib/extensions/object-packs';
+import { isPresetPackAvailableForObjects } from '$lib/extensions/preset-pack-availability';
 import { BUILT_IN_PRESET_PACKS } from '$lib/extensions/preset-packs';
 import { getObjectAliases } from '$lib/objects/object-definitions';
 
@@ -188,10 +189,9 @@ export const enabledPresets = derived(
       const pack = BUILT_IN_PRESET_PACKS.find((p) => p.id === packId);
       if (!pack) continue;
 
-      // Only include presets if at least one required object is enabled
-      // (partial availability - we filter unavailable, don't block entirely)
-      const hasAnyRequiredObject = pack.requiredObjects.some((obj) => $enabledObjects.has(obj));
-      if (!hasAnyRequiredObject) continue;
+      // Packs without requirements are always active. Otherwise, include the pack if at
+      // least one required object is enabled; individual preset UI filters by preset type.
+      if (!isPresetPackAvailableForObjects(pack.requiredObjects, $enabledObjects)) continue;
 
       for (const preset of pack.presets) {
         presets.add(preset);

--- a/ui/src/stores/preset-library.store.ts
+++ b/ui/src/stores/preset-library.store.ts
@@ -15,7 +15,7 @@ import {
   getPresetByPath,
   isPreset
 } from '$lib/presets/preset-utils';
-import { migrateLegacyPresets } from '$lib/presets/migrate-legacy';
+import { buildBuiltInPresetPackFolders } from '$lib/extensions/preset-pack-index';
 import { PRESETS } from '$lib/presets/presets';
 
 const STORAGE_KEY = 'patchies:preset-libraries';
@@ -31,7 +31,7 @@ function createBuiltinLibrary(): PresetLibrary {
     name: 'Built-in',
     description: 'Default presets included with Patchies',
     readonly: true,
-    presets: migrateLegacyPresets(PRESETS)
+    presets: buildBuiltInPresetPackFolders(PRESETS)
   };
 }
 

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -53,6 +53,12 @@ import {
 } from './glUniformUtils';
 import type { WorkerSettingsProxy } from '../shared/workerSettingsProxy';
 
+export const FBO_RENDERER_CONTEXT_ATTRIBUTES: WebGLContextAttributes = {
+  alpha: true,
+  antialias: false,
+  premultipliedAlpha: false
+};
+
 export class FBORenderer {
   public outputSize = DEFAULT_OUTPUT_SIZE;
   public backgroundSize: [number, number] = [...DEFAULT_OUTPUT_SIZE];
@@ -177,7 +183,7 @@ export class FBORenderer {
     const [width, height] = this.outputSize;
 
     this.offscreenCanvas = new OffscreenCanvas(width, height);
-    this.gl = this.offscreenCanvas.getContext('webgl2', { antialias: false })!;
+    this.gl = this.offscreenCanvas.getContext('webgl2', FBO_RENDERER_CONTEXT_ATTRIBUTES)!;
 
     // Float textures are created via raw WebGL2 in createFboTexture(), bypassing
     // regl entirely. No need to request float extensions through regl — doing so

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -45,7 +45,8 @@ Enable the texture preset packs for basic operators:
 - **Texture Masks & Keys**: `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`,
   `Matte`
 - **Texture Transform**: `Transform`, `Crop`, `Fit`, `Flip`, `Mirror`, `Tile`, `Lens Distort`, `Displace`, `Noise Displace`
-- **Texture Filters**: `Blur`, `Edge`, `Emboss`, `Slope`, `Normal Map`
+- **Texture Filters**: `Blur`, `Edge`, `Anti Alias`, `Emboss`, `Slope`,
+  `Normal Map`
 
 The `glsl>` preset is the best starting point for building GLSL shaders
 that process video inputs.

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -46,8 +46,8 @@ Enable the texture preset packs for basic operators:
 - **Texture Masks & Keys**: `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`,
   `Matte`
 - **Texture Transform**: `Transform`, `Crop`, `Fit`, `Flip`, `Mirror`, `Tile`, `Lens Distort`, `Displace`, `Noise Displace`
-- **Texture Filters**: `Blur`, `Luma Blur`, `Edge`, `Anti Alias`, `Emboss`,
-  `Slope`, `Normal Map`
+- **Texture Filters**: `Blur`, `Luma Blur`, `Convolve`, `Edge`, `Anti Alias`,
+  `Emboss`, `Slope`, `Normal Map`
 
 The `glsl>` preset is the best starting point for building GLSL shaders
 that process video inputs.

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -38,7 +38,8 @@ Enable the texture preset packs for basic operators:
 - **Visual Shader Starters**: `glsl>` passthrough shader
 - **Texture Generators**: `Constant`, `Linear Ramp`, `Radial Ramp`,
   `Circular Ramp`, `Noise`
-- **Texture Composite**: `Mix`, `Overlay`, `Multiply`, `Switcher`
+- **Texture Composite**: `Mix`, `Multiply`, `Add`, `Subtract`, `Difference`,
+  `Composite`, `Over`, `Under`, `Switcher`
 - **Texture Color**: `Level`, `Reorder`
 - **Texture Transform**: `Transform`, `Crop`, `Displace`, `Noise Displace`
 - **Texture Filters**: `Blur`, `Edge`

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -41,6 +41,8 @@ Enable the texture preset packs for basic operators:
 - **Texture Composite**: `Mix`, `Multiply`, `Add`, `Subtract`, `Difference`,
   `Composite`, `Over`, `Under`, `Switcher`
 - **Texture Color**: `Level`, `Reorder`
+- **Texture Masks & Keys**: `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`,
+  `Matte`
 - **Texture Transform**: `Transform`, `Crop`, `Displace`, `Noise Displace`
 - **Texture Filters**: `Blur`, `Edge`
 - **Texture Feedback & Data**: `Feedback`

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -33,32 +33,21 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
 ## Basic Presets
 
-Enable the **GLSL Operators** preset pack for basic presets:
+Enable the texture preset packs for basic operators:
 
-- `glsl>` - a passthrough shader
-- `Constant` - constant color and alpha
-- `Mix` - mix two video inputs
-- `Overlay` - overlay a foreground input on a background input
-- `Switcher` - switch between 6 inputs
-- `Linear Ramp` - generate a directional linear ramp
-- `Radial Ramp` - generate a radial ramp from a center point
-- `Circular Ramp` - generate an angular ramp around a center point
-- `Level` - adjust black, white, gamma, brightness, contrast, and opacity
-- `Transform` - translate, scale, rotate, and tile an input texture
-- `Multiply` - multiply two input textures
-- `Blur` - single-pass 2D blur
-- `Crop` - crop an input texture with optional feathering
-- `Reorder` - swizzle color and alpha channels
-- `Displace` - warp an input using a displacement texture
-- `Edge` - Sobel-style edge detection
-- `Noise` - animated procedural noise
-- `Noise Displace` - warp an input using procedural noise
-- `Feedback` - accumulate an input with a manually wired feedback inlet
+- **Visual Shader Starters**: `glsl>` passthrough shader
+- **Texture Generators**: `Constant`, `Linear Ramp`, `Radial Ramp`,
+  `Circular Ramp`, `Noise`
+- **Texture Composite**: `Mix`, `Overlay`, `Multiply`, `Switcher`
+- **Texture Color**: `Level`, `Reorder`
+- **Texture Transform**: `Transform`, `Crop`, `Displace`, `Noise Displace`
+- **Texture Filters**: `Blur`, `Edge`
+- **Texture Feedback & Data**: `Feedback`
 
 The `glsl>` preset is the best starting point for building GLSL shaders
 that process video inputs.
 
-The GLSL Operators presets are inspired by
+The texture operator presets are inspired by
 [TouchDesigner](https://derivative.ca/) Texture Operators (TOPs) by Derivative
 Inc. Patchies does not include or port TouchDesigner source code, shaders,
 assets, documentation, or proprietary implementations; the presets are

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -39,7 +39,7 @@ Enable the texture preset packs for basic operators:
 - **Texture Generators**: `Constant`, `Linear Ramp`, `Radial Ramp`,
   `Circular Ramp`, `Noise`, `Circle`, `Rectangle`, `Cross`
 - **Texture Composite**: `Mix`, `Multiply`, `Add`, `Subtract`, `Difference`,
-  `Composite`, `Over`, `Under`, `Feedback`, `Switcher`
+  `Math`, `Composite`, `Over`, `Under`, `Feedback`, `Switcher`
 - **Texture Color**: `Level`, `Luma Level`, `HSV Adjust`, `Monochrome`,
   `Channel Mix`, `Pack`, `Limit`, `Remap`, `Lookup`, `RGB to HSV`, `HSV to RGB`,
   `Tone Map`, `Reorder`

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -41,7 +41,7 @@ Enable the texture preset packs for basic operators:
 - **Texture Composite**: `Mix`, `Multiply`, `Add`, `Subtract`, `Difference`,
   `Composite`, `Over`, `Under`, `Feedback`, `Switcher`
 - **Texture Color**: `Level`, `Luma Level`, `HSV Adjust`, `Monochrome`,
-  `Channel Mix`, `Limit`, `Remap`, `Lookup`, `RGB to HSV`, `HSV to RGB`,
+  `Channel Mix`, `Pack`, `Limit`, `Remap`, `Lookup`, `RGB to HSV`, `HSV to RGB`,
   `Tone Map`, `Reorder`
 - **Texture Masks & Keys**: `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`,
   `Matte`

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -39,14 +39,13 @@ Enable the texture preset packs for basic operators:
 - **Texture Generators**: `Constant`, `Linear Ramp`, `Radial Ramp`,
   `Circular Ramp`, `Noise`, `Circle`, `Rectangle`, `Cross`
 - **Texture Composite**: `Mix`, `Multiply`, `Add`, `Subtract`, `Difference`,
-  `Composite`, `Over`, `Under`, `Switcher`
+  `Composite`, `Over`, `Under`, `Feedback`, `Switcher`
 - **Texture Color**: `Level`, `HSV Adjust`, `Monochrome`, `Channel Mix`,
   `Limit`, `Remap`, `Lookup`, `RGB to HSV`, `HSV to RGB`, `Tone Map`, `Reorder`
 - **Texture Masks & Keys**: `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`,
   `Matte`
 - **Texture Transform**: `Transform`, `Crop`, `Fit`, `Flip`, `Mirror`, `Tile`, `Lens Distort`, `Displace`, `Noise Displace`
 - **Texture Filters**: `Blur`, `Edge`, `Emboss`, `Slope`, `Normal Map`
-- **Texture Feedback & Data**: `Feedback`
 
 The `glsl>` preset is the best starting point for building GLSL shaders
 that process video inputs.

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -44,7 +44,7 @@ Enable the texture preset packs for basic operators:
   `Limit`, `Remap`, `Lookup`, `RGB to HSV`, `HSV to RGB`, `Tone Map`, `Reorder`
 - **Texture Masks & Keys**: `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`,
   `Matte`
-- **Texture Transform**: `Transform`, `Crop`, `Displace`, `Noise Displace`
+- **Texture Transform**: `Transform`, `Crop`, `Fit`, `Flip`, `Mirror`, `Tile`, `Lens Distort`, `Displace`, `Noise Displace`
 - **Texture Filters**: `Blur`, `Edge`
 - **Texture Feedback & Data**: `Feedback`
 

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -45,8 +45,8 @@ Enable the texture preset packs for basic operators:
 - **Texture Masks & Keys**: `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`,
   `Matte`
 - **Texture Transform**: `Transform`, `Crop`, `Fit`, `Flip`, `Mirror`, `Tile`, `Lens Distort`, `Displace`, `Noise Displace`
-- **Texture Filters**: `Blur`, `Edge`, `Anti Alias`, `Emboss`, `Slope`,
-  `Normal Map`
+- **Texture Filters**: `Blur`, `Luma Blur`, `Edge`, `Anti Alias`, `Emboss`,
+  `Slope`, `Normal Map`
 
 The `glsl>` preset is the best starting point for building GLSL shaders
 that process video inputs.

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -40,7 +40,8 @@ Enable the texture preset packs for basic operators:
   `Circular Ramp`, `Noise`
 - **Texture Composite**: `Mix`, `Multiply`, `Add`, `Subtract`, `Difference`,
   `Composite`, `Over`, `Under`, `Switcher`
-- **Texture Color**: `Level`, `Reorder`
+- **Texture Color**: `Level`, `HSV Adjust`, `Monochrome`, `Channel Mix`,
+  `Limit`, `Remap`, `Lookup`, `RGB to HSV`, `HSV to RGB`, `Tone Map`, `Reorder`
 - **Texture Masks & Keys**: `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`,
   `Matte`
 - **Texture Transform**: `Transform`, `Crop`, `Displace`, `Noise Displace`

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -40,8 +40,9 @@ Enable the texture preset packs for basic operators:
   `Circular Ramp`, `Noise`, `Circle`, `Rectangle`, `Cross`
 - **Texture Composite**: `Mix`, `Multiply`, `Add`, `Subtract`, `Difference`,
   `Composite`, `Over`, `Under`, `Feedback`, `Switcher`
-- **Texture Color**: `Level`, `HSV Adjust`, `Monochrome`, `Channel Mix`,
-  `Limit`, `Remap`, `Lookup`, `RGB to HSV`, `HSV to RGB`, `Tone Map`, `Reorder`
+- **Texture Color**: `Level`, `Luma Level`, `HSV Adjust`, `Monochrome`,
+  `Channel Mix`, `Limit`, `Remap`, `Lookup`, `RGB to HSV`, `HSV to RGB`,
+  `Tone Map`, `Reorder`
 - **Texture Masks & Keys**: `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`,
   `Matte`
 - **Texture Transform**: `Transform`, `Crop`, `Fit`, `Flip`, `Mirror`, `Tile`, `Lens Distort`, `Displace`, `Noise Displace`

--- a/ui/static/content/objects/glsl.md
+++ b/ui/static/content/objects/glsl.md
@@ -37,7 +37,7 @@ Enable the texture preset packs for basic operators:
 
 - **Visual Shader Starters**: `glsl>` passthrough shader
 - **Texture Generators**: `Constant`, `Linear Ramp`, `Radial Ramp`,
-  `Circular Ramp`, `Noise`
+  `Circular Ramp`, `Noise`, `Circle`, `Rectangle`, `Cross`
 - **Texture Composite**: `Mix`, `Multiply`, `Add`, `Subtract`, `Difference`,
   `Composite`, `Over`, `Under`, `Switcher`
 - **Texture Color**: `Level`, `HSV Adjust`, `Monochrome`, `Channel Mix`,
@@ -45,7 +45,7 @@ Enable the texture preset packs for basic operators:
 - **Texture Masks & Keys**: `Threshold`, `Chroma Key`, `RGB Key`, `Luma Key`,
   `Matte`
 - **Texture Transform**: `Transform`, `Crop`, `Fit`, `Flip`, `Mirror`, `Tile`, `Lens Distort`, `Displace`, `Noise Displace`
-- **Texture Filters**: `Blur`, `Edge`
+- **Texture Filters**: `Blur`, `Edge`, `Emboss`, `Slope`, `Normal Map`
 - **Texture Feedback & Data**: `Feedback`
 
 The `glsl>` preset is the best starting point for building GLSL shaders


### PR DESCRIPTION
Adds more texture operator GLSL presets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 30+ new built-in shader effects including color operations (Add, Subtract, Channel Mix), key effects (Chroma Key, Luma Key, RGB Key), distortions (Lens Distort, Tile), and more.
  * Reorganized preset packs into texture-focused categories (Visual Starters, Generators, Composite, Color, Masks, Transform, Filters, Feedback).

* **Documentation**
  * Updated shader preset documentation with new pack organization and expanded effect library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->