### PR TITLE
feat(hydra): port the datamosh extension

### DIFF
--- a/docs/design-docs/specs/100-hydra-datamosh.md
+++ b/docs/design-docs/specs/100-hydra-datamosh.md
@@ -1,0 +1,57 @@
+# 100. Hydra Datamosh
+
+## Goal
+
+Add a native `datamosh()` helper to the `hydra` object so sketches can route a
+Hydra source through a lightweight WebCodecs feedback effect without importing
+the DOM-dependent `hydra-datamosh` browser extension.
+
+## API
+
+Hydra user code can call:
+
+```javascript
+const mosh = datamosh(s0, { speed: 2 })
+src(mosh).out()
+```
+
+`datamosh(source, params)` returns a Hydra `Source` object. The returned source
+is cached per input source so repeated calls during one code run reuse the same
+encoder/decoder pipeline.
+
+Supported params:
+
+- `speed?: number` - how many times to decode non-key frames, default `2`
+- `keyFrame?: boolean` - request a key frame on the next encoded frame
+- `fps?: number` - encoding frame rate cap, default `60`
+- `bitrate?: number` - VP8 bitrate, default `1_000_000`
+
+## Runtime Design
+
+Patchies Hydra runs inside the render worker, so the implementation must not use
+`window`, `document`, DOM canvases, or the global browser Hydra constructor.
+Instead, it uses worker-native primitives:
+
+- read the input Hydra source texture through the render worker WebGL context
+- convert the WebGL readback buffer to a `Uint8ClampedArray` before constructing
+  `ImageData`
+- build a `VideoFrame` from an `OffscreenCanvas`
+- encode with `VideoEncoder`
+- decode with `VideoDecoder`
+- draw decoded frames into an `OffscreenCanvas`
+- expose that canvas through a normal Hydra `Source`; the render loop advances
+  datamosh pipelines before Hydra output shaders draw, so texture sampling does
+  not run nested WebGL commands during uniform binding
+- reconfigure the WebCodecs encoder when the captured source dimensions change,
+  including the common case where a video inlet is connected after the Hydra
+  code already started running
+
+If WebCodecs is unavailable or VP8 is unsupported, `datamosh()` should return
+the original input source and log a warning once for that pipeline.
+
+## Non-Goals
+
+- Do not support the remote `https://emptyfla.sh/hydra-datamosh/datamosh.js`
+  module as-is.
+- Do not create a second browser Hydra instance.
+- Do not add a new object type.

--- a/docs/design-docs/specs/100-hydra-datamosh.md
+++ b/docs/design-docs/specs/100-hydra-datamosh.md
@@ -23,8 +23,13 @@ Supported params:
 
 - `speed?: number` - how many times to decode non-key frames, default `2`
 - `keyFrame?: boolean` - request a key frame on the next encoded frame
-- `fps?: number` - encoding frame rate cap, default `60`
+- `fps?: number` - encoding frame rate cap, default `60`; capped by the global
+  render FPS cap when it is not unlimited
 - `bitrate?: number` - VP8 bitrate, default `1_000_000`
+- `scale?: number` - encode/readback scale from `0.05` to `1`, default `1`
+- `width?: number` / `height?: number` - fixed encode/readback size; setting
+  one preserves source aspect ratio, setting both uses the requested size capped
+  to the source dimensions
 
 ## Runtime Design
 
@@ -38,6 +43,10 @@ Instead, it uses worker-native primitives:
 - use `PixelReadbackService` PBOs for async readback: one tick initiates the
   read, a later tick harvests it with `clientWaitSync(..., 0, 0)` and encodes it
   without blocking the render loop
+- scale or resize the readback before the PBO read so readback, canvas upload,
+  and WebCodecs encode costs drop with pixel count
+- cap datamosh encoding FPS by the renderer's global FPS cap, so a 30 FPS render
+  cap prevents datamosh from encoding at 60 FPS even when params request it
 - build a `VideoFrame` from an `OffscreenCanvas`
 - encode with `VideoEncoder`
 - decode with `VideoDecoder`

--- a/docs/design-docs/specs/100-hydra-datamosh.md
+++ b/docs/design-docs/specs/100-hydra-datamosh.md
@@ -45,6 +45,9 @@ Instead, it uses worker-native primitives:
 - reconfigure the WebCodecs encoder when the captured source dimensions change,
   including the common case where a video inlet is connected after the Hydra
   code already started running
+- lazy-load and create the datamosh runtime only when Hydra code uses
+  `datamosh(...)`, so normal Hydra sketches do not pay WebCodecs setup or
+  per-pipeline tick overhead
 
 If WebCodecs is unavailable or VP8 is unsupported, `datamosh()` should return
 the original input source and log a warning once for that pipeline.

--- a/docs/design-docs/specs/100-hydra-datamosh.md
+++ b/docs/design-docs/specs/100-hydra-datamosh.md
@@ -32,9 +32,12 @@ Patchies Hydra runs inside the render worker, so the implementation must not use
 `window`, `document`, DOM canvases, or the global browser Hydra constructor.
 Instead, it uses worker-native primitives:
 
-- read the input Hydra source texture through the render worker WebGL context
-- convert the WebGL readback buffer to a `Uint8ClampedArray` before constructing
-  `ImageData`
+- read the input Hydra source texture through the render worker WebGL context,
+  flipping Y in the GPU copy shader so the CPU path does not need a scratch
+  canvas flip
+- use `PixelReadbackService` PBOs for async readback: one tick initiates the
+  read, a later tick harvests it with `clientWaitSync(..., 0, 0)` and encodes it
+  without blocking the render loop
 - build a `VideoFrame` from an `OffscreenCanvas`
 - encode with `VideoEncoder`
 - decode with `VideoDecoder`

--- a/docs/design-docs/specs/59-preset-packs.md
+++ b/docs/design-docs/specs/59-preset-packs.md
@@ -208,6 +208,11 @@ preset pack. Larger visual effect libraries remain in their own opt-in preset pa
 - various glsl presets
 - three.js presets
 
+**Hydra Operators:**
+
+- Include compact Hydra utility presets such as `add.hydra`, `diff.hydra`, and `Datamosh`.
+- Operator presets should expose the inlet/outlet counts needed for immediate patching.
+
 **Hydra Demos:**
 
 - Community Hydra sketches live in the **Hydra Demos** preset pack.

--- a/ui/src/lib/ai/object-prompts/hydra.ts
+++ b/ui/src/lib/ai/object-prompts/hydra.ts
@@ -5,7 +5,7 @@ Live coding video synthesis with chainable Hydra functions.
 
 **Hydra-specific methods:**
 - setVideoCount(inlets, outlets) - Configure video ports (default 1, 1); max 8 each
-- datamosh(source, params) - Native WebCodecs datamosh effect; use like src(datamosh(s0, { speed: 2 })).out()
+- datamosh(source, params) - Native WebCodecs datamosh effect; use like src(datamosh(s0, { speed: 2, fps: 30, scale: 0.5 })).out()
 - src(s0), src(s1), etc. - Access video inputs from setVideoCount
 - out(o0), out(o1), etc. - Route to specific outlet; setVideoCount(0, 2) creates 2 outlets
 - Multiple outputs: setVideoCount(0, 2) then osc().out(o0); noise().out(o1)

--- a/ui/src/lib/ai/object-prompts/hydra.ts
+++ b/ui/src/lib/ai/object-prompts/hydra.ts
@@ -5,6 +5,7 @@ Live coding video synthesis with chainable Hydra functions.
 
 **Hydra-specific methods:**
 - setVideoCount(inlets, outlets) - Configure video ports (default 1, 1); max 8 each
+- datamosh(source, params) - Native WebCodecs datamosh effect; use like src(datamosh(s0, { speed: 2 })).out()
 - src(s0), src(s1), etc. - Access video inputs from setVideoCount
 - out(o0), out(o1), etc. - Route to specific outlet; setVideoCount(0, 2) creates 2 outlets
 - Multiple outputs: setVideoCount(0, 2) then osc().out(o0); noise().out(o1)

--- a/ui/src/lib/ai/object-prompts/hydra.ts
+++ b/ui/src/lib/ai/object-prompts/hydra.ts
@@ -5,11 +5,11 @@ Live coding video synthesis with chainable Hydra functions.
 
 **Hydra-specific methods:**
 - setVideoCount(inlets, outlets) - Configure video ports (default 1, 1); max 8 each
-- datamosh(source, params) - Native WebCodecs datamosh effect; use like src(datamosh(s0, { speed: 2, fps: 30, scale: 0.5 })).out()
 - src(s0), src(s1), etc. - Access video inputs from setVideoCount
 - out(o0), out(o1), etc. - Route to specific outlet; setVideoCount(0, 2) creates 2 outlets
 - Multiple outputs: setVideoCount(0, 2) then osc().out(o0); noise().out(o1)
 - Standard Hydra: .blend(), .add(), .mult(), .diff(), .kaleid(), etc.
+- datamosh(source, params) - datamosh effect e.g. src(datamosh(s0, { speed: 2, fps: 30, scale: 0.5 })).out()
 
 **setFunction — define custom generators/modifiers (always \`await\`):**
 - \`type: 'src'\` — generator; receives \`vec2 _st\`, returns the function to call

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -108,8 +108,8 @@ const patchiesAPICompletions: Completion[] = [
     label: 'datamosh',
     type: 'function',
     detail: '(source, params?) => Source',
-    info: 'Route a Hydra source through the native WebCodecs datamosh effect. Params: speed, keyFrame, fps, bitrate.',
-    apply: 'datamosh(s0, { speed: 2 })'
+    info: 'Route a Hydra source through the native WebCodecs datamosh effect. Params: speed, keyFrame, fps, bitrate, scale, width, height.',
+    apply: 'datamosh(s0, { speed: 2, fps: 30, scale: 0.5 })'
   },
 
   // Node Configuration

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -104,6 +104,13 @@ const patchiesAPICompletions: Completion[] = [
     info: "Set mouse tracking scope. 'local' (default) tracks within canvas, 'global' tracks across entire screen",
     apply: "setMouseScope('global')"
   },
+  {
+    label: 'datamosh',
+    type: 'function',
+    detail: '(source, params?) => Source',
+    info: 'Route a Hydra source through the native WebCodecs datamosh effect. Params: speed, keyFrame, fps, bitrate.',
+    apply: 'datamosh(s0, { speed: 2 })'
+  },
 
   // Node Configuration
   {
@@ -579,6 +586,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   setResolution: ['hydra', 'canvas', 'three', 'regl', 'swgl', 'textmode'],
   setPrimaryButton: ['js', 'worker', 'p5', 'hydra', 'canvas', 'regl', 'swgl', 'textmode', 'three'],
   setVideoCount: ['hydra', 'regl', 'swgl', 'three', 'worker'],
+  datamosh: ['hydra'],
   getTexture: ['hydra', 'regl', 'swgl', 'three'],
   OrbitControls: ['three'],
   onPointerDrag: ['three'],

--- a/ui/src/lib/data/license-data.ts
+++ b/ui/src/lib/data/license-data.ts
@@ -484,6 +484,16 @@ export const portedCode: PortedCode[] = [
       'Local fork at ui/src/lib/hydra/ modifies error handling to integrate with Patchies error reporting instead of console.log.'
   },
   {
+    name: 'hydra-datamosh',
+    description:
+      'Patchies datamosh support is based on the WebCodecs source/output datamosh approach from the hydra-datamosh extension.',
+    authors: 'emptyflash',
+    repository: 'https://github.com/emptyflash/hydra-datamosh',
+    license: 'No license listed',
+    notes:
+      'Patchies implements a worker-native datamosh helper for its local Hydra renderer instead of importing the browser extension directly. Upstream documentation: https://github.com/emptyflash/hydra-datamosh/blob/main/README.md'
+  },
+  {
     name: 'Superdough (patched)',
     description:
       'Superdough is used by the Strudel node for audio synthesis. Patchies includes a patched version with minor modifications.',

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -41,7 +41,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'Video operators built with Hydra',
     icon: 'Palette',
     requiredObjects: ['hydra'],
-    presets: ['add.hydra', 'diff.hydra', 'sub.hydra', 'blend.hydra', 'mask.hydra']
+    presets: ['add.hydra', 'diff.hydra', 'sub.hydra', 'blend.hydra', 'mask.hydra', 'Datamosh']
   },
   {
     id: 'texture-generators',

--- a/ui/src/lib/presets/builtin/hydra/datamosh.ts
+++ b/ui/src/lib/presets/builtin/hydra/datamosh.ts
@@ -3,7 +3,7 @@ import type { HydraPreset } from './types';
 const code = `// based on https://github.com/emptyflash/hydra-datamosh
 setVideoCount(1)
 
-src(datamosh(s0, { speed: 3 })).out()`;
+src(datamosh(s0, { speed: 3, fps: 30, scale: 0.5 })).out()`;
 
 export const preset: HydraPreset = {
   type: 'hydra',

--- a/ui/src/lib/presets/builtin/hydra/datamosh.ts
+++ b/ui/src/lib/presets/builtin/hydra/datamosh.ts
@@ -1,0 +1,19 @@
+import type { HydraPreset } from './types';
+
+const code = `// based on https://github.com/emptyflash/hydra-datamosh
+setVideoCount(1)
+
+src(datamosh(s0, { speed: 3 })).out()`;
+
+export const preset: HydraPreset = {
+  type: 'hydra',
+  description: 'Datamosh a video inlet with a WebCodecs feedback effect',
+  data: {
+    code: code.trim(),
+    messageInletCount: 0,
+    messageOutletCount: 0,
+    videoInletCount: 1,
+    videoOutletCount: 1,
+    title: 'Datamosh'
+  }
+};

--- a/ui/src/lib/presets/builtin/hydra/index.ts
+++ b/ui/src/lib/presets/builtin/hydra/index.ts
@@ -63,6 +63,7 @@ import { preset as preset61 } from './ee-2-multiverse';
 import { preset as preset62 } from './ee-3-lines';
 import { preset as preset63 } from './ee-5-fugitive-geometry-vhs';
 import { preset as preset64 } from './ee-1-eye-in-the-sky';
+import { preset as preset65 } from './datamosh';
 
 import type { HydraPreset } from './types';
 
@@ -135,6 +136,7 @@ export const HYDRA_PRESETS: Record<string, HydraPreset> = {
   'blend.hydra': preset4,
   'mask.hydra': preset5,
   'fft.hydra': preset6,
+  Datamosh: preset65,
   ...HYDRA_DEMO_PRESETS
 };
 

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -130,6 +130,7 @@ export class FBORenderer {
 
   /** Minimum interval between rendered frames (ms). 0 = unlimited. */
   private renderIntervalMs: number = 0;
+  public renderFpsCap: number = 0;
   private lastRenderTime: number = 0;
 
   /** Transport time from main thread for synchronized timing */
@@ -1750,6 +1751,8 @@ export class FBORenderer {
 
   /** Set the render FPS cap. 0 = unlimited (render every frame). */
   setRenderFpsCap(fps: number): void {
+    this.renderFpsCap = fps;
+
     // Subtract 1ms tolerance so rAF timing jitter doesn't cause us to skip
     // the correct frame (e.g. 60 FPS on 120Hz: 16.6ms is just under 16.67ms)
     this.renderIntervalMs = fps > 0 ? 1000 / fps - 1 : 0;

--- a/ui/src/workers/rendering/hydraDatamosh.test.ts
+++ b/ui/src/workers/rendering/hydraDatamosh.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createHydraDatamosh } from './hydraDatamosh';
+import { createHydraDatamosh, getDatamoshFrameSize, normalizeFps } from './hydraDatamosh';
 
 type TestCodecs = NonNullable<Parameters<typeof createHydraDatamosh>[0]['codecs']>;
 
@@ -132,6 +132,43 @@ describe('createHydraDatamosh', () => {
       expect.any(codecs.VideoFrame),
       expect.objectContaining({ keyFrame: true })
     );
+  });
+});
+
+describe('getDatamoshFrameSize', () => {
+  it('scales source dimensions down by scale', () => {
+    expect(getDatamoshFrameSize(1920, 1080, { scale: 0.5 })).toEqual({
+      width: 960,
+      height: 540
+    });
+  });
+
+  it('preserves aspect ratio when only width is set', () => {
+    expect(getDatamoshFrameSize(1920, 1080, { width: 640 })).toEqual({
+      width: 640,
+      height: 360
+    });
+  });
+
+  it('caps explicit dimensions to source size', () => {
+    expect(getDatamoshFrameSize(320, 180, { width: 640, height: 360 })).toEqual({
+      width: 320,
+      height: 180
+    });
+  });
+});
+
+describe('normalizeFps', () => {
+  it('caps default datamosh fps by the global render fps cap', () => {
+    expect(normalizeFps(undefined, 30)).toBe(30);
+  });
+
+  it('caps user-provided datamosh fps by the global render fps cap', () => {
+    expect(normalizeFps(60, 30)).toBe(30);
+  });
+
+  it('treats global render fps cap 0 as unlimited', () => {
+    expect(normalizeFps(60, 0)).toBe(60);
   });
 });
 

--- a/ui/src/workers/rendering/hydraDatamosh.test.ts
+++ b/ui/src/workers/rendering/hydraDatamosh.test.ts
@@ -170,6 +170,16 @@ describe('normalizeFps', () => {
   it('treats global render fps cap 0 as unlimited', () => {
     expect(normalizeFps(60, 0)).toBe(60);
   });
+
+  it('falls back to default fps when user fps is non-finite', () => {
+    expect(normalizeFps(Number.NaN, 0)).toBe(60);
+    expect(normalizeFps(Number.POSITIVE_INFINITY, 0)).toBe(60);
+  });
+
+  it('treats non-finite global render fps cap as unlimited', () => {
+    expect(normalizeFps(60, Number.NaN)).toBe(60);
+    expect(normalizeFps(60, Number.POSITIVE_INFINITY)).toBe(60);
+  });
 });
 
 function createCodecs() {

--- a/ui/src/workers/rendering/hydraDatamosh.test.ts
+++ b/ui/src/workers/rendering/hydraDatamosh.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createHydraDatamosh } from './hydraDatamosh';
+
+type TestCodecs = NonNullable<Parameters<typeof createHydraDatamosh>[0]['codecs']>;
+
+const createSource = () => ({
+  init: vi.fn(),
+  tick: vi.fn(),
+  getTexture: vi.fn()
+});
+
+describe('createHydraDatamosh', () => {
+  it('returns the original source and warns once when WebCodecs are unavailable', () => {
+    const warn = vi.fn();
+    const datamosh = createHydraDatamosh({
+      createSource,
+      captureSourceFrame: vi.fn(),
+      codecs: {},
+      console: { warn }
+    });
+    const source = createSource();
+
+    expect(datamosh(source)).toBe(source);
+    expect(datamosh(source)).toBe(source);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches the datamoshed source per input source', () => {
+    const datamosh = createHydraDatamosh({
+      createSource,
+      captureSourceFrame: vi.fn(),
+      codecs: createCodecs() as unknown as TestCodecs,
+      console: { warn: vi.fn() },
+      createCanvas
+    });
+    const source = createSource();
+
+    expect(datamosh(source)).toBe(datamosh(source));
+    expect(datamosh(source)).not.toBe(source);
+  });
+
+  it('decodes non-key frames according to speed', () => {
+    const codecs = createCodecs();
+    const datamosh = createHydraDatamosh({
+      createSource,
+      captureSourceFrame: vi.fn(),
+      codecs: codecs as unknown as TestCodecs,
+      console: { warn: vi.fn() },
+      createCanvas,
+      now: () => 100
+    });
+
+    const source = createSource();
+    const moshed = datamosh(source, { speed: 3 });
+
+    moshed.tick();
+    codecs.encoderOutput({ type: 'delta' });
+
+    expect(codecs.decoderDecode).toHaveBeenCalledTimes(3);
+  });
+
+  it('advances active pipelines from the render tick', () => {
+    const codecs = createCodecs();
+    const captureSourceFrame = vi.fn(() => ({ width: 2, height: 2 }));
+    const datamosh = createHydraDatamosh({
+      createSource,
+      captureSourceFrame,
+      codecs: codecs as unknown as TestCodecs,
+      console: { warn: vi.fn() },
+      createCanvas,
+      now: () => 100
+    });
+
+    const source = createSource();
+    datamosh(source);
+
+    datamosh.tick();
+
+    expect(captureSourceFrame).toHaveBeenCalledTimes(1);
+    expect(codecs.encoderEncode).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not advance the pipeline while sampling the returned source texture', () => {
+    const codecs = createCodecs();
+    const captureSourceFrame = vi.fn(() => ({ width: 2, height: 2 }));
+    const datamosh = createHydraDatamosh({
+      createSource,
+      captureSourceFrame,
+      codecs: codecs as unknown as TestCodecs,
+      console: { warn: vi.fn() },
+      createCanvas,
+      now: () => 100
+    });
+
+    const source = createSource();
+    const moshed = datamosh(source);
+
+    moshed.getTexture();
+
+    expect(captureSourceFrame).not.toHaveBeenCalled();
+    expect(codecs.encoderEncode).not.toHaveBeenCalled();
+  });
+
+  it('reconfigures the encoder when a later connected video inlet changes source size', () => {
+    const codecs = createCodecs();
+    let currentTime = 100;
+    let size = { width: 1, height: 1 };
+    const captureSourceFrame = vi.fn(() => size);
+    const datamosh = createHydraDatamosh({
+      createSource,
+      captureSourceFrame,
+      codecs: codecs as unknown as TestCodecs,
+      console: { warn: vi.fn() },
+      createCanvas,
+      now: () => currentTime
+    });
+
+    const source = createSource();
+    datamosh(source);
+
+    datamosh.tick();
+    size = { width: 640, height: 360 };
+    currentTime = 200;
+    datamosh.tick();
+
+    expect(codecs.encoderConfigure).toHaveBeenCalledTimes(2);
+    expect(codecs.encoderConfigure).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ width: 640, height: 360 })
+    );
+    expect(codecs.encoderEncode).toHaveBeenLastCalledWith(
+      expect.any(codecs.VideoFrame),
+      expect.objectContaining({ keyFrame: true })
+    );
+  });
+});
+
+function createCodecs() {
+  let encoderOutput: (chunk: { type: 'key' | 'delta' }) => void = () => {};
+  const encoderConfigure = vi.fn();
+  const encoderEncode = vi.fn();
+  const decoderDecode = vi.fn();
+
+  class VideoEncoder {
+    state = 'unconfigured';
+
+    constructor(init: { output: typeof encoderOutput }) {
+      encoderOutput = init.output;
+    }
+
+    configure(config: unknown) {
+      encoderConfigure(config);
+      this.state = 'configured';
+    }
+
+    encode = encoderEncode;
+    close = vi.fn();
+  }
+
+  class VideoDecoder {
+    state = 'unconfigured';
+
+    constructor() {}
+
+    configure() {
+      this.state = 'configured';
+    }
+
+    decode = decoderDecode;
+    close = vi.fn();
+  }
+
+  class VideoFrame {
+    constructor() {}
+    close = vi.fn();
+  }
+
+  return {
+    VideoEncoder,
+    VideoDecoder,
+    VideoFrame,
+    encoderConfigure,
+    encoderEncode,
+    encoderOutput: (chunk: { type: 'key' | 'delta' }) => encoderOutput(chunk),
+    decoderDecode
+  };
+}
+
+function createCanvas(width: number, height: number) {
+  return {
+    width,
+    height,
+    getContext: () => ({ drawImage: vi.fn() })
+  } as unknown as OffscreenCanvas;
+}

--- a/ui/src/workers/rendering/hydraDatamosh.ts
+++ b/ui/src/workers/rendering/hydraDatamosh.ts
@@ -455,8 +455,10 @@ export class HydraDatamoshRuntime {
 const normalizeSpeed = (speed: number | undefined): number => Math.max(1, Math.floor(speed ?? 2));
 
 export const normalizeFps = (fps: number | undefined, renderFpsCap = 0): number => {
-  const requestedFps = Math.max(1, Math.min(240, Math.floor(fps ?? 60)));
-  const cap = Math.floor(renderFpsCap);
+  const safeFps = Number.isFinite(fps) ? fps : 60;
+  const safeRenderFpsCap = Number.isFinite(renderFpsCap) ? renderFpsCap : 0;
+  const requestedFps = Math.max(1, Math.min(240, Math.floor(safeFps ?? 60)));
+  const cap = Math.floor(safeRenderFpsCap);
 
   if (cap <= 0) {
     return requestedFps;

--- a/ui/src/workers/rendering/hydraDatamosh.ts
+++ b/ui/src/workers/rendering/hydraDatamosh.ts
@@ -8,6 +8,9 @@ export type DatamoshParams = {
   keyFrame?: boolean;
   fps?: number;
   bitrate?: number;
+  scale?: number;
+  width?: number;
+  height?: number;
 };
 
 type HydraSource = Pick<Source, 'init' | 'tick' | 'getTexture'>;
@@ -15,7 +18,8 @@ type HydraSource = Pick<Source, 'init' | 'tick' | 'getTexture'>;
 type CaptureSourceFrame = (
   source: HydraSource,
   canvas: OffscreenCanvas,
-  ctx: OffscreenCanvasRenderingContext2D
+  ctx: OffscreenCanvasRenderingContext2D,
+  params: DatamoshParams
 ) => { width: number; height: number } | null;
 
 type VideoEncoderConstructor = new (init: VideoEncoderInit) => VideoEncoder;
@@ -65,6 +69,7 @@ export function createHydraDatamosh(options: {
   codecs?: CodecConstructors;
   console?: DatamoshConsole;
   createCanvas?: (width: number, height: number) => OffscreenCanvas;
+  getRenderFpsCap?: () => number;
   now?: () => number;
 }): HydraDatamosh {
   const codecs = options.codecs ?? globalThis;
@@ -166,7 +171,7 @@ export function createHydraDatamosh(options: {
 
     outputSource.tick = () => {
       const currentTime = now();
-      const fpsInterval = 1000 / normalizeFps(pipelineParams.fps);
+      const fpsInterval = 1000 / normalizeFps(pipelineParams.fps, options.getRenderFpsCap?.());
 
       if (currentTime - lastFrame >= fpsInterval) {
         const encoded = processFrame(
@@ -204,7 +209,7 @@ export function createHydraDatamosh(options: {
     encoder: VideoEncoder,
     encoderSize: EncoderSize
   ): boolean {
-    const size = options.captureSourceFrame(source, encodeCanvas, encodeCtx);
+    const size = options.captureSourceFrame(source, encodeCanvas, encodeCtx, params);
     if (!size) return false;
 
     if (outputCanvas.width !== size.width || outputCanvas.height !== size.height) {
@@ -220,7 +225,7 @@ export function createHydraDatamosh(options: {
         width: size.width,
         height: size.height,
         bitrate: params.bitrate ?? 1_000_000,
-        framerate: normalizeFps(params.fps),
+        framerate: normalizeFps(params.fps, options.getRenderFpsCap?.()),
         latencyMode: 'realtime'
       });
 
@@ -260,6 +265,7 @@ export class HydraDatamoshRuntime {
     this.datamosh = createHydraDatamosh({
       createSource: () => new Source(this.hydra.glEnvironment),
       captureSourceFrame: this.captureSourceFrame.bind(this),
+      getRenderFpsCap: () => this.renderer.renderFpsCap,
       console
     });
   }
@@ -286,16 +292,19 @@ export class HydraDatamoshRuntime {
   private captureSourceFrame(
     source: { getTexture: () => regl.Texture2D | regl.Framebuffer2D },
     canvas: OffscreenCanvas,
-    ctx: OffscreenCanvasRenderingContext2D
+    ctx: OffscreenCanvasRenderingContext2D,
+    params: DatamoshParams
   ): { width: number; height: number } | null {
     const texture = source.getTexture();
     if (!texture) return null;
 
-    const { width, height } = getTextureSize(texture);
-    if (!width || !height) return null;
+    const sourceSize = getTextureSize(texture);
+    if (!sourceSize.width || !sourceSize.height) return null;
 
+    const targetSize = getDatamoshFrameSize(sourceSize.width, sourceSize.height, params);
     const completed = this.harvestRead(source, canvas, ctx);
-    this.initiateRead(source, texture, width, height);
+
+    this.initiateRead(source, texture, targetSize);
 
     return completed;
   }
@@ -355,14 +364,14 @@ export class HydraDatamoshRuntime {
   private initiateRead(
     source: object,
     texture: regl.Texture2D | regl.Framebuffer2D,
-    width: number,
-    height: number
+    targetSize: { width: number; height: number }
   ) {
     if (this.pendingReads.has(source)) {
       return;
     }
 
     const { gl, pixelReadbackService } = this.renderer;
+    const { width, height } = targetSize;
 
     pixelReadbackService.ensureIntermediateFboSize(width, height);
 
@@ -445,8 +454,64 @@ export class HydraDatamoshRuntime {
 
 const normalizeSpeed = (speed: number | undefined): number => Math.max(1, Math.floor(speed ?? 2));
 
-const normalizeFps = (fps: number | undefined): number =>
-  Math.max(1, Math.min(240, Math.floor(fps ?? 60)));
+export const normalizeFps = (fps: number | undefined, renderFpsCap = 0): number => {
+  const requestedFps = Math.max(1, Math.min(240, Math.floor(fps ?? 60)));
+  const cap = Math.floor(renderFpsCap);
+
+  if (cap <= 0) {
+    return requestedFps;
+  }
+
+  return Math.max(1, Math.min(requestedFps, cap));
+};
+
+export function getDatamoshFrameSize(
+  sourceWidth: number,
+  sourceHeight: number,
+  params: DatamoshParams
+): { width: number; height: number } {
+  const explicitWidth = normalizeDimension(params.width);
+  const explicitHeight = normalizeDimension(params.height);
+
+  if (explicitWidth && explicitHeight) {
+    return clampFrameSize(explicitWidth, explicitHeight, sourceWidth, sourceHeight);
+  }
+
+  if (explicitWidth) {
+    const height = Math.round(explicitWidth * (sourceHeight / sourceWidth));
+
+    return clampFrameSize(explicitWidth, height, sourceWidth, sourceHeight);
+  }
+
+  if (explicitHeight) {
+    const width = Math.round(explicitHeight * (sourceWidth / sourceHeight));
+
+    return clampFrameSize(width, explicitHeight, sourceWidth, sourceHeight);
+  }
+
+  const scale = Math.max(0.05, Math.min(1, params.scale ?? 1));
+
+  return {
+    width: Math.max(1, Math.floor(sourceWidth * scale)),
+    height: Math.max(1, Math.floor(sourceHeight * scale))
+  };
+}
+
+const normalizeDimension = (value: number | undefined): number | null => {
+  if (!Number.isFinite(value) || value === undefined) return null;
+
+  return Math.max(1, Math.floor(value));
+};
+
+const clampFrameSize = (
+  width: number,
+  height: number,
+  sourceWidth: number,
+  sourceHeight: number
+): { width: number; height: number } => ({
+  width: Math.max(1, Math.min(width, sourceWidth)),
+  height: Math.max(1, Math.min(height, sourceHeight))
+});
 
 function closeCodec(codec: { state?: string; close: () => void }) {
   if (codec.state === 'closed') return;

--- a/ui/src/workers/rendering/hydraDatamosh.ts
+++ b/ui/src/workers/rendering/hydraDatamosh.ts
@@ -47,6 +47,13 @@ type CopyDrawProps = {
   framebuffer: regl.Framebuffer2D | null;
 };
 
+type PendingRead = {
+  pbo: WebGLBuffer;
+  sync: WebGLSync;
+  width: number;
+  height: number;
+};
+
 export type HydraDatamosh = ((source: HydraSource, params?: DatamoshParams) => HydraSource) & {
   destroy: () => void;
   tick: () => void;
@@ -162,7 +169,7 @@ export function createHydraDatamosh(options: {
       const fpsInterval = 1000 / normalizeFps(pipelineParams.fps);
 
       if (currentTime - lastFrame >= fpsInterval) {
-        processFrame(
+        const encoded = processFrame(
           source,
           pipelineParams,
           encodeCanvas,
@@ -172,7 +179,9 @@ export function createHydraDatamosh(options: {
           encoderSize
         );
 
-        lastFrame = currentTime;
+        if (encoded) {
+          lastFrame = currentTime;
+        }
       }
 
       originalTick();
@@ -194,9 +203,9 @@ export function createHydraDatamosh(options: {
     outputCanvas: OffscreenCanvas,
     encoder: VideoEncoder,
     encoderSize: EncoderSize
-  ) {
+  ): boolean {
     const size = options.captureSourceFrame(source, encodeCanvas, encodeCtx);
-    if (!size) return;
+    if (!size) return false;
 
     if (outputCanvas.width !== size.width || outputCanvas.height !== size.height) {
       outputCanvas.width = size.width;
@@ -229,6 +238,8 @@ export function createHydraDatamosh(options: {
 
     params.keyFrame = false;
     frame.close();
+
+    return true;
   }
 
   return datamosh;
@@ -238,12 +249,8 @@ export class HydraDatamoshRuntime {
   readonly datamosh: HydraDatamosh;
 
   private copyDraw: regl.DrawCommand | null = null;
-  private readFbo: regl.Framebuffer2D | null = null;
-  private readWidth = 0;
-  private readHeight = 0;
-  private pixels: Uint8Array | null = null;
-  private scratchCanvas: OffscreenCanvas | null = null;
-  private scratchCtx: OffscreenCanvasRenderingContext2D | null = null;
+  private pendingReads = new WeakMap<object, PendingRead>();
+  private activePendingReads = new Set<PendingRead>();
 
   constructor(
     private hydra: Hydra,
@@ -260,8 +267,16 @@ export class HydraDatamoshRuntime {
   destroy() {
     this.datamosh.destroy();
 
-    this.readFbo?.destroy();
-    this.readFbo = null;
+    const { gl, pixelReadbackService } = this.renderer;
+
+    for (const pending of this.activePendingReads) {
+      gl.deleteSync(pending.sync);
+
+      pixelReadbackService.returnPbo(pending.pbo);
+    }
+
+    this.activePendingReads.clear();
+    this.pendingReads = new WeakMap();
   }
 
   tick() {
@@ -279,56 +294,109 @@ export class HydraDatamoshRuntime {
     const { width, height } = getTextureSize(texture);
     if (!width || !height) return null;
 
-    this.ensureReadback(width, height);
+    const completed = this.harvestRead(source, canvas, ctx);
+    this.initiateRead(source, texture, width, height);
 
-    const draw = this.getCopyDraw();
-    draw({ sourceTexture: texture, framebuffer: this.readFbo });
+    return completed;
+  }
 
-    const gl = this.renderer.gl;
-    gl.bindFramebuffer(gl.FRAMEBUFFER, getFramebuffer(this.readFbo));
-    gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, this.pixels!);
-    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  private harvestRead(
+    source: object,
+    canvas: OffscreenCanvas,
+    ctx: OffscreenCanvasRenderingContext2D
+  ): { width: number; height: number } | null {
+    const pending = this.pendingReads.get(source);
+    if (!pending) return null;
+
+    const { gl, pixelReadbackService } = this.renderer;
+    const status = gl.clientWaitSync(pending.sync, 0, 0);
+
+    if (status === gl.TIMEOUT_EXPIRED) {
+      return null;
+    }
+
+    gl.deleteSync(pending.sync);
+    this.pendingReads.delete(source);
+    this.activePendingReads.delete(pending);
+
+    if (status === gl.WAIT_FAILED) {
+      pixelReadbackService.returnPbo(pending.pbo);
+
+      return null;
+    }
+
+    const { pbo, width, height } = pending;
+    const pixels = new Uint8ClampedArray(width * height * 4);
+
+    gl.bindBuffer(gl.PIXEL_PACK_BUFFER, pbo);
+
+    const start = pixelReadbackService.profiler.isEnabled ? performance.now() : 0;
+
+    gl.getBufferSubData(gl.PIXEL_PACK_BUFFER, 0, pixels);
+
+    if (pixelReadbackService.profiler.isEnabled) {
+      pixelReadbackService.profiler.recordReglRead(performance.now() - start);
+    }
+
+    gl.bindBuffer(gl.PIXEL_PACK_BUFFER, null);
+    pixelReadbackService.returnPbo(pbo);
 
     if (canvas.width !== width || canvas.height !== height) {
       canvas.width = width;
       canvas.height = height;
     }
 
-    const array = new Uint8ClampedArray(this.pixels!);
-    const imageData = new ImageData(array, width, height);
-
-    this.scratchCtx!.putImageData(imageData, 0, 0);
-
-    ctx.save();
-    ctx.scale(1, -1);
-    ctx.drawImage(this.scratchCanvas!, 0, -height);
-    ctx.restore();
+    const imageData = new ImageData(pixels, width, height);
+    ctx.putImageData(imageData, 0, 0);
 
     return { width, height };
   }
 
-  private ensureReadback(width: number, height: number) {
-    if (this.readFbo && this.readWidth === width && this.readHeight === height) {
+  private initiateRead(
+    source: object,
+    texture: regl.Texture2D | regl.Framebuffer2D,
+    width: number,
+    height: number
+  ) {
+    if (this.pendingReads.has(source)) {
       return;
     }
 
-    this.readFbo?.destroy();
+    const { gl, pixelReadbackService } = this.renderer;
 
-    this.readFbo = this.renderer.regl.framebuffer({
-      color: this.renderer.regl.texture({
-        width,
-        height,
-        wrapS: 'clamp',
-        wrapT: 'clamp'
-      }),
-      depthStencil: false
-    });
+    pixelReadbackService.ensureIntermediateFboSize(width, height);
 
-    this.readWidth = width;
-    this.readHeight = height;
-    this.pixels = new Uint8Array(width * height * 4);
-    this.scratchCanvas = new OffscreenCanvas(width, height);
-    this.scratchCtx = this.scratchCanvas.getContext('2d');
+    const draw = this.getCopyDraw();
+    draw({ sourceTexture: texture, framebuffer: pixelReadbackService.getIntermediateFbo() });
+
+    const pbo = pixelReadbackService.getPbo();
+    const size = width * height * 4;
+
+    gl.bindBuffer(gl.PIXEL_PACK_BUFFER, pbo);
+    gl.bufferData(gl.PIXEL_PACK_BUFFER, size, gl.STREAM_READ);
+
+    gl.bindFramebuffer(
+      gl.READ_FRAMEBUFFER,
+      getFramebuffer(pixelReadbackService.getIntermediateFbo())
+    );
+
+    gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, 0);
+
+    const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
+
+    gl.bindBuffer(gl.PIXEL_PACK_BUFFER, null);
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null);
+
+    if (!sync) {
+      pixelReadbackService.returnPbo(pbo);
+
+      return;
+    }
+
+    const pending = { pbo, sync, width, height };
+
+    this.pendingReads.set(source, pending);
+    this.activePendingReads.add(pending);
   }
 
   private getCopyDraw() {
@@ -343,7 +411,7 @@ export class HydraDatamoshRuntime {
         uniform sampler2D sourceTexture;
 
         void main () {
-          gl_FragColor = texture2D(sourceTexture, uv);
+          gl_FragColor = texture2D(sourceTexture, vec2(uv.x, 1.0 - uv.y));
         }
       `,
       vert: `

--- a/ui/src/workers/rendering/hydraDatamosh.ts
+++ b/ui/src/workers/rendering/hydraDatamosh.ts
@@ -1,0 +1,396 @@
+import { Source, type Hydra } from '$lib/hydra';
+import type regl from 'regl';
+import type { FBORenderer } from './fboRenderer';
+import { getFramebuffer } from './utils';
+
+export type DatamoshParams = {
+  speed?: number;
+  keyFrame?: boolean;
+  fps?: number;
+  bitrate?: number;
+};
+
+type HydraSource = Pick<Source, 'init' | 'tick' | 'getTexture'>;
+
+type CaptureSourceFrame = (
+  source: HydraSource,
+  canvas: OffscreenCanvas,
+  ctx: OffscreenCanvasRenderingContext2D
+) => { width: number; height: number } | null;
+
+type VideoEncoderConstructor = new (init: VideoEncoderInit) => VideoEncoder;
+type VideoDecoderConstructor = new (init: VideoDecoderInit) => VideoDecoder;
+type VideoFrameConstructor = new (source: CanvasImageSource, init?: VideoFrameInit) => VideoFrame;
+
+type CodecConstructors = {
+  VideoEncoder?: VideoEncoderConstructor;
+  VideoDecoder?: VideoDecoderConstructor;
+  VideoFrame?: VideoFrameConstructor;
+};
+
+type DatamoshConsole = Pick<Console, 'warn'>;
+
+type DatamoshPipeline = {
+  encoder: VideoEncoder;
+  decoder: VideoDecoder;
+  outputSource: HydraSource;
+  params: DatamoshParams;
+};
+
+type EncoderSize = {
+  width: number;
+  height: number;
+};
+
+type CopyDrawProps = {
+  sourceTexture: regl.Texture2D | regl.Framebuffer2D;
+  framebuffer: regl.Framebuffer2D | null;
+};
+
+export type HydraDatamosh = ((source: HydraSource, params?: DatamoshParams) => HydraSource) & {
+  destroy: () => void;
+  tick: () => void;
+};
+
+export function createHydraDatamosh(options: {
+  createSource: () => HydraSource;
+  captureSourceFrame: CaptureSourceFrame;
+  codecs?: CodecConstructors;
+  console?: DatamoshConsole;
+  createCanvas?: (width: number, height: number) => OffscreenCanvas;
+  now?: () => number;
+}): HydraDatamosh {
+  const codecs = options.codecs ?? globalThis;
+  const warn = options.console?.warn ?? console.warn;
+
+  const createCanvas =
+    options.createCanvas ?? ((width, height) => new OffscreenCanvas(width, height));
+
+  const now = options.now ?? (() => performance.now());
+  const pipelines = new WeakMap<object, DatamoshPipeline>();
+  const activePipelines = new Set<DatamoshPipeline>();
+
+  let warnedUnsupported = false;
+
+  const hasWebCodecs = () =>
+    Boolean(codecs.VideoEncoder && codecs.VideoDecoder && codecs.VideoFrame);
+
+  const datamosh = ((source: HydraSource, params: DatamoshParams = {}) => {
+    if (!hasWebCodecs()) {
+      if (!warnedUnsupported) {
+        warn('datamosh() requires WebCodecs support; returning the original Hydra source.');
+        warnedUnsupported = true;
+      }
+
+      return source;
+    }
+
+    const cached = pipelines.get(source);
+    if (cached) {
+      Object.assign(cached.params, params);
+      return cached.outputSource;
+    }
+
+    const pipeline = createPipeline(source, params);
+    pipelines.set(source, pipeline);
+    activePipelines.add(pipeline);
+
+    return pipeline.outputSource;
+  }) as HydraDatamosh;
+
+  datamosh.destroy = () => {
+    for (const pipeline of activePipelines) {
+      closeCodec(pipeline.encoder);
+      closeCodec(pipeline.decoder);
+    }
+
+    activePipelines.clear();
+  };
+
+  datamosh.tick = () => {
+    for (const pipeline of activePipelines) {
+      pipeline.outputSource.tick();
+    }
+  };
+
+  function createPipeline(source: HydraSource, params: DatamoshParams): DatamoshPipeline {
+    const VideoDecoderCtor = codecs.VideoDecoder!;
+    const VideoEncoderCtor = codecs.VideoEncoder!;
+    const pipelineParams = { ...params };
+    const encodeCanvas = createCanvas(1, 1);
+    const encodeCtx = encodeCanvas.getContext('2d')!;
+    const outputCanvas = createCanvas(1, 1);
+    const outputCtx = outputCanvas.getContext('2d')!;
+    const outputSource = options.createSource();
+    const originalTick = outputSource.tick.bind(outputSource);
+    const encoderSize: EncoderSize = { width: 0, height: 0 };
+
+    let lastFrame = 0;
+
+    const decoder = new VideoDecoderCtor({
+      output(frame) {
+        outputCtx.drawImage(frame, 0, 0, outputCanvas.width, outputCanvas.height);
+        frame.close();
+      },
+      error(error) {
+        warn(`datamosh() decoder error: ${error.message}`);
+      }
+    });
+
+    decoder.configure({ codec: 'vp8' });
+
+    const encoder = new VideoEncoderCtor({
+      output(chunk) {
+        const repetitions = chunk.type === 'key' ? 1 : normalizeSpeed(pipelineParams.speed);
+
+        for (let i = 0; i < repetitions; i++) {
+          decoder.decode(chunk);
+        }
+      },
+      error(error) {
+        warn(`datamosh() encoder error: ${error.message}`);
+      }
+    });
+
+    outputSource.init({
+      src: outputCanvas as unknown as Source['src'],
+      dynamic: true
+    });
+
+    outputSource.tick = () => {
+      const currentTime = now();
+      const fpsInterval = 1000 / normalizeFps(pipelineParams.fps);
+
+      if (currentTime - lastFrame >= fpsInterval) {
+        processFrame(
+          source,
+          pipelineParams,
+          encodeCanvas,
+          encodeCtx,
+          outputCanvas,
+          encoder,
+          encoderSize
+        );
+
+        lastFrame = currentTime;
+      }
+
+      originalTick();
+    };
+
+    return {
+      encoder,
+      decoder,
+      outputSource,
+      params: pipelineParams
+    };
+  }
+
+  function processFrame(
+    source: HydraSource,
+    params: DatamoshParams,
+    encodeCanvas: OffscreenCanvas,
+    encodeCtx: OffscreenCanvasRenderingContext2D,
+    outputCanvas: OffscreenCanvas,
+    encoder: VideoEncoder,
+    encoderSize: EncoderSize
+  ) {
+    const size = options.captureSourceFrame(source, encodeCanvas, encodeCtx);
+    if (!size) return;
+
+    if (outputCanvas.width !== size.width || outputCanvas.height !== size.height) {
+      outputCanvas.width = size.width;
+      outputCanvas.height = size.height;
+    }
+
+    const sizeChanged = encoderSize.width !== size.width || encoderSize.height !== size.height;
+
+    if (encoder.state === 'unconfigured' || sizeChanged) {
+      encoder.configure({
+        codec: 'vp8',
+        width: size.width,
+        height: size.height,
+        bitrate: params.bitrate ?? 1_000_000,
+        framerate: normalizeFps(params.fps),
+        latencyMode: 'realtime'
+      });
+
+      encoderSize.width = size.width;
+      encoderSize.height = size.height;
+    }
+
+    const VideoFrameConstructor = codecs.VideoFrame!;
+
+    const frame = new VideoFrameConstructor(encodeCanvas, {
+      timestamp: now() * 1000
+    });
+
+    encoder.encode(frame, { keyFrame: sizeChanged || Boolean(params.keyFrame) });
+
+    params.keyFrame = false;
+    frame.close();
+  }
+
+  return datamosh;
+}
+
+export class HydraDatamoshRuntime {
+  readonly datamosh: HydraDatamosh;
+
+  private copyDraw: regl.DrawCommand | null = null;
+  private readFbo: regl.Framebuffer2D | null = null;
+  private readWidth = 0;
+  private readHeight = 0;
+  private pixels: Uint8Array | null = null;
+  private scratchCanvas: OffscreenCanvas | null = null;
+  private scratchCtx: OffscreenCanvasRenderingContext2D | null = null;
+
+  constructor(
+    private hydra: Hydra,
+    private renderer: FBORenderer,
+    console: DatamoshConsole
+  ) {
+    this.datamosh = createHydraDatamosh({
+      createSource: () => new Source(this.hydra.glEnvironment),
+      captureSourceFrame: this.captureSourceFrame.bind(this),
+      console
+    });
+  }
+
+  destroy() {
+    this.datamosh.destroy();
+
+    this.readFbo?.destroy();
+    this.readFbo = null;
+  }
+
+  tick() {
+    this.datamosh.tick();
+  }
+
+  private captureSourceFrame(
+    source: { getTexture: () => regl.Texture2D | regl.Framebuffer2D },
+    canvas: OffscreenCanvas,
+    ctx: OffscreenCanvasRenderingContext2D
+  ): { width: number; height: number } | null {
+    const texture = source.getTexture();
+    if (!texture) return null;
+
+    const { width, height } = getTextureSize(texture);
+    if (!width || !height) return null;
+
+    this.ensureReadback(width, height);
+
+    const draw = this.getCopyDraw();
+    draw({ sourceTexture: texture, framebuffer: this.readFbo });
+
+    const gl = this.renderer.gl;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, getFramebuffer(this.readFbo));
+    gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, this.pixels!);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width;
+      canvas.height = height;
+    }
+
+    const array = new Uint8ClampedArray(this.pixels!);
+    const imageData = new ImageData(array, width, height);
+
+    this.scratchCtx!.putImageData(imageData, 0, 0);
+
+    ctx.save();
+    ctx.scale(1, -1);
+    ctx.drawImage(this.scratchCanvas!, 0, -height);
+    ctx.restore();
+
+    return { width, height };
+  }
+
+  private ensureReadback(width: number, height: number) {
+    if (this.readFbo && this.readWidth === width && this.readHeight === height) {
+      return;
+    }
+
+    this.readFbo?.destroy();
+
+    this.readFbo = this.renderer.regl.framebuffer({
+      color: this.renderer.regl.texture({
+        width,
+        height,
+        wrapS: 'clamp',
+        wrapT: 'clamp'
+      }),
+      depthStencil: false
+    });
+
+    this.readWidth = width;
+    this.readHeight = height;
+    this.pixels = new Uint8Array(width * height * 4);
+    this.scratchCanvas = new OffscreenCanvas(width, height);
+    this.scratchCtx = this.scratchCanvas.getContext('2d');
+  }
+
+  private getCopyDraw() {
+    if (this.copyDraw) {
+      return this.copyDraw;
+    }
+
+    this.copyDraw = this.renderer.regl({
+      frag: `
+        precision mediump float;
+        varying vec2 uv;
+        uniform sampler2D sourceTexture;
+
+        void main () {
+          gl_FragColor = texture2D(sourceTexture, uv);
+        }
+      `,
+      vert: `
+        precision mediump float;
+        attribute vec2 position;
+        varying vec2 uv;
+
+        void main () {
+          uv = position;
+          gl_Position = vec4(2.0 * position - 1.0, 0, 1);
+        }
+      `,
+      attributes: {
+        position: [
+          [-2, 0],
+          [0, -2],
+          [2, 2]
+        ]
+      },
+      uniforms: {
+        sourceTexture: this.renderer.regl.prop<CopyDrawProps, 'sourceTexture'>('sourceTexture')
+      },
+      framebuffer: this.renderer.regl.prop<CopyDrawProps, 'framebuffer'>('framebuffer'),
+      count: 3,
+      depth: { enable: false }
+    });
+
+    return this.copyDraw;
+  }
+}
+
+const normalizeSpeed = (speed: number | undefined): number => Math.max(1, Math.floor(speed ?? 2));
+
+const normalizeFps = (fps: number | undefined): number =>
+  Math.max(1, Math.min(240, Math.floor(fps ?? 60)));
+
+function closeCodec(codec: { state?: string; close: () => void }) {
+  if (codec.state === 'closed') return;
+
+  codec.close();
+}
+
+function getTextureSize(texture: regl.Texture2D | regl.Framebuffer2D): {
+  width: number;
+  height: number;
+} {
+  const sized = texture as unknown as { width?: number; height?: number };
+
+  return { width: sized.width ?? 0, height: sized.height ?? 0 };
+}

--- a/ui/src/workers/rendering/hydraRenderer.test.ts
+++ b/ui/src/workers/rendering/hydraRenderer.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { usesHydraDatamosh } from './hydraRenderer';
+
+describe('usesHydraDatamosh', () => {
+  it('detects code that calls datamosh', () => {
+    expect(usesHydraDatamosh('src(datamosh(s0, { speed: 10 })).out()')).toBe(true);
+  });
+
+  it('does not match ordinary hydra code', () => {
+    expect(usesHydraDatamosh('osc(10, 0.1, 1.5).out()')).toBe(false);
+  });
+});

--- a/ui/src/workers/rendering/hydraRenderer.ts
+++ b/ui/src/workers/rendering/hydraRenderer.ts
@@ -14,7 +14,7 @@ import { getFramebuffer } from './utils';
 import { parseJSError, countLines } from '$lib/js-runner/js-error-parser';
 import { HYDRA_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
 import { BaseWorkerRenderer, type BaseRendererConfig } from './BaseWorkerRenderer';
-import { HydraDatamoshRuntime } from './hydraDatamosh';
+import type { HydraDatamoshRuntime } from './hydraDatamosh';
 
 export interface HydraRendererConfig extends BaseRendererConfig {
   videoInletCount?: number;
@@ -226,12 +226,18 @@ export class HydraRenderer extends BaseWorkerRenderer<HydraRendererConfig> {
       const { sources, outputs, hush, render } = this.hydra;
 
       this.datamoshRuntime?.destroy();
+      this.datamoshRuntime = null;
 
-      this.datamoshRuntime = new HydraDatamoshRuntime(
-        this.hydra,
-        this.renderer,
-        this.createCustomConsole()
-      );
+      // Lazy-load the datamosh plugin if it is used
+      if (usesHydraDatamosh(this.config.code)) {
+        const { HydraDatamoshRuntime } = await import('./hydraDatamosh');
+
+        this.datamoshRuntime = new HydraDatamoshRuntime(
+          this.hydra,
+          this.renderer,
+          this.createCustomConsole()
+        );
+      }
 
       // Apply Hydra-specific code transformation (.out() -> .out(o0))
       const hydraCode = processCode(this.config.code);
@@ -239,6 +245,10 @@ export class HydraRenderer extends BaseWorkerRenderer<HydraRendererConfig> {
       // Build sN/oN context entries dynamically from the actual sources/outputs arrays
       const sourceContext = Object.fromEntries(sources.map((s, i) => [`s${i}`, s]));
       const outputContext = Object.fromEntries(outputs.map((o, i) => [`o${i}`, o]));
+
+      const datamoshContext = this.datamoshRuntime
+        ? { datamosh: this.datamoshRuntime.datamosh }
+        : {};
 
       const extraContext = {
         ...this.buildBaseExtraContext(),
@@ -260,7 +270,7 @@ export class HydraRenderer extends BaseWorkerRenderer<HydraRendererConfig> {
         ...outputContext,
 
         setFunction,
-        datamosh: this.datamoshRuntime.datamosh,
+        ...datamoshContext,
         setVideoCount: this.setVideoCount.bind(this),
         setMouseScope: this.setMouseScope.bind(this)
       };
@@ -384,3 +394,5 @@ export class HydraRenderer extends BaseWorkerRenderer<HydraRendererConfig> {
 }
 
 const processCode = (code: string) => code.replace('.out()', '.out(o0)');
+
+export const usesHydraDatamosh = (code: string): boolean => /\bdatamosh\b/.test(code);

--- a/ui/src/workers/rendering/hydraRenderer.ts
+++ b/ui/src/workers/rendering/hydraRenderer.ts
@@ -14,6 +14,7 @@ import { getFramebuffer } from './utils';
 import { parseJSError, countLines } from '$lib/js-runner/js-error-parser';
 import { HYDRA_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
 import { BaseWorkerRenderer, type BaseRendererConfig } from './BaseWorkerRenderer';
+import { HydraDatamoshRuntime } from './hydraDatamosh';
 
 export interface HydraRendererConfig extends BaseRendererConfig {
   videoInletCount?: number;
@@ -34,6 +35,7 @@ export class HydraRenderer extends BaseWorkerRenderer<HydraRendererConfig> {
   // Hydra-specific error throttling (separate from base class to avoid key collisions)
   private hydraLastRuntimeError: string | null = null;
   private hydraLastRuntimeErrorTime = 0;
+  private datamoshRuntime: HydraDatamoshRuntime | null = null;
 
   private constructor(
     config: HydraRendererConfig,
@@ -110,6 +112,8 @@ export class HydraRenderer extends BaseWorkerRenderer<HydraRendererConfig> {
 
       source.tick();
     });
+
+    this.datamoshRuntime?.tick();
 
     this.hydra.outputs.forEach((output) => {
       if (!this.hydra) return;
@@ -221,6 +225,14 @@ export class HydraRenderer extends BaseWorkerRenderer<HydraRendererConfig> {
 
       const { sources, outputs, hush, render } = this.hydra;
 
+      this.datamoshRuntime?.destroy();
+
+      this.datamoshRuntime = new HydraDatamoshRuntime(
+        this.hydra,
+        this.renderer,
+        this.createCustomConsole()
+      );
+
       // Apply Hydra-specific code transformation (.out() -> .out(o0))
       const hydraCode = processCode(this.config.code);
 
@@ -248,6 +260,7 @@ export class HydraRenderer extends BaseWorkerRenderer<HydraRendererConfig> {
         ...outputContext,
 
         setFunction,
+        datamosh: this.datamoshRuntime.datamosh,
         setVideoCount: this.setVideoCount.bind(this),
         setMouseScope: this.setMouseScope.bind(this)
       };
@@ -278,6 +291,7 @@ export class HydraRenderer extends BaseWorkerRenderer<HydraRendererConfig> {
     if (!this.hydra) return;
 
     this.stop();
+    this.datamoshRuntime?.destroy();
 
     for (const source of this.hydra.sources) {
       source.getTexture()?.destroy();
@@ -288,6 +302,7 @@ export class HydraRenderer extends BaseWorkerRenderer<HydraRendererConfig> {
     }
 
     this.hydra = null;
+    this.datamoshRuntime = null;
 
     super.destroy();
   }

--- a/ui/static/content/objects/hydra.md
+++ b/ui/static/content/objects/hydra.md
@@ -34,9 +34,19 @@ Hydra-specific functions:
   of video source ports
   - `setVideoCount(2)` initializes `s0` and `s1` sources with the
      first two visual inlets
+
 - `setMouseScope('global' | 'local')` - sets mouse tracking scope
   - `'local'` (default) tracks mouse within the canvas preview
   - `'global'` tracks mouse across the entire screen
+
+- `datamosh(source, params)` - routes a Hydra source through a native
+  WebCodecs datamosh effect
+  - `src(datamosh(s0, { speed: 3 })).out()`
+  - params: `speed`, `keyFrame`, `fps`, `bitrate`
+
+Patchies' `datamosh()` helper is based on the WebCodecs approach from
+[@emptyflash](https://github.com/emptyflash)'s
+[hydra-datamosh extension](https://github.com/emptyflash/hydra-datamosh).
 
 ## Multiple Video Outputs
 
@@ -201,6 +211,8 @@ osc(() => fft().getEnergy('bass')).out()
 - [Hydra Documentation](https://hydra.ojack.xyz/docs)
 - [Hydra Functions Reference](https://hydra.ojack.xyz/api)
 - [Hydra Book](https://hydra-book.glitches.me)
+- [hydra-datamosh](https://github.com/emptyflash/hydra-datamosh) - WebCodecs
+  datamosh extension by @emptyflash
 - [Olivia Jack's Website](https://ojack.xyz/)
 
 ## See Also

--- a/ui/static/content/objects/hydra.md
+++ b/ui/static/content/objects/hydra.md
@@ -41,8 +41,8 @@ Hydra-specific functions:
 
 - `datamosh(source, params)` - routes a Hydra source through a native
   WebCodecs datamosh effect
-  - `src(datamosh(s0, { speed: 3 })).out()`
-  - params: `speed`, `keyFrame`, `fps`, `bitrate`
+  - `src(datamosh(s0, { speed: 3, fps: 30, scale: 0.5 })).out()`
+  - params: `speed`, `keyFrame`, `fps`, `bitrate`, `scale`, `width`, `height`
 
 Patchies' `datamosh()` helper is based on the WebCodecs approach from
 [@emptyflash](https://github.com/emptyflash)'s

--- a/ui/static/content/objects/hydra.md
+++ b/ui/static/content/objects/hydra.md
@@ -39,10 +39,18 @@ Hydra-specific functions:
   - `'local'` (default) tracks mouse within the canvas preview
   - `'global'` tracks mouse across the entire screen
 
-- `datamosh(source, params)` - routes a Hydra source through a native
-  WebCodecs datamosh effect
-  - `src(datamosh(s0, { speed: 3, fps: 30, scale: 0.5 })).out()`
-  - params: `speed`, `keyFrame`, `fps`, `bitrate`, `scale`, `width`, `height`
+## Datamoshing
+
+`datamosh(source, params)` routes a Hydra source through a native
+WebCodecs datamosh effect
+
+```javascript
+src(datamosh(s0, {
+  speed: 3, fps: 30, scale: 0.5
+})).out()
+```
+
+params: `speed`, `keyFrame`, `fps`, `bitrate`, `scale`, `width`, `height`
 
 Patchies' `datamosh()` helper is based on the WebCodecs approach from
 [@emptyflash](https://github.com/emptyflash)'s


### PR DESCRIPTION
Ports the datamosh extension from @emptyflash at https://github.com/emptyflash/hydra-datamosh to work with Patchies' rendering pipeline, with some performance-conscious parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `datamosh(source, params)` method to Hydra for creating WebCodecs-based visual datamosh effects.
  * Supports configurable parameters: `speed`, `keyFrame`, `fps`, `bitrate`, `scale`, `width`, and `height`.
  * Added built-in "Datamosh" preset for quick access.

* **Documentation**
  * Updated Hydra object documentation with datamosh usage examples and parameter descriptions.
  * Added AI prompt guidance and code completion support for the datamosh function.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->