### PR TITLE
feat(glsl): codemirror code completions for glsl object

### DIFF
--- a/docs/design-docs/specs/125-glsl-metadata-directives.md
+++ b/docs/design-docs/specs/125-glsl-metadata-directives.md
@@ -8,6 +8,9 @@ GLSL nodes always display "glsl" as their title — you can't tell what a node d
 
 Parse `// @title`, `// @param`, and `// @noinlet` comment directives from shader code. Use `@title` to set the node title. Use `@param` to enrich uniform sliders with min/max/step and descriptions. Use `@noinlet` to keep selected uniforms configurable through the settings UI only, without exposing node inlet handles. These directives are already part of the shader effect format (spec 123) but are independently useful for any GLSL node right now.
 
+The GLSL editor should also provide concise shader completions for Patchies-injected values, core GLSL types, common built-in functions, and useful snippets. Patchies injects `uv`, but video uniforms are user-declared: the editor may suggest `uniform sampler2D image;` snippets, but must not imply `iChannel0`-`iChannel3` exist unless the shader declares them.
+Completions should cover documented GLSL object workflows such as dynamic uniforms, array uniforms, MRT output declarations, color/select `@param` directives, `@format`, and `@resolution`.
+
 ## Directives
 
 ### `@title`

--- a/docs/design-docs/specs/125-glsl-metadata-directives.md
+++ b/docs/design-docs/specs/125-glsl-metadata-directives.md
@@ -9,7 +9,7 @@ GLSL nodes always display "glsl" as their title — you can't tell what a node d
 Parse `// @title`, `// @param`, and `// @noinlet` comment directives from shader code. Use `@title` to set the node title. Use `@param` to enrich uniform sliders with min/max/step and descriptions. Use `@noinlet` to keep selected uniforms configurable through the settings UI only, without exposing node inlet handles. These directives are already part of the shader effect format (spec 123) but are independently useful for any GLSL node right now.
 
 The GLSL editor should also provide concise shader completions for Patchies-injected values, core GLSL types, common built-in functions, and useful snippets. Patchies injects `uv`, but video uniforms are user-declared: the editor may suggest `uniform sampler2D image;` snippets, but must not imply `iChannel0`-`iChannel3` exist unless the shader declares them.
-Completions should cover documented GLSL object workflows such as dynamic uniforms, array uniforms, MRT output declarations, color/select `@param` directives, `@format`, and `@resolution`.
+Completions should cover documented GLSL object workflows such as dynamic uniforms, array uniforms, MRT output declarations, color/select `@param` directives, `@format`, and `@resolution`. Opaque GLSL types such as `sampler2D` should appear only in declaration/type contexts, such as `uniform sampler2D image;` or function parameters, not expression positions.
 
 ## Directives
 

--- a/ui/src/lib/ai/object-prompts/shaderpark.ts
+++ b/ui/src/lib/ai/object-prompts/shaderpark.ts
@@ -23,7 +23,7 @@ Example - Simple Sphere:
 {
   "type": "shaderpark",
   "data": {
-    "code": "// @title Simple Sphere\\nsphere(0.35);\\ncolor(vec3(0.2, 0.6, 1.0));\\nshine(0.6);\\nrotateY(time * 0.5);"
+    "code": "// @title Simple Sphere\\ncolor(vec3(0.2, 0.6, 1.0));\\nshine(0.6);\\nrotateY(time * 0.5);\\nsphere(0.35);"
   }
 }
 \`\`\`
@@ -33,7 +33,7 @@ Example - Animated Field:
 {
   "type": "shaderpark",
   "data": {
-    "code": "let p = getSpace();\\nsphere(0.25 + 0.08 * sin(time + p.x * 8.0));\\ncolor(hsv2rgb(vec3(0.55 + p.y * 0.2, 0.8, 1.0)));\\nmetal(0.2);\\nshine(0.7);"
+    "code": "let p = getSpace();\\nmetal(0.2);\\nshine(0.7);\\ncolor(hsv2rgb(vec3(0.55 + p.y * 0.2, 0.8, 1.0)));\\nsphere(0.25 + 0.08 * sin(time + p.x * 8.0));"
   }
 }
 \`\`\``;

--- a/ui/src/lib/canvas/constants.ts
+++ b/ui/src/lib/canvas/constants.ts
@@ -273,9 +273,9 @@ function render(time) {
 export const DEFAULT_SHADERPARK_CODE = `let sizeBase = input(0.5, 0.1, 1.2);
 let pulse = 0.08 * nsin(time * 2.0);
 
+shine(0.7);
 color(vec3(0.2, 0.7, 1.0));
-sphere(sizeBase + pulse);
-shine(0.7);`;
+sphere(sizeBase + pulse);`;
 
 export const DEFAULT_TEXTMODE_CODE = `t.setup(() => {
   t.fontSize(32)

--- a/ui/src/lib/canvas/constants.ts
+++ b/ui/src/lib/canvas/constants.ts
@@ -20,16 +20,16 @@ export const DEFAULT_GLSL_CODE = `// uniforms: iResolution, iTime, iMouse
 // you can define your own uniforms!
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-    vec3 color = vec3(0.0);
-    float time = iTime * 0.5;
+  vec3 color = vec3(0.0);
+  float time = iTime * 0.5;
 
-    color.r = sin(uv.x * 10.0 + time) * 0.5 + 0.5;
-    color.g = sin(uv.y * 10.0 + time * 1.2) * 0.5 + 0.5;
-    color.b = sin((uv.x + uv.y) * 5.0 + time * 0.8) * 0.5 + 0.5;
+  color.r = sin(uv.x * 10.0 + time) * 0.5 + 0.5;
+  color.g = sin(uv.y * 10.0 + time * 1.2) * 0.5 + 0.5;
+  color.b = sin((uv.x + uv.y) * 5.0 + time * 0.8) * 0.5 + 0.5;
 
-    float brightness = sin(time * 2.0) * 0.2 + 0.8;
-    color *= brightness;
-    fragColor = vec4(color, 1.0);
+  float brightness = sin(time * 2.0) * 0.2 + 0.8;
+  color *= brightness;
+  fragColor = vec4(color, 1.0);
 }`;
 
 export const DEFAULT_JS_CODE = `console.log(1 + 1)`;

--- a/ui/src/lib/codemirror/glsl-completions.test.ts
+++ b/ui/src/lib/codemirror/glsl-completions.test.ts
@@ -66,14 +66,24 @@ describe('glsl completions', () => {
 
   it('suggests generic sampler and entry point snippets', () => {
     expect(getGlslCompletionLabels('uniform s')).toContain('sampler2D');
-    expect(getGlslCompletionLabels('uniform s')).toContain('sampler2D uniform');
-    expect(getGlslCompletion('uniform s', 'sampler2D uniform')).toMatchObject({
-      detail: 'declare video texture input',
-      info: 'Declare a named video texture uniform. Patchies creates an inlet for the chosen name.'
+    expect(getGlslCompletionLabels('uniform s')).not.toContain('sampler2D uniform');
+    expect(getGlslCompletion('uniform s', 'sampler2D')).toMatchObject({
+      info: 'Opaque 2D texture sampler type for uniforms and function parameters.'
     });
 
     expect(getGlslCompletionLabels('m')).toContain('mainImage');
     expect(getGlslCompletionLabels('m')).toContain('mainImage MRT');
+  });
+
+  it('only suggests sampler2D in declaration contexts', () => {
+    expect(getGlslCompletionLabels('s')).not.toContain('sampler2D');
+    expect(getGlslCompletionLabels('fragColor = s')).not.toContain('sampler2D');
+
+    expect(getGlslCompletionLabels('uniform s')).toContain('sampler2D');
+    expect(getGlslCompletionLabels('vec4 sample(s')).toContain('sampler2D');
+    expect(getGlslCompletionLabels('vec4 sample(float amount, s')).toContain('sampler2D');
+    expect(getGlslCompletionLabels('vec4 sample(in s')).toContain('sampler2D');
+    expect(getGlslCompletionLabels('vec4 sample(s')).not.toContain('sampler2D uniform');
   });
 
   it('suggests dynamic uniform and array uniform snippets from the GLSL docs', () => {

--- a/ui/src/lib/codemirror/glsl-completions.test.ts
+++ b/ui/src/lib/codemirror/glsl-completions.test.ts
@@ -1,0 +1,125 @@
+import { CompletionContext } from '@codemirror/autocomplete';
+import { EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+import { glslDirectiveCompletions } from '$lib/codemirror/glsl.codemirror';
+import { createGlslCompletionSource } from '$lib/codemirror/glsl-completions';
+
+function getGlslCompletions(doc: string) {
+  const state = EditorState.create({ doc });
+  const context = new CompletionContext(state, doc.length, true);
+  const result = createGlslCompletionSource()(context);
+
+  return result?.options ?? [];
+}
+
+function getGlslCompletionLabels(doc: string) {
+  return getGlslCompletions(doc).map((option) => option.label);
+}
+
+function getGlslCompletion(doc: string, label: string) {
+  const completion = getGlslCompletions(doc).find((option) => option.label === label);
+
+  if (!completion) {
+    throw new Error(`Missing GLSL completion: ${label}`);
+  }
+
+  return completion;
+}
+
+function getGlslDirectiveCompletionLabels(doc: string) {
+  const state = EditorState.create({ doc });
+  const context = new CompletionContext(state, doc.length, true);
+  const result = glslDirectiveCompletions(context);
+
+  return result?.options.map((option) => option.label) ?? [];
+}
+
+describe('glsl completions', () => {
+  it('suggests Patchies injected GLSL values only in expression positions', () => {
+    expect(getGlslCompletionLabels('vec2 p = u')).toContain('uv');
+    expect(getGlslCompletion('vec2 p = u', 'uv')).toMatchObject({
+      detail: 'vec2',
+      info: 'Patchies-injected normalized UV coordinate.'
+    });
+
+    expect(getGlslCompletionLabels('u')).toContain('uv');
+  });
+
+  it('suggests documented GLSL uniforms even at statement starts', () => {
+    expect(getGlslCompletionLabels('i')).toContain('iTime');
+    expect(getGlslCompletionLabels('i')).toContain('iResolution');
+    expect(getGlslCompletionLabels('i')).toContain('iMouse');
+    expect(getGlslCompletionLabels('i')).not.toContain('if');
+    expect(getGlslCompletionLabels('i')).not.toContain('in');
+    expect(getGlslCompletion('i', 'iTime')).toMatchObject({
+      detail: 'float',
+      info: 'Shader playback time in seconds.'
+    });
+  });
+
+  it('does not pretend iChannel sampler uniforms are injected', () => {
+    expect(getGlslCompletionLabels('vec4 c = i')).toContain('iResolution');
+    expect(getGlslCompletionLabels('vec4 c = i')).toContain('iTime');
+    expect(getGlslCompletionLabels('vec4 c = i')).not.toContain('iChannel0');
+    expect(getGlslCompletionLabels('vec4 c = i')).not.toContain('iChannel3');
+  });
+
+  it('suggests generic sampler and entry point snippets', () => {
+    expect(getGlslCompletionLabels('uniform s')).toContain('sampler2D');
+    expect(getGlslCompletionLabels('uniform s')).toContain('sampler2D uniform');
+    expect(getGlslCompletion('uniform s', 'sampler2D uniform')).toMatchObject({
+      detail: 'declare video texture input',
+      info: 'Declare a named video texture uniform. Patchies creates an inlet for the chosen name.'
+    });
+
+    expect(getGlslCompletionLabels('m')).toContain('mainImage');
+    expect(getGlslCompletionLabels('m')).toContain('mainImage MRT');
+  });
+
+  it('suggests dynamic uniform and array uniform snippets from the GLSL docs', () => {
+    expect(getGlslCompletionLabels('uniform f')).toContain('float uniform');
+    expect(getGlslCompletion('uniform f', 'float uniform')).toMatchObject({
+      detail: 'declare numeric inlet',
+      info: 'Declare a float uniform. Patchies creates a message inlet for it.'
+    });
+
+    expect(getGlslCompletionLabels('uniform v')).toContain('vec2 uniform');
+    expect(getGlslCompletionLabels('uniform v')).toContain('vec2 array uniform');
+    expect(getGlslCompletionLabels('uniform v')).toContain('vec3 uniform');
+  });
+
+  it('suggests common GLSL built-ins with useful signatures in expression positions', () => {
+    expect(getGlslCompletion('fragColor = f', 'fragColor')).toMatchObject({
+      detail: 'vec4',
+      info: 'Conventional mainImage output color parameter.'
+    });
+    expect(getGlslCompletion('fragColor = tex', 'texture')).toMatchObject({
+      detail: '(sampler: sampler2D, uv: vec2) => vec4',
+      info: 'Sample a 2D texture.'
+    });
+    expect(getGlslCompletion('float x = sm', 'smoothstep')).toMatchObject({
+      detail: '(edge0: T | float, edge1: T | float, x: T) => T',
+      info: 'Smooth Hermite interpolation.'
+    });
+  });
+
+  it('does not show normal GLSL completions inside comments', () => {
+    expect(getGlslCompletionLabels('// u')).toEqual([]);
+  });
+
+  it('suggests include snippets from preprocessor context', () => {
+    expect(getGlslCompletionLabels('#inc')).toContain('#include <lygia/...>');
+    expect(getGlslCompletionLabels('#inc')).toContain('#include "..."');
+  });
+
+  it('suggests documented GLSL directive variants', () => {
+    const labels = getGlslDirectiveCompletionLabels('// @');
+
+    expect(labels).toContain('@param color');
+    expect(labels).toContain('@param select');
+    expect(labels).toContain('@format rgba16f');
+    expect(labels).toContain('@format rgba8');
+    expect(labels).toContain('@resolution WxH');
+    expect(labels).toContain('@resolution 1/n');
+  });
+});

--- a/ui/src/lib/codemirror/glsl-completions.ts
+++ b/ui/src/lib/codemirror/glsl-completions.ts
@@ -1,0 +1,259 @@
+import {
+  CompletionContext as CMCompletionContext,
+  type Completion,
+  snippetCompletion
+} from '@codemirror/autocomplete';
+import { isCompletionSuppressedByComment } from '$lib/codemirror/completion-utils';
+
+const statementCompletions: Completion[] = [
+  ...[
+    ['void', 'No return value.'],
+    ['bool', 'Boolean scalar.'],
+    ['int', 'Signed integer scalar.'],
+    ['uint', 'Unsigned integer scalar.'],
+    ['float', 'Floating-point scalar.'],
+    ['vec2', 'Two-component float vector.'],
+    ['vec3', 'Three-component float vector.'],
+    ['vec4', 'Four-component float vector.'],
+    ['ivec2', 'Two-component integer vector.'],
+    ['ivec3', 'Three-component integer vector.'],
+    ['ivec4', 'Four-component integer vector.'],
+    ['mat2', '2x2 float matrix.'],
+    ['mat3', '3x3 float matrix.'],
+    ['mat4', '4x4 float matrix.'],
+    ['sampler2D', '2D texture sampler uniform.']
+  ].map(([label, info]) => ({
+    label,
+    type: 'type',
+    info
+  })),
+  snippetCompletion('mainImage(out vec4 fragColor, in vec2 fragCoord) {\n  ${body}\n}', {
+    label: 'mainImage',
+    type: 'function',
+    detail: '(out vec4 fragColor, in vec2 fragCoord) => void',
+    info: 'Patchies/Shadertoy fragment entry point.'
+  }),
+  snippetCompletion('mainImage(vec2 fragCoord) {\n  ${body}\n}', {
+    label: 'mainImage MRT',
+    type: 'function',
+    detail: '(vec2 fragCoord) => void',
+    info: 'Patchies multi-output entry point. Write to layout(location) outputs directly.'
+  }),
+  snippetCompletion('uniform float ${name};', {
+    label: 'float uniform',
+    type: 'keyword',
+    detail: 'declare numeric inlet',
+    info: 'Declare a float uniform. Patchies creates a message inlet for it.'
+  }),
+  snippetCompletion('uniform vec2 ${name};', {
+    label: 'vec2 uniform',
+    type: 'keyword',
+    detail: 'declare vec2 inlet',
+    info: 'Declare a vec2 uniform. Patchies accepts two-number array messages.'
+  }),
+  snippetCompletion('uniform vec3 ${name};', {
+    label: 'vec3 uniform',
+    type: 'keyword',
+    detail: 'declare vec3 inlet',
+    info: 'Declare a vec3 uniform. Can be paired with a color @param directive.'
+  }),
+  snippetCompletion('uniform vec2 ${name}[${4}];', {
+    label: 'vec2 array uniform',
+    type: 'keyword',
+    detail: 'declare vec2 array inlet',
+    info: 'Declare an array uniform. Patchies accepts nested array messages.'
+  }),
+  snippetCompletion('uniform sampler2D ${image};', {
+    label: 'sampler2D uniform',
+    type: 'keyword',
+    detail: 'declare video texture input',
+    info: 'Declare a named video texture uniform. Patchies creates an inlet for the chosen name.'
+  }),
+  snippetCompletion('layout(location = ${0}) out vec4 ${color};', {
+    label: 'layout(location)',
+    type: 'keyword',
+    detail: 'declare MRT output',
+    info: 'Declare an additional render target output.'
+  })
+];
+
+const builtInValueCompletions: Completion[] = [
+  {
+    label: 'uv',
+    type: 'variable',
+    detail: 'vec2',
+    info: 'Patchies-injected normalized UV coordinate.'
+  },
+  {
+    label: 'iResolution',
+    type: 'variable',
+    detail: 'vec3',
+    info: 'Viewport resolution: width, height, aspect.'
+  },
+  { label: 'iTime', type: 'variable', detail: 'float', info: 'Shader playback time in seconds.' },
+  {
+    label: 'iTimeDelta',
+    type: 'variable',
+    detail: 'float',
+    info: 'Seconds since the previous frame.'
+  },
+  { label: 'iFrame', type: 'variable', detail: 'int', info: 'Current rendered frame number.' },
+  { label: 'iMouse', type: 'variable', detail: 'vec4', info: 'Mouse position and button state.' },
+  {
+    label: 'fragColor',
+    type: 'variable',
+    detail: 'vec4',
+    info: 'Conventional mainImage output color parameter.'
+  },
+  {
+    label: 'gl_FragCoord',
+    type: 'variable',
+    detail: 'vec4',
+    info: 'Window-relative fragment coordinate.'
+  },
+  {
+    label: 'gl_FragColor',
+    type: 'variable',
+    detail: 'vec4',
+    info: 'Legacy single fragment color output.'
+  },
+  {
+    label: 'PI',
+    type: 'constant',
+    detail: 'float',
+    info: 'Pi constant, if defined by included code.'
+  },
+  {
+    label: 'TAU',
+    type: 'constant',
+    detail: 'float',
+    info: 'Two-pi constant, if defined by included code.'
+  }
+];
+
+const expressionFunctionCompletions: Completion[] = [
+  ...[
+    ['texture', '(sampler: sampler2D, uv: vec2) => vec4', 'Sample a 2D texture.'],
+    [
+      'texelFetch',
+      '(sampler: sampler2D, coord: ivec2, lod: int) => vec4',
+      'Fetch a texture texel by integer coordinate.'
+    ],
+    ['sin', '(x: float | vecN) => same', 'Sine of an angle in radians.'],
+    ['cos', '(x: float | vecN) => same', 'Cosine of an angle in radians.'],
+    ['tan', '(x: float | vecN) => same', 'Tangent of an angle in radians.'],
+    ['asin', '(x: float | vecN) => same', 'Inverse sine, returning radians.'],
+    ['acos', '(x: float | vecN) => same', 'Inverse cosine, returning radians.'],
+    ['atan', '(y: float, x: float) => float', 'Arctangent from y and x, returning radians.'],
+    ['pow', '(base: T, exponent: T) => T', 'Raise base to exponent.'],
+    ['exp', '(x: float | vecN) => same', 'Raise e to the input value.'],
+    ['log', '(x: float | vecN) => same', 'Natural logarithm.'],
+    ['sqrt', '(x: float | vecN) => same', 'Square root.'],
+    ['inversesqrt', '(x: float | vecN) => same', 'Reciprocal square root.'],
+    ['abs', '(x: float | vecN) => same', 'Absolute value.'],
+    ['sign', '(x: float | vecN) => same', 'Return -1, 0, or 1 from the sign of x.'],
+    ['floor', '(x: float | vecN) => same', 'Largest integer not greater than x.'],
+    ['ceil', '(x: float | vecN) => same', 'Smallest integer not less than x.'],
+    ['fract', '(x: float | vecN) => same', 'Fractional part of x.'],
+    ['mod', '(x: T, y: T | float) => T', 'Remainder after division.'],
+    ['min', '(a: T, b: T | float) => T', 'Component-wise minimum.'],
+    ['max', '(a: T, b: T | float) => T', 'Component-wise maximum.'],
+    ['clamp', '(x: T, min: T | float, max: T | float) => T', 'Constrain x between min and max.'],
+    ['mix', '(a: T, b: T, amount: T | float) => T', 'Linearly interpolate between values.'],
+    ['step', '(edge: T | float, x: T) => T', 'Return 0 below edge, otherwise 1.'],
+    [
+      'smoothstep',
+      '(edge0: T | float, edge1: T | float, x: T) => T',
+      'Smooth Hermite interpolation.'
+    ],
+    ['length', '(v: vecN) => float', 'Vector magnitude.'],
+    ['distance', '(a: vecN, b: vecN) => float', 'Distance between two points.'],
+    ['dot', '(a: vecN, b: vecN) => float', 'Dot product.'],
+    ['cross', '(a: vec3, b: vec3) => vec3', 'Cross product of two vec3 values.'],
+    ['normalize', '(v: vecN) => vecN', 'Scale a vector to unit length.'],
+    [
+      'reflect',
+      '(incident: vecN, normal: vecN) => vecN',
+      'Reflect an incident vector around a normal.'
+    ],
+    [
+      'refract',
+      '(incident: vecN, normal: vecN, eta: float) => vecN',
+      'Refract an incident vector through a surface normal.'
+    ]
+  ].map(([label, detail, info]) => ({
+    label,
+    type: 'function',
+    detail,
+    info,
+    apply: `${label}()`
+  }))
+];
+
+const includeCompletions: Completion[] = [
+  snippetCompletion('#include <lygia/${path}>', {
+    label: '#include <lygia/...>',
+    type: 'keyword',
+    detail: 'include Lygia shader library code',
+    info: 'Import a GLSL helper from Lygia.'
+  }),
+  snippetCompletion('#include "${path}"', {
+    label: '#include "..."',
+    type: 'keyword',
+    detail: 'include VFS or URL shader code',
+    info: 'Import GLSL from the patch VFS, npm-style path, or URL.'
+  })
+];
+
+function isExpressionCompletionPosition(context: CMCompletionContext, from: number): boolean {
+  const line = context.state.doc.lineAt(context.pos);
+  const linePrefix = line.text.slice(0, from - line.from);
+  const trimmedPrefix = linePrefix.trimEnd();
+
+  if (!trimmedPrefix) return false;
+
+  return /[=([,{?:+\-*/%&|^!<>]$/.test(trimmedPrefix) || /(?:^|[^\w$])return\s+$/.test(linePrefix);
+}
+
+function isPreprocessorCompletionPosition(context: CMCompletionContext) {
+  const line = context.state.doc.lineAt(context.pos);
+  const beforeCursor = line.text.slice(0, context.pos - line.from);
+
+  return /^[ \t]*#\w*$/.test(beforeCursor);
+}
+
+export function createGlslCompletionSource() {
+  return (context: CMCompletionContext) => {
+    if (isPreprocessorCompletionPosition(context)) {
+      const directive = context.matchBefore(/#\w*/);
+      if (!directive) return null;
+
+      return {
+        from: directive.from,
+        options: includeCompletions,
+        validFor: /^#\w*$/
+      };
+    }
+
+    const word = context.matchBefore(/[A-Za-z_]\w*/);
+    if (!word) return null;
+    if (word.from === word.to && !context.explicit) return null;
+    if (isCompletionSuppressedByComment(context, word.from)) return null;
+
+    const typedText = context.state.doc.sliceString(word.from, word.to).toLowerCase();
+    const isExpressionPosition = isExpressionCompletionPosition(context, word.from);
+    const options = [
+      ...statementCompletions,
+      ...builtInValueCompletions,
+      ...(isExpressionPosition ? expressionFunctionCompletions : [])
+    ].filter((completion) => completion.label.toLowerCase().startsWith(typedText));
+
+    return {
+      from: word.from,
+      options,
+      validFor: /^[A-Za-z_]\w*$/
+    };
+  };
+}
+
+export const glslCompletions = createGlslCompletionSource();

--- a/ui/src/lib/codemirror/glsl-completions.ts
+++ b/ui/src/lib/codemirror/glsl-completions.ts
@@ -20,8 +20,7 @@ const statementCompletions: Completion[] = [
     ['ivec4', 'Four-component integer vector.'],
     ['mat2', '2x2 float matrix.'],
     ['mat3', '3x3 float matrix.'],
-    ['mat4', '4x4 float matrix.'],
-    ['sampler2D', '2D texture sampler uniform.']
+    ['mat4', '4x4 float matrix.']
   ].map(([label, info]) => ({
     label,
     type: 'type',
@@ -63,12 +62,6 @@ const statementCompletions: Completion[] = [
     detail: 'declare vec2 array inlet',
     info: 'Declare an array uniform. Patchies accepts nested array messages.'
   }),
-  snippetCompletion('uniform sampler2D ${image};', {
-    label: 'sampler2D uniform',
-    type: 'keyword',
-    detail: 'declare video texture input',
-    info: 'Declare a named video texture uniform. Patchies creates an inlet for the chosen name.'
-  }),
   snippetCompletion('layout(location = ${0}) out vec4 ${color};', {
     label: 'layout(location)',
     type: 'keyword',
@@ -76,6 +69,14 @@ const statementCompletions: Completion[] = [
     info: 'Declare an additional render target output.'
   })
 ];
+
+const sampler2DTypeCompletion: Completion = {
+  label: 'sampler2D',
+  type: 'type',
+  info: 'Opaque 2D texture sampler type for uniforms and function parameters.'
+};
+
+const sampler2DDeclarationCompletions: Completion[] = [sampler2DTypeCompletion];
 
 const builtInValueCompletions: Completion[] = [
   {
@@ -116,18 +117,6 @@ const builtInValueCompletions: Completion[] = [
     type: 'variable',
     detail: 'vec4',
     info: 'Legacy single fragment color output.'
-  },
-  {
-    label: 'PI',
-    type: 'constant',
-    detail: 'float',
-    info: 'Pi constant, if defined by included code.'
-  },
-  {
-    label: 'TAU',
-    type: 'constant',
-    detail: 'float',
-    info: 'Two-pi constant, if defined by included code.'
   }
 ];
 
@@ -215,6 +204,21 @@ function isExpressionCompletionPosition(context: CMCompletionContext, from: numb
   return /[=([,{?:+\-*/%&|^!<>]$/.test(trimmedPrefix) || /(?:^|[^\w$])return\s+$/.test(linePrefix);
 }
 
+function isSampler2DDeclarationPosition(context: CMCompletionContext, from: number): boolean {
+  const line = context.state.doc.lineAt(context.pos);
+  const linePrefix = line.text.slice(0, from - line.from);
+  const trimmedPrefix = linePrefix.trimEnd();
+  const lastOpenParen = trimmedPrefix.lastIndexOf('(');
+  const lastCloseParen = trimmedPrefix.lastIndexOf(')');
+
+  return (
+    /(?:^|[^\w])uniform\s+$/.test(linePrefix) ||
+    (lastOpenParen > lastCloseParen &&
+      (/[,(]\s*(?:in\s+|out\s+|inout\s+)?$/.test(trimmedPrefix) ||
+        /(?:^|[^\w])(?:in|out|inout)\s+$/.test(linePrefix)))
+  );
+}
+
 function isPreprocessorCompletionPosition(context: CMCompletionContext) {
   const line = context.state.doc.lineAt(context.pos);
   const beforeCursor = line.text.slice(0, context.pos - line.from);
@@ -245,6 +249,9 @@ export function createGlslCompletionSource() {
     const options = [
       ...statementCompletions,
       ...builtInValueCompletions,
+      ...(isSampler2DDeclarationPosition(context, word.from)
+        ? sampler2DDeclarationCompletions
+        : []),
       ...(isExpressionPosition ? expressionFunctionCompletions : [])
     ].filter((completion) => completion.label.toLowerCase().startsWith(typedText));
 

--- a/ui/src/lib/codemirror/glsl.codemirror.ts
+++ b/ui/src/lib/codemirror/glsl.codemirror.ts
@@ -200,6 +200,21 @@ const directiveCompletions: Completion[] = [
     detail: 'Enrich uniform with UI metadata',
     info: '// @param strength 0.5 0.0 1.0 "Effect strength"'
   }),
+  snippetCompletion('@param ${name} color ${hex} "${title}"', {
+    label: '@param color',
+    type: 'keyword',
+    detail: 'Render vec3 uniform as color picker',
+    info: '// @param tint color #ff8800 "Tint"'
+  }),
+  snippetCompletion(
+    '@param ${name} ${default} (${valueA}: ${labelA}, ${valueB}: ${labelB}) "${title}"',
+    {
+      label: '@param select',
+      type: 'keyword',
+      detail: 'Render numeric uniform as select options',
+      info: '// @param mode 0 (0: Linear, 1: Radial) "Mode"'
+    }
+  ),
   snippetCompletion('@noinlet ${name}', {
     label: '@noinlet',
     type: 'keyword',
@@ -212,11 +227,35 @@ const directiveCompletions: Completion[] = [
     detail: 'Set FBO texture format',
     info: '// @format rgba32f'
   }),
+  snippetCompletion('@format rgba16f', {
+    label: '@format rgba16f',
+    type: 'keyword',
+    detail: 'Use 16-bit float output texture',
+    info: '// @format rgba16f'
+  }),
+  snippetCompletion('@format rgba8', {
+    label: '@format rgba8',
+    type: 'keyword',
+    detail: 'Use default 8-bit output texture',
+    info: '// @format rgba8'
+  }),
   snippetCompletion('@resolution 256', {
     label: '@resolution',
     type: 'keyword',
     detail: 'Set FBO size (number, WxH, or 1/n)',
     info: '// @resolution 256 or 256x128 or 1/2'
+  }),
+  snippetCompletion('@resolution 256x128', {
+    label: '@resolution WxH',
+    type: 'keyword',
+    detail: 'Set explicit non-square FBO size',
+    info: '// @resolution 256x128'
+  }),
+  snippetCompletion('@resolution 1/2', {
+    label: '@resolution 1/n',
+    type: 'keyword',
+    detail: 'Set output size as viewport fraction',
+    info: '// @resolution 1/2'
   }),
   snippetCompletion('@primaryButton settings', {
     label: '@primaryButton',

--- a/ui/src/lib/codemirror/language.ts
+++ b/ui/src/lib/codemirror/language.ts
@@ -49,16 +49,18 @@ export async function loadLanguageExtension(language: string, context?: Patchies
       const [
         { LanguageSupport },
         { autocompletion },
-        { glslLanguage, glslIncludeHighlighter, glslDirectiveCompletions }
+        { glslLanguage, glslIncludeHighlighter, glslDirectiveCompletions },
+        { glslCompletions }
       ] = await Promise.all([
         import('@codemirror/language'),
         import('@codemirror/autocomplete'),
-        import('$lib/codemirror/glsl.codemirror')
+        import('$lib/codemirror/glsl.codemirror'),
+        import('$lib/codemirror/glsl-completions')
       ]);
 
       return [
         new LanguageSupport(glslLanguage),
-        autocompletion({ override: [glslDirectiveCompletions] }),
+        autocompletion({ override: [glslDirectiveCompletions, glslCompletions] }),
         ...glslIncludeHighlighter
       ];
     })

--- a/ui/src/lib/presets/builtin/shaderpark.presets.ts
+++ b/ui/src/lib/presets/builtin/shaderpark.presets.ts
@@ -85,11 +85,10 @@ color(vec3(
   1.0 - smoothstep(0.0, 0.8, d)
 ));
 
-displace(mouse.x, mouse.y, 0.0);
-sphere(0.22 + 0.08 * sin(time * 2.0));
-
 shine(0.8);
-metal(0.15);`;
+metal(0.15);
+displace(mouse.x, mouse.y, 0.0);
+sphere(0.22 + 0.08 * sin(time * 2.0));`;
 
 type ShaderParkPresetData = {
   code: string;


### PR DESCRIPTION
Add codemirror code completions for glsl object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GLSL code autocomplete suggestions for built-in functions, types, and variables.
  * Enhanced metadata directive autocomplete with expanded `@param`, `@format`, and `@resolution` options.

* **Tests**
  * Added test coverage for GLSL completion system.

* **Documentation**
  * Updated GLSL editor specification for shader completions and directives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->