### PR TITLE
feat(codemirror, glsl): add glsl-in-javascript codemirror autocompletion

### DIFF
--- a/docs/design-docs/specs/142-codemirror-glsl-in-js-completions.md
+++ b/docs/design-docs/specs/142-codemirror-glsl-in-js-completions.md
@@ -1,0 +1,20 @@
+# 142. CodeMirror GLSL-in-JS Completions
+
+## Goal
+
+Improve completions for JavaScript-based visual objects that embed GLSL source in strings, including `hydra`, `shaderpark`, `swgl`, `regl`, and other nodes that use the shared GLSL-in-JS parser wrapper.
+
+## Behavior
+
+- Patchies JavaScript runtime completions must not appear inside string literals or template-string text.
+- Shader Park Sculpt completions must not appear inside string literals or template-string text.
+- When the cursor is inside a template string that `glsl-in-js.ts` recognizes as GLSL, the editor should offer GLSL completions instead of JavaScript runtime completions.
+- GLSL completions should work for the same contexts as GLSL-in-JS highlighting:
+  - `glsl\`...\`` tagged templates.
+  - Shader Park helpers: `glslFunc(...)`, `glslFuncES3(...)`, and `glslSDF(...)`.
+  - Object properties used as shader bodies: `frag`, `vert`, `glsl`, `FP`, and `VP`.
+- Template-string interpolation bodies (`${...}`) remain JavaScript contexts, so JavaScript completions may appear there and GLSL completions should not.
+
+## Notes
+
+Completion context should reuse the existing GLSL-in-JS detection rules rather than duplicating ad hoc node-specific checks.

--- a/ui/src/lib/codemirror/glsl-in-js.test.ts
+++ b/ui/src/lib/codemirror/glsl-in-js.test.ts
@@ -1,12 +1,19 @@
 import type { Input, SyntaxNodeRef } from '@lezer/common';
+import { CompletionContext } from '@codemirror/autocomplete';
 import { javascriptLanguage } from '@codemirror/lang-javascript';
+import { EditorState } from '@codemirror/state';
 import { describe, expect, it } from 'vitest';
-import { isGlslTemplateString } from '$lib/codemirror/glsl-in-js';
+import {
+  glslInJsCompletions,
+  glslInJsWrap,
+  isGlslTemplateString
+} from '$lib/codemirror/glsl-in-js';
 
 function findTemplateStrings(doc: string) {
   const input = {
     read: (from: number, to: number) => doc.slice(from, to)
   } as Input;
+
   const results: boolean[] = [];
 
   javascriptLanguage.parser.parse(doc).iterate({
@@ -20,14 +27,28 @@ function findTemplateStrings(doc: string) {
   return results;
 }
 
+function getGlslInJsCompletionLabels(doc: string) {
+  const state = EditorState.create({
+    doc,
+    extensions: [javascriptLanguage.configure({ wrap: glslInJsWrap })]
+  });
+
+  const context = new CompletionContext(state, doc.length, true);
+  const result = glslInJsCompletions(context);
+
+  return result?.options.map((option) => option.label) ?? [];
+}
+
 describe('glsl in js mixed parsing', () => {
   it('detects Shader Park GLSL helper strings as GLSL shader bodies', () => {
     expect(findTemplateStrings('let f = glslFunc(`vec3 f(){ return vec3(1.0); }`);')).toEqual([
       true
     ]);
+
     expect(findTemplateStrings('let f = glslFuncES3(`vec3 f(){ return vec3(1.0); }`);')).toEqual([
       true
     ]);
+
     expect(findTemplateStrings('let f = glslSDF(`float f(vec3 p){ return length(p); }`);')).toEqual(
       [true]
     );
@@ -36,5 +57,16 @@ describe('glsl in js mixed parsing', () => {
   it('keeps unrelated function template strings in JavaScript mode', () => {
     expect(findTemplateStrings('let f = String.raw`not glsl`;')).toEqual([false]);
     expect(findTemplateStrings('let f = shaderParkHelper(`not glsl`);')).toEqual([false]);
+  });
+
+  it('offers GLSL completions inside recognized GLSL template strings', () => {
+    expect(getGlslInJsCompletionLabels('setFunction({ glsl: `vec2 p = u')).toContain('uv');
+    expect(getGlslInJsCompletionLabels('glsl({ FP: `RGBA = tex')).toContain('texture');
+    expect(getGlslInJsCompletionLabels('let sdf = glslSDF(`return l')).toContain('length');
+  });
+
+  it('does not offer GLSL completions in normal template strings or interpolations', () => {
+    expect(getGlslInJsCompletionLabels('let text = `u')).toEqual([]);
+    expect(getGlslInJsCompletionLabels('glsl`vec2 p = ${u')).toEqual([]);
   });
 });

--- a/ui/src/lib/codemirror/glsl-in-js.ts
+++ b/ui/src/lib/codemirror/glsl-in-js.ts
@@ -1,4 +1,8 @@
+import type { CompletionContext as CMCompletionContext } from '@codemirror/autocomplete';
+import { javascriptLanguage } from '@codemirror/lang-javascript';
 import { parseMixed } from '@lezer/common';
+import type { Input, SyntaxNodeRef } from '@lezer/common';
+import { createGlslCompletionSource } from './glsl-completions';
 import { glslLanguage } from './glsl.codemirror';
 
 // glsl`` tagged template (Three.js / explicit preprocessing)
@@ -12,7 +16,7 @@ const GLSL_CALLS = new Set(['glslFunc', 'glslFuncES3', 'glslSDF']);
 const GLSL_PROPERTY_KEYS = new Set(['frag', 'vert', 'glsl', 'FP', 'VP']);
 
 export function isGlslTemplateString(
-  node: import('@lezer/common').SyntaxNodeRef,
+  node: SyntaxNodeRef,
   input: import('@lezer/common').Input
 ): boolean {
   const parent = node.node.parent;
@@ -28,6 +32,7 @@ export function isGlslTemplateString(
   if (parent.name === 'ArgList') {
     const call = parent.parent;
     const callee = call?.firstChild;
+
     return (
       !!call &&
       call.name === 'CallExpression' &&
@@ -40,6 +45,7 @@ export function isGlslTemplateString(
   // { frag: `...`, vert: `...`, glsl: `...`, FP: `...`, VP: `...` }
   if (parent.name === 'Property') {
     const key = parent.firstChild;
+
     return (
       !!key &&
       key.name === 'PropertyDefinition' &&
@@ -50,6 +56,93 @@ export function isGlslTemplateString(
   return false;
 }
 
+function isPositionInTemplateContent(node: SyntaxNodeRef, pos: number, doc: string): boolean {
+  const hasClosingBacktick = doc[node.to - 1] === '`';
+  const contentFrom = node.from + 1;
+  const contentTo = hasClosingBacktick ? node.to - 1 : node.to;
+
+  if (pos < contentFrom || pos > contentTo) {
+    return false;
+  }
+
+  for (let child = node.node.firstChild; child; child = child.nextSibling) {
+    if (child.name === 'Interpolation' && pos > child.from && pos <= child.to) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isPositionInStringContent(node: SyntaxNodeRef, pos: number, doc: string): boolean {
+  const quote = doc[node.from];
+  const hasClosingQuote = doc[node.to - 1] === quote;
+
+  const contentFrom = node.from + 1;
+  const contentTo = hasClosingQuote ? node.to - 1 : node.to;
+
+  return pos >= contentFrom && pos <= contentTo;
+}
+
+function findJavaScriptStringContext(context: CMCompletionContext): {
+  isString: boolean;
+  isGlsl: boolean;
+} {
+  const doc = context.state.doc.toString();
+
+  const input = {
+    read: (from: number, to: number) => doc.slice(from, to)
+  } as Input;
+
+  let result = { isString: false, isGlsl: false };
+
+  javascriptLanguage.parser.parse(doc).iterate({
+    enter(node: SyntaxNodeRef) {
+      if (result.isString) return false;
+
+      if (node.name === 'TemplateString') {
+        if (!isPositionInTemplateContent(node, context.pos, doc)) return;
+
+        result = {
+          isString: true,
+          isGlsl: isGlslTemplateString(node, input)
+        };
+
+        return false;
+      }
+
+      if (node.name === 'String' && isPositionInStringContent(node, context.pos, doc)) {
+        result = { isString: true, isGlsl: false };
+
+        return false;
+      }
+    }
+  });
+
+  return result;
+}
+
+export const isJavaScriptStringCompletionContext = (context: CMCompletionContext): boolean =>
+  findJavaScriptStringContext(context).isString;
+
+export function isGlslInJavaScriptCompletionContext(context: CMCompletionContext): boolean {
+  const stringContext = findJavaScriptStringContext(context);
+
+  return stringContext.isString && stringContext.isGlsl;
+}
+
+export function createGlslInJsCompletionSource() {
+  const glslSource = createGlslCompletionSource();
+
+  return (context: CMCompletionContext) => {
+    if (!isGlslInJavaScriptCompletionContext(context)) return null;
+
+    return glslSource(context);
+  };
+}
+
+export const glslInJsCompletions = createGlslInJsCompletionSource();
+
 function glslOverlay(node: import('@lezer/common').SyntaxNodeRef): { from: number; to: number }[] {
   // Collect ranges covering all non-interpolation content inside the backticks.
   const overlay: { from: number; to: number }[] = [];
@@ -58,12 +151,14 @@ function glslOverlay(node: import('@lezer/common').SyntaxNodeRef): { from: numbe
   for (let child = node.node.firstChild; child; child = child.nextSibling) {
     if (child.name === 'Interpolation') {
       if (pos < child.from) overlay.push({ from: pos, to: child.from });
+
       pos = child.to;
     }
   }
 
   const end = node.to - 1; // skip closing backtick
   if (pos < end) overlay.push({ from: pos, to: end });
+
   return overlay;
 }
 

--- a/ui/src/lib/codemirror/language.ts
+++ b/ui/src/lib/codemirror/language.ts
@@ -23,7 +23,7 @@ export async function loadLanguageExtension(language: string, context?: Patchies
         { autocompletion },
         { patchiesCompletions },
         { shaderParkCompletionsSource },
-        { glslInJsWrap },
+        { glslInJsCompletions, glslInJsWrap },
         { glslIncludeHighlighter }
       ] = await Promise.all([
         import('@codemirror/lang-javascript'),
@@ -40,7 +40,11 @@ export async function loadLanguageExtension(language: string, context?: Patchies
       return [
         new LanguageSupport(jsWithGlsl, jsSupport.support),
         autocompletion({
-          override: [shaderParkCompletionsSource(context), patchiesCompletions(context)]
+          override: [
+            glslInJsCompletions,
+            shaderParkCompletionsSource(context),
+            patchiesCompletions(context)
+          ]
         }),
         ...glslIncludeHighlighter
       ];

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -44,6 +44,17 @@ function getShaderParkCompletion(label: string) {
 }
 
 describe('patchies completions', () => {
+  it('does not show Patchies API completions inside strings or template strings', () => {
+    expect(getCompletionLabels('hydra', "'se")).toEqual([]);
+    expect(getCompletionLabels('hydra', '"se')).toEqual([]);
+    expect(getCompletionLabels('hydra', '`se')).toEqual([]);
+    expect(getCompletionLabels('hydra', 'glsl`vec2 p = u')).toEqual([]);
+  });
+
+  it('still shows Patchies API completions inside template interpolations', () => {
+    expect(getCompletionLabels('hydra', 'glsl`vec2 p = ${se')).toContain('send');
+  });
+
   it('does not show Patchies API completions for shaderpark code', () => {
     expect(shouldShowPatchiesCompletions({ nodeType: 'shaderpark' })).toBe(false);
     expect(createPatchiesCompletionSource({ nodeType: 'shaderpark' })).toBeDefined();
@@ -61,6 +72,7 @@ describe('patchies completions', () => {
     expect(getShaderParkCompletionLabels('shaderpark', 'sp')).toContain('sphere');
     expect(getShaderParkCompletionLabels('shaderpark', 'setSpace(getS')).toContain('getSpace');
     expect(getShaderParkCompletionLabels('shaderpark', 'tim')).toContain('time');
+    expect(getShaderParkCompletionLabels('shaderpark', 'glslSDF(`l')).toEqual([]);
 
     expect(getShaderParkCompletionLabels('js', 'sp')).toEqual([]);
     expect(getShaderParkCompletionLabels('shaderpark', '// sp')).toEqual([]);

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -3,6 +3,7 @@ import {
   type Completion
 } from '@codemirror/autocomplete';
 import { isCompletionSuppressedByComment } from '$lib/codemirror/completion-utils';
+import { isJavaScriptStringCompletionContext } from '$lib/codemirror/glsl-in-js';
 
 /**
  * Patchies API function completions for JavaScript-based nodes
@@ -887,6 +888,7 @@ function isInsideFunctionBody(text: string): boolean {
 export function createPatchiesCompletionSource(patchiesContext?: PatchiesContext) {
   return (context: CMCompletionContext) => {
     if (!shouldShowPatchiesCompletions(patchiesContext)) return null;
+    if (isJavaScriptStringCompletionContext(context)) return null;
 
     // Skip completions for non-JS nodes (expressions are pure, messages are JSON5)
     if (patchiesContext?.nodeType === 'expr') return null;

--- a/ui/src/lib/codemirror/shaderpark-completions.ts
+++ b/ui/src/lib/codemirror/shaderpark-completions.ts
@@ -3,6 +3,7 @@ import {
   type Completion
 } from '@codemirror/autocomplete';
 import { isCompletionSuppressedByComment } from '$lib/codemirror/completion-utils';
+import { isJavaScriptStringCompletionContext } from '$lib/codemirror/glsl-in-js';
 import type { PatchiesContext } from '$lib/codemirror/patchies-completions';
 
 const SHADERPARK_NODE_TYPE = 'shaderpark';
@@ -610,6 +611,7 @@ function isExpressionCompletionPosition(context: CMCompletionContext, from: numb
 export function createShaderParkCompletionSource(patchiesContext?: PatchiesContext) {
   return (context: CMCompletionContext) => {
     if (patchiesContext?.nodeType !== SHADERPARK_NODE_TYPE) return null;
+    if (isJavaScriptStringCompletionContext(context)) return null;
 
     const word = context.matchBefore(/[A-Za-z_$][\w$]*/);
     if (!word) return null;

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -244,7 +244,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'SDF raymarched visual presets made with Shader Park',
     icon: 'Shapes',
     requiredObjects: ['shaderpark'],
-    presets: ['Noise Sphere', 'Square Symmetry', 'Mouse Follower']
+    presets: ['Noise Sphere', 'Square Symmetry', 'Mouse Follower', 'Octahedron SDF']
   },
   {
     id: 'chuck-demos',

--- a/ui/src/lib/presets/builtin/shaderpark.presets.ts
+++ b/ui/src/lib/presets/builtin/shaderpark.presets.ts
@@ -1,3 +1,5 @@
+import type { ShaderParkRenderMode } from '$lib/rendering/types';
+
 const NOISE_SPHERE_SHADERPARK = `// @title Noise Sphere
 // @primaryButton settings
 
@@ -29,6 +31,7 @@ const sz = sizeBase + nsin(time) * sizeAmp;
 
 const complexDiv = (a, b) => {
   const dm = 1.0 / (b.x * b.x + b.y * b.y);
+
   return dm * vec2(
     a.x * b.x + a.y * b.y,
     a.y * b.x - a.x * b.y
@@ -46,6 +49,7 @@ for (let i = 0.0; i < lineCount; i += 1.0) {
   const a = vec2(s.x - xoff, s.y - sz);
   const b = vec2(s.x - xoff, s.y + sz);
   const q = complexDiv(a, b);
+
   phi += strength * atan(q.y, q.x) + 0.35 * i * sin(time * 0.9);
 }
 
@@ -54,6 +58,7 @@ for (let i = 0.0; i < lineCount; i += 1.0) {
   const a = vec2(s.y - yoff, s.x - sz);
   const b = vec2(s.y - yoff, s.x + sz);
   const q = complexDiv(a, b);
+
   phi += strength * atan(q.y, q.x) + 0.35 * i * sin(time * 0.9);
 }
 
@@ -90,9 +95,38 @@ metal(0.15);
 displace(mouse.x, mouse.y, 0.0);
 sphere(0.22 + 0.08 * sin(time * 2.0));`;
 
+const OCTAHEDRON_SDF_SHADERPARK = `// @title Octahedron SDF
+// https://iquilezles.org/articles/distfunctions/
+
+let octahedron = glslSDF(\`
+  float sdOctahedron(vec3 p, float s) {
+    vec3 q;
+    p = abs(p);
+
+    float m = p.x + p.y + p.z - s;
+
+    if (3.0 * p.x < m) {
+      q = p.xyz;
+    } else if (3.0 * p.y < m) {
+      q = p.yzx;
+    } else if (3.0 * p.z < m) {
+      q = p.zxy;
+    } else {
+      return m * 0.57735027;
+    }
+
+    float k = clamp(0.5 * (q.z - q.y + s), 0.0, s);
+
+    return length(vec3(q.x, q.y - s + k, q.z - k));
+  }
+\`);
+
+octahedron(.6);`;
+
 type ShaderParkPresetData = {
   code: string;
   title?: string;
+  renderMode?: ShaderParkRenderMode;
   videoInletCount?: number;
   videoOutletCount?: number;
 };
@@ -127,6 +161,17 @@ export const SHADERPARK_PRESETS: Record<
     data: {
       title: 'Mouse Follower',
       code: MOUSE_FOLLOWER_SHADERPARK,
+      videoInletCount: 0,
+      videoOutletCount: 1
+    }
+  },
+  'Octahedron SDF': {
+    type: 'shaderpark',
+    description: 'An octahedron SDF made with Shader Park glslSDF',
+    data: {
+      title: 'Octahedron SDF',
+      code: OCTAHEDRON_SDF_SHADERPARK,
+      renderMode: '3d',
       videoInletCount: 0,
       videoOutletCount: 1
     }


### PR DESCRIPTION
Add GLSL-in-JavaScript codemirror autocompletions, and a bonus Octahedron SDF preset for testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GLSL code completions for embedded GLSL in JavaScript templates and shader functions.
  * Added "Octahedron SDF" shader preset for Shader Park.

* **Improvements**
  * Fixed code completions to no longer appear inappropriately inside JavaScript string contexts.

* **Documentation**
  * Added design specification for GLSL completion behavior.

* **Tests**
  * Added test coverage for GLSL completion scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->