### PR TITLE
feat(three): mouse interaction and orbit control support on worker thread

### DIFF
--- a/docs/design-docs/specs/141-three-worker-interaction-controls.md
+++ b/docs/design-docs/specs/141-three-worker-interaction-controls.md
@@ -97,6 +97,10 @@ The worker `ThreeRenderer` should reuse its instance across code updates when th
 
 When user code re-runs, raw callbacks should be cleared and registered again by the new code. Orbit control state should be restored into newly constructed controls so live-coding does not snap the camera back to its default position.
 
+## Built-In Preset
+
+Add a `mouse-cube.three` preset that demonstrates the worker-side `OrbitControls` API with a `MeshNormalMaterial` cube. The preset should use `new OrbitControls(camera)` with pan and zoom enabled, and it should not pass `renderer.domElement` because worker `three` has no DOM element.
+
 ## Documentation Updates
 
 Update:

--- a/docs/design-docs/specs/141-three-worker-interaction-controls.md
+++ b/docs/design-docs/specs/141-three-worker-interaction-controls.md
@@ -1,0 +1,108 @@
+# 141. Three Worker Interaction Controls
+
+## Goal
+
+Add worker-side interaction APIs to the `three` object so it can react to pointer drag and wheel input without moving rendering back to the main thread.
+
+The `three` object should keep its fast video-chainable worker renderer while supporting common interactive 3D workflows:
+
+- Orbit, pan, and wheel zoom a camera with an API that looks familiar to Three.js users.
+- Receive raw pointer drag and wheel events for raycasting, object dragging, brush controls, scroll-driven animation, and custom camera rigs.
+- Preserve control state across code re-evaluation when the worker renderer can be reused.
+
+## API Shape
+
+Expose raw interaction hooks in worker `three` code:
+
+```js
+onPointerDrag(({ x, y, dx, dy, buttons, down }) => {
+  // Custom interaction, such as raycasting or dragging an object.
+});
+
+onWheel(({ x, y, deltaX, deltaY, deltaMode }) => {
+  // Custom wheel behavior, such as brush size or timeline scrubbing.
+});
+```
+
+Extend the existing `mouse` global for worker `three`:
+
+```js
+mouse.x;
+mouse.y;
+mouse.down;
+mouse.buttons;
+mouse.dx;
+mouse.dy;
+mouse.wheelDelta;
+```
+
+Expose a Patchies worker implementation of an OrbitControls-like class:
+
+```js
+const controls = new OrbitControls(camera);
+
+function draw() {
+  controls.update();
+  renderer.render(scene, camera);
+}
+```
+
+This is not Three.js' DOM `OrbitControls` addon. It is a worker-safe compatibility layer with a familiar constructor and common properties.
+It intentionally does not require `renderer.domElement`, because worker `three` has no real DOM element.
+
+## Initial OrbitControls Compatibility
+
+Support the practical subset first:
+
+- `target`
+- `enabled`
+- `enableRotate`
+- `enablePan`
+- `enableZoom`
+- `rotateSpeed`
+- `panSpeed`
+- `zoomSpeed`
+- `minDistance`
+- `maxDistance`
+- `mouseButtons`
+- `update()`
+- `reset()`
+- `saveState()`
+- `dispose()`
+- `getDistance()`
+- `getAzimuthalAngle()`
+- `getPolarAngle()`
+- `rotateLeft(angle)`
+- `rotateUp(angle)`
+- `pan(deltaX, deltaY)`
+- `dollyIn(scale)`
+- `dollyOut(scale)`
+
+Defer full parity features such as keyboard listeners, touch gestures, damping, auto-rotate, `zoomToCursor`, and detailed orthographic camera support.
+
+## Input Forwarding
+
+`three` should receive Shadertoy-style pointer state from both the node preview and the surface forwarder:
+
+- `mouseX`, `mouseY`: current pointer position in framebuffer pixels.
+- `mouseZ`, `mouseW`: positive click origin while down, negative after release.
+- `mouseButtons`: raw pointer button bitmask when available.
+
+Wheel input needs its own render-worker message because it is a discrete event rather than durable frame state. The wheel payload should include pointer coordinates when available, `deltaX`, `deltaY`, and `deltaMode`.
+
+## Renderer Reuse
+
+The worker `ThreeRenderer` should reuse its instance across code updates when the FBO can be reused, similar to Hydra and Shader Park 3D. Reusing the renderer keeps worker-side interaction state, registered resources, and control snapshots alive across `run` / `setCode` re-evaluation.
+
+When user code re-runs, raw callbacks should be cleared and registered again by the new code. Orbit control state should be restored into newly constructed controls so live-coding does not snap the camera back to its default position.
+
+## Documentation Updates
+
+Update:
+
+- `ui/static/content/objects/three.md`
+- `ui/static/content/objects/three.dom.md` comparison copy
+- `ui/src/lib/codemirror/patchies-completions.ts`
+- `ui/src/lib/ai/object-prompts/three.ts`
+
+The docs should still say keyboard interaction belongs to `three.dom` for now.

--- a/docs/design-docs/specs/141-three-worker-interaction-controls.md
+++ b/docs/design-docs/specs/141-three-worker-interaction-controls.md
@@ -91,6 +91,8 @@ Defer full parity features such as keyboard listeners, touch gestures, damping, 
 
 Wheel input needs its own render-worker message because it is a discrete event rather than durable frame state. The wheel payload should include pointer coordinates when available, `deltaX`, `deltaY`, and `deltaMode`.
 
+The `surface` node should forward fullscreen and preview wheel events through the same worker paths: `three` receives `sendThreeWheelData`, and Shader Park 3D receives `zoomShaderParkOrbit`.
+
 ## Renderer Reuse
 
 The worker `ThreeRenderer` should reuse its instance across code updates when the FBO can be reused, similar to Hydra and Shader Park 3D. Reusing the renderer keeps worker-side interaction state, registered resources, and control snapshots alive across `run` / `setCode` re-evaluation.

--- a/docs/design-docs/specs/141-three-worker-interaction-controls.md
+++ b/docs/design-docs/specs/141-three-worker-interaction-controls.md
@@ -65,6 +65,7 @@ Support the practical subset first:
 - `zoomSpeed`
 - `minDistance`
 - `maxDistance`
+- `screenSpacePanning`
 - `mouseButtons`
 - `update()`
 - `reset()`
@@ -80,6 +81,11 @@ Support the practical subset first:
 - `dollyOut(scale)`
 
 Defer full parity features such as keyboard listeners, touch gestures, damping, auto-rotate, `zoomToCursor`, and detailed orthographic camera support.
+
+`screenSpacePanning` follows Three.js OrbitControls semantics for perspective cameras:
+
+- `true`: pan vertically along the camera's local up axis.
+- `false`: pan vertically in the plane perpendicular to the camera view direction, using the camera up vector crossed with the view direction.
 
 ## Input Forwarding
 

--- a/docs/design-docs/specs/141-three-worker-interaction-controls.md
+++ b/docs/design-docs/specs/141-three-worker-interaction-controls.md
@@ -49,6 +49,7 @@ function draw() {
 
 This is not Three.js' DOM `OrbitControls` addon. It is a worker-safe compatibility layer with a familiar constructor and common properties.
 It intentionally does not require `renderer.domElement`, because worker `three` has no real DOM element.
+Constructing `OrbitControls` should automatically send the same interaction updates as `noDrag()` and `noWheel()` so Patchies canvas gestures do not compete with camera drag and wheel zoom.
 
 ## Initial OrbitControls Compatibility
 

--- a/ui/src/lib/ai/object-descriptions-types.ts
+++ b/ui/src/lib/ai/object-descriptions-types.ts
@@ -52,9 +52,9 @@ export const OBJECT_TYPE_LIST = `## Basic Control & UI
 - glsl: GLSL fragment shaders for visual effects
 - float.tex: Convert Float32Array or Float32Array[] channel data into a 32-bit float video texture for shaders
 - shaderpark: Shader Park SDF raymarching visuals for the video pipeline
-- three: Three.js 3D graphics (offscreen worker, for video chaining)
+- three: Three.js 3D graphics (offscreen worker, video chaining, pointer drag/wheel interaction)
 - regl: GPU renderer with regl draw commands (custom vertices, buffers, multi-pass, blend modes)
-- three.dom: Three.js 3D graphics (main thread, for mouse/keyboard interaction)
+- three.dom: Three.js 3D graphics (main thread, for keyboard/DOM interaction)
 - projmap: Projection mapper — warp video textures onto N-point polygon surfaces with built-in point editor and expand mode
 - dom: write to the DOM element
 - swgl: do not use unless explicitly requested
@@ -144,8 +144,8 @@ export const SPARKS_OBJECT_LIST = `## Visuals
 - hydra: Live video synthesis — feedback loops, texture blending, webcam warping
 - glsl: GLSL fragment shaders — pixel-level visual effects, raymarching, procedural textures
 - shaderpark: Shader Park — concise SDF/raymarched procedural 3D visuals
-- three: Three.js 3D graphics (offscreen worker) — meshes, lighting, cameras, 3D scenes; for video chaining
-- three.dom: Three.js 3D graphics (main thread) — same as three but supports mouse/keyboard interaction
+- three: Three.js 3D graphics (offscreen worker) — meshes, lighting, cameras, 3D scenes, pointer drag/wheel interaction; for video chaining
+- three.dom: Three.js 3D graphics (main thread) — same as three but supports keyboard and DOM interaction
 - regl: Low-level GPU rendering — custom vertices, multi-pass, blend modes
 - canvas.dom: HTML5 Canvas (main thread) — supports mouse/keyboard, lower overhead than p5
 - projmap: Projection mapping — warp video onto surfaces with a built-in point editor

--- a/ui/src/lib/ai/object-prompts/three.ts
+++ b/ui/src/lib/ai/object-prompts/three.ts
@@ -13,17 +13,22 @@ const material = new THREE.ShaderMaterial({
 - THREE: Full Three.js library namespace
 - renderer: WebGLRenderer instance
 - width, height: Canvas dimensions
-- mouse: {x, y} coordinates
+- mouse: {x, y, down, buttons, dx, dy, wheelDelta} pointer state
+- OrbitControls: Worker-safe OrbitControls-compatible class
 
 **Three-specific methods:**
 - setVideoCount(inlets, outlets) - Configure video inlets/outlets (default 1, 1)
 - getTexture(index) - Get Three.js Texture from video inlet (0-based index)
+- onPointerDrag(callback) - Receive raw drag events with {x, y, dx, dy, buttons, down}
+- onWheel(callback) - Receive raw wheel events with {x, y, deltaX, deltaY, deltaMode}
 - noDrag(), noPan(), noWheel(), noInteract() - Interaction control
 - noOutput() - Hide video output port
 - setHidePorts(bool) - Toggle port visibility
 
 **Three-specific gotchas:**
 - Use draw(time) function for render loop instead of requestAnimationFrame
+- Use new OrbitControls(camera) for worker-side orbit/pan/wheel zoom; worker three has no DOM element
+- Call controls.update() inside draw() before renderer.render(scene, camera)
 - Runs in web worker - no direct DOM access
 
 **Font & element sizes:**

--- a/ui/src/lib/canvas/CanvasMouseHandler.ts
+++ b/ui/src/lib/canvas/CanvasMouseHandler.ts
@@ -141,8 +141,6 @@ export class CanvasMouseHandler {
       this.glSystem.setMouseData(config.nodeId, x, y, 0, 0);
     };
 
-    console.log('local attached!');
-
     config.canvas.addEventListener('mousemove', handleLocalMouseMove);
 
     this.cleanupFn = () => {
@@ -235,9 +233,11 @@ export class CanvasMouseHandler {
           const rect = config.canvas.getBoundingClientRect();
           const screenX = event.clientX - rect.left;
           const screenY = event.clientY - rect.top;
+
           this.glSystem.sendThreeWheelData(config.nodeId, {
             x: (screenX / rect.width) * config.outputWidth,
             y: this.mapY(screenY, rect.height, config),
+
             deltaX: event.deltaX,
             deltaY: event.deltaY,
             deltaMode: event.deltaMode

--- a/ui/src/lib/canvas/CanvasMouseHandler.ts
+++ b/ui/src/lib/canvas/CanvasMouseHandler.ts
@@ -1,4 +1,5 @@
 import { GLSystem } from './GLSystem';
+import { match } from 'ts-pattern';
 
 export type MouseScope = 'local' | 'global';
 
@@ -18,6 +19,8 @@ export interface ShadertoyMouseConfig {
   outputWidth: number;
   outputHeight: number;
   wheelZoom?: boolean;
+  wheelTarget?: 'shaderparkOrbit' | 'threeInteraction';
+  flipY?: boolean;
 }
 
 export type MouseHandlerConfig = SimpleMouseConfig | ShadertoyMouseConfig;
@@ -160,7 +163,7 @@ export class CanvasMouseHandler {
       // Map from displayed rect to actual framebuffer resolution (outputSize)
       // Y is flipped because gl_FragCoord has origin at bottom, but mouse events have origin at top
       const x = (screenX / rect.width) * config.outputWidth;
-      const y = config.outputHeight - (screenY / rect.height) * config.outputHeight;
+      const y = this.mapY(screenY, rect.height, config);
 
       this.mouseState.x = x;
       this.mouseState.y = y;
@@ -169,7 +172,14 @@ export class CanvasMouseHandler {
       const z = this.isMouseDown ? Math.abs(this.mouseState.z) : -Math.abs(this.mouseState.z);
       const w = this.isMouseDown ? Math.abs(this.mouseState.w) : -Math.abs(this.mouseState.w);
 
-      this.glSystem.setMouseData(config.nodeId, this.mouseState.x, this.mouseState.y, z, w);
+      this.glSystem.setMouseData(
+        config.nodeId,
+        this.mouseState.x,
+        this.mouseState.y,
+        z,
+        w,
+        event.buttons
+      );
     };
 
     const handleMouseDown = (event: MouseEvent) => {
@@ -182,7 +192,7 @@ export class CanvasMouseHandler {
       // Map from displayed rect to actual framebuffer resolution (outputSize)
       // Y is flipped because gl_FragCoord has origin at bottom, but mouse events have origin at top
       const x = (screenX / rect.width) * config.outputWidth;
-      const y = config.outputHeight - (screenY / rect.height) * config.outputHeight;
+      const y = this.mapY(screenY, rect.height, config);
 
       this.isMouseDown = true;
       this.mouseState.z = x;
@@ -196,7 +206,8 @@ export class CanvasMouseHandler {
         this.mouseState.x,
         this.mouseState.y,
         this.mouseState.z,
-        this.mouseState.w
+        this.mouseState.w,
+        event.buttons || 1
       );
     };
 
@@ -209,7 +220,8 @@ export class CanvasMouseHandler {
         this.mouseState.x,
         this.mouseState.y,
         -Math.abs(this.mouseState.z),
-        -Math.abs(this.mouseState.w)
+        -Math.abs(this.mouseState.w),
+        0
       );
     };
 
@@ -218,7 +230,23 @@ export class CanvasMouseHandler {
 
       event.preventDefault();
 
-      this.glSystem.zoomShaderParkOrbit(config.nodeId, event.deltaY);
+      match(config.wheelTarget ?? 'shaderparkOrbit')
+        .with('threeInteraction', () => {
+          const rect = config.canvas.getBoundingClientRect();
+          const screenX = event.clientX - rect.left;
+          const screenY = event.clientY - rect.top;
+          this.glSystem.sendThreeWheelData(config.nodeId, {
+            x: (screenX / rect.width) * config.outputWidth,
+            y: this.mapY(screenY, rect.height, config),
+            deltaX: event.deltaX,
+            deltaY: event.deltaY,
+            deltaMode: event.deltaMode
+          });
+        })
+        .with('shaderparkOrbit', () =>
+          this.glSystem.zoomShaderParkOrbit(config.nodeId, event.deltaY)
+        )
+        .exhaustive();
     };
 
     config.canvas.addEventListener('mousemove', handleMouseMove);
@@ -234,5 +262,11 @@ export class CanvasMouseHandler {
       config.canvas.removeEventListener('mouseleave', handleMouseUp);
       config.canvas.removeEventListener('wheel', handleWheel);
     };
+  }
+
+  private mapY(screenY: number, rectHeight: number, config: ShadertoyMouseConfig) {
+    const y = (screenY / rectHeight) * config.outputHeight;
+
+    return config.flipY === false ? y : config.outputHeight - y;
   }
 }

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -751,13 +751,24 @@ export class GLSystem {
     });
   }
 
-  setMouseData(nodeId: string, x: number, y: number, z: number, w: number) {
+  setMouseData(nodeId: string, x: number, y: number, z: number, w: number, buttons?: number) {
     this.send('setMouseData', {
       nodeId,
       x,
       y,
       z,
-      w
+      w,
+      buttons
+    });
+  }
+
+  sendThreeWheelData(
+    nodeId: string,
+    event: { x?: number; y?: number; deltaX?: number; deltaY: number; deltaMode?: number }
+  ) {
+    this.send('sendThreeWheelData', {
+      nodeId,
+      ...event
     });
   }
 

--- a/ui/src/lib/canvas/SurfaceListeners.ts
+++ b/ui/src/lib/canvas/SurfaceListeners.ts
@@ -9,6 +9,14 @@ export type PointerEvent_ = {
   type: string;
 };
 
+export type SurfaceWheelEvent_ = {
+  x: number;
+  y: number;
+  deltaX: number;
+  deltaY: number;
+  deltaMode: number;
+};
+
 export type TouchPoint = {
   id: number;
   x: number;
@@ -18,9 +26,12 @@ export type TouchPoint = {
 
 export interface SurfaceListenersOptions {
   onPointer: (e: PointerEvent_) => void;
+  onWheel: (e: SurfaceWheelEvent_) => void;
   onTouch: ((touches: TouchPoint[]) => void) | null;
+
   /** Called when pointer leaves the canvas */
   onLeave: () => void;
+
   /** For error reporting */
   code: string;
   nodeId: string;
@@ -61,6 +72,7 @@ export class SurfaceListeners {
 
     const normalize = (clientX: number, clientY: number) => {
       const rect = getContentRect();
+
       return {
         x: (clientX - rect.left) / rect.width,
         y: (clientY - rect.top) / rect.height
@@ -69,6 +81,7 @@ export class SurfaceListeners {
 
     const normalizeTouches = (e: TouchEvent): TouchPoint[] => {
       const rect = getContentRect();
+
       return Array.from(e.touches).map((t) => ({
         id: t.identifier,
         x: (t.clientX - rect.left) / rect.width,
@@ -79,7 +92,9 @@ export class SurfaceListeners {
 
     const fireTouches = (e: TouchEvent) => {
       e.preventDefault();
+
       if (!opts.onTouch) return;
+
       try {
         opts.onTouch(normalizeTouches(e));
       } catch (err) {
@@ -89,6 +104,7 @@ export class SurfaceListeners {
 
     const onPointerMove = (e: PointerEvent) => {
       const { x, y } = normalize(e.clientX, e.clientY);
+
       try {
         opts.onPointer({
           x,
@@ -102,28 +118,52 @@ export class SurfaceListeners {
         handleCodeError(err, opts.code, opts.nodeId, opts.customConsole, opts.wrapperOffset);
       }
     };
+
     const onPointerDown = (e: PointerEvent) => {
       const { x, y } = normalize(e.clientX, e.clientY);
+
       try {
         opts.onPointer({ x, y, pressure: 0, buttons: e.buttons || 1, down: true, type: 'down' });
       } catch (err) {
         handleCodeError(err, opts.code, opts.nodeId, opts.customConsole, opts.wrapperOffset);
       }
     };
+
     const onPointerUp = (e: PointerEvent) => {
       const { x, y } = normalize(e.clientX, e.clientY);
+
       try {
         opts.onPointer({ x, y, pressure: 0, buttons: 0, down: false, type: 'up' });
       } catch (err) {
         handleCodeError(err, opts.code, opts.nodeId, opts.customConsole, opts.wrapperOffset);
       }
     };
+
     const onPointerLeave = () => opts.onLeave();
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+
+      const { x, y } = normalize(e.clientX, e.clientY);
+
+      try {
+        opts.onWheel({
+          x,
+          y,
+          deltaX: e.deltaX,
+          deltaY: e.deltaY,
+          deltaMode: e.deltaMode
+        });
+      } catch (err) {
+        handleCodeError(err, opts.code, opts.nodeId, opts.customConsole, opts.wrapperOffset);
+      }
+    };
 
     canvas.addEventListener('pointermove', onPointerMove);
     canvas.addEventListener('pointerdown', onPointerDown);
     canvas.addEventListener('pointerup', onPointerUp);
     canvas.addEventListener('pointerleave', onPointerLeave);
+    canvas.addEventListener('wheel', onWheel, { passive: false });
     canvas.addEventListener('touchstart', fireTouches, { passive: false });
     canvas.addEventListener('touchmove', fireTouches, { passive: false });
     canvas.addEventListener('touchend', fireTouches, { passive: false });
@@ -133,6 +173,7 @@ export class SurfaceListeners {
       canvas.removeEventListener('pointerdown', onPointerDown);
       canvas.removeEventListener('pointerup', onPointerUp);
       canvas.removeEventListener('pointerleave', onPointerLeave);
+      canvas.removeEventListener('wheel', onWheel);
       canvas.removeEventListener('touchstart', fireTouches);
       canvas.removeEventListener('touchmove', fireTouches);
       canvas.removeEventListener('touchend', fireTouches);

--- a/ui/src/lib/canvas/SurfaceMouseForwarder.ts
+++ b/ui/src/lib/canvas/SurfaceMouseForwarder.ts
@@ -5,7 +5,6 @@ import type { Node } from '@xyflow/svelte';
 
 const SHADERTOY_TYPES = new Set(['glsl', 'swgl', 'regl']);
 const SIMPLE_TYPES = new Set(['hydra', 'canvas', 'textmode', 'shaderpark']);
-const WORKER_THREE_TYPES = new Set(['three']);
 
 /**
  * Forwards normalized surface mouse events to all render nodes in the graph.
@@ -28,10 +27,10 @@ export class SurfaceMouseForwarder {
    */
   forward(x: number, y: number, _buttons: number, type: string): void {
     const renderNodes = this.getNodes().filter(
-      (n) =>
-        SHADERTOY_TYPES.has(n.type ?? '') ||
-        SIMPLE_TYPES.has(n.type ?? '') ||
-        WORKER_THREE_TYPES.has(n.type ?? '')
+      (node) =>
+        SHADERTOY_TYPES.has(node.type ?? '') ||
+        SIMPLE_TYPES.has(node.type ?? '') ||
+        node.type === 'three'
     );
 
     if (renderNodes.length === 0) return;
@@ -48,7 +47,7 @@ export class SurfaceMouseForwarder {
       const nodeType = node.type ?? '';
       const isShaderPark3d = nodeType === 'shaderpark' && node.data.renderMode === '3d';
 
-      if (WORKER_THREE_TYPES.has(nodeType)) {
+      if (node.type === 'three') {
         this.forwardShadertoy(node.id, xFB, yFBSimple, type, _buttons);
       } else if (SHADERTOY_TYPES.has(nodeType) || isShaderPark3d) {
         this.forwardShadertoy(node.id, xFB, yFBShadertoy, type, _buttons);
@@ -66,6 +65,7 @@ export class SurfaceMouseForwarder {
     deltaMode: number;
   }): void {
     const [w, h] = this.glSystem.outputSize;
+
     const xFB = event.x * w;
     const yFB = event.y * h;
 
@@ -90,9 +90,9 @@ export class SurfaceMouseForwarder {
    */
   forceHydraScope(scope: 'global' | 'local'): void {
     this.getNodes()
-      .filter((n) => n.type === 'hydra')
-      .forEach((n) =>
-        this.eventBus.dispatch({ type: 'nodeMouseScopeUpdate', nodeId: n.id, scope })
+      .filter((node) => node.type === 'hydra')
+      .forEach((node) =>
+        this.eventBus.dispatch({ type: 'nodeMouseScopeUpdate', nodeId: node.id, scope })
       );
   }
 
@@ -107,14 +107,17 @@ export class SurfaceMouseForwarder {
       this.isMouseDown = true;
       this.clickX = x;
       this.clickY = y;
+
       this.glSystem.setMouseData(nodeId, x, y, x, y, buttons || 1);
     } else if (type === 'up') {
       this.isMouseDown = false;
+
       this.glSystem.setMouseData(nodeId, x, y, -Math.abs(this.clickX), -Math.abs(this.clickY), 0);
     } else {
       // move
       const z = this.isMouseDown ? Math.abs(this.clickX) : -Math.abs(this.clickX);
       const w = this.isMouseDown ? Math.abs(this.clickY) : -Math.abs(this.clickY);
+
       this.glSystem.setMouseData(nodeId, x, y, z, w, this.isMouseDown ? buttons : 0);
     }
   }

--- a/ui/src/lib/canvas/SurfaceMouseForwarder.ts
+++ b/ui/src/lib/canvas/SurfaceMouseForwarder.ts
@@ -3,7 +3,8 @@ import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
 import type { Node } from '@xyflow/svelte';
 
 const SHADERTOY_TYPES = new Set(['glsl', 'swgl', 'regl']);
-const SIMPLE_TYPES = new Set(['hydra', 'three', 'canvas', 'textmode', 'shaderpark']);
+const SIMPLE_TYPES = new Set(['hydra', 'canvas', 'textmode', 'shaderpark']);
+const WORKER_THREE_TYPES = new Set(['three']);
 
 /**
  * Forwards normalized surface mouse events to all render nodes in the graph.
@@ -26,7 +27,10 @@ export class SurfaceMouseForwarder {
    */
   forward(x: number, y: number, _buttons: number, type: string): void {
     const renderNodes = this.getNodes().filter(
-      (n) => SHADERTOY_TYPES.has(n.type ?? '') || SIMPLE_TYPES.has(n.type ?? '')
+      (n) =>
+        SHADERTOY_TYPES.has(n.type ?? '') ||
+        SIMPLE_TYPES.has(n.type ?? '') ||
+        WORKER_THREE_TYPES.has(n.type ?? '')
     );
 
     if (renderNodes.length === 0) return;
@@ -43,8 +47,10 @@ export class SurfaceMouseForwarder {
       const nodeType = node.type ?? '';
       const isShaderPark3d = nodeType === 'shaderpark' && node.data.renderMode === '3d';
 
-      if (SHADERTOY_TYPES.has(nodeType) || isShaderPark3d) {
-        this.forwardShadertoy(node.id, xFB, yFBShadertoy, type);
+      if (WORKER_THREE_TYPES.has(nodeType)) {
+        this.forwardShadertoy(node.id, xFB, yFBSimple, type, _buttons);
+      } else if (SHADERTOY_TYPES.has(nodeType) || isShaderPark3d) {
+        this.forwardShadertoy(node.id, xFB, yFBShadertoy, type, _buttons);
       } else if (SIMPLE_TYPES.has(nodeType)) {
         this.glSystem.setMouseData(node.id, xFB, yFBSimple, 0, 0);
       }
@@ -63,20 +69,26 @@ export class SurfaceMouseForwarder {
       );
   }
 
-  private forwardShadertoy(nodeId: string, x: number, y: number, type: string): void {
+  private forwardShadertoy(
+    nodeId: string,
+    x: number,
+    y: number,
+    type: string,
+    buttons: number
+  ): void {
     if (type === 'down') {
       this.isMouseDown = true;
       this.clickX = x;
       this.clickY = y;
-      this.glSystem.setMouseData(nodeId, x, y, x, y);
+      this.glSystem.setMouseData(nodeId, x, y, x, y, buttons || 1);
     } else if (type === 'up') {
       this.isMouseDown = false;
-      this.glSystem.setMouseData(nodeId, x, y, -Math.abs(this.clickX), -Math.abs(this.clickY));
+      this.glSystem.setMouseData(nodeId, x, y, -Math.abs(this.clickX), -Math.abs(this.clickY), 0);
     } else {
       // move
       const z = this.isMouseDown ? Math.abs(this.clickX) : -Math.abs(this.clickX);
       const w = this.isMouseDown ? Math.abs(this.clickY) : -Math.abs(this.clickY);
-      this.glSystem.setMouseData(nodeId, x, y, z, w);
+      this.glSystem.setMouseData(nodeId, x, y, z, w, this.isMouseDown ? buttons : 0);
     }
   }
 }

--- a/ui/src/lib/canvas/SurfaceMouseForwarder.ts
+++ b/ui/src/lib/canvas/SurfaceMouseForwarder.ts
@@ -1,5 +1,6 @@
 import { GLSystem } from './GLSystem';
 import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+import { getSurfaceWheelTargets } from './surfaceMouseForwarding';
 import type { Node } from '@xyflow/svelte';
 
 const SHADERTOY_TYPES = new Set(['glsl', 'swgl', 'regl']);
@@ -53,6 +54,32 @@ export class SurfaceMouseForwarder {
         this.forwardShadertoy(node.id, xFB, yFBShadertoy, type, _buttons);
       } else if (SIMPLE_TYPES.has(nodeType)) {
         this.glSystem.setMouseData(node.id, xFB, yFBSimple, 0, 0);
+      }
+    }
+  }
+
+  forwardWheel(event: {
+    x: number;
+    y: number;
+    deltaX: number;
+    deltaY: number;
+    deltaMode: number;
+  }): void {
+    const [w, h] = this.glSystem.outputSize;
+    const xFB = event.x * w;
+    const yFB = event.y * h;
+
+    for (const target of getSurfaceWheelTargets(this.getNodes())) {
+      if (target.kind === 'three') {
+        this.glSystem.sendThreeWheelData(target.nodeId, {
+          x: xFB,
+          y: yFB,
+          deltaX: event.deltaX,
+          deltaY: event.deltaY,
+          deltaMode: event.deltaMode
+        });
+      } else {
+        this.glSystem.zoomShaderParkOrbit(target.nodeId, event.deltaY);
       }
     }
   }

--- a/ui/src/lib/canvas/surfaceMouseForwarding.test.ts
+++ b/ui/src/lib/canvas/surfaceMouseForwarding.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import type { Node } from '@xyflow/svelte';
+
+import { getSurfaceWheelTargets } from './surfaceMouseForwarding';
+
+describe('surface mouse forwarding', () => {
+  it('targets worker Three and Shader Park 3D nodes for surface wheel events', () => {
+    const nodes = [
+      { id: 'three-1', type: 'three', data: {} },
+      { id: 'shaderpark-3d-1', type: 'shaderpark', data: { renderMode: '3d' } },
+      { id: 'shaderpark-flat-1', type: 'shaderpark', data: { renderMode: 'flat' } },
+      { id: 'glsl-1', type: 'glsl', data: {} }
+    ] as Node[];
+
+    expect(getSurfaceWheelTargets(nodes)).toEqual([
+      { kind: 'three', nodeId: 'three-1' },
+      { kind: 'shaderpark3d', nodeId: 'shaderpark-3d-1' }
+    ]);
+  });
+});

--- a/ui/src/lib/canvas/surfaceMouseForwarding.ts
+++ b/ui/src/lib/canvas/surfaceMouseForwarding.ts
@@ -1,0 +1,17 @@
+import { match } from 'ts-pattern';
+import type { Node } from '@xyflow/svelte';
+
+export type SurfaceWheelTarget =
+  | { kind: 'three'; nodeId: string }
+  | { kind: 'shaderpark3d'; nodeId: string };
+
+export function getSurfaceWheelTargets(nodes: Node[]): SurfaceWheelTarget[] {
+  return nodes.flatMap((node) =>
+    match({ type: node.type, renderMode: node.data?.renderMode })
+      .with({ type: 'three' }, (): SurfaceWheelTarget[] => [{ kind: 'three', nodeId: node.id }])
+      .with({ type: 'shaderpark', renderMode: '3d' }, (): SurfaceWheelTarget[] => [
+        { kind: 'shaderpark3d', nodeId: node.id }
+      ])
+      .otherwise((): SurfaceWheelTarget[] => [])
+  );
+}

--- a/ui/src/lib/canvas/use-waveform-zoom.svelte.ts
+++ b/ui/src/lib/canvas/use-waveform-zoom.svelte.ts
@@ -34,6 +34,7 @@ export function useWaveformZoom() {
       newStart = 0;
       newEnd = newSpan;
     }
+
     if (newEnd > 1) {
       newEnd = 1;
       newStart = 1 - newSpan;

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -398,7 +398,8 @@ const MOUSE_INTERACTION_JS_NODES = [
   'three',
   'three.dom',
   'vue',
-  'dom'
+  'dom',
+  'surface'
 ];
 
 // Node-specific functions - only show in certain node types

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -61,6 +61,27 @@ const patchiesAPICompletions: Completion[] = [
     apply: 'getTexture(0)'
   },
   {
+    label: 'OrbitControls',
+    type: 'class',
+    detail: 'new OrbitControls(camera)',
+    info: 'Worker-safe OrbitControls-compatible helper for three nodes. Supports rotate, pan, and wheel zoom without a DOM element.',
+    apply: 'new OrbitControls(camera)'
+  },
+  {
+    label: 'onPointerDrag',
+    type: 'function',
+    detail: '(callback: (event) => void) => () => void',
+    info: 'Receive raw pointer drag events in worker three nodes. Event includes x, y, dx, dy, buttons, and down.',
+    apply: 'onPointerDrag(({ x, y, dx, dy, buttons }) => {\n  \n})'
+  },
+  {
+    label: 'onWheel',
+    type: 'function',
+    detail: '(callback: (event) => void) => () => void',
+    info: 'Receive raw wheel events in worker three nodes. Event includes x, y, deltaX, deltaY, and deltaMode.',
+    apply: 'onWheel(({ x, y, deltaY }) => {\n  \n})'
+  },
+  {
     label: 'onVideoFrame',
     type: 'function',
     detail: '(callback: (frames, timestamp) => void) => void',
@@ -350,6 +371,8 @@ const topLevelOnlyFunctions = new Set([
   'onCleanup',
   'onKeyDown',
   'onKeyUp',
+  'onPointerDrag',
+  'onWheel',
   'onMessage',
   'onVideoFrame',
   'recv',
@@ -482,6 +505,9 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   setPrimaryButton: ['js', 'worker', 'p5', 'hydra', 'canvas', 'regl', 'swgl', 'textmode', 'three'],
   setVideoCount: ['hydra', 'regl', 'swgl', 'three', 'worker'],
   getTexture: ['hydra', 'regl', 'swgl', 'three'],
+  OrbitControls: ['three'],
+  onPointerDrag: ['three'],
+  onWheel: ['three'],
   onVideoFrame: ['worker'],
   getVideoFrames: ['worker'],
   getVfsUrl: [

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -25,7 +25,11 @@
   import { outputSize as outputSizeStore } from '../../../stores/renderer.store';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { SurfaceOverlay } from '$lib/canvas/SurfaceOverlay';
-  import { SurfaceListeners, type PointerEvent_ } from '$lib/canvas/SurfaceListeners';
+  import {
+    SurfaceListeners,
+    type PointerEvent_,
+    type SurfaceWheelEvent_
+  } from '$lib/canvas/SurfaceListeners';
   import { shouldShowHandles } from '../../../stores/ui.store';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { createCustomConsole } from '$lib/utils/createCustomConsole';
@@ -114,9 +118,11 @@
         type: string;
       }) => void)
     | null = null;
+
   let touchCallback:
     | ((touches: { x: number; y: number; pressure: number; id: number }[]) => void)
     | null = null;
+
   let keyboardCallbacks: {
     onKeyDown?: (event: KeyboardEvent) => void;
     onKeyUp?: (event: KeyboardEvent) => void;
@@ -179,6 +185,7 @@
   $effect(() => {
     if (data.executeCode && data.executeCode !== previousExecuteCode) {
       previousExecuteCode = data.executeCode;
+
       runCode();
     }
   });
@@ -240,13 +247,27 @@
 
     mouseForwarder.forward(x, y, buttons, type);
 
-    if (drawMode === 'interact') triggerDraw();
+    if (drawMode === 'interact') {
+      triggerDraw();
+    }
+  }
+
+  function dispatchWheel(x: number, y: number, deltaX: number, deltaY: number, deltaMode: number) {
+    mouse.x = x;
+    mouse.y = y;
+
+    mouseForwarder.forwardWheel({ x, y, deltaX, deltaY, deltaMode });
+
+    if (drawMode === 'interact') {
+      triggerDraw();
+    }
   }
 
   // ── Draw mode & rAF ──────────────────────────────────────────────────────
 
   function triggerDraw() {
     if (drawMode !== 'manual' && drawMode !== 'interact') return;
+
     if (pausedCallback) {
       pausedCallback(performance.now());
       sendBitmap();
@@ -259,6 +280,7 @@
     if (!activeCanvas) return;
     if (!videoOutputEnabled) return;
     if (!glSystem.hasOutgoingVideoConnections(nodeId)) return;
+
     glSystem.setBitmapSource(nodeId, activeCanvas);
   }
 
@@ -272,7 +294,9 @@
         thumbnailFrameId = null;
         return;
       }
+
       previewCtx.drawImage(activeCanvas, 0, 0, previewCanvas.width, previewCanvas.height);
+
       thumbnailFrameId = requestAnimationFrame(copyFrame);
     }
 
@@ -282,6 +306,7 @@
   function stopThumbnailLoop() {
     if (thumbnailFrameId !== null) {
       cancelAnimationFrame(thumbnailFrameId);
+
       thumbnailFrameId = null;
     }
   }
@@ -293,7 +318,12 @@
 
   function listenerOpts() {
     return {
-      onPointer: (e: PointerEvent_) => dispatchPointer(e.x, e.y, e.buttons, e.type),
+      onPointer(e: PointerEvent_) {
+        dispatchPointer(e.x, e.y, e.buttons, e.type);
+      },
+      onWheel(e: SurfaceWheelEvent_) {
+        dispatchWheel(e.x, e.y, e.deltaX, e.deltaY, e.deltaMode);
+      },
       get onTouch() {
         return touchCallback;
       },

--- a/ui/src/lib/components/nodes/ThreeNode.svelte
+++ b/ui/src/lib/components/nodes/ThreeNode.svelte
@@ -31,6 +31,7 @@
   import { SettingsManager, createWorkerSettingsCallbacks } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
+  import { CanvasMouseHandler } from '$lib/canvas/CanvasMouseHandler';
 
   let {
     id: nodeId,
@@ -81,6 +82,7 @@
 
   let audioAnalysisSystem: AudioAnalysisSystem;
   let messageContext: MessageContext;
+  let mouseHandler: CanvasMouseHandler | null = null;
   let previewCanvas = $state<HTMLCanvasElement | undefined>();
   let previewBitmapContext: ImageBitmapRenderingContext;
   let dragEnabled = $state(true);
@@ -104,6 +106,28 @@
       previousExecuteCode = data.executeCode;
       updateThree();
     }
+  });
+
+  $effect(() => {
+    if (!previewCanvas) return;
+
+    mouseHandler = new CanvasMouseHandler({
+      type: 'shadertoy',
+      nodeId,
+      canvas: previewCanvas,
+      outputWidth: $outputWidth,
+      outputHeight: $outputHeight,
+      wheelZoom: true,
+      wheelTarget: 'threeInteraction',
+      flipY: false
+    });
+
+    mouseHandler.attach();
+
+    return () => {
+      mouseHandler?.detach();
+      mouseHandler = null;
+    };
   });
 
   // Event handlers for worker messages
@@ -240,6 +264,7 @@
 
     eventBus.removeEventListener('consoleOutput', handleConsoleOutput);
 
+    mouseHandler?.detach();
     glSystem?.unregisterSettingsCallbacks(nodeId);
     audioAnalysisSystem?.disableFFT(nodeId);
     glSystem?.removeNode(nodeId);
@@ -303,7 +328,7 @@
   }}
 >
   {#snippet topHandle()}
-    {#each Array.from({ length: videoInletCount }) as _, index (index)}
+    {#each Array.from({ length: videoInletCount }, (_, index) => index) as index (index)}
       <TypedHandle
         port="inlet"
         spec={{ handleType: 'video', handleId: index.toString() }}
@@ -315,7 +340,7 @@
       />
     {/each}
 
-    {#each Array.from({ length: messageInletCount }) as _, index (index)}
+    {#each Array.from({ length: messageInletCount }, (_, index) => index) as index (index)}
       <TypedHandle
         port="inlet"
         spec={{ handleType: 'message', handleId: index }}
@@ -330,7 +355,7 @@
 
   {#snippet bottomHandle()}
     {#if videoOutputEnabled}
-      {#each Array.from({ length: videoOutletCount }) as _, index (index)}
+      {#each Array.from({ length: videoOutletCount }, (_, index) => index) as index (index)}
         <TypedHandle
           port="outlet"
           spec={{ handleType: 'video', handleId: index.toString() }}
@@ -343,7 +368,7 @@
       {/each}
     {/if}
 
-    {#each Array.from({ length: messageOutletCount }) as _, index (index)}
+    {#each Array.from({ length: messageOutletCount }, (_, index) => index) as index (index)}
       <TypedHandle
         port="outlet"
         spec={{ handleType: 'message', handleId: index }}

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -268,7 +268,13 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: '3D graphics with Three.js',
     icon: 'Box',
     requiredObjects: ['three', 'glsl'],
-    presets: ['video-cube.three', 'video-torus.three', 'video-sphere.three', 'crate.three']
+    presets: [
+      'video-cube.three',
+      'video-torus.three',
+      'video-sphere.three',
+      'crate.three',
+      'mouse-cube.three'
+    ]
   },
   {
     id: 'gpu-geometry',

--- a/ui/src/lib/objects/schemas/three.ts
+++ b/ui/src/lib/objects/schemas/three.ts
@@ -7,7 +7,7 @@ import { Run, SetCode } from './common';
 export const threeSchema: ObjectSchema = {
   type: 'three',
   category: 'video',
-  description: 'Creates Three.js 3D graphics on web worker',
+  description: 'Creates interactive Three.js 3D graphics on web worker',
   inlets: [
     {
       id: 'message',
@@ -19,7 +19,7 @@ export const threeSchema: ObjectSchema = {
     }
   ],
   outlets: [],
-  tags: ['3d', 'webgl', 'graphics', 'animation', 'scene'],
+  tags: ['3d', 'webgl', 'graphics', 'animation', 'scene', 'interactive'],
   hasDynamicOutlets: true,
   handlePatterns: {
     inlet: {

--- a/ui/src/lib/presets/builtin/three.preset.ts
+++ b/ui/src/lib/presets/builtin/three.preset.ts
@@ -106,6 +106,26 @@ function draw(t) {
   renderer.render(scene, camera)
 }`;
 
+const MOUSE_CUBE_THREE = `const { Scene, PerspectiveCamera, BoxGeometry, Mesh, MeshNormalMaterial } = THREE
+
+const scene = new Scene()
+const camera = new PerspectiveCamera(75, width / height, 0.1, 1000)
+camera.position.z = 3
+
+const controls = new OrbitControls(camera)
+controls.enablePan = true
+controls.enableZoom = true
+
+const geometry = new BoxGeometry(1, 1, 1)
+const material = new MeshNormalMaterial()
+const mesh = new Mesh(geometry, material)
+scene.add(mesh)
+
+function draw() {
+  controls.update()
+  renderer.render(scene, camera)
+}`;
+
 const PIPE_THREE = `const { Scene, OrthographicCamera, PlaneGeometry, Mesh, MeshBasicMaterial } = THREE
 
 setVideoCount(1, 1)
@@ -404,6 +424,7 @@ export const THREE_PRESETS: Record<string, { type: string; data: { code: string 
   'video-torus.three': { type: 'three', data: { code: VIDEO_TORUS_THREE.trim() } },
   'video-sphere.three': { type: 'three', data: { code: VIDEO_SPHERE_THREE.trim() } },
   'crate.three': { type: 'three', data: { code: CRATE_THREE.trim() } },
+  'mouse-cube.three': { type: 'three', data: { code: MOUSE_CUBE_THREE.trim() } },
   'point-cloud-from-texture.three': {
     type: 'three',
     data: { code: POINT_CLOUD_FROM_TEXTURE.trim() }

--- a/ui/src/lib/rendering/types.ts
+++ b/ui/src/lib/rendering/types.ts
@@ -49,7 +49,15 @@ export type RenderNode = {
     }
   | { type: 'canvas'; data: { code: string; fboFormat?: FBOFormat; resolution?: FBOResolution } }
   | { type: 'textmode'; data: { code: string; fboFormat?: FBOFormat; resolution?: FBOResolution } }
-  | { type: 'three'; data: { code: string; fboFormat?: FBOFormat; resolution?: FBOResolution } }
+  | {
+      type: 'three';
+      data: {
+        code: string;
+        fboFormat?: FBOFormat;
+        resolution?: FBOResolution;
+        _runRevision?: number;
+      };
+    }
   | {
       type: 'shaderpark';
       data: {
@@ -126,6 +134,7 @@ export interface RenderParams {
   mouseY: number;
   mouseZ: number;
   mouseW: number;
+  mouseButtons?: number;
   userParams: UserParam[];
 
   /** Global transport time in seconds for synchronized timing */
@@ -176,6 +185,15 @@ export type WorkerMessage =
   | { type: 'stopAnimation' }
   | { type: 'setPreviewEnabled'; nodeId: string; enabled: boolean }
   | { type: 'zoomShaderParkOrbit'; nodeId: string; deltaY: number }
+  | {
+      type: 'sendThreeWheelData';
+      nodeId: string;
+      x?: number;
+      y?: number;
+      deltaX?: number;
+      deltaY: number;
+      deltaMode?: number;
+    }
   | { type: 'animationFrame'; outputBitmap: ImageBitmap }
   | { type: 'updateOutput'; buffer: ArrayBuffer }
   | {

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -102,7 +102,7 @@ export class FBORenderer {
   public nodePausedMap: Map<string, boolean> = new Map();
 
   /** Mapping of nodeID to mouse state (iMouse vec4: xy = current, zw = click) */
-  public mouseDataByNode: Map<string, [number, number, number, number]> = new Map();
+  public mouseDataByNode: Map<string, [number, number, number, number, number?]> = new Map();
 
   public hydraByNode = new Map<string, HydraRenderer | null>();
   public canvasByNode = new Map<string, CanvasRenderer | null>();
@@ -457,8 +457,9 @@ export class FBORenderer {
           node.type === 'shaderpark' &&
           node.data.renderMode === '3d' &&
           this.shaderParkThreeByNode.has(node.id);
+        const isReusableThree = node.type === 'three' && this.threeByNode.has(node.id);
 
-        if (!isHydra && !isShaderPark3D) {
+        if (!isHydra && !isShaderPark3D && !isReusableThree) {
           existingFbo.cleanup?.();
         }
       } else {
@@ -471,8 +472,9 @@ export class FBORenderer {
             node.type === 'shaderpark' &&
             node.data.renderMode === '3d' &&
             this.shaderParkThreeByNode.has(node.id);
+          const isReusableThree = node.type === 'three' && this.threeByNode.has(node.id);
 
-          if (!isHydra && !isShaderPark3D) {
+          if (!isHydra && !isShaderPark3D && !isReusableThree) {
             existingFbo.cleanup?.();
           }
 
@@ -910,16 +912,23 @@ export class FBORenderer {
   ): Promise<{ render: RenderFunction; cleanup: () => void } | null> {
     if (node.type !== 'three') return null;
 
-    // Delete existing three renderer if it exists.
-    if (this.threeByNode.has(node.id)) {
-      this.threeByNode.get(node.id)?.destroy();
+    const existingRenderer = this.threeByNode.get(node.id);
+    const runRevision = node.data._runRevision;
+    const config = { code: node.data.code, nodeId: node.id, runRevision };
+
+    if (existingRenderer) {
+      await existingRenderer.updateConfig(config, framebuffer);
+
+      return {
+        render: existingRenderer.renderFrame.bind(existingRenderer),
+        cleanup: () => {
+          existingRenderer.destroy();
+          this.threeByNode.delete(node.id);
+        }
+      };
     }
 
-    const threeRenderer = await ThreeRenderer.create(
-      { code: node.data.code, nodeId: node.id },
-      framebuffer,
-      this
-    );
+    const threeRenderer = await ThreeRenderer.create(config, framebuffer, this);
 
     this.threeByNode.set(node.id, threeRenderer);
 
@@ -1383,8 +1392,15 @@ export class FBORenderer {
   }
 
   /** Set mouse data for a node (Shadertoy iMouse format) */
-  setMouseData(nodeId: string, x: number, y: number, z: number, w: number) {
-    this.mouseDataByNode.set(nodeId, [x, y, z, w]);
+  setMouseData(nodeId: string, x: number, y: number, z: number, w: number, buttons?: number) {
+    this.mouseDataByNode.set(nodeId, [x, y, z, w, buttons]);
+  }
+
+  sendThreeWheelData(
+    nodeId: string,
+    event: { x?: number; y?: number; deltaX?: number; deltaY: number; deltaMode?: number }
+  ) {
+    this.threeByNode.get(nodeId)?.handleWheelData(event);
   }
 
   zoomShaderParkOrbit(nodeId: string, deltaY: number) {
@@ -1577,6 +1593,7 @@ export class FBORenderer {
           mouseY: mouseData[1],
           mouseZ: mouseData[2],
           mouseW: mouseData[3],
+          mouseButtons: mouseData[4],
           userParams: userUniformParams as UserParam[],
           transportTime
         });

--- a/ui/src/workers/rendering/renderWorker.ts
+++ b/ui/src/workers/rendering/renderWorker.ts
@@ -43,9 +43,18 @@ self.onmessage = (event) => {
       fboRenderer.setUniformData(data.nodeId, data.uniformName, data.uniformValue)
     )
     .with('setMouseData', () =>
-      fboRenderer.setMouseData(data.nodeId, data.x, data.y, data.z, data.w)
+      fboRenderer.setMouseData(data.nodeId, data.x, data.y, data.z, data.w, data.buttons)
     )
     .with('zoomShaderParkOrbit', () => fboRenderer.zoomShaderParkOrbit(data.nodeId, data.deltaY))
+    .with('sendThreeWheelData', () =>
+      fboRenderer.sendThreeWheelData(data.nodeId, {
+        x: data.x,
+        y: data.y,
+        deltaX: data.deltaX,
+        deltaY: data.deltaY,
+        deltaMode: data.deltaMode
+      })
+    )
     .with('setOutputSize', () => fboRenderer.setOutputSize(data.width, data.height))
     .with('setBackgroundSize', () => fboRenderer.setBackgroundSize(data.width, data.height))
     .with('setBitmap', () => fboRenderer.setBitmap(data.nodeId, data.bitmap))

--- a/ui/src/workers/rendering/threeRenderer.test.ts
+++ b/ui/src/workers/rendering/threeRenderer.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ThreeRenderer } from './threeRenderer';
+
+describe('ThreeRenderer', () => {
+  it('resizes the Three renderer and render target when the framebuffer size changes', async () => {
+    const previousFramebuffer = { width: 100, height: 50 };
+    const nextFramebuffer = { width: 200, height: 100 };
+    const renderer = Object.create(ThreeRenderer.prototype) as ThreeRenderer & {
+      config: { code: string; nodeId: string; runRevision: number };
+      framebuffer: typeof previousFramebuffer;
+      threeWebGLRenderer: { setSize: ReturnType<typeof vi.fn> };
+      renderTarget: { setSize: ReturnType<typeof vi.fn> };
+      updateCode: ReturnType<typeof vi.fn>;
+    };
+
+    renderer.config = { code: 'old code', nodeId: 'three-node', runRevision: 1 };
+    renderer.framebuffer = previousFramebuffer;
+    renderer.threeWebGLRenderer = { setSize: vi.fn() };
+    renderer.renderTarget = { setSize: vi.fn() };
+    renderer.updateCode = vi.fn().mockResolvedValue(undefined);
+
+    await renderer.updateConfig(
+      { code: 'new code', nodeId: 'three-node', runRevision: 2 },
+      nextFramebuffer as never
+    );
+
+    expect(renderer.threeWebGLRenderer.setSize).toHaveBeenCalledWith(200, 100, false);
+    expect(renderer.renderTarget.setSize).toHaveBeenCalledWith(200, 100);
+    expect(renderer.updateCode).toHaveBeenCalledTimes(1);
+    expect(renderer.threeWebGLRenderer.setSize.mock.invocationCallOrder[0]).toBeLessThan(
+      renderer.updateCode.mock.invocationCallOrder[0]
+    );
+  });
+});

--- a/ui/src/workers/rendering/threeRenderer.test.ts
+++ b/ui/src/workers/rendering/threeRenderer.test.ts
@@ -5,7 +5,8 @@ describe('ThreeRenderer', () => {
   it('resizes the Three renderer and render target when the framebuffer size changes', async () => {
     const previousFramebuffer = { width: 100, height: 50 };
     const nextFramebuffer = { width: 200, height: 100 };
-    const renderer = Object.create(ThreeRenderer.prototype) as ThreeRenderer & {
+    const renderer = Object.create(ThreeRenderer.prototype) as {
+      updateConfig: ThreeRenderer['updateConfig'];
       config: { code: string; nodeId: string; runRevision: number };
       framebuffer: typeof previousFramebuffer;
       threeWebGLRenderer: { setSize: ReturnType<typeof vi.fn> };
@@ -21,7 +22,7 @@ describe('ThreeRenderer', () => {
 
     await renderer.updateConfig(
       { code: 'new code', nodeId: 'three-node', runRevision: 2 },
-      nextFramebuffer as never
+      nextFramebuffer as unknown as Parameters<ThreeRenderer['updateConfig']>[1]
     );
 
     expect(renderer.threeWebGLRenderer.setSize).toHaveBeenCalledWith(200, 100, false);

--- a/ui/src/workers/rendering/threeRenderer.ts
+++ b/ui/src/workers/rendering/threeRenderer.ts
@@ -89,6 +89,7 @@ export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
     // Update mouse state from render params
     this.mouseX = params.mouseX;
     this.mouseY = params.mouseY;
+
     this.interaction.updatePointer({
       mouseX: params.mouseX,
       mouseY: params.mouseY,
@@ -96,6 +97,7 @@ export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
       mouseW: params.mouseW,
       mouseButtons: params.mouseButtons
     });
+
     this.interaction.flushWheelCallbacks();
 
     // Store input textures for getTexture() access
@@ -171,6 +173,7 @@ export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
       const THREE = this.THREE;
       const renderer = this.threeWebGLRenderer;
       const renderTarget = this.renderTarget;
+
       const OrbitControls = createWorkerOrbitControlsClass(
         THREE,
         this.interaction,

--- a/ui/src/workers/rendering/threeRenderer.ts
+++ b/ui/src/workers/rendering/threeRenderer.ts
@@ -14,6 +14,11 @@ type ThreeRendererConfig = BaseRendererConfig & {
   runRevision?: number;
 };
 
+type SizedFramebuffer = regl.Framebuffer2D & {
+  width: number;
+  height: number;
+};
+
 export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
   private animationId: number | null = null;
 
@@ -222,9 +227,19 @@ export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
   async updateConfig(config: ThreeRendererConfig, framebuffer: regl.Framebuffer2D) {
     const shouldUpdateCode =
       this.config.code !== config.code || this.config.runRevision !== config.runRevision;
+    const previousFramebuffer = this.framebuffer as SizedFramebuffer | null;
+    const nextFramebuffer = framebuffer as SizedFramebuffer;
+    const didFramebufferSizeChange =
+      previousFramebuffer?.width !== nextFramebuffer.width ||
+      previousFramebuffer?.height !== nextFramebuffer.height;
 
     this.config = config;
     this.framebuffer = framebuffer;
+
+    if (didFramebufferSizeChange) {
+      this.threeWebGLRenderer?.setSize(nextFramebuffer.width, nextFramebuffer.height, false);
+      this.renderTarget?.setSize(nextFramebuffer.width, nextFramebuffer.height);
+    }
 
     if (shouldUpdateCode) {
       await this.updateCode();

--- a/ui/src/workers/rendering/threeRenderer.ts
+++ b/ui/src/workers/rendering/threeRenderer.ts
@@ -4,8 +4,17 @@ import type { RenderParams } from '$lib/rendering/types';
 import { getFramebuffer } from './utils';
 import { THREE_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
 import { BaseWorkerRenderer, type BaseRendererConfig } from './BaseWorkerRenderer';
+import {
+  WorkerThreeInteraction,
+  createWorkerOrbitControlsClass,
+  type WorkerWheelEvent
+} from './workerThreeInteraction';
 
-export class ThreeRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
+type ThreeRendererConfig = BaseRendererConfig & {
+  runRevision?: number;
+};
+
+export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
   private animationId: number | null = null;
 
   // Three.js instances
@@ -21,9 +30,10 @@ export class ThreeRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
 
   // Three.js textures wrapping regl textures
   private threeInputTextures: import('three').Texture[] = [];
+  private interaction = new WorkerThreeInteraction();
 
   private constructor(
-    config: BaseRendererConfig,
+    config: ThreeRendererConfig,
     framebuffer: regl.Framebuffer2D,
     renderer: FBORenderer
   ) {
@@ -31,7 +41,7 @@ export class ThreeRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
   }
 
   static async create(
-    config: BaseRendererConfig,
+    config: ThreeRendererConfig,
     framebuffer: regl.Framebuffer2D,
     renderer: FBORenderer
   ): Promise<ThreeRenderer> {
@@ -79,6 +89,14 @@ export class ThreeRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
     // Update mouse state from render params
     this.mouseX = params.mouseX;
     this.mouseY = params.mouseY;
+    this.interaction.updatePointer({
+      mouseX: params.mouseX,
+      mouseY: params.mouseY,
+      mouseZ: params.mouseZ,
+      mouseW: params.mouseW,
+      mouseButtons: params.mouseButtons
+    });
+    this.interaction.flushWheelCallbacks();
 
     // Store input textures for getTexture() access
     this.inputTextures = params.userParams as (regl.Texture2D | undefined)[];
@@ -141,6 +159,7 @@ export class ThreeRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
     if (!this.THREE || !this.threeWebGLRenderer || !this.renderTarget) return;
 
     this.resetState();
+    this.interaction.clearCallbacks();
 
     // Cancel any existing animation frame
     if (this.animationId !== null) {
@@ -152,14 +171,23 @@ export class ThreeRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
       const THREE = this.THREE;
       const renderer = this.threeWebGLRenderer;
       const renderTarget = this.renderTarget;
+      const OrbitControls = createWorkerOrbitControlsClass(
+        THREE,
+        this.interaction,
+        () => this.renderer.outputSize
+      );
 
       const extraContext = {
         ...this.buildBaseExtraContext(),
         THREE,
+        OrbitControls,
         renderer,
         renderTarget,
+        mouse: this.interaction.mouse,
         setVideoCount: this.setVideoCount.bind(this),
         getTexture: this.getTexture.bind(this),
+        onPointerDrag: this.interaction.onPointerDrag.bind(this.interaction),
+        onWheel: this.interaction.onWheel.bind(this.interaction),
         requestAnimationFrame: () => {}
       };
 
@@ -185,6 +213,36 @@ export class ThreeRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
     } catch (error) {
       this.handleCodeError(error, THREE_WRAPPER_OFFSET);
     }
+  }
+
+  async updateConfig(config: ThreeRendererConfig, framebuffer: regl.Framebuffer2D) {
+    const shouldUpdateCode =
+      this.config.code !== config.code || this.config.runRevision !== config.runRevision;
+
+    this.config = config;
+    this.framebuffer = framebuffer;
+
+    if (shouldUpdateCode) {
+      await this.updateCode();
+    }
+  }
+
+  handleWheelData(event: {
+    x?: number;
+    y?: number;
+    deltaX?: number;
+    deltaY: number;
+    deltaMode?: number;
+  }) {
+    const wheelEvent: WorkerWheelEvent = {
+      x: event.x ?? this.mouseX,
+      y: event.y ?? this.mouseY,
+      deltaX: event.deltaX ?? 0,
+      deltaY: event.deltaY,
+      deltaMode: event.deltaMode ?? 0
+    };
+
+    this.interaction.queueWheel(wheelEvent);
   }
 
   destroy() {

--- a/ui/src/workers/rendering/threeRenderer.ts
+++ b/ui/src/workers/rendering/threeRenderer.ts
@@ -174,7 +174,8 @@ export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
       const OrbitControls = createWorkerOrbitControlsClass(
         THREE,
         this.interaction,
-        () => this.renderer.outputSize
+        () => this.renderer.outputSize,
+        () => this.disablePatchCanvasCameraInteractions()
       );
 
       const extraContext = {
@@ -243,6 +244,11 @@ export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
     };
 
     this.interaction.queueWheel(wheelEvent);
+  }
+
+  private disablePatchCanvasCameraInteractions() {
+    this.setInteraction('drag', false);
+    this.setInteraction('wheel', false);
   }
 
   destroy() {

--- a/ui/src/workers/rendering/workerThreeInteraction.test.ts
+++ b/ui/src/workers/rendering/workerThreeInteraction.test.ts
@@ -85,4 +85,39 @@ describe('worker three interaction', () => {
     expect(controls.target.x).not.toBeCloseTo(0);
     expect(camera.position.x).not.toBeCloseTo(0);
   });
+
+  it('supports OrbitControls world-space panning when screenSpacePanning is disabled', () => {
+    const createCamera = () => {
+      const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+      camera.position.set(0, 3, 3);
+      camera.lookAt(0, 0, 0);
+      camera.updateMatrix();
+
+      return camera;
+    };
+
+    const screenInteraction = new WorkerThreeInteraction();
+    const ScreenOrbitControls = createWorkerOrbitControlsClass(THREE, screenInteraction, () => [
+      100, 100
+    ]);
+    const screenCamera = createCamera();
+    const screenControls = new ScreenOrbitControls(screenCamera);
+
+    screenControls.pan(0, 10);
+    screenControls.update();
+
+    const worldInteraction = new WorkerThreeInteraction();
+    const WorldOrbitControls = createWorkerOrbitControlsClass(THREE, worldInteraction, () => [
+      100, 100
+    ]);
+    const worldCamera = createCamera();
+    const worldControls = new WorldOrbitControls(worldCamera);
+
+    worldControls.screenSpacePanning = false;
+    worldControls.pan(0, 10);
+    worldControls.update();
+
+    expect(worldControls.target.z).not.toBeCloseTo(screenControls.target.z);
+    expect(worldCamera.position.z).not.toBeCloseTo(screenCamera.position.z);
+  });
 });

--- a/ui/src/workers/rendering/workerThreeInteraction.test.ts
+++ b/ui/src/workers/rendering/workerThreeInteraction.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { WorkerThreeInteraction, createWorkerOrbitControlsClass } from './workerThreeInteraction';
 import * as THREE from 'three';
 
@@ -33,8 +33,10 @@ describe('worker three interaction', () => {
   it('mimics OrbitControls rotation and wheel dolly for a perspective camera', () => {
     const interaction = new WorkerThreeInteraction();
     const OrbitControls = createWorkerOrbitControlsClass(THREE, interaction, () => [100, 100]);
+
     const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
     camera.position.set(0, 0, 3);
+
     const controls = new OrbitControls(camera);
 
     interaction.updatePointer({ mouseX: 50, mouseY: 50, mouseZ: 50, mouseW: 50, mouseButtons: 1 });
@@ -50,10 +52,29 @@ describe('worker three interaction', () => {
     expect(controls.getDistance()).toBeLessThan(distance);
   });
 
+  it('notifies when OrbitControls are registered', () => {
+    const interaction = new WorkerThreeInteraction();
+    const onRegister = vi.fn();
+
+    const OrbitControls = createWorkerOrbitControlsClass(
+      THREE,
+      interaction,
+      () => [100, 100],
+      onRegister
+    );
+
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+    new OrbitControls(camera);
+
+    expect(onRegister).toHaveBeenCalledTimes(1);
+  });
+
   it('mimics OrbitControls right-button panning', () => {
     const interaction = new WorkerThreeInteraction();
+
     const OrbitControls = createWorkerOrbitControlsClass(THREE, interaction, () => [100, 100]);
     const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+
     camera.position.set(0, 0, 3);
     const controls = new OrbitControls(camera);
 

--- a/ui/src/workers/rendering/workerThreeInteraction.test.ts
+++ b/ui/src/workers/rendering/workerThreeInteraction.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { WorkerThreeInteraction, createWorkerOrbitControlsClass } from './workerThreeInteraction';
+import * as THREE from 'three';
+
+describe('worker three interaction', () => {
+  it('emits raw drag events from forwarded pointer state', () => {
+    const interaction = new WorkerThreeInteraction();
+    const events: Array<{ dx: number; dy: number; buttons: number; down: boolean }> = [];
+
+    interaction.onPointerDrag((event) => events.push(event));
+    interaction.updatePointer({ mouseX: 10, mouseY: 20, mouseZ: 10, mouseW: 20, mouseButtons: 1 });
+    interaction.updatePointer({ mouseX: 16, mouseY: 28, mouseZ: 10, mouseW: 20, mouseButtons: 1 });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ dx: 0, dy: 0, buttons: 1, down: true });
+    expect(events[1]).toMatchObject({ dx: 6, dy: 8, buttons: 1, down: true });
+    expect(interaction.mouse.dx).toBe(6);
+    expect(interaction.mouse.dy).toBe(8);
+  });
+
+  it('emits raw wheel events and stores the latest wheel delta', () => {
+    const interaction = new WorkerThreeInteraction();
+    const events: Array<{ deltaX: number; deltaY: number; deltaMode: number }> = [];
+
+    interaction.onWheel((event) => events.push(event));
+    interaction.queueWheel({ x: 20, y: 30, deltaX: 1, deltaY: -120, deltaMode: 0 });
+    interaction.flushWheelCallbacks();
+
+    expect(events).toEqual([{ x: 20, y: 30, deltaX: 1, deltaY: -120, deltaMode: 0 }]);
+    expect(interaction.mouse.wheelDelta).toBe(-120);
+  });
+
+  it('mimics OrbitControls rotation and wheel dolly for a perspective camera', () => {
+    const interaction = new WorkerThreeInteraction();
+    const OrbitControls = createWorkerOrbitControlsClass(THREE, interaction, () => [100, 100]);
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+    camera.position.set(0, 0, 3);
+    const controls = new OrbitControls(camera);
+
+    interaction.updatePointer({ mouseX: 50, mouseY: 50, mouseZ: 50, mouseW: 50, mouseButtons: 1 });
+    interaction.updatePointer({ mouseX: 70, mouseY: 60, mouseZ: 50, mouseW: 50, mouseButtons: 1 });
+    controls.update();
+
+    expect(camera.position.x).not.toBeCloseTo(0);
+
+    const distance = controls.getDistance();
+    interaction.queueWheel({ x: 70, y: 60, deltaX: 0, deltaY: -120, deltaMode: 0 });
+    controls.update();
+
+    expect(controls.getDistance()).toBeLessThan(distance);
+  });
+
+  it('mimics OrbitControls right-button panning', () => {
+    const interaction = new WorkerThreeInteraction();
+    const OrbitControls = createWorkerOrbitControlsClass(THREE, interaction, () => [100, 100]);
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+    camera.position.set(0, 0, 3);
+    const controls = new OrbitControls(camera);
+
+    interaction.updatePointer({ mouseX: 50, mouseY: 50, mouseZ: 50, mouseW: 50, mouseButtons: 2 });
+    interaction.updatePointer({ mouseX: 70, mouseY: 60, mouseZ: 50, mouseW: 50, mouseButtons: 2 });
+    controls.update();
+
+    expect(controls.target.x).not.toBeCloseTo(0);
+    expect(camera.position.x).not.toBeCloseTo(0);
+  });
+});

--- a/ui/src/workers/rendering/workerThreeInteraction.ts
+++ b/ui/src/workers/rendering/workerThreeInteraction.ts
@@ -1,0 +1,372 @@
+import type { OrthographicCamera, PerspectiveCamera, Spherical, Vector3 } from 'three';
+
+type ThreeModule = typeof import('three');
+type ControlledCamera = PerspectiveCamera | OrthographicCamera;
+
+export type WorkerPointerState = {
+  mouseX: number;
+  mouseY: number;
+  mouseZ: number;
+  mouseW: number;
+  mouseButtons?: number;
+};
+
+export type WorkerPointerDragEvent = {
+  x: number;
+  y: number;
+  dx: number;
+  dy: number;
+  startX: number;
+  startY: number;
+  buttons: number;
+  down: boolean;
+};
+
+export type WorkerWheelEvent = {
+  x: number;
+  y: number;
+  deltaX: number;
+  deltaY: number;
+  deltaMode: number;
+};
+
+type OrbitSnapshot = {
+  position: [number, number, number];
+  target: [number, number, number];
+  zoom?: number;
+};
+
+export class WorkerThreeInteraction {
+  readonly mouse = {
+    x: 0,
+    y: 0,
+    down: false,
+    buttons: 0,
+    dx: 0,
+    dy: 0,
+    wheelDelta: 0
+  };
+
+  private dragCallbacks = new Set<(event: WorkerPointerDragEvent) => void>();
+  private wheelCallbacks = new Set<(event: WorkerWheelEvent) => void>();
+  private dragEvents: WorkerPointerDragEvent[] = [];
+  private wheelEvents: WorkerWheelEvent[] = [];
+  private notifiedWheelCount = 0;
+  private lastX = 0;
+  private lastY = 0;
+  private hasPointer = false;
+  private orbitSnapshot: OrbitSnapshot | null = null;
+
+  onPointerDrag(callback: (event: WorkerPointerDragEvent) => void) {
+    this.dragCallbacks.add(callback);
+
+    return () => this.dragCallbacks.delete(callback);
+  }
+
+  onWheel(callback: (event: WorkerWheelEvent) => void) {
+    this.wheelCallbacks.add(callback);
+
+    return () => this.wheelCallbacks.delete(callback);
+  }
+
+  clearCallbacks() {
+    this.dragCallbacks.clear();
+    this.wheelCallbacks.clear();
+  }
+
+  updatePointer(pointer: WorkerPointerState) {
+    const down = pointer.mouseZ >= 0 && pointer.mouseW >= 0;
+    const x = pointer.mouseX;
+    const y = pointer.mouseY;
+    const buttons = pointer.mouseButtons ?? (down ? 1 : 0);
+    const dx = this.hasPointer ? x - this.lastX : 0;
+    const dy = this.hasPointer ? y - this.lastY : 0;
+
+    this.mouse.x = x;
+    this.mouse.y = y;
+    this.mouse.down = down;
+    this.mouse.buttons = buttons;
+    this.mouse.dx = down ? dx : 0;
+    this.mouse.dy = down ? dy : 0;
+
+    this.lastX = x;
+    this.lastY = y;
+    this.hasPointer = true;
+
+    if (!down) {
+      this.dragEvents = [];
+      return;
+    }
+
+    const event: WorkerPointerDragEvent = {
+      x,
+      y,
+      dx,
+      dy,
+      startX: Math.abs(pointer.mouseZ),
+      startY: Math.abs(pointer.mouseW),
+      buttons,
+      down
+    };
+
+    this.dragEvents.push(event);
+
+    for (const callback of this.dragCallbacks) {
+      callback(event);
+    }
+  }
+
+  queueWheel(event: WorkerWheelEvent) {
+    this.mouse.x = event.x;
+    this.mouse.y = event.y;
+    this.mouse.wheelDelta = event.deltaY;
+    this.wheelEvents.push(event);
+  }
+
+  flushWheelCallbacks() {
+    for (const event of this.wheelEvents.slice(this.notifiedWheelCount)) {
+      for (const callback of this.wheelCallbacks) {
+        callback(event);
+      }
+    }
+
+    this.notifiedWheelCount = this.wheelEvents.length;
+  }
+
+  consumeDragEvents() {
+    const events = this.dragEvents;
+    this.dragEvents = [];
+    return events;
+  }
+
+  consumeWheelEvents() {
+    const events = this.wheelEvents;
+    this.wheelEvents = [];
+    this.notifiedWheelCount = 0;
+    return events;
+  }
+
+  saveOrbitSnapshot(camera: ControlledCamera, target: Vector3) {
+    this.orbitSnapshot = {
+      position: camera.position.toArray() as [number, number, number],
+      target: target.toArray() as [number, number, number],
+      zoom: 'zoom' in camera ? camera.zoom : undefined
+    };
+  }
+
+  restoreOrbitSnapshot(camera: ControlledCamera, target: Vector3) {
+    if (!this.orbitSnapshot) return false;
+
+    camera.position.fromArray(this.orbitSnapshot.position);
+    target.fromArray(this.orbitSnapshot.target);
+
+    if ('zoom' in camera && this.orbitSnapshot.zoom !== undefined) {
+      camera.zoom = this.orbitSnapshot.zoom;
+      camera.updateProjectionMatrix();
+    }
+
+    return true;
+  }
+}
+
+export function createWorkerOrbitControlsClass(
+  THREE: ThreeModule,
+  interaction: WorkerThreeInteraction,
+  getSize: () => [number, number]
+) {
+  return class OrbitControls {
+    enabled = true;
+    enableRotate = true;
+    enablePan = true;
+    enableZoom = true;
+    rotateSpeed = 1;
+    panSpeed = 1;
+    zoomSpeed = 1;
+    minDistance = 0;
+    maxDistance = Infinity;
+    screenSpacePanning = true;
+    mouseButtons = {
+      LEFT: THREE.MOUSE.ROTATE,
+      MIDDLE: THREE.MOUSE.DOLLY,
+      RIGHT: THREE.MOUSE.PAN
+    };
+    target: Vector3;
+
+    private spherical: Spherical;
+    private position0: Vector3;
+    private target0: Vector3;
+    private zoom0: number;
+
+    constructor(
+      public object: ControlledCamera,
+      public domElement?: unknown
+    ) {
+      this.target = new THREE.Vector3();
+      interaction.restoreOrbitSnapshot(object, this.target);
+      this.spherical = new THREE.Spherical().setFromVector3(
+        object.position.clone().sub(this.target)
+      );
+      this.position0 = object.position.clone();
+      this.target0 = this.target.clone();
+      this.zoom0 = 'zoom' in object ? object.zoom : 1;
+      this.update();
+    }
+
+    update() {
+      if (!this.enabled) return false;
+
+      let changed = false;
+
+      for (const event of interaction.consumeDragEvents()) {
+        changed = this.applyDragEvent(event) || changed;
+      }
+
+      for (const event of interaction.consumeWheelEvents()) {
+        if (!this.enableZoom) continue;
+
+        const zoomFactor = Math.exp(event.deltaY * 0.001 * this.zoomSpeed);
+        this.spherical.radius *= zoomFactor;
+        changed = true;
+      }
+
+      this.applyCamera();
+      interaction.saveOrbitSnapshot(this.object, this.target);
+
+      return changed;
+    }
+
+    dispose() {}
+
+    saveState() {
+      this.position0.copy(this.object.position);
+      this.target0.copy(this.target);
+      this.zoom0 = 'zoom' in this.object ? this.object.zoom : 1;
+    }
+
+    reset() {
+      this.object.position.copy(this.position0);
+      this.target.copy(this.target0);
+
+      if ('zoom' in this.object) {
+        this.object.zoom = this.zoom0;
+        this.object.updateProjectionMatrix();
+      }
+
+      this.syncSphericalFromCamera();
+      this.applyCamera();
+    }
+
+    getDistance() {
+      return this.object.position.distanceTo(this.target);
+    }
+
+    getAzimuthalAngle() {
+      return this.spherical.theta;
+    }
+
+    getPolarAngle() {
+      return this.spherical.phi;
+    }
+
+    rotateLeft(angle: number) {
+      this.spherical.theta -= angle;
+    }
+
+    rotateUp(angle: number) {
+      this.spherical.phi -= angle;
+    }
+
+    pan(deltaX: number, deltaY: number) {
+      this.applyPan(deltaX, deltaY);
+    }
+
+    dollyIn(dollyScale: number) {
+      this.spherical.radius /= dollyScale;
+    }
+
+    dollyOut(dollyScale: number) {
+      this.spherical.radius *= dollyScale;
+    }
+
+    private applyDragEvent(event: WorkerPointerDragEvent) {
+      const action = this.getMouseAction(event.buttons);
+
+      if (action === THREE.MOUSE.PAN && this.enablePan) {
+        this.applyPan(event.dx, event.dy);
+        return true;
+      }
+
+      if (action === THREE.MOUSE.DOLLY && this.enableZoom) {
+        this.spherical.radius *= Math.exp(event.dy * 0.01 * this.zoomSpeed);
+        return true;
+      }
+
+      if (action === THREE.MOUSE.ROTATE && this.enableRotate) {
+        const [, height] = getSize();
+        const safeHeight = Math.max(1, height);
+
+        this.rotateLeft(((2 * Math.PI * event.dx) / safeHeight) * this.rotateSpeed);
+        this.rotateUp(((2 * Math.PI * event.dy) / safeHeight) * this.rotateSpeed);
+        return true;
+      }
+
+      return false;
+    }
+
+    private getMouseAction(buttons: number) {
+      if ((buttons & 2) === 2) return this.mouseButtons.RIGHT;
+      if ((buttons & 4) === 4) return this.mouseButtons.MIDDLE;
+      return this.mouseButtons.LEFT;
+    }
+
+    private applyPan(deltaX: number, deltaY: number) {
+      const [, height] = getSize();
+      const safeHeight = Math.max(1, height);
+      const offset = this.object.position.clone().sub(this.target);
+      const targetDistance = this.getPerspectiveTargetDistance(offset);
+      const panX = ((2 * deltaX * targetDistance) / safeHeight) * this.panSpeed;
+      const panY = ((2 * deltaY * targetDistance) / safeHeight) * this.panSpeed;
+      const panOffset = new THREE.Vector3();
+      const matrix = this.object.matrix;
+
+      panOffset.setFromMatrixColumn(matrix, 0).multiplyScalar(-panX);
+      this.object.position.add(panOffset);
+      this.target.add(panOffset);
+
+      panOffset.setFromMatrixColumn(matrix, 1).multiplyScalar(panY);
+      this.object.position.add(panOffset);
+      this.target.add(panOffset);
+
+      this.syncSphericalFromCamera();
+    }
+
+    private getPerspectiveTargetDistance(offset: Vector3) {
+      if ('isPerspectiveCamera' in this.object && this.object.isPerspectiveCamera) {
+        return (
+          offset.length() * Math.tan(((this.object as PerspectiveCamera).fov / 2) * (Math.PI / 180))
+        );
+      }
+
+      return offset.length();
+    }
+
+    private syncSphericalFromCamera() {
+      this.spherical.setFromVector3(this.object.position.clone().sub(this.target));
+    }
+
+    private applyCamera() {
+      this.spherical.makeSafe();
+      this.spherical.radius = Math.max(
+        this.minDistance,
+        Math.min(this.maxDistance, this.spherical.radius)
+      );
+
+      const offset = new THREE.Vector3().setFromSpherical(this.spherical);
+      this.object.position.copy(this.target).add(offset);
+      this.object.lookAt(this.target);
+      this.object.updateProjectionMatrix();
+    }
+  };
+}
+
+export type WorkerOrbitControls = InstanceType<ReturnType<typeof createWorkerOrbitControlsClass>>;

--- a/ui/src/workers/rendering/workerThreeInteraction.ts
+++ b/ui/src/workers/rendering/workerThreeInteraction.ts
@@ -172,7 +172,8 @@ export class WorkerThreeInteraction {
 export function createWorkerOrbitControlsClass(
   THREE: ThreeModule,
   interaction: WorkerThreeInteraction,
-  getSize: () => [number, number]
+  getSize: () => [number, number],
+  onRegister?: () => void
 ) {
   return class OrbitControls {
     enabled = true;
@@ -209,6 +210,7 @@ export function createWorkerOrbitControlsClass(
       this.position0 = object.position.clone();
       this.target0 = this.target.clone();
       this.zoom0 = 'zoom' in object ? object.zoom : 1;
+      onRegister?.();
       this.update();
     }
 

--- a/ui/src/workers/rendering/workerThreeInteraction.ts
+++ b/ui/src/workers/rendering/workerThreeInteraction.ts
@@ -95,6 +95,7 @@ export class WorkerThreeInteraction {
 
     if (!down) {
       this.dragEvents = [];
+
       return;
     }
 
@@ -120,6 +121,7 @@ export class WorkerThreeInteraction {
     this.mouse.x = event.x;
     this.mouse.y = event.y;
     this.mouse.wheelDelta = event.deltaY;
+
     this.wheelEvents.push(event);
   }
 
@@ -136,6 +138,7 @@ export class WorkerThreeInteraction {
   consumeDragEvents() {
     const events = this.dragEvents;
     this.dragEvents = [];
+
     return events;
   }
 
@@ -143,6 +146,7 @@ export class WorkerThreeInteraction {
     const events = this.wheelEvents;
     this.wheelEvents = [];
     this.notifiedWheelCount = 0;
+
     return events;
   }
 
@@ -186,11 +190,13 @@ export function createWorkerOrbitControlsClass(
     minDistance = 0;
     maxDistance = Infinity;
     screenSpacePanning = true;
+
     mouseButtons = {
       LEFT: THREE.MOUSE.ROTATE,
       MIDDLE: THREE.MOUSE.DOLLY,
       RIGHT: THREE.MOUSE.PAN
     };
+
     target: Vector3;
 
     private spherical: Spherical;
@@ -198,18 +204,18 @@ export function createWorkerOrbitControlsClass(
     private target0: Vector3;
     private zoom0: number;
 
-    constructor(
-      public object: ControlledCamera,
-      public domElement?: unknown
-    ) {
+    constructor(public object: ControlledCamera) {
       this.target = new THREE.Vector3();
       interaction.restoreOrbitSnapshot(object, this.target);
+
       this.spherical = new THREE.Spherical().setFromVector3(
         object.position.clone().sub(this.target)
       );
+
       this.position0 = object.position.clone();
       this.target0 = this.target.clone();
       this.zoom0 = 'zoom' in object ? object.zoom : 1;
+
       onRegister?.();
       this.update();
     }
@@ -295,11 +301,13 @@ export function createWorkerOrbitControlsClass(
 
       if (action === THREE.MOUSE.PAN && this.enablePan) {
         this.applyPan(event.dx, event.dy);
+
         return true;
       }
 
       if (action === THREE.MOUSE.DOLLY && this.enableZoom) {
         this.spherical.radius *= Math.exp(event.dy * 0.01 * this.zoomSpeed);
+
         return true;
       }
 
@@ -309,6 +317,7 @@ export function createWorkerOrbitControlsClass(
 
         this.rotateLeft(((2 * Math.PI * event.dx) / safeHeight) * this.rotateSpeed);
         this.rotateUp(((2 * Math.PI * event.dy) / safeHeight) * this.rotateSpeed);
+
         return true;
       }
 
@@ -318,16 +327,20 @@ export function createWorkerOrbitControlsClass(
     private getMouseAction(buttons: number) {
       if ((buttons & 2) === 2) return this.mouseButtons.RIGHT;
       if ((buttons & 4) === 4) return this.mouseButtons.MIDDLE;
+
       return this.mouseButtons.LEFT;
     }
 
     private applyPan(deltaX: number, deltaY: number) {
       const [, height] = getSize();
       const safeHeight = Math.max(1, height);
+
       const offset = this.object.position.clone().sub(this.target);
       const targetDistance = this.getPerspectiveTargetDistance(offset);
+
       const panX = ((2 * deltaX * targetDistance) / safeHeight) * this.panSpeed;
       const panY = ((2 * deltaY * targetDistance) / safeHeight) * this.panSpeed;
+
       const panOffset = new THREE.Vector3();
       const matrix = this.object.matrix;
 
@@ -358,6 +371,7 @@ export function createWorkerOrbitControlsClass(
 
     private applyCamera() {
       this.spherical.makeSafe();
+
       this.spherical.radius = Math.max(
         this.minDistance,
         Math.min(this.maxDistance, this.spherical.radius)
@@ -365,6 +379,7 @@ export function createWorkerOrbitControlsClass(
 
       const offset = new THREE.Vector3().setFromSpherical(this.spherical);
       this.object.position.copy(this.target).add(offset);
+
       this.object.lookAt(this.target);
       this.object.updateProjectionMatrix();
     }

--- a/ui/src/workers/rendering/workerThreeInteraction.ts
+++ b/ui/src/workers/rendering/workerThreeInteraction.ts
@@ -342,13 +342,20 @@ export function createWorkerOrbitControlsClass(
       const panY = ((2 * deltaY * targetDistance) / safeHeight) * this.panSpeed;
 
       const panOffset = new THREE.Vector3();
-      const matrix = this.object.matrix;
+      this.object.updateMatrixWorld();
 
-      panOffset.setFromMatrixColumn(matrix, 0).multiplyScalar(-panX);
+      const nextMatrix = this.object.matrixWorld;
+      panOffset.setFromMatrixColumn(nextMatrix, 0).multiplyScalar(-panX);
+
       this.object.position.add(panOffset);
       this.target.add(panOffset);
 
-      panOffset.setFromMatrixColumn(matrix, 1).multiplyScalar(panY);
+      if (this.screenSpacePanning) {
+        panOffset.setFromMatrixColumn(nextMatrix, 1).multiplyScalar(panY);
+      } else {
+        panOffset.setFromMatrixColumn(nextMatrix, 0).cross(this.object.up).multiplyScalar(-panY);
+      }
+
       this.object.position.add(panOffset);
       this.target.add(panOffset);
 

--- a/ui/static/content/objects/three.dom.md
+++ b/ui/static/content/objects/three.dom.md
@@ -1,4 +1,4 @@
-The `three.dom` object creates 3D graphics using [Three.js](https://threejs.org). It runs on the main thread with full interactivity support.
+The `three.dom` object creates 3D graphics using [Three.js](https://threejs.org). It runs on the main thread for low-latency DOM interaction.
 
 ![Three.js torus demo](/content/images/threejs-torus.webp)
 
@@ -30,14 +30,19 @@ function draw() {
 ## Comparison with three
 
 | Feature | `three` | `three.dom` |
-|---------|---------|-------------|
+| -------- | -------- | -------- |
 | Runs on | Web worker | Main thread |
-| Video chaining | Fast | Slow (CPU-to-GPU copy) |
-| OrbitControls | No | Yes |
+| Video chaining | Fast, stays in the render pipeline | Slower, copies canvas back into the pipeline |
+| Input latency | A little higher because pointer events are forwarded to the worker | Lowest, handles DOM input directly |
+| Pointer drag/wheel | Yes, via `mouse`, `onPointerDrag()`, and `onWheel()` | Yes, via direct DOM mouse events |
+| Orbit controls | Worker-safe `OrbitControls` compatibility layer | Three.js DOM `OrbitControls` |
 | Keyboard events | No | Yes |
+| DOM APIs | No | Yes |
 | Video textures | Yes (`getTexture`) | No |
 
-Use `three` for pure video processing. Use `three.dom` when you need interactivity.
+Use `three` for video chaining with pointer drag, wheel, and worker camera
+controls. Use `three.dom` when interaction latency matters most, or when you need
+keyboard events or DOM APIs.
 
 ## Available Variables
 

--- a/ui/static/content/objects/three.md
+++ b/ui/static/content/objects/three.md
@@ -76,7 +76,9 @@ const controls = new OrbitControls(camera);
 controls.enablePan = true;
 controls.enableZoom = true;
 
-const mesh = new Mesh(new BoxGeometry(1, 1, 1), new MeshNormalMaterial());
+const geometry = new BoxGeometry(1, 1, 1)
+const material = new MeshNormalMaterial();
+const mesh = new Mesh(geometry, material);
 scene.add(mesh);
 
 function draw() {
@@ -84,6 +86,10 @@ function draw() {
   renderer.render(scene, camera);
 }
 ```
+
+Creating `OrbitControls` automatically disables Patchies object dragging and
+canvas wheel handling for this node, so drag and wheel gestures go to the camera
+instead.
 
 Use raw events when the scene should decide what drag or wheel means:
 

--- a/ui/static/content/objects/three.md
+++ b/ui/static/content/objects/three.md
@@ -1,8 +1,10 @@
-The `three` object creates 3D graphics using [Three.js](https://threejs.org). It runs on a web worker for fast video chaining.
+The `three` object creates 3D graphics using [Three.js](https://threejs.org). It
+runs on a web worker for fast video chaining.
 
 ![Three.js torus demo](/content/images/threejs-torus.webp)
 
-> ✨ [Try this patch](/?id=1c484xkin7p7p2r) showing how to use 2D textures from other objects in Three.js!
+> ✨ [Try this patch](/?id=1c484xkin7p7p2r) showing how to use 2D textures from
+  other objects in Three.js!
 
 ## Getting Started
 
@@ -18,11 +20,13 @@ camera.position.z = 2;
 const geometry = new BoxGeometry(1, 1, 1);
 const material = new MeshNormalMaterial();
 const cube = new Mesh(geometry, material);
+
 scene.add(cube);
 
 function draw() {
   cube.rotation.x += 0.01;
   cube.rotation.y += 0.01;
+
   renderer.render(scene, camera);
 }
 ```
@@ -30,14 +34,19 @@ function draw() {
 ## Comparison with three.dom
 
 | Feature | `three` | `three.dom` |
-|---------|---------|-------------|
+| -------- | -------- | -------- |
 | Runs on | Web worker | Main thread |
-| Video chaining | Fast | Slow (CPU-to-GPU copy) |
-| OrbitControls | No | Yes |
+| Video chaining | Fast, stays in the render pipeline | Slower, copies canvas back into the pipeline |
+| Input latency | A little higher because pointer events are forwarded to the worker | Lowest, handles DOM input directly |
+| Pointer drag/wheel | Yes, via `mouse`, `onPointerDrag()`, and `onWheel()` | Yes, via direct DOM mouse events |
+| Orbit controls | Worker-safe `OrbitControls` compatibility layer | Three.js DOM `OrbitControls` |
 | Keyboard events | No | Yes |
+| DOM APIs | No | Yes |
 | Video textures | Yes (`getTexture`) | No |
 
-Need interactivity? Use [three.dom](/docs/objects/three.dom) instead.
+Use `three` when you want video chaining plus pointer drag, wheel, and camera
+controls. Use [three.dom](/docs/objects/three.dom) when you need the lowest input
+latency, keyboard events, or direct DOM APIs.
 
 ## Available Variables
 
@@ -45,15 +54,66 @@ Need interactivity? Use [three.dom](/docs/objects/three.dom) instead.
 - `renderer` - WebGLRenderer instance
 - `width`, `height` - output dimensions
 - `mouse.x`, `mouse.y` - mouse position
+- `mouse.down`, `mouse.buttons` - pointer button state
+- `mouse.dx`, `mouse.dy` - latest drag delta
+- `mouse.wheelDelta` - latest wheel delta
+- `OrbitControls` - worker-safe camera controls with a Three.js-like API
+
+## Interaction
+
+Use `OrbitControls` when you want familiar camera movement while keeping
+the renderer in the worker. There is no DOM element in the worker, so pass the
+camera only:
+
+```javascript
+const { Scene, PerspectiveCamera, BoxGeometry, Mesh, MeshNormalMaterial } = THREE;
+
+const scene = new Scene();
+const camera = new PerspectiveCamera(75, width / height, 0.1, 1000);
+camera.position.z = 3;
+
+const controls = new OrbitControls(camera);
+controls.enablePan = true;
+controls.enableZoom = true;
+
+const mesh = new Mesh(new BoxGeometry(1, 1, 1), new MeshNormalMaterial());
+scene.add(mesh);
+
+function draw() {
+  controls.update();
+  renderer.render(scene, camera);
+}
+```
+
+Use raw events when the scene should decide what drag or wheel means:
+
+```javascript
+const raycaster = new THREE.Raycaster();
+const pointer = new THREE.Vector2();
+
+onPointerDrag(({ x, y }) => {
+  pointer.x = (x / width) * 2 - 1;
+  pointer.y = -(y / height) * 2 + 1;
+
+  raycaster.setFromCamera(pointer, camera);
+});
+
+onWheel(({ deltaY }) => {
+  camera.position.z += deltaY * 0.01;
+});
+```
 
 ## Special Functions (three only)
 
 - `getTexture(inlet)` - get video input as Three.js texture
 - `setVideoCount(ins, outs)` - set number of video inlets/outlets
+- `onPointerDrag(callback)` - receive raw drag events
+- `onWheel(callback)` - receive raw wheel events
 
 ## Common Functions
 
-See the [Patchies JavaScript Runner](/docs/javascript-runner) for all available functions.
+See the [Patchies JavaScript Runner](/docs/javascript-runner) for all
+available functions.
 
 - `noOutput()` - hides video output port
 - `setHidePorts(true | false)` - hide/show all ports
@@ -68,7 +128,8 @@ See the [Patchies JavaScript Runner](/docs/javascript-runner) for all available 
 
 ## See Also
 
-- [GLSL Imports](/docs/glsl-imports) - import functions from lygia and other GLSL libraries
+- [GLSL Imports](/docs/glsl-imports) - import functions from lygia and
+  other GLSL libraries
 - [three.dom](/docs/objects/three.dom) - main thread variant with interactivity
 - [glsl](/docs/objects/glsl) - GPU shaders
 - [swgl](/docs/objects/swgl) - SwissGL for quick WebGL


### PR DESCRIPTION
Add worker thread-safe OrbitControls and mouse pointer drag + mouse wheel event listener for the `three` object, to mimic mouse capability of the main thread `three.dom` object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added worker-safe OrbitControls for interactive 3D camera control in three nodes.
  * Added `onPointerDrag()` and `onWheel()` callbacks for custom pointer and wheel event handling.
  * Added `mouse-cube.three` preset demonstrating interactive 3D controls.

* **Documentation**
  * Enhanced three and three.dom documentation with interaction capabilities, feature comparisons, and usage examples.
  * Added comprehensive specification for worker-side interaction APIs.

* **Tests**
  * Added test suite for worker interaction handling and OrbitControls functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->