### PR TITLE
Expand visual objects to fullscreen with menu item

### DIFF
--- a/docs/design-docs/specs/147-canvas-preview-expand.md
+++ b/docs/design-docs/specs/147-canvas-preview-expand.md
@@ -1,0 +1,53 @@
+# 147. Canvas Preview Expand
+
+## Goal
+
+Add a shared **Expand** action for visual objects that use `CanvasPreviewLayout`.
+Expanded mode should hide the editor UI, show the selected object's render output
+as the fullscreen background, and forward fullscreen pointer, touch, and wheel
+input to that same object.
+
+## Behavior
+
+- `CanvasPreviewLayout` objects can opt into a shared Expand menu item.
+- Entering expanded mode stores the previous background-output override.
+- The selected node becomes the temporary background output via
+  `GLSystem.setOverrideOutputNode(nodeId)`.
+- `SurfaceOverlay` provides the fullscreen transparent input canvas and hides the
+  editor UI through the existing `isFullscreenActive` store.
+- `SurfaceListeners` normalizes pointer, touch, and wheel input from the overlay.
+- `SurfaceMouseForwarder` forwards input only to the expanded node by using
+  `{ only: [nodeId] }` forwarding rules.
+- Exiting expanded mode detaches overlay listeners, deactivates the overlay, and
+  restores the previous background-output override.
+
+## Scope
+
+This pass covers existing render nodes that already participate in
+`SurfaceMouseForwarder`: `glsl`, `swgl`, `regl`, `hydra`, `canvas`, `textmode`,
+`shaderpark`, and `three`.
+
+DOM-renderer objects that use `CanvasPreviewLayout` can still be pinned as
+background output if they already upload bitmap frames through `GLSystem`, but
+their DOM-specific local preview input is not moved into the overlay.
+
+## Implementation Notes
+
+The shared behavior should live in a small controller under `src/lib/canvas/`
+rather than duplicating surface-specific code in every node component.
+
+`surface` keeps its custom implementation because it draws directly into the
+overlay canvas and exposes surface-specific JavaScript APIs such as `activate()`,
+`deactivate()`, `onTouch()`, and `hideExitButton()`.
+
+`ObjectPreviewLayout` should own the shared menu action because it already owns
+background-output pinning and the overflow/context menus used by
+`CanvasPreviewLayout`.
+
+## Testing
+
+Add unit coverage for the controller:
+
+- entering stores and replaces the current background override
+- pointer and wheel events are forwarded only to the expanded node
+- exiting restores the previous override and disposes listeners/forwarder

--- a/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
+++ b/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
@@ -89,7 +89,7 @@ export const jsRunnerInstructions = `
 
 **User-defined Settings:**
 - only add a few settings by default where it makes sense.
-  - tell the user in the response what settings they have and how to show it i.e. in the overflow menu > "Show settings"
+  - tell the user in the response what settings they have and how to show it i.e. in the overflow menu > "Settings"
   - do NOT add too much settings, 1 - 3 is enough. users can always ask to add more in a follow-up.
 - await settings.define([...schema]) - expose a settings panel on the node (gear icon appears)
   - on P5.js: do NOT await in setup() - do it at top level outside setup()

--- a/ui/src/lib/canvas/CanvasPreviewExpandController.test.ts
+++ b/ui/src/lib/canvas/CanvasPreviewExpandController.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Node } from '@xyflow/svelte';
+import { CanvasPreviewExpandController } from './CanvasPreviewExpandController';
+import type { SurfaceListenersOptions } from './SurfaceListeners';
+
+const renderNode = (id: string, type: string): Node => ({
+  id,
+  type,
+  data: {},
+  position: { x: 0, y: 0 }
+});
+
+describe('CanvasPreviewExpandController', () => {
+  it('pins the node, forwards overlay input to only that node, and restores the previous pin on exit', () => {
+    let currentOverride: string | null = 'glsl-old';
+    let active = false;
+    let listenerOptions: SurfaceListenersOptions | undefined;
+    let overlayExit: (() => void) | undefined;
+
+    const canvas = {} as HTMLCanvasElement;
+    const forwarder = {
+      setForwardingRules: vi.fn(),
+      forward: vi.fn(),
+      forwardWheel: vi.fn(),
+      dispose: vi.fn()
+    };
+    const listeners = {
+      attach: vi.fn((_canvas: HTMLCanvasElement, opts: SurfaceListenersOptions) => {
+        listenerOptions = opts;
+      }),
+      detach: vi.fn()
+    };
+    const overlay = {
+      canvas,
+      activate: vi.fn(
+        (_nodeId: string, _nodes: { id: string; type?: string }[], onExit: () => void) => {
+          overlayExit = onExit;
+        }
+      ),
+      deactivate: vi.fn()
+    };
+    const setOverride = vi.fn((nodeId: string | null) => {
+      currentOverride = nodeId;
+    });
+
+    const controller = new CanvasPreviewExpandController({
+      nodeId: 'three-1',
+      getNodes: () => [renderNode('three-1', 'three'), renderNode('glsl-old', 'glsl')],
+      getOverrideOutputNode: () => currentOverride,
+      setOverrideOutputNode: setOverride,
+      overlay,
+      createForwarder: () => forwarder,
+      createListeners: () => listeners,
+      onActiveChange: (next) => {
+        active = next;
+      }
+    });
+
+    controller.enter();
+
+    expect(active).toBe(true);
+    expect(setOverride).toHaveBeenCalledWith('three-1');
+    expect(overlay.activate).toHaveBeenCalledWith(
+      'three-1',
+      [
+        { id: 'three-1', type: 'three' },
+        { id: 'glsl-old', type: 'glsl' }
+      ],
+      expect.any(Function)
+    );
+    expect(forwarder.setForwardingRules).toHaveBeenCalledWith({ only: ['three-1'] });
+    expect(listeners.attach).toHaveBeenCalledWith(canvas, expect.any(Object));
+
+    expect(listenerOptions).toBeDefined();
+    const opts = listenerOptions as SurfaceListenersOptions;
+    opts.onPointer({ x: 0.25, y: 0.5, pressure: 0, buttons: 1, down: true, type: 'down' });
+    opts.onWheel({ x: 0.75, y: 0.25, deltaX: 1, deltaY: -20, deltaMode: 0 });
+
+    expect(forwarder.forward).toHaveBeenCalledWith(0.25, 0.5, 1, 'down');
+    expect(forwarder.forwardWheel).toHaveBeenCalledWith({
+      x: 0.75,
+      y: 0.25,
+      deltaX: 1,
+      deltaY: -20,
+      deltaMode: 0
+    });
+
+    expect(overlayExit).toBeDefined();
+    const exit = overlayExit as () => void;
+    exit();
+
+    expect(active).toBe(false);
+    expect(listeners.detach).toHaveBeenCalled();
+    expect(overlay.deactivate).toHaveBeenCalledWith('three-1');
+    expect(forwarder.dispose).toHaveBeenCalled();
+    expect(currentOverride).toBe('glsl-old');
+    expect(setOverride).toHaveBeenLastCalledWith('glsl-old');
+  });
+});

--- a/ui/src/lib/canvas/CanvasPreviewExpandController.test.ts
+++ b/ui/src/lib/canvas/CanvasPreviewExpandController.test.ts
@@ -96,4 +96,54 @@ describe('CanvasPreviewExpandController', () => {
     expect(currentOverride).toBe('glsl-old');
     expect(setOverride).toHaveBeenLastCalledWith('glsl-old');
   });
+
+  it('rolls back allocated resources and output pin when entering fails', () => {
+    let currentOverride: string | null = 'glsl-old';
+    let active = false;
+    const error = new Error('attach failed');
+
+    const forwarder = {
+      setForwardingRules: vi.fn(),
+      forward: vi.fn(),
+      forwardWheel: vi.fn(),
+      dispose: vi.fn()
+    };
+    const listeners = {
+      attach: vi.fn(() => {
+        throw error;
+      }),
+      detach: vi.fn()
+    };
+    const overlay = {
+      canvas: {} as HTMLCanvasElement,
+      activate: vi.fn(),
+      deactivate: vi.fn()
+    };
+    const setOverride = vi.fn((nodeId: string | null) => {
+      currentOverride = nodeId;
+    });
+
+    const controller = new CanvasPreviewExpandController({
+      nodeId: 'three-1',
+      getNodes: () => [renderNode('three-1', 'three')],
+      getOverrideOutputNode: () => currentOverride,
+      setOverrideOutputNode: setOverride,
+      overlay,
+      createForwarder: () => forwarder,
+      createListeners: () => listeners,
+      onActiveChange: (next) => {
+        active = next;
+      }
+    });
+
+    expect(() => controller.enter()).toThrow(error);
+
+    expect(active).toBe(false);
+    expect(controller.isActive).toBe(false);
+    expect(listeners.detach).toHaveBeenCalled();
+    expect(overlay.deactivate).toHaveBeenCalledWith('three-1');
+    expect(forwarder.dispose).toHaveBeenCalled();
+    expect(currentOverride).toBe('glsl-old');
+    expect(setOverride).toHaveBeenLastCalledWith('glsl-old');
+  });
 });

--- a/ui/src/lib/canvas/CanvasPreviewExpandController.ts
+++ b/ui/src/lib/canvas/CanvasPreviewExpandController.ts
@@ -3,6 +3,7 @@ import type { SurfaceListenersOptions } from './SurfaceListeners';
 
 type ExpandOverlay = {
   canvas: HTMLCanvasElement;
+
   activate: (nodeId: string, nodes: { id: string; type?: string }[], onExit: () => void) => void;
   deactivate: (nodeId: string) => void;
 };
@@ -13,7 +14,7 @@ type ExpandForwarder = {
     only?: readonly string[];
     except?: readonly string[];
   }) => void;
-  forward: (x: number, y: number, buttons: number, type: string) => void;
+
   forwardWheel: (event: {
     x: number;
     y: number;
@@ -21,6 +22,8 @@ type ExpandForwarder = {
     deltaY: number;
     deltaMode: number;
   }) => void;
+
+  forward: (x: number, y: number, buttons: number, type: string) => void;
   dispose: () => void;
 };
 
@@ -65,20 +68,47 @@ export class CanvasPreviewExpandController {
   enter(): void {
     if (this.active) return;
 
-    const forwarder = this.options.createForwarder();
-    const listeners = this.options.createListeners();
+    const previousOverrideNodeId = this.options.getOverrideOutputNode();
+    let forwarder: ExpandForwarder | null = null;
+    let listeners: ExpandListeners | null = null;
+    let overlayActivated = false;
 
-    this.previousOverrideNodeId = this.options.getOverrideOutputNode();
-    this.forwarder = forwarder;
-    this.listeners = listeners;
-    this.active = true;
-    this.options.onActiveChange?.(true);
+    try {
+      forwarder = this.options.createForwarder();
+      listeners = this.options.createListeners();
 
-    forwarder.setForwardingRules({ only: [this.options.nodeId] });
-    this.options.setOverrideOutputNode(this.options.nodeId);
+      this.forwarder = forwarder;
+      this.listeners = listeners;
 
-    this.options.overlay.activate(this.options.nodeId, this.getOverlayNodes(), () => this.exit());
-    listeners.attach(this.options.overlay.canvas, this.createListenerOptions());
+      forwarder.setForwardingRules({ only: [this.options.nodeId] });
+      this.options.setOverrideOutputNode(this.options.nodeId);
+
+      this.options.overlay.activate(this.options.nodeId, this.getOverlayNodes(), () => this.exit());
+      overlayActivated = true;
+
+      listeners.attach(this.options.overlay.canvas, this.createListenerOptions());
+      this.previousOverrideNodeId = previousOverrideNodeId;
+
+      this.active = true;
+      this.options.onActiveChange?.(true);
+    } catch (error) {
+      listeners?.detach();
+
+      if (overlayActivated) {
+        this.options.overlay.deactivate(this.options.nodeId);
+      }
+
+      forwarder?.dispose();
+      this.options.setOverrideOutputNode(previousOverrideNodeId);
+
+      this.previousOverrideNodeId = null;
+      this.listeners = null;
+      this.forwarder = null;
+      this.active = false;
+      this.options.onActiveChange?.(false);
+
+      throw error;
+    }
   }
 
   exit(): void {
@@ -96,6 +126,7 @@ export class CanvasPreviewExpandController {
 
     listeners?.detach();
     this.options.overlay.deactivate(this.options.nodeId);
+
     forwarder?.dispose();
     this.options.setOverrideOutputNode(previousOverrideNodeId);
   }

--- a/ui/src/lib/canvas/CanvasPreviewExpandController.ts
+++ b/ui/src/lib/canvas/CanvasPreviewExpandController.ts
@@ -1,0 +1,126 @@
+import type { Node } from '@xyflow/svelte';
+import type { SurfaceListenersOptions } from './SurfaceListeners';
+
+type ExpandOverlay = {
+  canvas: HTMLCanvasElement;
+  activate: (nodeId: string, nodes: { id: string; type?: string }[], onExit: () => void) => void;
+  deactivate: (nodeId: string) => void;
+};
+
+type ExpandForwarder = {
+  setForwardingRules: (rules?: {
+    enabled?: boolean;
+    only?: readonly string[];
+    except?: readonly string[];
+  }) => void;
+  forward: (x: number, y: number, buttons: number, type: string) => void;
+  forwardWheel: (event: {
+    x: number;
+    y: number;
+    deltaX: number;
+    deltaY: number;
+    deltaMode: number;
+  }) => void;
+  dispose: () => void;
+};
+
+type ExpandListeners = {
+  attach: (canvas: HTMLCanvasElement, opts: SurfaceListenersOptions) => void;
+  detach: () => void;
+};
+
+const fallbackConsole: SurfaceListenersOptions['customConsole'] = {
+  log: (...args: unknown[]) => console.log(...args),
+  error: (...args: unknown[]) => console.error(...args),
+  warn: (...args: unknown[]) => console.warn(...args),
+  debug: (...args: unknown[]) => console.debug(...args),
+  info: (...args: unknown[]) => console.info(...args)
+};
+
+export type CanvasPreviewExpandControllerOptions = {
+  nodeId: string;
+  getNodes: () => Node[];
+  getOverrideOutputNode: () => string | null;
+  setOverrideOutputNode: (nodeId: string | null) => void;
+  overlay: ExpandOverlay;
+  createForwarder: () => ExpandForwarder;
+  createListeners: () => ExpandListeners;
+  customConsole?: SurfaceListenersOptions['customConsole'];
+  onActiveChange?: (active: boolean) => void;
+};
+
+export class CanvasPreviewExpandController {
+  private active = false;
+  private previousOverrideNodeId: string | null = null;
+  private forwarder: ExpandForwarder | null = null;
+  private listeners: ExpandListeners | null = null;
+  private lastPointer = { x: 0, y: 0 };
+
+  constructor(private options: CanvasPreviewExpandControllerOptions) {}
+
+  get isActive(): boolean {
+    return this.active;
+  }
+
+  enter(): void {
+    if (this.active) return;
+
+    const forwarder = this.options.createForwarder();
+    const listeners = this.options.createListeners();
+
+    this.previousOverrideNodeId = this.options.getOverrideOutputNode();
+    this.forwarder = forwarder;
+    this.listeners = listeners;
+    this.active = true;
+    this.options.onActiveChange?.(true);
+
+    forwarder.setForwardingRules({ only: [this.options.nodeId] });
+    this.options.setOverrideOutputNode(this.options.nodeId);
+
+    this.options.overlay.activate(this.options.nodeId, this.getOverlayNodes(), () => this.exit());
+    listeners.attach(this.options.overlay.canvas, this.createListenerOptions());
+  }
+
+  exit(): void {
+    if (!this.active) return;
+
+    const previousOverrideNodeId = this.previousOverrideNodeId;
+    const listeners = this.listeners;
+    const forwarder = this.forwarder;
+
+    this.active = false;
+    this.previousOverrideNodeId = null;
+    this.listeners = null;
+    this.forwarder = null;
+    this.options.onActiveChange?.(false);
+
+    listeners?.detach();
+    this.options.overlay.deactivate(this.options.nodeId);
+    forwarder?.dispose();
+    this.options.setOverrideOutputNode(previousOverrideNodeId);
+  }
+
+  private createListenerOptions(): SurfaceListenersOptions {
+    return {
+      onPointer: (event) => {
+        this.lastPointer = { x: event.x, y: event.y };
+        this.forwarder?.forward(event.x, event.y, event.buttons, event.type);
+      },
+      onWheel: (event) => {
+        this.forwarder?.forwardWheel(event);
+      },
+      onTouch: null,
+      onLeave: () => {
+        this.forwarder?.forward(this.lastPointer.x, this.lastPointer.y, 0, 'up');
+      },
+      code: '',
+      nodeId: this.options.nodeId,
+      customConsole: this.options.customConsole ?? fallbackConsole,
+      wrapperOffset: 0
+    };
+  }
+
+  private getOverlayNodes(): { id: string; type?: string }[] {
+    return this.options.getNodes().map((node) => ({ id: node.id, type: node.type }));
+  }
+}

--- a/ui/src/lib/components/CanvasPreviewLayout.svelte
+++ b/ui/src/lib/components/CanvasPreviewLayout.svelte
@@ -41,6 +41,7 @@
     onSettingsRevertAll = undefined,
     extraMenuItems = undefined,
     showBgOutputOption = true,
+    showExpandOption = true,
     class: className = ''
   }: {
     title: string;
@@ -78,6 +79,7 @@
     onSettingsRevertAll?: () => void;
     extraMenuItems?: ExtraMenuItem[];
     showBgOutputOption?: boolean;
+    showExpandOption?: boolean;
     class?: string;
   } = $props();
 
@@ -106,6 +108,7 @@
   {previewVisible}
   {showPauseButton}
   {showBgOutputOption}
+  {showExpandOption}
   {topHandle}
   {bottomHandle}
   {codeEditor}

--- a/ui/src/lib/components/ObjectPreviewContextMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewContextMenu.svelte
@@ -59,6 +59,14 @@
     onOpenHelp: () => void;
     extraMenuItems?: ExtraMenuItem[];
   } = $props();
+
+  const hasTopItems = $derived(
+    Boolean(onrun || (settingsSchema && settingsSchema.length > 0) || extraMenuItems?.length)
+  );
+
+  const hasOutputItems = $derived(
+    Boolean((showBgOutputOption && nodeId !== undefined) || onCodeToggle || onExpandToggle)
+  );
 </script>
 
 <ContextMenu.Content>
@@ -85,7 +93,9 @@
     {/each}
   {/if}
 
-  <ContextMenu.Separator />
+  {#if hasTopItems && hasOutputItems}
+    <ContextMenu.Separator />
+  {/if}
 
   {#if showBgOutputOption && nodeId !== undefined}
     <ContextMenu.Item onclick={onBgOutputToggle}>

--- a/ui/src/lib/components/ObjectPreviewContextMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewContextMenu.svelte
@@ -116,6 +116,10 @@
     </ContextMenu.Item>
   {/if}
 
+  {#if onExpandToggle || showPauseButton || onPreviewToggle}
+    <ContextMenu.Separator />
+  {/if}
+
   {#if onExpandToggle}
     <ContextMenu.Item onclick={onExpandToggle}>
       {#if isExpanded}
@@ -126,10 +130,6 @@
         Expand
       {/if}
     </ContextMenu.Item>
-  {/if}
-
-  {#if showPauseButton || onPreviewToggle}
-    <ContextMenu.Separator />
   {/if}
 
   {#if showPauseButton}

--- a/ui/src/lib/components/ObjectPreviewContextMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewContextMenu.svelte
@@ -4,12 +4,14 @@
     Code,
     Eye,
     EyeOff,
+    Expand,
     Monitor,
     MonitorOff,
     Pin,
     PinOff,
     Play,
-    Settings
+    Settings,
+    Shrink
   } from '@lucide/svelte/icons';
   import * as ContextMenu from './ui/context-menu';
   import type { SettingsSchema } from '$lib/settings';
@@ -29,6 +31,8 @@
     showSettings,
     onSettingsToggle,
     onCodeToggle,
+    onExpandToggle,
+    isExpanded = false,
     onBgOutputToggle,
     onPlaybackToggle,
     onOpenHelp,
@@ -48,6 +52,8 @@
     onSettingsToggle: () => void;
     /** Provided when code editor is NOT the primary button — adds an "Edit code" entry. */
     onCodeToggle?: () => void;
+    onExpandToggle?: () => void;
+    isExpanded?: boolean;
     onBgOutputToggle: () => void;
     onPlaybackToggle: () => void;
     onOpenHelp: () => void;
@@ -63,29 +69,23 @@
     </ContextMenu.Item>
   {/if}
 
-  {#if onCodeToggle}
-    <ContextMenu.Item onclick={onCodeToggle}>
-      <Code class="mr-2 h-4 w-4" />
-      Edit code
+  {#if settingsSchema && settingsSchema.length > 0}
+    <ContextMenu.Item onclick={onSettingsToggle}>
+      <Settings class="mr-2 h-4 w-4" />
+      {showSettings ? 'Hide settings' : 'Settings'}
     </ContextMenu.Item>
   {/if}
 
   {#if extraMenuItems && extraMenuItems.length > 0}
-    {#each extraMenuItems as item}
+    {#each extraMenuItems as item, index (index)}
       <ContextMenu.Item onclick={item.onclick}>
         <item.icon class="mr-2 h-4 w-4 {item.variant === 'danger' ? 'text-red-400' : ''}" />
         <span class={item.variant === 'danger' ? 'text-red-400' : ''}>{item.label}</span>
       </ContextMenu.Item>
     {/each}
-    <ContextMenu.Separator />
   {/if}
 
-  {#if settingsSchema && settingsSchema.length > 0}
-    <ContextMenu.Item onclick={onSettingsToggle}>
-      <Settings class="mr-2 h-4 w-4" />
-      {showSettings ? 'Hide settings' : 'Show settings'}
-    </ContextMenu.Item>
-  {/if}
+  <ContextMenu.Separator />
 
   {#if showBgOutputOption && nodeId !== undefined}
     <ContextMenu.Item onclick={onBgOutputToggle}>
@@ -97,6 +97,29 @@
         Output to background
       {/if}
     </ContextMenu.Item>
+  {/if}
+
+  {#if onExpandToggle}
+    <ContextMenu.Item onclick={onExpandToggle}>
+      {#if isExpanded}
+        <Shrink class="mr-2 h-4 w-4 text-red-400" />
+        <span class="text-red-400">Exit expanded</span>
+      {:else}
+        <Expand class="mr-2 h-4 w-4" />
+        Expand
+      {/if}
+    </ContextMenu.Item>
+  {/if}
+
+  {#if onCodeToggle}
+    <ContextMenu.Item onclick={onCodeToggle}>
+      <Code class="mr-2 h-4 w-4" />
+      Edit code
+    </ContextMenu.Item>
+  {/if}
+
+  {#if showPauseButton || onPreviewToggle}
+    <ContextMenu.Separator />
   {/if}
 
   {#if showPauseButton}

--- a/ui/src/lib/components/ObjectPreviewContextMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewContextMenu.svelte
@@ -97,6 +97,13 @@
     <ContextMenu.Separator />
   {/if}
 
+  {#if onCodeToggle}
+    <ContextMenu.Item onclick={onCodeToggle}>
+      <Code class="mr-2 h-4 w-4" />
+      Edit code
+    </ContextMenu.Item>
+  {/if}
+
   {#if showBgOutputOption && nodeId !== undefined}
     <ContextMenu.Item onclick={onBgOutputToggle}>
       {#if isOutputOverride}
@@ -118,13 +125,6 @@
         <Expand class="mr-2 h-4 w-4" />
         Expand
       {/if}
-    </ContextMenu.Item>
-  {/if}
-
-  {#if onCodeToggle}
-    <ContextMenu.Item onclick={onCodeToggle}>
-      <Code class="mr-2 h-4 w-4" />
-      Edit code
     </ContextMenu.Item>
   {/if}
 

--- a/ui/src/lib/components/ObjectPreviewContextMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewContextMenu.svelte
@@ -91,10 +91,10 @@
     <ContextMenu.Item onclick={onBgOutputToggle}>
       {#if isOutputOverride}
         <MonitorOff class="mr-2 h-4 w-4 text-orange-400" />
-        <span class="text-orange-400">Remove background output</span>
+        <span class="text-orange-400">Hide output</span>
       {:else}
         <Monitor class="mr-2 h-4 w-4" />
-        Output to background
+        Use as output
       {/if}
     </ContextMenu.Item>
   {/if}

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -9,6 +9,7 @@
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings';
   import type { ExtraMenuItem } from './ObjectPreviewOverflowMenu.svelte';
+  import { outputTarget } from '../../stores/canvas.store';
   import { transportStore } from '../../stores/transport.store';
   import { isSidebarOpen, sidebarView } from '../../stores/ui.store';
   import { helpViewStore } from '../../stores/help-view.store';
@@ -228,6 +229,10 @@
     showBgOutputOption && nodeId !== undefined && $overrideOutputNodeId === nodeId
   );
 
+  let canExpand = $derived(
+    showExpandOption && nodeId !== undefined && $outputTarget === 'background'
+  );
+
   function handleBgOutputToggle() {
     if (!nodeId) return;
 
@@ -271,6 +276,8 @@
   }
 
   function handleExpandToggle() {
+    if (!canExpand) return;
+
     const controller = getExpandController();
     if (!controller) return;
 
@@ -320,7 +327,7 @@
                   if (showSettings) showEditor = false;
                 }}
                 onCodeToggle={resolvedPrimary === 'code' ? undefined : toggleCode}
-                onExpandToggle={showExpandOption && nodeId ? handleExpandToggle : undefined}
+                onExpandToggle={canExpand ? handleExpandToggle : undefined}
                 {isExpanded}
                 onBgOutputToggle={handleBgOutputToggle}
                 onPlaybackToggle={handlePlaybackToggle}
@@ -422,7 +429,7 @@
         if (showEditor) showSettings = false;
         measureContainerWidth();
       }}
-      onExpandToggle={showExpandOption && nodeId ? handleExpandToggle : undefined}
+      onExpandToggle={canExpand ? handleExpandToggle : undefined}
       {isExpanded}
       onBgOutputToggle={handleBgOutputToggle}
       onPlaybackToggle={handlePlaybackToggle}

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -97,7 +97,9 @@
   let showSettings = $state(false);
   let isExpanded = $state(false);
   let previewContainerWidth = $state(0);
+
   let expandController: CanvasPreviewExpandController | null = null;
+  let controllerNodeId: string | null = null;
 
   // Which button is rendered as the primary (rightmost) action.
   // Set via setPrimaryButton('settings'|'run'|'code') from worker code, or
@@ -107,9 +109,14 @@
   // Resolved primary — falls back to 'code' if the requested mode isn't usable
   // (e.g. 'settings' selected but no schema yet, 'run' selected but no onrun).
   let resolvedPrimary = $derived.by<PrimaryButton>(() => {
-    if (primaryButton === 'settings' && (!settingsSchema || settingsSchema.length === 0))
+    if (primaryButton === 'settings' && (!settingsSchema || settingsSchema.length === 0)) {
       return 'code';
-    if (primaryButton === 'run' && !onrun) return 'code';
+    }
+
+    if (primaryButton === 'run' && !onrun) {
+      return 'code';
+    }
+
     return primaryButton;
   });
 
@@ -142,9 +149,12 @@
   function handleConsoleToggle() {
     if (nodeId) {
       const node = getNode(nodeId);
+
       if (node) {
-        const newShowConsole = !node.data.showConsole;
-        updateNodeData(nodeId, { ...node.data, showConsole: newShowConsole });
+        updateNodeData(nodeId, {
+          ...node.data,
+          showConsole: !node.data.showConsole
+        });
       }
     }
   }
@@ -157,10 +167,13 @@
   // require threading `data` as a prop through every node component using this layout.
   function handlePrimaryButtonUpdate(e: NodePrimaryButtonUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     // Defensive whitelist — TypeScript guarantees this at the type level, but the
     // event bus is loosely typed at runtime so a buggy dispatcher could send anything.
-    if (e.primaryButton !== 'code' && e.primaryButton !== 'settings' && e.primaryButton !== 'run')
+    if (e.primaryButton !== 'code' && e.primaryButton !== 'settings' && e.primaryButton !== 'run') {
       return;
+    }
+
     if (e.primaryButton === primaryButton) return;
 
     primaryButton = e.primaryButton;
@@ -196,7 +209,9 @@
 
     return () => {
       expandController?.exit();
+
       expandController = null;
+      controllerNodeId = null;
       resizeObserver?.disconnect();
 
       eventBus.removeEventListener('nodePrimaryButtonUpdate', handlePrimaryButtonUpdate);
@@ -225,6 +240,13 @@
   function getExpandController() {
     if (!nodeId) return null;
 
+    if (controllerNodeId !== null && controllerNodeId !== nodeId) {
+      expandController?.exit();
+
+      expandController = null;
+      controllerNodeId = null;
+    }
+
     if (!expandController) {
       expandController = new CanvasPreviewExpandController({
         nodeId,
@@ -241,6 +263,8 @@
           isExpanded = active;
         }
       });
+
+      controllerNodeId = nodeId;
     }
 
     return expandController;

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -326,7 +326,7 @@
                   <Tooltip.Trigger>
                     <button
                       class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
-                      aria-label={showSettings ? 'Hide settings' : 'Show settings'}
+                      aria-label={showSettings ? 'Hide settings' : 'Settings'}
                       onclick={() => {
                         showSettings = !showSettings;
                         if (showSettings) showEditor = false;
@@ -335,9 +335,7 @@
                       <SettingsIcon class="h-4 w-4 text-zinc-300" />
                     </button>
                   </Tooltip.Trigger>
-                  <Tooltip.Content
-                    >{showSettings ? 'Hide settings' : 'Show settings'}</Tooltip.Content
-                  >
+                  <Tooltip.Content>{showSettings ? 'Hide settings' : 'Settings'}</Tooltip.Content>
                 </Tooltip.Root>
               {:else if resolvedPrimary === 'run'}
                 <Tooltip.Root>

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -14,13 +14,17 @@
   import { helpViewStore } from '../../stores/help-view.store';
   import { overrideOutputNodeId, previewBackgroundColor } from '../../stores/renderer.store';
   import { GLSystem } from '$lib/canvas/GLSystem';
+  import { CanvasPreviewExpandController } from '$lib/canvas/CanvasPreviewExpandController';
+  import { SurfaceListeners } from '$lib/canvas/SurfaceListeners';
+  import { SurfaceMouseForwarder } from '$lib/canvas/SurfaceMouseForwarder';
+  import { SurfaceOverlay } from '$lib/canvas/SurfaceOverlay';
   import { useNodeSetPaused } from '$lib/canvas/use-node-set-paused.svelte';
   import { useIncludeProcessing } from '$lib/canvas/use-include-processing.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { NodePrimaryButtonUpdateEvent, PrimaryButton } from '$lib/eventbus/events';
 
   let previewContainer: HTMLDivElement | null = null;
-  const { getNode, updateNodeData } = useSvelteFlow();
+  const { getNode, getNodes, updateNodeData } = useSvelteFlow();
 
   let {
     title,
@@ -33,6 +37,7 @@
     previewVisible = true,
     showPauseButton = false,
     showBgOutputOption = false,
+    showExpandOption = false,
 
     topHandle,
     bottomHandle,
@@ -59,6 +64,7 @@
     previewVisible?: boolean;
     showPauseButton?: boolean;
     showBgOutputOption?: boolean;
+    showExpandOption?: boolean;
 
     topHandle?: Snippet;
     bottomHandle?: Snippet;
@@ -89,7 +95,9 @@
 
   let showEditor = $state(false);
   let showSettings = $state(false);
+  let isExpanded = $state(false);
   let previewContainerWidth = $state(0);
+  let expandController: CanvasPreviewExpandController | null = null;
 
   // Which button is rendered as the primary (rightmost) action.
   // Set via setPrimaryButton('settings'|'run'|'code') from worker code, or
@@ -187,6 +195,8 @@
     eventBus.addEventListener('nodePrimaryButtonUpdate', handlePrimaryButtonUpdate);
 
     return () => {
+      expandController?.exit();
+      expandController = null;
       resizeObserver?.disconnect();
 
       eventBus.removeEventListener('nodePrimaryButtonUpdate', handlePrimaryButtonUpdate);
@@ -210,6 +220,41 @@
     overrideOutputNodeId.set(next);
 
     GLSystem.getInstance().setOverrideOutputNode(next);
+  }
+
+  function getExpandController() {
+    if (!nodeId) return null;
+
+    if (!expandController) {
+      expandController = new CanvasPreviewExpandController({
+        nodeId,
+        getNodes,
+        getOverrideOutputNode: () => $overrideOutputNodeId,
+        setOverrideOutputNode: (next) => {
+          overrideOutputNodeId.set(next);
+          GLSystem.getInstance().setOverrideOutputNode(next);
+        },
+        overlay: SurfaceOverlay.getInstance(),
+        createForwarder: () => new SurfaceMouseForwarder(() => getNodes()),
+        createListeners: () => new SurfaceListeners(),
+        onActiveChange: (active) => {
+          isExpanded = active;
+        }
+      });
+    }
+
+    return expandController;
+  }
+
+  function handleExpandToggle() {
+    const controller = getExpandController();
+    if (!controller) return;
+
+    if (controller.isActive) {
+      controller.exit();
+    } else {
+      controller.enter();
+    }
   }
 
   const toggleCode = () => {
@@ -251,6 +296,8 @@
                   if (showSettings) showEditor = false;
                 }}
                 onCodeToggle={resolvedPrimary === 'code' ? undefined : toggleCode}
+                onExpandToggle={showExpandOption && nodeId ? handleExpandToggle : undefined}
+                {isExpanded}
                 onBgOutputToggle={handleBgOutputToggle}
                 onPlaybackToggle={handlePlaybackToggle}
                 onOpenHelp={handleOpenHelp}
@@ -348,13 +395,13 @@
         showSettings = !showSettings;
         if (showSettings) showEditor = false;
       }}
-      onCodeToggle={resolvedPrimary === 'code'
-        ? undefined
-        : () => {
-            showEditor = !showEditor;
-            if (showEditor) showSettings = false;
-            measureContainerWidth();
-          }}
+      onCodeToggle={() => {
+        showEditor = !showEditor;
+        if (showEditor) showSettings = false;
+        measureContainerWidth();
+      }}
+      onExpandToggle={showExpandOption && nodeId ? handleExpandToggle : undefined}
+      {isExpanded}
       onBgOutputToggle={handleBgOutputToggle}
       onPlaybackToggle={handlePlaybackToggle}
       onOpenHelp={handleOpenHelp}

--- a/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
@@ -68,6 +68,14 @@
     onOpenHelp: () => void;
     extraMenuItems?: ExtraMenuItem[];
   } = $props();
+
+  const hasTopItems = $derived(
+    Boolean(onrun || (settingsSchema && settingsSchema.length > 0) || extraMenuItems?.length)
+  );
+
+  const hasOutputItems = $derived(
+    Boolean((showBgOutputOption && nodeId !== undefined) || onCodeToggle || onExpandToggle)
+  );
 </script>
 
 <Popover.Root>
@@ -122,7 +130,9 @@
       {/each}
     {/if}
 
-    <Separator />
+    {#if hasTopItems && hasOutputItems}
+      <Separator />
+    {/if}
 
     {#if showBgOutputOption && nodeId !== undefined}
       <Popover.Close class="contents">

--- a/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
@@ -133,11 +133,11 @@
           {#if isOutputOverride}
             <MonitorOff class="h-4 w-4 text-orange-400" />
 
-            <span class="text-orange-400">Remove background output</span>
+            <span class="text-orange-400">Hide output</span>
           {:else}
             <Monitor class="h-4 w-4 text-zinc-300" />
 
-            <span>Output to background</span>
+            <span>Use as output</span>
           {/if}
         </button>
       </Popover.Close>

--- a/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
@@ -12,7 +12,8 @@
     PinOff,
     Play,
     Settings,
-    Shrink
+    Shrink,
+    OctagonPause
   } from '@lucide/svelte/icons';
   import * as Popover from './ui/popover';
   import type { SettingsSchema } from '$lib/settings';
@@ -166,6 +167,10 @@
       </Popover.Close>
     {/if}
 
+    {#if onExpandToggle || showPauseButton || onPreviewToggle}
+      <Separator />
+    {/if}
+
     {#if onExpandToggle}
       <Popover.Close class="contents">
         <button
@@ -183,10 +188,6 @@
           {/if}
         </button>
       </Popover.Close>
-    {/if}
-
-    {#if showPauseButton || onPreviewToggle}
-      <Separator />
     {/if}
 
     {#if showPauseButton}

--- a/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
@@ -134,6 +134,19 @@
       <Separator />
     {/if}
 
+    {#if onCodeToggle}
+      <Popover.Close class="contents">
+        <button
+          class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-zinc-700"
+          onclick={onCodeToggle}
+        >
+          <Code class="h-4 w-4 text-zinc-300" />
+
+          <span>Edit code</span>
+        </button>
+      </Popover.Close>
+    {/if}
+
     {#if showBgOutputOption && nodeId !== undefined}
       <Popover.Close class="contents">
         <button
@@ -168,19 +181,6 @@
 
             <span>Expand</span>
           {/if}
-        </button>
-      </Popover.Close>
-    {/if}
-
-    {#if onCodeToggle}
-      <Popover.Close class="contents">
-        <button
-          class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-zinc-700"
-          onclick={onCodeToggle}
-        >
-          <Code class="h-4 w-4 text-zinc-300" />
-
-          <span>Edit code</span>
         </button>
       </Popover.Close>
     {/if}

--- a/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
@@ -5,12 +5,14 @@
     Eye,
     EyeOff,
     Ellipsis,
+    Expand,
     Monitor,
     MonitorOff,
     Pin,
     PinOff,
     Play,
-    Settings
+    Settings,
+    Shrink
   } from '@lucide/svelte/icons';
   import * as Popover from './ui/popover';
   import type { SettingsSchema } from '$lib/settings';
@@ -38,6 +40,8 @@
     previewVisible = true,
     onSettingsToggle,
     onCodeToggle,
+    onExpandToggle,
+    isExpanded = false,
     onBgOutputToggle,
     onPlaybackToggle,
     onOpenHelp,
@@ -57,6 +61,8 @@
     onSettingsToggle?: () => void;
     /** Provided when code editor is NOT the primary button — adds an "Edit code" entry to the menu. */
     onCodeToggle?: () => void;
+    onExpandToggle?: () => void;
+    isExpanded?: boolean;
     onBgOutputToggle?: () => void;
     onPlaybackToggle?: () => void;
     onOpenHelp: () => void;
@@ -87,21 +93,21 @@
       </Popover.Close>
     {/if}
 
-    {#if onCodeToggle}
+    {#if settingsSchema && settingsSchema.length > 0}
       <Popover.Close class="contents">
         <button
           class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-zinc-700"
-          onclick={onCodeToggle}
+          onclick={onSettingsToggle}
         >
-          <Code class="h-4 w-4 text-zinc-300" />
+          <Settings class="h-4 w-4 text-zinc-300" />
 
-          <span>Edit code</span>
+          <span>{showSettings ? 'Hide settings' : 'Settings'}</span>
         </button>
       </Popover.Close>
     {/if}
 
     {#if extraMenuItems && extraMenuItems.length > 0}
-      {#each extraMenuItems as item}
+      {#each extraMenuItems as item, index (index)}
         <Popover.Close class="contents">
           <button
             class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-zinc-700"
@@ -114,21 +120,9 @@
           </button>
         </Popover.Close>
       {/each}
-      <Separator />
     {/if}
 
-    {#if settingsSchema && settingsSchema.length > 0}
-      <Popover.Close class="contents">
-        <button
-          class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-zinc-700"
-          onclick={onSettingsToggle}
-        >
-          <Settings class="h-4 w-4 text-zinc-300" />
-
-          <span>{showSettings ? 'Hide settings' : 'Show settings'}</span>
-        </button>
-      </Popover.Close>
-    {/if}
+    <Separator />
 
     {#if showBgOutputOption && nodeId !== undefined}
       <Popover.Close class="contents">
@@ -147,6 +141,42 @@
           {/if}
         </button>
       </Popover.Close>
+    {/if}
+
+    {#if onExpandToggle}
+      <Popover.Close class="contents">
+        <button
+          class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-zinc-700"
+          onclick={onExpandToggle}
+        >
+          {#if isExpanded}
+            <Shrink class="h-4 w-4 text-red-400" />
+
+            <span class="text-red-400">Exit expanded</span>
+          {:else}
+            <Expand class="h-4 w-4 text-zinc-300" />
+
+            <span>Expand</span>
+          {/if}
+        </button>
+      </Popover.Close>
+    {/if}
+
+    {#if onCodeToggle}
+      <Popover.Close class="contents">
+        <button
+          class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-zinc-700"
+          onclick={onCodeToggle}
+        >
+          <Code class="h-4 w-4 text-zinc-300" />
+
+          <span>Edit code</span>
+        </button>
+      </Popover.Close>
+    {/if}
+
+    {#if showPauseButton || onPreviewToggle}
+      <Separator />
     {/if}
 
     {#if showPauseButton}

--- a/ui/src/lib/components/nodes/CodeBlockBase.svelte
+++ b/ui/src/lib/components/nodes/CodeBlockBase.svelte
@@ -359,7 +359,7 @@
               </Tooltip.Trigger>
 
               <Tooltip.Content>
-                {showSettings ? 'Hide settings' : 'Show settings'}
+                {showSettings ? 'Hide settings' : 'Settings'}
               </Tooltip.Content>
             </Tooltip.Root>
           {:else}

--- a/ui/src/lib/components/nodes/CodeBlockOverflowMenu.svelte
+++ b/ui/src/lib/components/nodes/CodeBlockOverflowMenu.svelte
@@ -43,7 +43,7 @@
         >
           <Settings class="h-4 w-4 text-zinc-300" />
 
-          <span>{showSettings ? 'Hide settings' : 'Show settings'}</span>
+          <span>{showSettings ? 'Hide settings' : 'Settings'}</span>
         </button>
       </Popover.Close>
     {/if}

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -684,6 +684,7 @@
   paused={data.paused}
   showPauseButton={true}
   showBgOutputOption={false}
+  showExpandOption={false}
   bind:previewCanvas
   nodrag={!dragEnabled}
   nopan={!panEnabled}

--- a/ui/src/objects/projmap/ProjectionMapContextMenu.svelte
+++ b/ui/src/objects/projmap/ProjectionMapContextMenu.svelte
@@ -121,10 +121,10 @@
   <ContextMenu.Item onclick={ontoggleoutput}>
     {#if isOutputOverride}
       <MonitorOff class="mr-2 h-4 w-4 text-orange-400" />
-      <span class="text-orange-400">Remove background output</span>
+      <span class="text-orange-400">Hide output</span>
     {:else}
       <Monitor class="mr-2 h-4 w-4" />
-      Output to background
+      Use as output
     {/if}
   </ContextMenu.Item>
 

--- a/ui/src/objects/projmap/ProjectionMapOverflowMenu.svelte
+++ b/ui/src/objects/projmap/ProjectionMapOverflowMenu.svelte
@@ -142,10 +142,10 @@
     >
       {#if isOutputOverride}
         <MonitorOff class="h-4 w-4 text-orange-400" />
-        <span class="text-orange-400">Remove background output</span>
+        <span class="text-orange-400">Hide output</span>
       {:else}
         <Monitor class="h-4 w-4 text-zinc-400" />
-        Output to background
+        Use as output
       {/if}
     </button>
   </Popover.Content>

--- a/ui/static/content/topics/video-chaining.md
+++ b/ui/static/content/topics/video-chaining.md
@@ -21,7 +21,7 @@ Connect orange outlet → orange inlet to chain them:
 [p5] → [hydra>] → [glsl>] → [bg.out]
 ```
 
-To hear — er, *see* — anything, connect the final object to `bg.out` or use **Output to Background**.
+To hear — er, *see* — anything, connect the final object to `bg.out` or use **Use as output**.
 
 ## Try It
 
@@ -47,11 +47,11 @@ The preset library has ready-made building blocks for video chaining. Enable the
 - **`diff.hydra`, `add.hydra`, `sub.hydra`** — blend two video inputs with Hydra
 - Check the [hydra](/docs/objects/hydra) and [glsl](/docs/objects/glsl) docs for more preset ideas
 
-## Output to Background
+## Sending to output
 
-Right-click any visual object (or use its **···** menu) and choose **Output to background** to make it the fullscreen output. This overrides any `bg.out` connection.
+Right-click any visual object (or use its **···** menu) and choose **Use as output** to make it the fullscreen output. This overrides any `bg.out` connection.
 
-- Click **Output to background** again on the same object to clear the override
+- Click **Use as output** again on the same object to clear the override
 - Switching to a different object replaces the current output — only one at a time
 - This is great for live performance; it is not saved across sessions
 
@@ -69,7 +69,7 @@ screen re-connects within a second.
 
 1. Open the output screen (`Cmd+K` → "Open Output Screen")
 2. Create a `hydra` object and write a pattern
-3. Right-click the hydra object → **Output to background**
+3. Right-click the hydra object → **Use as output**
 4. Drag the output window to a second monitor or projector — your audience sees clean visuals while you keep editing.
 
 ## Output Resolution


### PR DESCRIPTION
Adds a context and overflow menu item on CanvasPreviewLayout-based visual objects that lets you expand a visual object to fullscreen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fullscreen "expand" mode for canvas previews with input forwarding and new Expand/Exit controls in preview menus and context menus.
  * Per-node ability to opt out of the expand option.

* **UI**
  * Tweaked settings label text to consistently show "Settings" when collapsed.

* **Documentation**
  * Added design spec describing the canvas preview expand behavior.

* **Tests**
  * Added unit tests covering expand controller enter/exit behavior and input forwarding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->