### PR TITLE
feat(surface): specify mouse forwarding targets with setMouseForwarding

### DIFF
--- a/docs/design-docs/specs/126-surface-fullscreen-interaction.md
+++ b/docs/design-docs/specs/126-surface-fullscreen-interaction.md
@@ -162,11 +162,13 @@ User code can narrow that behavior by node ID:
 
 ```js
 setMouseForwarding({
+  enabled: true, // optional, default true
   only: ["shaderpark-1", "three-1"], // optional whitelist
   except: ["glsl-1"], // optional blacklist
 });
 ```
 
+Set `enabled: false` or `only: []` to disable all pointer and wheel forwarding.
 `only` restricts forwarding to the listed node IDs. `except` removes matching
 node IDs after the whitelist is applied. Call `setMouseForwarding()` with no
 arguments to restore the default "all mouse-aware render nodes" behavior.

--- a/docs/design-docs/specs/126-surface-fullscreen-interaction.md
+++ b/docs/design-docs/specs/126-surface-fullscreen-interaction.md
@@ -58,11 +58,11 @@ Escape always returns to `preview`, never to `stopped`.
 Available globals inside the code editor (same as `canvas.dom`):
 
 ```js
-canvas // HTMLCanvasElement — always at fullscreen resolution (window.innerWidth × window.innerHeight)
-ctx    // CanvasRenderingContext2D
-width  // = window.innerWidth  (constant regardless of preview vs fullscreen mode)
-height // = window.innerHeight (constant regardless of preview vs fullscreen mode)
-mouse  // { x, y, down, buttons } — normalized 0–1 coords
+canvas; // HTMLCanvasElement — always at fullscreen resolution (window.innerWidth × window.innerHeight)
+ctx; // CanvasRenderingContext2D
+width; // = window.innerWidth  (constant regardless of preview vs fullscreen mode)
+height; // = window.innerHeight (constant regardless of preview vs fullscreen mode)
+mouse; // { x, y, down, buttons } — normalized 0–1 coords
 ```
 
 In `preview` mode the canvas is CSS-scaled down to fit the node (same `PREVIEW_SCALE_FACTOR`
@@ -76,25 +76,25 @@ based on the current draw mode. No `requestAnimationFrame` or manual invocation 
 
 ```js
 function draw() {
-  ctx.clearRect(0, 0, width, height)
+  ctx.clearRect(0, 0, width, height);
   // draw your frame here
 }
 ```
 
 ```js
-setDrawMode('always')   // rAF loop — redraws every frame (default)
-setDrawMode('interact') // redraws only on pointer/touch events — saves CPU when idle
-setDrawMode('manual')   // user calls redraw() explicitly
+setDrawMode("always"); // rAF loop — redraws every frame (default)
+setDrawMode("interact"); // redraws only on pointer/touch events — saves CPU when idle
+setDrawMode("manual"); // user calls redraw() explicitly
 ```
 
 ```js
-redraw() // trigger one draw pass (useful in manual mode)
+redraw(); // trigger one draw pass (useful in manual mode)
 ```
 
 ### Video Output
 
 ```js
-noOutput() // disable CPU→GPU texture copy (default: enabled, same as canvas.dom)
+noOutput(); // disable CPU→GPU texture copy (default: enabled, same as canvas.dom)
 ```
 
 CPU→GPU copy is expensive. Call `noOutput()` if you don't need to composite the overlay
@@ -103,8 +103,8 @@ into the FBO pipeline.
 ### Surface Activation
 
 ```js
-activate() // enter fullscreen state: show overlay, hide XYFlow, freeze DOM-renderer nodes
-deactivate() // return to preview state: remove overlay, restore XYFlow and frozen nodes
+activate(); // enter fullscreen state: show overlay, hide XYFlow, freeze DOM-renderer nodes
+deactivate(); // return to preview state: remove overlay, restore XYFlow and frozen nodes
 ```
 
 Messages also trigger these:
@@ -117,8 +117,8 @@ Messages also trigger these:
 ### Browser Fullscreen (optional)
 
 ```js
-goFullscreen() // call document.documentElement.requestFullscreen()
-exitFullscreen() // call document.exitFullscreen()
+goFullscreen(); // call document.documentElement.requestFullscreen()
+exitFullscreen(); // call document.exitFullscreen()
 ```
 
 `surface` does NOT auto-fullscreen on activation. Use `goFullscreen()` explicitly,
@@ -126,16 +126,16 @@ or combine with activation:
 
 ```js
 recv((msg) => {
-  if (msg.type === 'live') {
-    activate()
-    goFullscreen()
+  if (msg.type === "live") {
+    activate();
+    goFullscreen();
   }
 
-  if (msg.type === 'exit') {
-    deactivate()
-    exitFullscreen()
+  if (msg.type === "exit") {
+    deactivate();
+    exitFullscreen();
   }
-})
+});
 ```
 
 ### Interaction Callbacks
@@ -144,13 +144,32 @@ recv((msg) => {
 onPointer((event) => {
   // event: { x, y, pressure, buttons, type: 'down'|'move'|'up' }
   // coordinates normalized 0–1
-})
+});
 
 onTouch((touches) => {
   // touches: Array<{ x, y, pressure, id }>
   // coordinates normalized 0–1
-})
+});
 ```
+
+### Mouse Forwarding
+
+By default, `surface` forwards pointer and wheel events to every mouse-aware
+render node in the graph (`glsl`, `swgl`, `regl`, `hydra`, `canvas`, `textmode`,
+`shaderpark`, and worker `three`).
+
+User code can narrow that behavior by node ID:
+
+```js
+setMouseForwarding({
+  only: ["shaderpark-1", "three-1"], // optional whitelist
+  except: ["glsl-1"], // optional blacklist
+});
+```
+
+`only` restricts forwarding to the listed node IDs. `except` removes matching
+node IDs after the whitelist is applied. Call `setMouseForwarding()` with no
+arguments to restore the default "all mouse-aware render nodes" behavior.
 
 ### Message Outlets
 
@@ -179,25 +198,25 @@ send(outlet, msg)
 
 ```js
 // Draw red rectangles wherever the user clicks
-setDrawMode('interact')
+setDrawMode("interact");
 
 onPointer((e) => {
-  if (!e.down) return
-  ctx.fillStyle = 'rgba(255, 0, 0, 0.5)'
-  ctx.fillRect(e.x * width - 25, e.y * height - 25, 50, 50)
-  redraw()
-})
+  if (!e.down) return;
+  ctx.fillStyle = "rgba(255, 0, 0, 0.5)";
+  ctx.fillRect(e.x * width - 25, e.y * height - 25, 50, 50);
+  redraw();
+});
 ```
 
 ```js
 // Flower blooms performance: send pointer position as messages,
 // receive bloom regions back from a JS node
-setDrawMode('interact')
-noOutput()
+setDrawMode("interact");
+noOutput();
 
 onPointer((e) => {
-  if (e.type === 'down') send(0, {x: e.x, y: e.y})
-})
+  if (e.type === "down") send(0, { x: e.x, y: e.y });
+});
 ```
 
 ---

--- a/ui/src/lib/ai/object-prompts/surface.ts
+++ b/ui/src/lib/ai/object-prompts/surface.ts
@@ -13,7 +13,7 @@ Fullscreen interactive canvas overlay for live performance. Captures pointer/tou
 - onKeyUp(event => {}) — keyboard up
 - setDrawMode('always'|'interact'|'manual') — control render loop
 - redraw() — trigger a draw in manual mode
-- setMouseForwarding({ only?: string[], except?: string[] }) — restrict forwarded mouse events by node ID
+- setMouseForwarding({ enabled?: boolean, only?: string[], except?: string[] }) — enable/disable or restrict forwarded mouse events by node ID
 - activate() / deactivate() — enter/exit fullscreen from code
 - noOutput() — hide video output port
 
@@ -25,6 +25,7 @@ Fullscreen interactive canvas overlay for live performance. Captures pointer/tou
 - Call noOutput() unless the sketch explicitly outputs video to another node.
 - Use setDrawMode('interact') for sketches that only update on input (saves CPU).
 - Use setMouseForwarding() when the patch has multiple mouse-aware render nodes and only some should receive surface pointer/wheel events.
+- Use setMouseForwarding({ enabled: false }) or setMouseForwarding({ only: [] }) to disable mouse forwarding entirely.
 - Do NOT call setCanvasSize — the surface always fills the window.
 - Do NOT call noDrag/noPan/noWheel — the surface canvas is non-interactive by default.
 

--- a/ui/src/lib/ai/object-prompts/surface.ts
+++ b/ui/src/lib/ai/object-prompts/surface.ts
@@ -13,6 +13,7 @@ Fullscreen interactive canvas overlay for live performance. Captures pointer/tou
 - onKeyUp(event => {}) — keyboard up
 - setDrawMode('always'|'interact'|'manual') — control render loop
 - redraw() — trigger a draw in manual mode
+- setMouseForwarding({ only?: string[], except?: string[] }) — restrict forwarded mouse events by node ID
 - activate() / deactivate() — enter/exit fullscreen from code
 - noOutput() — hide video output port
 
@@ -23,6 +24,7 @@ Fullscreen interactive canvas overlay for live performance. Captures pointer/tou
 **Default behaviors to apply unless there's a reason not to:**
 - Call noOutput() unless the sketch explicitly outputs video to another node.
 - Use setDrawMode('interact') for sketches that only update on input (saves CPU).
+- Use setMouseForwarding() when the patch has multiple mouse-aware render nodes and only some should receive surface pointer/wheel events.
 - Do NOT call setCanvasSize — the surface always fills the window.
 - Do NOT call noDrag/noPan/noWheel — the surface canvas is non-interactive by default.
 

--- a/ui/src/lib/canvas/SurfaceMouseForwarder.ts
+++ b/ui/src/lib/canvas/SurfaceMouseForwarder.ts
@@ -102,6 +102,7 @@ export class SurfaceMouseForwarder {
    */
   forceHydraScope(scope: 'global' | 'local'): void {
     const allNodes = this.getNodes();
+
     const nodes =
       scope === 'global'
         ? this.mouseTargets

--- a/ui/src/lib/canvas/SurfaceMouseForwarder.ts
+++ b/ui/src/lib/canvas/SurfaceMouseForwarder.ts
@@ -1,10 +1,13 @@
 import { GLSystem } from './GLSystem';
 import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
-import { getSurfaceWheelTargets } from './surfaceMouseForwarding';
+import {
+  getSurfaceMouseTargets,
+  getSurfaceWheelTargets,
+  type SurfaceMouseForwardingRules,
+  type SurfaceMouseTarget,
+  type SurfaceWheelTarget
+} from './surfaceMouseForwarding';
 import type { Node } from '@xyflow/svelte';
-
-const SHADERTOY_TYPES = new Set(['glsl', 'swgl', 'regl']);
-const SIMPLE_TYPES = new Set(['hydra', 'canvas', 'textmode', 'shaderpark']);
 
 /**
  * Forwards normalized surface mouse events to all render nodes in the graph.
@@ -19,19 +22,31 @@ export class SurfaceMouseForwarder {
   private isMouseDown = false;
   private clickX = 0;
   private clickY = 0;
+  private forwardingRules: SurfaceMouseForwardingRules | undefined;
+  private mouseTargets: SurfaceMouseTarget[] = [];
+  private wheelTargets: SurfaceWheelTarget[] = [];
 
-  constructor(private getNodes: () => Node[]) {}
+  constructor(private getNodes: () => Node[]) {
+    this.refreshForwardingTargets();
+  }
+
+  setForwardingRules(rules?: SurfaceMouseForwardingRules): void {
+    this.forwardingRules = rules;
+    this.refreshForwardingTargets();
+  }
+
+  refreshForwardingTargets(): void {
+    const nodes = this.getNodes();
+
+    this.mouseTargets = getSurfaceMouseTargets(nodes, this.forwardingRules);
+    this.wheelTargets = getSurfaceWheelTargets(nodes, this.forwardingRules);
+  }
 
   /**
    * Forward a normalized (0–1) pointer event to all render nodes.
    */
   forward(x: number, y: number, _buttons: number, type: string): void {
-    const renderNodes = this.getNodes().filter(
-      (node) =>
-        SHADERTOY_TYPES.has(node.type ?? '') ||
-        SIMPLE_TYPES.has(node.type ?? '') ||
-        node.type === 'three'
-    );
+    const renderNodes = this.mouseTargets;
 
     if (renderNodes.length === 0) return;
 
@@ -44,15 +59,12 @@ export class SurfaceMouseForwarder {
     const yFBShadertoy = (1 - y) * h; // Y-flip for GL origin (bottom-left)
 
     for (const node of renderNodes) {
-      const nodeType = node.type ?? '';
-      const isShaderPark3d = nodeType === 'shaderpark' && node.data.renderMode === '3d';
-
       if (node.type === 'three') {
-        this.forwardShadertoy(node.id, xFB, yFBSimple, type, _buttons);
-      } else if (SHADERTOY_TYPES.has(nodeType) || isShaderPark3d) {
-        this.forwardShadertoy(node.id, xFB, yFBShadertoy, type, _buttons);
-      } else if (SIMPLE_TYPES.has(nodeType)) {
-        this.glSystem.setMouseData(node.id, xFB, yFBSimple, 0, 0);
+        this.forwardShadertoy(node.nodeId, xFB, yFBSimple, type, _buttons);
+      } else if (node.kind === 'shadertoy') {
+        this.forwardShadertoy(node.nodeId, xFB, yFBShadertoy, type, _buttons);
+      } else {
+        this.glSystem.setMouseData(node.nodeId, xFB, yFBSimple, 0, 0);
       }
     }
   }
@@ -69,7 +81,7 @@ export class SurfaceMouseForwarder {
     const xFB = event.x * w;
     const yFB = event.y * h;
 
-    for (const target of getSurfaceWheelTargets(this.getNodes())) {
+    for (const target of this.wheelTargets) {
       if (target.kind === 'three') {
         this.glSystem.sendThreeWheelData(target.nodeId, {
           x: xFB,
@@ -89,11 +101,18 @@ export class SurfaceMouseForwarder {
    * Call with 'global' on surface fullscreen entry, 'local' on exit.
    */
   forceHydraScope(scope: 'global' | 'local'): void {
-    this.getNodes()
-      .filter((node) => node.type === 'hydra')
-      .forEach((node) =>
-        this.eventBus.dispatch({ type: 'nodeMouseScopeUpdate', nodeId: node.id, scope })
-      );
+    const allNodes = this.getNodes();
+    const nodes =
+      scope === 'global'
+        ? this.mouseTargets
+            .filter((node) => node.kind === 'simple')
+            .map((node) => allNodes.find((candidate) => candidate.id === node.nodeId))
+            .filter((node): node is Node => node?.type === 'hydra')
+        : allNodes.filter((node) => node.type === 'hydra');
+
+    nodes.forEach((node) =>
+      this.eventBus.dispatch({ type: 'nodeMouseScopeUpdate', nodeId: node.id, scope })
+    );
   }
 
   private forwardShadertoy(
@@ -114,7 +133,6 @@ export class SurfaceMouseForwarder {
 
       this.glSystem.setMouseData(nodeId, x, y, -Math.abs(this.clickX), -Math.abs(this.clickY), 0);
     } else {
-      // move
       const z = this.isMouseDown ? Math.abs(this.clickX) : -Math.abs(this.clickX);
       const w = this.isMouseDown ? Math.abs(this.clickY) : -Math.abs(this.clickY);
 

--- a/ui/src/lib/canvas/surfaceMouseForwarding.test.ts
+++ b/ui/src/lib/canvas/surfaceMouseForwarding.test.ts
@@ -1,20 +1,47 @@
 import { describe, expect, it } from 'vitest';
 import type { Node } from '@xyflow/svelte';
 
-import { getSurfaceWheelTargets } from './surfaceMouseForwarding';
+import { getSurfaceMouseTargets, getSurfaceWheelTargets } from './surfaceMouseForwarding';
 
 describe('surface mouse forwarding', () => {
-  it('targets worker Three and Shader Park 3D nodes for surface wheel events', () => {
-    const nodes = [
-      { id: 'three-1', type: 'three', data: {} },
-      { id: 'shaderpark-3d-1', type: 'shaderpark', data: { renderMode: '3d' } },
-      { id: 'shaderpark-flat-1', type: 'shaderpark', data: { renderMode: 'flat' } },
-      { id: 'glsl-1', type: 'glsl', data: {} }
-    ] as Node[];
+  const nodes = [
+    { id: 'three-1', type: 'three', data: {} },
+    { id: 'shaderpark-3d-1', type: 'shaderpark', data: { renderMode: '3d' } },
+    { id: 'shaderpark-flat-1', type: 'shaderpark', data: { renderMode: 'flat' } },
+    { id: 'glsl-1', type: 'glsl', data: {} }
+  ] as Node[];
 
+  it('targets worker Three and Shader Park 3D nodes for surface wheel events', () => {
     expect(getSurfaceWheelTargets(nodes)).toEqual([
       { kind: 'three', nodeId: 'three-1' },
       { kind: 'shaderpark3d', nodeId: 'shaderpark-3d-1' }
     ]);
+  });
+
+  it('keeps all mouse-aware render nodes by default', () => {
+    expect(getSurfaceMouseTargets(nodes).map((target) => target.nodeId)).toEqual([
+      'three-1',
+      'shaderpark-3d-1',
+      'shaderpark-flat-1',
+      'glsl-1'
+    ]);
+  });
+
+  it('applies whitelist before blacklist when forwarding mouse events', () => {
+    expect(
+      getSurfaceMouseTargets(nodes, {
+        only: ['three-1', 'glsl-1', 'missing-node'],
+        except: ['glsl-1']
+      })
+    ).toEqual([{ kind: 'three', nodeId: 'three-1', type: 'three' }]);
+  });
+
+  it('applies forwarding filters to wheel targets too', () => {
+    expect(
+      getSurfaceWheelTargets(nodes, {
+        only: ['three-1', 'shaderpark-3d-1'],
+        except: ['three-1']
+      })
+    ).toEqual([{ kind: 'shaderpark3d', nodeId: 'shaderpark-3d-1' }]);
   });
 });

--- a/ui/src/lib/canvas/surfaceMouseForwarding.test.ts
+++ b/ui/src/lib/canvas/surfaceMouseForwarding.test.ts
@@ -27,6 +27,14 @@ describe('surface mouse forwarding', () => {
     ]);
   });
 
+  it('disables pointer forwarding when enabled is false', () => {
+    expect(getSurfaceMouseTargets(nodes, { enabled: false })).toEqual([]);
+  });
+
+  it('disables pointer forwarding when only is an empty list', () => {
+    expect(getSurfaceMouseTargets(nodes, { only: [] })).toEqual([]);
+  });
+
   it('applies whitelist before blacklist when forwarding mouse events', () => {
     expect(
       getSurfaceMouseTargets(nodes, {
@@ -43,5 +51,13 @@ describe('surface mouse forwarding', () => {
         except: ['three-1']
       })
     ).toEqual([{ kind: 'shaderpark3d', nodeId: 'shaderpark-3d-1' }]);
+  });
+
+  it('disables wheel forwarding when enabled is false', () => {
+    expect(getSurfaceWheelTargets(nodes, { enabled: false })).toEqual([]);
+  });
+
+  it('disables wheel forwarding when only is an empty list', () => {
+    expect(getSurfaceWheelTargets(nodes, { only: [] })).toEqual([]);
   });
 });

--- a/ui/src/lib/canvas/surfaceMouseForwarding.ts
+++ b/ui/src/lib/canvas/surfaceMouseForwarding.ts
@@ -5,6 +5,7 @@ const SHADERTOY_TYPES = new Set(['glsl', 'swgl', 'regl']);
 const SIMPLE_TYPES = new Set(['hydra', 'canvas', 'textmode', 'shaderpark']);
 
 export type SurfaceMouseForwardingRules = {
+  enabled?: boolean;
   only?: readonly string[];
   except?: readonly string[];
 };
@@ -19,10 +20,12 @@ export type SurfaceWheelTarget =
   | { kind: 'shaderpark3d'; nodeId: string };
 
 function matchesForwardingRules(nodeId: string, rules?: SurfaceMouseForwardingRules): boolean {
+  if (rules?.enabled === false) return false;
+
   const only = rules?.only ?? [];
   const except = rules?.except ?? [];
 
-  if (only.length > 0 && !only.includes(nodeId)) return false;
+  if (rules?.only !== undefined && !only.includes(nodeId)) return false;
 
   return !except.includes(nodeId);
 }

--- a/ui/src/lib/canvas/surfaceMouseForwarding.ts
+++ b/ui/src/lib/canvas/surfaceMouseForwarding.ts
@@ -1,17 +1,70 @@
 import { match } from 'ts-pattern';
 import type { Node } from '@xyflow/svelte';
 
+const SHADERTOY_TYPES = new Set(['glsl', 'swgl', 'regl']);
+const SIMPLE_TYPES = new Set(['hydra', 'canvas', 'textmode', 'shaderpark']);
+
+export type SurfaceMouseForwardingRules = {
+  only?: readonly string[];
+  except?: readonly string[];
+};
+
+export type SurfaceMouseTarget =
+  | { kind: 'three'; nodeId: string; type: string }
+  | { kind: 'shadertoy'; nodeId: string; type: string }
+  | { kind: 'simple'; nodeId: string; type: string };
+
 export type SurfaceWheelTarget =
   | { kind: 'three'; nodeId: string }
   | { kind: 'shaderpark3d'; nodeId: string };
 
-export function getSurfaceWheelTargets(nodes: Node[]): SurfaceWheelTarget[] {
-  return nodes.flatMap((node) =>
-    match({ type: node.type, renderMode: node.data?.renderMode })
+function matchesForwardingRules(nodeId: string, rules?: SurfaceMouseForwardingRules): boolean {
+  const only = rules?.only ?? [];
+  const except = rules?.except ?? [];
+
+  if (only.length > 0 && !only.includes(nodeId)) return false;
+
+  return !except.includes(nodeId);
+}
+
+export const getSurfaceMouseTargets = (
+  nodes: Node[],
+  rules?: SurfaceMouseForwardingRules
+): SurfaceMouseTarget[] =>
+  nodes.flatMap((node) => {
+    if (!matchesForwardingRules(node.id, rules)) return [];
+
+    return match({ type: node.type, renderMode: node.data?.renderMode })
+      .with({ type: 'three' }, (): SurfaceMouseTarget[] => [
+        { kind: 'three', nodeId: node.id, type: 'three' }
+      ])
+      .with({ type: 'shaderpark', renderMode: '3d' }, (): SurfaceMouseTarget[] => [
+        { kind: 'shadertoy', nodeId: node.id, type: 'shaderpark' }
+      ])
+      .when(
+        ({ type }) => SHADERTOY_TYPES.has(type ?? ''),
+        ({ type }): SurfaceMouseTarget[] => [
+          { kind: 'shadertoy', nodeId: node.id, type: type ?? '' }
+        ]
+      )
+      .when(
+        ({ type }) => SIMPLE_TYPES.has(type ?? ''),
+        ({ type }): SurfaceMouseTarget[] => [{ kind: 'simple', nodeId: node.id, type: type ?? '' }]
+      )
+      .otherwise((): SurfaceMouseTarget[] => []);
+  });
+
+export const getSurfaceWheelTargets = (
+  nodes: Node[],
+  rules?: SurfaceMouseForwardingRules
+): SurfaceWheelTarget[] =>
+  nodes.flatMap((node) => {
+    if (!matchesForwardingRules(node.id, rules)) return [];
+
+    return match({ type: node.type, renderMode: node.data?.renderMode })
       .with({ type: 'three' }, (): SurfaceWheelTarget[] => [{ kind: 'three', nodeId: node.id }])
       .with({ type: 'shaderpark', renderMode: '3d' }, (): SurfaceWheelTarget[] => [
         { kind: 'shaderpark3d', nodeId: node.id }
       ])
-      .otherwise((): SurfaceWheelTarget[] => [])
-  );
-}
+      .otherwise((): SurfaceWheelTarget[] => []);
+  });

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -231,6 +231,13 @@ const patchiesAPICompletions: Completion[] = [
     apply: 'noOutput()'
   },
   {
+    label: 'setMouseForwarding',
+    type: 'function',
+    detail: '({ only?: string[], except?: string[] }) => void',
+    info: 'Restrict surface mouse forwarding by node ID. Use only as a whitelist and except as a blacklist.',
+    apply: "setMouseForwarding({\n  only: ['node-id'],\n  except: []\n})"
+  },
+  {
     label: 'setCanvasSize',
     type: 'function',
     detail: '(width: number, height: number) => void',
@@ -381,6 +388,7 @@ const topLevelOnlyFunctions = new Set([
   'setHidePorts',
   'setKeepAlive',
   'setMouseScope',
+  'setMouseForwarding',
   'setPortCount',
   'setPrimaryButton',
   'setResolution',
@@ -448,6 +456,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   noPan: MOUSE_INTERACTION_JS_NODES,
   noWheel: MOUSE_INTERACTION_JS_NODES,
   noInteract: MOUSE_INTERACTION_JS_NODES,
+  setMouseForwarding: ['surface'],
   noOutput: [
     'p5',
     'canvas',

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -233,9 +233,9 @@ const patchiesAPICompletions: Completion[] = [
   {
     label: 'setMouseForwarding',
     type: 'function',
-    detail: '({ only?: string[], except?: string[] }) => void',
-    info: 'Restrict surface mouse forwarding by node ID. Use only as a whitelist and except as a blacklist.',
-    apply: "setMouseForwarding({\n  only: ['node-id'],\n  except: []\n})"
+    detail: '(args?: { enabled?: boolean, only?: string[], except?: string[] }) => void',
+    info: 'Enable, disable, whitelist, or blacklist surface mouse forwarding by node ID. Use enabled: false or only: [] to disable all.',
+    apply: 'setMouseForwarding({ enabled: false })'
   },
   {
     label: 'setCanvasSize',

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -147,6 +147,8 @@
   // Mouse state (normalized 0–1)
   let mouse = $state({ x: 0, y: 0, down: false, buttons: 0 });
 
+  const { updateNodeData, getNodes } = useSvelteFlow();
+  const updateNodeInternals = useUpdateNodeInternals();
   const mouseForwarder = new SurfaceMouseForwarder(() => getNodes());
 
   function clearCanvas() {
@@ -168,9 +170,6 @@
       onclick: clearCanvas
     }
   ]);
-
-  const { updateNodeData, getNodes } = useSvelteFlow();
-  const updateNodeInternals = useUpdateNodeInternals();
 
   let inletCount = $derived(data.inletCount ?? 1);
   let outletCount = $derived(data.outletCount ?? 0);

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -36,6 +36,7 @@
   import { handleCodeError } from '$lib/js-runner/handleCodeError';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import { SurfaceMouseForwarder } from '$lib/canvas/SurfaceMouseForwarder';
+  import type { SurfaceMouseForwardingRules } from '$lib/canvas/surfaceMouseForwarding';
   import type { ConsoleOutputEvent } from '$lib/eventbus/events';
   import { CANVAS_DOM_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
   import type { ExtraMenuItem } from '$lib/components/ObjectPreviewOverflowMenu.svelte';
@@ -263,6 +264,15 @@
     }
   }
 
+  function setMouseForwarding(rules?: SurfaceMouseForwardingRules) {
+    mouseForwarder.setForwardingRules(rules);
+
+    if (isFullscreen) {
+      mouseForwarder.forceHydraScope('local');
+      mouseForwarder.forceHydraScope('global');
+    }
+  }
+
   // ── Draw mode & rAF ──────────────────────────────────────────────────────
 
   function triggerDraw() {
@@ -346,6 +356,7 @@
     const nodes = getNodes().map((n) => ({ id: n.id, type: n.type }));
 
     overlay.activate(nodeId, nodes, () => exitSurface());
+    mouseForwarder.refreshForwardingTargets();
     mouseForwarder.forceHydraScope('global');
 
     // Switch to output dimensions (overlay canvas uses object-fit: cover)
@@ -468,6 +479,7 @@
     pointerCallback = null;
     touchCallback = null;
     keyboardCallbacks = {};
+    setMouseForwarding();
 
     if (animationFrameId !== null) {
       cancelAnimationFrame(animationFrameId);
@@ -518,6 +530,7 @@
           activate: () => enterFullscreen(),
           deactivate: () => exitSurface(),
           hideExitButton: () => SurfaceOverlay.getInstance().hideBadge(),
+          setMouseForwarding,
 
           // Browser fullscreen (separate from surface activation)
           goFullscreen: () => document.documentElement.requestFullscreen?.(),
@@ -685,7 +698,7 @@
   {extraMenuItems}
 >
   {#snippet topHandle()}
-    {#each Array.from({ length: inletCount }) as _, index (index)}
+    {#each Array.from({ length: inletCount }), index (index)}
       <TypedHandle
         port="inlet"
         spec={{ handleId: index }}
@@ -711,7 +724,7 @@
       />
     {/if}
 
-    {#each Array.from({ length: outletCount }) as _, index (index)}
+    {#each Array.from({ length: outletCount }), index (index)}
       <TypedHandle
         port="outlet"
         spec={{ handleId: index + (videoOutputEnabled ? 1 : 0) }}

--- a/ui/static/content/objects/surface.md
+++ b/ui/static/content/objects/surface.md
@@ -53,6 +53,24 @@ onPointer(({ x, y, buttons, down, type }) => {
 
 Pointer events are also sent to the **pointer outlet** as messages.
 
+## Mouse Forwarding
+
+By default, pointer and wheel events are forwarded to all mouse-aware render
+nodes in the graph, including `glsl`, `hydra`, `shaderpark`, and `three`.
+
+Use `setMouseForwarding()` to restrict forwarding by node ID:
+
+```javascript
+setMouseForwarding({
+  only: ['shaderpark-1', 'three-1'],
+  except: ['glsl-1']
+});
+```
+
+`only` is an optional whitelist. `except` is an optional blacklist applied after
+the whitelist. Call `setMouseForwarding()` with no arguments to restore the
+default forwarding behavior.
+
 ## Touch Events
 
 `onTouch(callback)` fires with all active touch points:
@@ -126,6 +144,7 @@ plus:
 - `onKeyDown(cb)` / `onKeyUp(cb)` — keyboard callbacks
 - `setDrawMode('always'|'interact'|'manual')` — control render loop
 - `redraw()` — manually trigger a draw (manual mode)
+- `setMouseForwarding({ only, except })` — whitelist/blacklist forwarded mouse events by node ID
 - `activate()` / `deactivate()` — enter/exit fullscreen
 - `hideExitButton()` — hide the "Exit surface (Shift+Esc)" badge
 - `noOutput()` — hide video output port

--- a/ui/static/content/objects/surface.md
+++ b/ui/static/content/objects/surface.md
@@ -62,11 +62,13 @@ Use `setMouseForwarding()` to restrict forwarding by node ID:
 
 ```javascript
 setMouseForwarding({
+  enabled: true,
   only: ['shaderpark-1', 'three-1'],
   except: ['glsl-1']
 });
 ```
 
+Set `enabled: false` or `only: []` to disable all pointer and wheel forwarding.
 `only` is an optional whitelist. `except` is an optional blacklist applied after
 the whitelist. Call `setMouseForwarding()` with no arguments to restore the
 default forwarding behavior.
@@ -144,7 +146,7 @@ plus:
 - `onKeyDown(cb)` / `onKeyUp(cb)` — keyboard callbacks
 - `setDrawMode('always'|'interact'|'manual')` — control render loop
 - `redraw()` — manually trigger a draw (manual mode)
-- `setMouseForwarding({ only, except })` — whitelist/blacklist forwarded mouse events by node ID
+- `setMouseForwarding({ enabled, only, except })` — enable/disable or filter forwarded mouse events by node ID
 - `activate()` / `deactivate()` — enter/exit fullscreen
 - `hideExitButton()` — hide the "Exit surface (Shift+Esc)" badge
 - `noOutput()` — hide video output port


### PR DESCRIPTION
Allow manually specifying mouse forwarding targets for the `surface` object via `setMouseForwarding()` function to restrict mouse forwarding to some objects only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `setMouseForwarding()` method to control which render nodes receive mouse and pointer events
  * Supports optional `only` (whitelist) and `except` (blacklist) parameters for fine-grained event routing
  * Call with no arguments to restore default forwarding behavior

* **Documentation**
  * Updated surface node design specifications for fullscreen interactions
  * Added "Mouse Forwarding" section to surface API documentation with usage examples
  * Enhanced code samples and API formatting for clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->