### PR TITLE
feat(codemirror): add hover hints based on completion data

### DIFF
--- a/docs/design-docs/specs/126-surface-fullscreen-interaction.md
+++ b/docs/design-docs/specs/126-surface-fullscreen-interaction.md
@@ -261,6 +261,9 @@ Based on `CanvasDom.svelte` with these differences:
 - Canvas element is the overlay canvas from `SurfaceOverlay`, not an inline preview canvas
 - `setDrawMode()` added to `extraContext`
 - `onPointer()` / `onTouch()` added to `extraContext`
+- CodeMirror Patchies API completions should expose the documented surface JavaScript API:
+  `onPointer`, `onTouch`, `setDrawMode`, `redraw`, `activate`, `deactivate`,
+  `hideExitButton`, `onKeyDown`, `onKeyUp`, `setMouseForwarding`, and `noOutput`.
 - `pointer` and `touch` message outlets added
 - On mount: calls `SurfaceOverlay.activate(nodeId)`
 - On destroy: calls `SurfaceOverlay.deactivate(nodeId)`

--- a/docs/design-docs/specs/143-codemirror-completion-hover-hints.md
+++ b/docs/design-docs/specs/143-codemirror-completion-hover-hints.md
@@ -1,0 +1,19 @@
+# 143. CodeMirror Completion Hover Hints
+
+## Goal
+
+Show lightweight hover hints for single-token functions and values in CodeMirror using the same metadata as autocomplete.
+
+## Initial Scope
+
+- Hovering a global Patchies JavaScript API name such as `send` should show its autocomplete label, signature/detail, and description.
+- Hovering a Shader Park Sculpt global such as `sin`, `sphere`, or `time` should show the Shader Park autocomplete metadata in `shaderpark` nodes.
+- Hovering GLSL names such as `sin`, `length`, `uv`, or `iTime` should show GLSL autocomplete metadata in GLSL editors and recognized GLSL-in-JS template strings.
+- Normal JavaScript strings should not show Patchies or Shader Park hover hints.
+- Template-string interpolation bodies (`${...}`) should remain JavaScript hover contexts.
+
+## Out Of Scope
+
+- Member hovers such as `kv.get`, `settings.define`, or `clock.time`.
+- Type inference or local symbol documentation.
+- Hover hints for snippets that are not represented by a single hovered token.

--- a/docs/design-docs/specs/143-codemirror-completion-hover-hints.md
+++ b/docs/design-docs/specs/143-codemirror-completion-hover-hints.md
@@ -11,6 +11,7 @@ Show lightweight hover hints for single-token functions and values in CodeMirror
 - Hovering GLSL names such as `sin`, `length`, `uv`, or `iTime` should show GLSL autocomplete metadata in GLSL editors and recognized GLSL-in-JS template strings.
 - Normal JavaScript strings should not show Patchies or Shader Park hover hints.
 - Template-string interpolation bodies (`${...}`) should remain JavaScript hover contexts.
+- Hover tooltip content should keep a readable minimum width even when the code editor node is narrow, while still fitting within small viewports.
 
 ## Out Of Scope
 

--- a/docs/design-docs/specs/143-codemirror-completion-hover-hints.md
+++ b/docs/design-docs/specs/143-codemirror-completion-hover-hints.md
@@ -10,6 +10,7 @@ Show lightweight hover hints for single-token functions and values in CodeMirror
 - Hovering a Shader Park Sculpt global such as `sin`, `sphere`, or `time` should show the Shader Park autocomplete metadata in `shaderpark` nodes.
 - Hovering GLSL names such as `sin`, `length`, `uv`, or `iTime` should show GLSL autocomplete metadata in GLSL editors and recognized GLSL-in-JS template strings.
 - Normal JavaScript strings should not show Patchies or Shader Park hover hints.
+- Line comments (`//`) and block comments (`/* ... */`) should not show hover hints.
 - Template-string interpolation bodies (`${...}`) should remain JavaScript hover contexts.
 - Hover tooltip content should keep a readable minimum width even when the code editor node is narrow, while still fitting within small viewports.
 

--- a/ui/src/lib/codemirror/glsl-completions.ts
+++ b/ui/src/lib/codemirror/glsl-completions.ts
@@ -240,12 +240,14 @@ export function createGlslCompletionSource() {
     }
 
     const word = context.matchBefore(/[A-Za-z_]\w*/);
+
     if (!word) return null;
     if (word.from === word.to && !context.explicit) return null;
     if (isCompletionSuppressedByComment(context, word.from)) return null;
 
     const typedText = context.state.doc.sliceString(word.from, word.to).toLowerCase();
     const isExpressionPosition = isExpressionCompletionPosition(context, word.from);
+
     const options = [
       ...statementCompletions,
       ...builtInValueCompletions,
@@ -263,13 +265,12 @@ export function createGlslCompletionSource() {
   };
 }
 
-export function getGlslCompletionByLabel(label: string): Completion | undefined {
-  return [
+export const getGlslCompletionByLabel = (label: string): Completion | undefined =>
+  [
     ...statementCompletions,
     ...builtInValueCompletions,
     ...sampler2DDeclarationCompletions,
     ...expressionFunctionCompletions
   ].find((completion) => completion.label === label);
-}
 
 export const glslCompletions = createGlslCompletionSource();

--- a/ui/src/lib/codemirror/glsl-completions.ts
+++ b/ui/src/lib/codemirror/glsl-completions.ts
@@ -263,4 +263,13 @@ export function createGlslCompletionSource() {
   };
 }
 
+export function getGlslCompletionByLabel(label: string): Completion | undefined {
+  return [
+    ...statementCompletions,
+    ...builtInValueCompletions,
+    ...sampler2DDeclarationCompletions,
+    ...expressionFunctionCompletions
+  ].find((completion) => completion.label === label);
+}
+
 export const glslCompletions = createGlslCompletionSource();

--- a/ui/src/lib/codemirror/hover-hints.test.ts
+++ b/ui/src/lib/codemirror/hover-hints.test.ts
@@ -1,0 +1,111 @@
+import { javascriptLanguage } from '@codemirror/lang-javascript';
+import { EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+import { glslInJsWrap } from '$lib/codemirror/glsl-in-js';
+import { glslLanguage } from '$lib/codemirror/glsl.codemirror';
+import { getCompletionHoverHint } from '$lib/codemirror/hover-hints';
+
+function cursor(doc: string) {
+  const pos = doc.indexOf('|');
+
+  if (pos === -1) {
+    throw new Error('Missing | cursor marker');
+  }
+
+  return {
+    doc: doc.slice(0, pos) + doc.slice(pos + 1),
+    pos
+  };
+}
+
+function jsState(doc: string) {
+  return EditorState.create({
+    doc,
+    extensions: [javascriptLanguage.configure({ wrap: glslInJsWrap })]
+  });
+}
+
+function glslState(doc: string) {
+  return EditorState.create({
+    doc,
+    extensions: [glslLanguage]
+  });
+}
+
+describe('completion hover hints', () => {
+  it('uses Patchies JavaScript completion metadata for single-token globals', () => {
+    const { doc, pos } = cursor('se|nd("hello")');
+    const hint = getCompletionHoverHint(jsState(doc), pos, {
+      language: 'javascript',
+      nodeType: 'hydra'
+    });
+
+    expect(hint?.completion).toMatchObject({
+      label: 'send',
+      detail: '(message, options?) => void',
+      info: 'Send a message to connected nodes. Options: {to: outletIndex}'
+    });
+  });
+
+  it('uses Shader Park completion metadata in shaderpark nodes', () => {
+    const { doc, pos } = cursor('let x = si|n(time);');
+    const hint = getCompletionHoverHint(jsState(doc), pos, {
+      language: 'javascript',
+      nodeType: 'shaderpark'
+    });
+
+    expect(hint?.completion).toMatchObject({
+      label: 'sin',
+      detail: '(x: float | vecN) => same',
+      info: 'Sine of an angle in radians.'
+    });
+  });
+
+  it('uses GLSL completion metadata in GLSL editors', () => {
+    const { doc, pos } = cursor('float d = leng|th(uv);');
+    const hint = getCompletionHoverHint(glslState(doc), pos, {
+      language: 'glsl'
+    });
+
+    expect(hint?.completion).toMatchObject({
+      label: 'length',
+      detail: '(v: vecN) => float',
+      info: 'Vector magnitude.'
+    });
+  });
+
+  it('uses GLSL completion metadata inside recognized GLSL-in-JS template strings', () => {
+    const { doc, pos } = cursor('let sdf = glslSDF(`return leng|th(p);`);');
+    const hint = getCompletionHoverHint(jsState(doc), pos, {
+      language: 'javascript',
+      nodeType: 'shaderpark'
+    });
+
+    expect(hint?.completion).toMatchObject({
+      label: 'length',
+      detail: '(v: vecN) => float',
+      info: 'Vector magnitude.'
+    });
+  });
+
+  it('does not show Patchies hover hints inside normal JavaScript strings', () => {
+    const { doc, pos } = cursor('const label = "se|nd";');
+
+    expect(
+      getCompletionHoverHint(jsState(doc), pos, {
+        language: 'javascript',
+        nodeType: 'hydra'
+      })
+    ).toBeNull();
+  });
+
+  it('keeps template-string interpolation bodies in JavaScript hover context', () => {
+    const { doc, pos } = cursor('glsl`vec2 p = ${se|nd("x")}`;');
+    const hint = getCompletionHoverHint(jsState(doc), pos, {
+      language: 'javascript',
+      nodeType: 'hydra'
+    });
+
+    expect(hint?.completion.label).toBe('send');
+  });
+});

--- a/ui/src/lib/codemirror/hover-hints.test.ts
+++ b/ui/src/lib/codemirror/hover-hints.test.ts
@@ -12,29 +12,18 @@ function cursor(doc: string) {
     throw new Error('Missing | cursor marker');
   }
 
-  return {
-    doc: doc.slice(0, pos) + doc.slice(pos + 1),
-    pos
-  };
+  return { doc: doc.slice(0, pos) + doc.slice(pos + 1), pos };
 }
 
-function jsState(doc: string) {
-  return EditorState.create({
-    doc,
-    extensions: [javascriptLanguage.configure({ wrap: glslInJsWrap })]
-  });
-}
+const jsState = (doc: string) =>
+  EditorState.create({ doc, extensions: [javascriptLanguage.configure({ wrap: glslInJsWrap })] });
 
-function glslState(doc: string) {
-  return EditorState.create({
-    doc,
-    extensions: [glslLanguage]
-  });
-}
+const glslState = (doc: string) => EditorState.create({ doc, extensions: [glslLanguage] });
 
 describe('completion hover hints', () => {
   it('uses Patchies JavaScript completion metadata for single-token globals', () => {
     const { doc, pos } = cursor('se|nd("hello")');
+
     const hint = getCompletionHoverHint(jsState(doc), pos, {
       language: 'javascript',
       nodeType: 'hydra'
@@ -49,6 +38,7 @@ describe('completion hover hints', () => {
 
   it('uses Shader Park completion metadata in shaderpark nodes', () => {
     const { doc, pos } = cursor('let x = si|n(time);');
+
     const hint = getCompletionHoverHint(jsState(doc), pos, {
       language: 'javascript',
       nodeType: 'shaderpark'
@@ -63,6 +53,7 @@ describe('completion hover hints', () => {
 
   it('uses GLSL completion metadata in GLSL editors', () => {
     const { doc, pos } = cursor('float d = leng|th(uv);');
+
     const hint = getCompletionHoverHint(glslState(doc), pos, {
       language: 'glsl'
     });
@@ -76,6 +67,7 @@ describe('completion hover hints', () => {
 
   it('uses GLSL completion metadata inside recognized GLSL-in-JS template strings', () => {
     const { doc, pos } = cursor('let sdf = glslSDF(`return leng|th(p);`);');
+
     const hint = getCompletionHoverHint(jsState(doc), pos, {
       language: 'javascript',
       nodeType: 'shaderpark'
@@ -101,6 +93,7 @@ describe('completion hover hints', () => {
 
   it('keeps template-string interpolation bodies in JavaScript hover context', () => {
     const { doc, pos } = cursor('glsl`vec2 p = ${se|nd("x")}`;');
+
     const hint = getCompletionHoverHint(jsState(doc), pos, {
       language: 'javascript',
       nodeType: 'hydra'

--- a/ui/src/lib/codemirror/hover-hints.test.ts
+++ b/ui/src/lib/codemirror/hover-hints.test.ts
@@ -91,6 +91,28 @@ describe('completion hover hints', () => {
     ).toBeNull();
   });
 
+  it('does not show hover hints inside line comments', () => {
+    const { doc, pos } = cursor('// se|nd("hello")');
+
+    expect(
+      getCompletionHoverHint(jsState(doc), pos, {
+        language: 'javascript',
+        nodeType: 'hydra'
+      })
+    ).toBeNull();
+  });
+
+  it('does not show hover hints inside block comments', () => {
+    const { doc, pos } = cursor('/* se|nd("hello") */');
+
+    expect(
+      getCompletionHoverHint(jsState(doc), pos, {
+        language: 'javascript',
+        nodeType: 'hydra'
+      })
+    ).toBeNull();
+  });
+
   it('keeps template-string interpolation bodies in JavaScript hover context', () => {
     const { doc, pos } = cursor('glsl`vec2 p = ${se|nd("x")}`;');
 

--- a/ui/src/lib/codemirror/hover-hints.ts
+++ b/ui/src/lib/codemirror/hover-hints.ts
@@ -1,0 +1,150 @@
+import type { Completion } from '@codemirror/autocomplete';
+import { EditorState, type Extension } from '@codemirror/state';
+import { hoverTooltip, type Tooltip } from '@codemirror/view';
+import { match } from 'ts-pattern';
+import {
+  isGlslInJavaScriptCompletionContext,
+  isJavaScriptStringCompletionContext
+} from '$lib/codemirror/glsl-in-js';
+import { getGlslCompletionByLabel } from '$lib/codemirror/glsl-completions';
+import {
+  getPatchiesCompletionByLabel,
+  type PatchiesContext
+} from '$lib/codemirror/patchies-completions';
+import { getShaderParkCompletionByLabel } from '$lib/codemirror/shaderpark-completions';
+import type { SupportedLanguage } from '$lib/codemirror/types';
+
+export interface CompletionHoverContext extends PatchiesContext {
+  language?: SupportedLanguage | string;
+}
+
+export interface CompletionHoverHint {
+  from: number;
+  to: number;
+  completion: Completion;
+}
+
+const WORD_CHAR = /[A-Za-z0-9_$]/;
+
+function getWordAt(
+  state: EditorState,
+  pos: number
+): { from: number; to: number; text: string } | null {
+  const line = state.doc.lineAt(pos);
+  let from = pos;
+  let to = pos;
+
+  while (from > line.from && WORD_CHAR.test(line.text[from - line.from - 1])) {
+    from--;
+  }
+
+  while (to < line.to && WORD_CHAR.test(line.text[to - line.from])) {
+    to++;
+  }
+
+  if (from === to) return null;
+
+  return {
+    from,
+    to,
+    text: state.doc.sliceString(from, to)
+  };
+}
+
+function createCompletionContext(state: EditorState, pos: number) {
+  return {
+    state,
+    pos
+  } as Parameters<typeof isJavaScriptStringCompletionContext>[0];
+}
+
+function getCompletionForWord(
+  word: string,
+  state: EditorState,
+  pos: number,
+  context: CompletionHoverContext
+): Completion | undefined {
+  return match(context.language)
+    .with('glsl', () => getGlslCompletionByLabel(word))
+    .with('javascript', () => {
+      const completionContext = createCompletionContext(state, pos);
+
+      if (isGlslInJavaScriptCompletionContext(completionContext)) {
+        return getGlslCompletionByLabel(word);
+      }
+
+      if (isJavaScriptStringCompletionContext(completionContext)) {
+        return undefined;
+      }
+
+      if (context.nodeType === 'shaderpark') {
+        return getShaderParkCompletionByLabel(word);
+      }
+
+      return getPatchiesCompletionByLabel(word, context);
+    })
+    .otherwise(() => undefined);
+}
+
+export function getCompletionHoverHint(
+  state: EditorState,
+  pos: number,
+  context: CompletionHoverContext
+): CompletionHoverHint | null {
+  const word = getWordAt(state, pos);
+  if (!word) return null;
+
+  const completion = getCompletionForWord(word.text, state, pos, context);
+  if (!completion) return null;
+
+  return {
+    from: word.from,
+    to: word.to,
+    completion
+  };
+}
+
+function appendTooltipLine(dom: HTMLElement, className: string, text: unknown) {
+  if (typeof text !== 'string' || text.length === 0) return;
+
+  const line = document.createElement('div');
+  line.className = className;
+  line.textContent = text;
+  dom.appendChild(line);
+}
+
+function createCompletionHintDom(completion: Completion) {
+  const dom = document.createElement('div');
+  dom.className = 'cm-completion-hover';
+
+  appendTooltipLine(dom, 'cm-completion-hover-label', completion.label);
+  appendTooltipLine(dom, 'cm-completion-hover-detail', completion.detail);
+  appendTooltipLine(dom, 'cm-completion-hover-info', completion.info);
+
+  return dom;
+}
+
+export function completionHoverHints(context: CompletionHoverContext = {}): Extension {
+  return hoverTooltip(
+    (view, pos, side) => {
+      const hint = getCompletionHoverHint(view.state, pos, context);
+      if (!hint) return null;
+
+      if ((hint.from === pos && side < 0) || (hint.to === pos && side > 0)) {
+        return null;
+      }
+
+      return {
+        pos: hint.from,
+        end: hint.to,
+        above: true,
+        create() {
+          return {
+            dom: createCompletionHintDom(hint.completion)
+          };
+        }
+      } satisfies Tooltip;
+    },
+    { hoverTime: 250 }
+  );
+}

--- a/ui/src/lib/codemirror/hover-hints.ts
+++ b/ui/src/lib/codemirror/hover-hints.ts
@@ -31,6 +31,7 @@ function getWordAt(
   pos: number
 ): { from: number; to: number; text: string } | null {
   const line = state.doc.lineAt(pos);
+
   let from = pos;
   let to = pos;
 
@@ -51,12 +52,8 @@ function getWordAt(
   };
 }
 
-function createCompletionContext(state: EditorState, pos: number) {
-  return {
-    state,
-    pos
-  } as Parameters<typeof isJavaScriptStringCompletionContext>[0];
-}
+const createCompletionContext = (state: EditorState, pos: number) =>
+  ({ state, pos }) as Parameters<typeof isJavaScriptStringCompletionContext>[0];
 
 function getCompletionForWord(
   word: string,
@@ -74,7 +71,7 @@ function getCompletionForWord(
       }
 
       if (isJavaScriptStringCompletionContext(completionContext)) {
-        return undefined;
+        return;
       }
 
       if (context.nodeType === 'shaderpark') {
@@ -110,6 +107,7 @@ function appendTooltipLine(dom: HTMLElement, className: string, text: unknown) {
   const line = document.createElement('div');
   line.className = className;
   line.textContent = text;
+
   dom.appendChild(line);
 }
 
@@ -124,8 +122,8 @@ function createCompletionHintDom(completion: Completion) {
   return dom;
 }
 
-export function completionHoverHints(context: CompletionHoverContext = {}): Extension {
-  return hoverTooltip(
+export const completionHoverHints = (context: CompletionHoverContext = {}): Extension =>
+  hoverTooltip(
     (view, pos, side) => {
       const hint = getCompletionHoverHint(view.state, pos, context);
       if (!hint) return null;
@@ -138,13 +136,8 @@ export function completionHoverHints(context: CompletionHoverContext = {}): Exte
         pos: hint.from,
         end: hint.to,
         above: true,
-        create() {
-          return {
-            dom: createCompletionHintDom(hint.completion)
-          };
-        }
+        create: () => ({ dom: createCompletionHintDom(hint.completion) })
       } satisfies Tooltip;
     },
     { hoverTime: 250 }
   );
-}

--- a/ui/src/lib/codemirror/hover-hints.ts
+++ b/ui/src/lib/codemirror/hover-hints.ts
@@ -2,6 +2,7 @@ import type { Completion } from '@codemirror/autocomplete';
 import { EditorState, type Extension } from '@codemirror/state';
 import { hoverTooltip, type Tooltip } from '@codemirror/view';
 import { match } from 'ts-pattern';
+import { isCompletionSuppressedByComment } from '$lib/codemirror/completion-utils';
 import {
   isGlslInJavaScriptCompletionContext,
   isJavaScriptStringCompletionContext
@@ -86,12 +87,18 @@ function getCompletionForWord(
 export function getCompletionHoverHint(
   state: EditorState,
   pos: number,
-  context: CompletionHoverContext
+  hoverCtx: CompletionHoverContext
 ): CompletionHoverHint | null {
   const word = getWordAt(state, pos);
   if (!word) return null;
 
-  const completion = getCompletionForWord(word.text, state, pos, context);
+  const completionCtx = createCompletionContext(state, pos);
+
+  if (isCompletionSuppressedByComment(completionCtx, word.from)) {
+    return null;
+  }
+
+  const completion = getCompletionForWord(word.text, state, pos, hoverCtx);
   if (!completion) return null;
 
   return {

--- a/ui/src/lib/codemirror/language.ts
+++ b/ui/src/lib/codemirror/language.ts
@@ -24,6 +24,7 @@ export async function loadLanguageExtension(language: string, context?: Patchies
         { patchiesCompletions },
         { shaderParkCompletionsSource },
         { glslInJsCompletions, glslInJsWrap },
+        { completionHoverHints },
         { glslIncludeHighlighter }
       ] = await Promise.all([
         import('@codemirror/lang-javascript'),
@@ -32,6 +33,7 @@ export async function loadLanguageExtension(language: string, context?: Patchies
         import('$lib/codemirror/patchies-completions'),
         import('$lib/codemirror/shaderpark-completions'),
         import('$lib/codemirror/glsl-in-js'),
+        import('$lib/codemirror/hover-hints'),
         import('$lib/codemirror/glsl.codemirror')
       ]);
 
@@ -46,6 +48,7 @@ export async function loadLanguageExtension(language: string, context?: Patchies
             patchiesCompletions(context)
           ]
         }),
+        completionHoverHints({ ...context, language: 'javascript' }),
         ...glslIncludeHighlighter
       ];
     })
@@ -54,17 +57,20 @@ export async function loadLanguageExtension(language: string, context?: Patchies
         { LanguageSupport },
         { autocompletion },
         { glslLanguage, glslIncludeHighlighter, glslDirectiveCompletions },
-        { glslCompletions }
+        { glslCompletions },
+        { completionHoverHints }
       ] = await Promise.all([
         import('@codemirror/language'),
         import('@codemirror/autocomplete'),
         import('$lib/codemirror/glsl.codemirror'),
-        import('$lib/codemirror/glsl-completions')
+        import('$lib/codemirror/glsl-completions'),
+        import('$lib/codemirror/hover-hints')
       ]);
 
       return [
         new LanguageSupport(glslLanguage),
         autocompletion({ override: [glslDirectiveCompletions, glslCompletions] }),
+        completionHoverHints({ ...context, language: 'glsl' }),
         ...glslIncludeHighlighter
       ];
     })

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -68,6 +68,26 @@ describe('patchies completions', () => {
     expect(getCompletionLabels('js', 'settings.')).toContain('define');
   });
 
+  it('shows the documented surface JavaScript API completions', () => {
+    const labels = getCompletionLabels('surface', '');
+
+    expect(labels).toEqual(
+      expect.arrayContaining([
+        'onPointer',
+        'onTouch',
+        'onKeyDown',
+        'onKeyUp',
+        'setDrawMode',
+        'redraw',
+        'setMouseForwarding',
+        'activate',
+        'deactivate',
+        'hideExitButton',
+        'noOutput'
+      ])
+    );
+  });
+
   it('shows Shader Park completions only for shaderpark code', () => {
     expect(getShaderParkCompletionLabels('shaderpark', 'sp')).toContain('sphere');
     expect(getShaderParkCompletionLabels('shaderpark', 'setSpace(getS')).toContain('getSpace');

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -848,6 +848,32 @@ export function shouldShowPatchiesCompletions(context?: PatchiesContext): boolea
   return !PATCHIES_COMPLETION_DISABLED_NODE_TYPES.has(context.nodeType);
 }
 
+function isCompletionAllowedForNode(completion: Completion, context?: PatchiesContext): boolean {
+  if (!context?.nodeType) return true;
+
+  const allowedNodes = nodeSpecificFunctions[completion.label];
+
+  if (allowedNodes) {
+    return allowedNodes.includes(context.nodeType);
+  }
+
+  return true;
+}
+
+export function getPatchiesCompletionByLabel(
+  label: string,
+  context?: PatchiesContext
+): Completion | undefined {
+  if (!shouldShowPatchiesCompletions(context)) return undefined;
+  if (context?.nodeType === 'expr') return undefined;
+  if (context?.nodeType === 'msg') return undefined;
+
+  const completion = patchiesAPICompletions.find((option) => option.label === label);
+  if (!completion) return undefined;
+
+  return isCompletionAllowedForNode(completion, context) ? completion : undefined;
+}
+
 /**
  * Check if cursor is inside a function body by counting braces
  */
@@ -947,17 +973,9 @@ export function createPatchiesCompletionSource(patchiesContext?: PatchiesContext
 
     // Filter based on node type
     if (patchiesContext?.nodeType) {
-      options = options.filter((completion) => {
-        const allowedNodes = nodeSpecificFunctions[completion.label];
-
-        // If function has node restrictions, check if current node is allowed
-        if (allowedNodes) {
-          return allowedNodes.includes(patchiesContext.nodeType!);
-        }
-
-        // No restrictions, always show
-        return true;
-      });
+      options = options.filter((completion) =>
+        isCompletionAllowedForNode(completion, patchiesContext)
+      );
     }
 
     // Filter by prefix match only (not substring) - "quan" shouldn't match "requestAnimationFrame"

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -239,6 +239,55 @@ const patchiesAPICompletions: Completion[] = [
     apply: 'setMouseForwarding({ enabled: false })'
   },
   {
+    label: 'setDrawMode',
+    type: 'function',
+    detail: "('always' | 'interact' | 'manual') => void",
+    info: 'Control when the surface draw() function runs: every frame, on interaction, or only when redraw() is called.',
+    apply: "setDrawMode('interact')"
+  },
+  {
+    label: 'redraw',
+    type: 'function',
+    detail: '() => void',
+    info: "Manually trigger the surface draw() function when using setDrawMode('manual').",
+    apply: 'redraw()'
+  },
+  {
+    label: 'activate',
+    type: 'function',
+    detail: '() => void',
+    info: 'Enter fullscreen surface mode.',
+    apply: 'activate()'
+  },
+  {
+    label: 'deactivate',
+    type: 'function',
+    detail: '() => void',
+    info: 'Exit fullscreen surface mode.',
+    apply: 'deactivate()'
+  },
+  {
+    label: 'hideExitButton',
+    type: 'function',
+    detail: '() => void',
+    info: 'Hide the fullscreen surface exit badge.',
+    apply: 'hideExitButton()'
+  },
+  {
+    label: 'onPointer',
+    type: 'function',
+    detail: '(callback: (event) => void) => void',
+    info: "Register a surface pointer callback. Event includes normalized x/y, buttons, down, and type: 'move' | 'down' | 'up'.",
+    apply: 'onPointer(({ x, y, buttons, down, type }) => {\n  \n})'
+  },
+  {
+    label: 'onTouch',
+    type: 'function',
+    detail: '(callback: (touches) => void) => void',
+    info: 'Register a surface touch callback. Touches include id, normalized x/y, and pressure.',
+    apply: 'onTouch((touches) => {\n  \n})'
+  },
+  {
     label: 'setCanvasSize',
     type: 'function',
     detail: '(width: number, height: number) => void',
@@ -379,13 +428,20 @@ const topLevelOnlyFunctions = new Set([
   'onCleanup',
   'onKeyDown',
   'onKeyUp',
+  'onPointer',
   'onPointerDrag',
+  'onTouch',
   'onWheel',
   'onMessage',
   'onVideoFrame',
   'recv',
+  'activate',
+  'deactivate',
+  'hideExitButton',
+  'redraw',
   'setAudioPortCount',
   'setCanvasSize',
+  'setDrawMode',
   'setHidePorts',
   'setKeepAlive',
   'setMouseScope',
@@ -466,10 +522,18 @@ const nodeSpecificFunctions: Record<string, string[]> = {
     'textmode',
     'textmode.dom',
     'three',
-    'three.dom'
+    'three.dom',
+    'surface'
   ],
-  onKeyDown: ['canvas.dom', 'three.dom'],
-  onKeyUp: ['canvas.dom', 'three.dom'],
+  onKeyDown: ['canvas.dom', 'three.dom', 'surface'],
+  onKeyUp: ['canvas.dom', 'three.dom', 'surface'],
+  onPointer: ['surface'],
+  onTouch: ['surface'],
+  setDrawMode: ['surface'],
+  redraw: ['surface'],
+  activate: ['surface'],
+  deactivate: ['surface'],
+  hideExitButton: ['surface'],
   setAudioPortCount: ['dsp~'],
   setCanvasSize: ['canvas.dom', 'textmode.dom', 'three.dom'],
   setHidePorts: [

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -928,12 +928,12 @@ export function getPatchiesCompletionByLabel(
   label: string,
   context?: PatchiesContext
 ): Completion | undefined {
-  if (!shouldShowPatchiesCompletions(context)) return undefined;
-  if (context?.nodeType === 'expr') return undefined;
-  if (context?.nodeType === 'msg') return undefined;
+  if (!shouldShowPatchiesCompletions(context)) return;
+  if (context?.nodeType === 'expr') return;
+  if (context?.nodeType === 'msg') return;
 
   const completion = patchiesAPICompletions.find((option) => option.label === label);
-  if (!completion) return undefined;
+  if (!completion) return;
 
   return isCompletionAllowedForNode(completion, context) ? completion : undefined;
 }

--- a/ui/src/lib/codemirror/shaderpark-completions.ts
+++ b/ui/src/lib/codemirror/shaderpark-completions.ts
@@ -634,9 +634,8 @@ export function createShaderParkCompletionSource(patchiesContext?: PatchiesConte
   };
 }
 
-export function getShaderParkCompletionByLabel(label: string): Completion | undefined {
-  return shaderParkCompletions.find((completion) => completion.label === label);
-}
+export const getShaderParkCompletionByLabel = (label: string): Completion | undefined =>
+  shaderParkCompletions.find((completion) => completion.label === label);
 
 export const shaderParkCompletionsSource = (context?: PatchiesContext) =>
   createShaderParkCompletionSource(context);

--- a/ui/src/lib/codemirror/shaderpark-completions.ts
+++ b/ui/src/lib/codemirror/shaderpark-completions.ts
@@ -634,5 +634,9 @@ export function createShaderParkCompletionSource(patchiesContext?: PatchiesConte
   };
 }
 
+export function getShaderParkCompletionByLabel(label: string): Completion | undefined {
+  return shaderParkCompletions.find((completion) => completion.label === label);
+}
+
 export const shaderParkCompletionsSource = (context?: PatchiesContext) =>
   createShaderParkCompletionSource(context);

--- a/ui/src/lib/components/CodeEditor.svelte
+++ b/ui/src/lib/components/CodeEditor.svelte
@@ -265,6 +265,8 @@
             borderLeft: '3px solid rgb(239 68 68)'
           },
           '.cm-completion-hover': {
+            boxSizing: 'border-box',
+            minWidth: 'min(260px, calc(100vw - 32px))',
             maxWidth: '320px',
             padding: '8px 10px',
             border: '1px solid rgb(63 63 70)',

--- a/ui/src/lib/components/CodeEditor.svelte
+++ b/ui/src/lib/components/CodeEditor.svelte
@@ -109,7 +109,7 @@
     placeholder = '',
     class: className = '',
     onrun = () => {},
-    onchange = (code: string) => {},
+    onchange = () => {},
     oncommit,
     nodeId,
     dataKey = 'code',
@@ -263,6 +263,31 @@
           '.cm-errorLine': {
             backgroundColor: 'rgba(239, 68, 68, 0.15)',
             borderLeft: '3px solid rgb(239 68 68)'
+          },
+          '.cm-completion-hover': {
+            maxWidth: '320px',
+            padding: '8px 10px',
+            border: '1px solid rgb(63 63 70)',
+            borderRadius: '4px',
+            backgroundColor: 'rgb(39 39 42)',
+            boxShadow: '0 4px 12px rgba(0, 0, 0, 0.4)',
+            lineHeight: '1.35'
+          },
+          '.cm-completion-hover-label': {
+            color: 'rgb(244 244 245)',
+            fontSize: '12px',
+            fontWeight: '600'
+          },
+          '.cm-completion-hover-detail': {
+            marginTop: '2px',
+            color: 'rgb(147 197 253)',
+            fontSize: '11px'
+          },
+          '.cm-completion-hover-info': {
+            marginTop: '6px',
+            color: 'rgb(212 212 216)',
+            fontFamily: 'var(--font-sans)',
+            fontSize: '12px'
           },
           '.cm-error-tooltip': {
             backgroundColor: 'rgb(39 39 42)',

--- a/ui/src/lib/presets/builtin/shaderpark.presets.ts
+++ b/ui/src/lib/presets/builtin/shaderpark.presets.ts
@@ -121,6 +121,12 @@ let octahedron = glslSDF(\`
   }
 \`);
 
+shine(nsin(time))
+metal(nsin(time))
+
+let ray = getRayDirection()
+color(ray.z, ray.x, ray.y)
+
 octahedron(.6);`;
 
 type ShaderParkPresetData = {


### PR DESCRIPTION
Add hover hints based on the existing codemirror completion data.

<img width="1584" height="1320" alt="CleanShot 2569-05-22 at 23 19 19@2x" src="https://github.com/user-attachments/assets/1af19a30-62bf-4c08-ab1f-9ca45e2a8a36" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hover hints displaying completion metadata when hovering over code
  * Extended surface API completions with drawing and interaction controls
  * Enhanced shader preset with additional rendering effects

* **Documentation**
  * Documented CodeMirror completion hover hints behavior and scope
  * Updated surface API documentation with additional method completions

* **Tests**
  * Added comprehensive tests for completion hover and surface API functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->