### PR TITLE
Fullscreen overlay codemirror editor layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,13 +85,13 @@ bun run test             # All tests
 
 ## Code Patterns
 
-- **Always use `ts-pattern`**, never `switch` statements. This includes:
-  - Conditional logic based on type/mode/state
-  - Dynamic CSS class selection based on variants
-  - Any branching on union types or enums
+- **Use `ts-pattern` when it improves clarity**, especially for:
+  - Exhaustive branching on discriminated unions, enums, or mode/state values
+  - Data-shape matching where destructuring in the branch is useful
+  - Replacing `switch` statements that would otherwise duplicate fallthrough/default logic
 
   ```ts
-  // WRONG - never use switch
+  // WRONG - avoid switch for union-style branching
   switch (mode) {
     case "edit":
       return "bg-amber-600";
@@ -101,13 +101,24 @@ bun run test             # All tests
       return "bg-purple-600";
   }
 
-  // RIGHT - always use ts-pattern
+  // RIGHT - ts-pattern makes this branch set clear
   import { match } from "ts-pattern";
   match(mode)
     .with("edit", () => "bg-amber-600")
     .with("multi", () => "bg-blue-600")
     .otherwise(() => "bg-purple-600");
   ```
+
+- **Do NOT use `ts-pattern` when it makes code heavier or harder to follow.** Prefer
+  normal `if` statements, guard clauses, or small helper functions for:
+  - Simple null/undefined checks
+  - Early returns in effects, event handlers, and setup/cleanup code
+  - Hot paths such as render loops, audio processing, worker message loops, or
+    high-frequency pointer/animation handlers
+  - Sequential control flow where each guard has side effects or depends on the
+    previous guard
+  - Cases where a `match(...).with(...).otherwise(...)` block is longer or less
+    direct than the equivalent `if` statements
 
 - Separate UI from business logic (manager pattern)
 - TypeScript for all code
@@ -118,7 +129,19 @@ bun run test             # All tests
 
 ## Styling
 
-- Tailwind classes only (no custom CSS)
+- Prefer Tailwind utility classes for DOM the component owns directly.
+- Do **not** force Tailwind classes when they make the code harder to read. Use a
+  small, local `<style>` block instead when:
+  - Styling generated or third-party DOM that cannot receive classes directly
+    (CodeMirror `.cm-*`, canvas/library internals, embedded editors, etc.)
+  - Tailwind arbitrary variants become long descendant-selector strings
+  - The same selector-based rule would be clearer, shorter, and more stable as
+    CSS
+  - You need to override library styles in one component boundary
+- Keep local CSS scoped and minimal. Prefer component-level selectors over broad
+  globals, avoid `!important` unless overriding a library requires it, and never
+  remove focus indicators without replacing them with an accessible visible
+  focus style.
 - Zinc palette, dark theme
 - Support `class` prop for component extension
 - Icons: `@lucide/svelte`

--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -27,6 +27,11 @@ Detached editor layouts should support:
 - a focused sidebar editor that uses the existing `SidebarPanel` system
 - future display-only or performance-oriented code views
 
+The first implementation focuses on visual code nodes that already use
+`CanvasPreviewLayout`. Expression-style nodes such as `CommonExprLayout` do not
+need detached editing initially because their inline editors are already compact
+and the code is less likely to be part of a performance visual.
+
 ## Source Of Truth
 
 Node data remains the source of truth for editable code.
@@ -40,6 +45,8 @@ interface CodeEditorTarget {
   title?: string;
   mode: 'overlay' | 'sidebar';
 }
+
+type EditorLayoutPreference = 'inline' | 'overlay' | 'sidebar';
 ```
 
 All editor accessors read from and write to the active node's `data[dataKey]`
@@ -54,6 +61,10 @@ and commit events, but it does not own the durable code value.
 - Only one detached editor target is active at a time.
 - Opening detached mode for a node stores `{ nodeId, dataKey, language,
   nodeType, title, mode }` in a shared store.
+- Code editor chrome in `CanvasPreviewLayout` exposes an expand action that opens
+  the current code field in overlay mode.
+- The user's default editor layout decides whether opening a visual node editor
+  starts inline or opens the overlay directly.
 - While a detached editor is active for a node field, the inline editor for that
   same field is hidden or replaced with a compact "editing elsewhere" affordance.
 - Closing detached mode clears the active target and allows the inline editor to
@@ -79,8 +90,11 @@ Expected presentation:
 
 - transparent editor background
 - large configurable font size
+- ample padding so the code reads well on a projected output
+- centered, wide layout that makes the code front-and-center
+- configurable editor transparency
 - optional line wrapping
-- minimal chrome, with close and layout-switch controls
+- minimal chrome, with close and layout-switch controls where available
 - `nodrag`, `nopan`, and `nowheel` behavior so XYFlow does not consume editor
   interactions
 
@@ -99,6 +113,27 @@ editor there.
 Sidebar mode is useful for focused editing without covering the background
 output.
 
+Sidebar mode is not part of the first implementation. The type and settings
+should leave room for it, but the first shipped behavior only needs inline and
+overlay.
+
+## Settings
+
+Add editor layout preferences to `SettingsModal.svelte`.
+
+Initial settings:
+
+- Default editor layout: `Inline` or `Overlay`
+- Overlay editor transparency
+
+Future setting:
+
+- `Sidebar` default layout, once the sidebar code view exists
+
+Settings should live in a dedicated store under `src/stores/`, not directly in
+the settings modal component. The default editor layout is user preference state,
+not patch data.
+
 ## Architecture
 
 ### Store
@@ -114,26 +149,41 @@ Responsibilities:
   inline editor when needed
 - avoid localStorage initially; layout state is session UI state, not patch data
 
+Create a separate persisted settings store for editor layout preferences, for
+example `editor-layout-settings.store.ts`.
+
+Responsibilities:
+
+- hold the default editor layout preference
+- hold the overlay transparency preference
+- persist user preferences to localStorage
+- leave room for `sidebar` as a future layout value without showing it in the
+  first dropdown
+
 ### Shared Shells
 
 Add dedicated presentation components:
 
 - `DetachedCodeEditorOverlay.svelte`
-- `SidebarCodeEditorView.svelte`
+- `SidebarCodeEditorView.svelte` in a follow-up
 
 Both components resolve the active node and code value from the canvas state,
 then pass normal props into `CodeEditor.svelte`.
 
 ### Inline Integration
 
-Node components should not duplicate detached-editor logic. Prefer a small helper
-or wrapper around existing code-editor render paths so common nodes can ask:
+Node components should not duplicate detached-editor logic. The first integration
+point should be `CanvasPreviewLayout`, because it is already shared by the visual
+objects that benefit most from performance-oriented code display.
+
+Prefer a small helper or wrapper around existing code-editor render paths so
+common nodes can ask:
 
 ```typescript
 const isEditingElsewhere = isDetachedTarget(nodeId, dataKey);
 ```
 
-For the first pass, wire the behavior through the common code-editor layouts
+For the first pass, wire the behavior through `CanvasPreviewLayout` consumers
 before handling one-off custom nodes.
 
 ## Undo And Concurrency
@@ -163,16 +213,21 @@ options:
 3. Omit detached `Shift-Enter` from the first prototype for node types where the
    run action is not available.
 
-The first implementation can support run for common code layouts first, then
-expand coverage as node-specific paths are traced.
+The first implementation should pass `onrun` through where the shared layout
+already has access to it. Nodes that cannot expose run cleanly can still edit in
+overlay mode, but `Shift-Enter` does not need to work for those nodes until their
+run path is traced.
 
 ## Scope
 
 First pass:
 
 - shared active detached-editor target store
-- overlay editor for common CodeMirror-backed code nodes
+- overlay editor for `CanvasPreviewLayout` consumers
+- Settings modal option for default editor layout: `Inline` or `Overlay`
+- Settings modal option for overlay editor transparency
 - hide inline editor while detached overlay is active
+- compact inline affordance showing that the editor is open in expanded view
 - close behavior when target node is removed
 - preserve undo/redo commit behavior
 
@@ -180,19 +235,21 @@ Follow-up:
 
 - sidebar `code` tab
 - layout switch between overlay and sidebar
-- typography controls for performance mode
+- typography controls for performance mode beyond the first overlay defaults
 - persisted user preferences for font size, line wrapping, and chrome density
 - broader support for node-specific run callbacks
 
 ## Files Likely Touched
 
 - `ui/src/lib/components/CodeEditor.svelte`
+- `ui/src/lib/components/CanvasPreviewLayout.svelte`
 - `ui/src/lib/components/FlowCanvasInner.svelte`
+- `ui/src/lib/components/settings-modal/SettingsModal.svelte`
 - `ui/src/lib/components/sidebar/SidebarPanel.svelte`
 - `ui/src/stores/ui.store.ts`
 - `ui/src/stores/code-editor-layout.store.ts`
-- common node layout components such as `CodeBlockBase.svelte` and
-  `ObjectPreviewLayout.svelte`
+- a dedicated settings store for editor layout preferences
+- common node layout components that feed `CanvasPreviewLayout`
 
 ## Testing
 
@@ -200,6 +257,7 @@ Unit or component coverage should verify:
 
 - opening detached mode stores the correct active target
 - closing detached mode clears the target
+- default editor layout setting opens visual code editors inline or in overlay
 - inline editor is hidden for the active detached node field
 - editing through detached mode updates the node data field
 - blur emits a single undo/redo commit for the edited field
@@ -209,5 +267,6 @@ Manual verification should cover:
 
 - overlay editor renders above background output
 - editor wheel and drag interactions do not pan or zoom the canvas
-- large font and transparent background remain readable over visual output
-- sidebar mode can edit the same node field without changing patch data shape
+- large font, ample padding, and transparent background remain readable over
+  visual output
+- overlay transparency setting changes the editor background opacity

--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -78,6 +78,10 @@ nodeType, title, mode }` in a shared store.
 - Deleting the target node closes detached mode.
 - If the target node's data changes externally, the detached editor receives the
   new value through the existing `value` prop sync path.
+- If no background output is active when overlay mode opens, the edited node
+  becomes a temporary output override.
+- Temporary output overrides are cleared on exit, but existing `bg.out`
+  connections or user-selected output overrides are preserved.
 
 ## Layouts
 

--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -68,6 +68,8 @@ nodeType, title, mode }` in a shared store.
 - `Shift+click` on the visual node code edit action opens the alternate layout
   for that invocation: inline defaults open overlay, and overlay defaults open
   inline.
+- Strudel editor views hide line-number gutters in both inline and detached
+  layouts so pattern code stays visually central.
 - While a detached editor is active for a node field, the inline editor for that
   same field is hidden or replaced with a compact "editing elsewhere" affordance.
 - Closing detached mode clears the active target and allows the inline editor to

--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -43,10 +43,10 @@ interface CodeEditorTarget {
   language: SupportedLanguage;
   nodeType?: string;
   title?: string;
-  mode: 'overlay' | 'sidebar';
+  mode: "overlay" | "sidebar";
 }
 
-type EditorLayoutPreference = 'inline' | 'overlay' | 'sidebar';
+type EditorLayoutPreference = "inline" | "overlay" | "sidebar";
 ```
 
 All editor accessors read from and write to the active node's `data[dataKey]`
@@ -60,7 +60,7 @@ and commit events, but it does not own the durable code value.
 
 - Only one detached editor target is active at a time.
 - Opening detached mode for a node stores `{ nodeId, dataKey, language,
-  nodeType, title, mode }` in a shared store.
+nodeType, title, mode }` in a shared store.
 - Code editor chrome in `CanvasPreviewLayout` exposes an expand action that opens
   the current code field in overlay mode.
 - The user's default editor layout decides whether opening a visual node editor
@@ -88,18 +88,21 @@ output and above `SvelteFlow`.
 
 Expected presentation:
 
-- transparent editor background
+- fullscreen transparent editor background
 - large configurable font size
 - ample padding so the code reads well on a projected output
-- centered, wide layout that makes the code front-and-center
+- code editor spans the screen with no outer margin, panel border, or title
+- close and run buttons sit inside the fullscreen editor padding
+- `Shift+Esc` closes the expanded editor, matching surface expand mode
 - configurable editor transparency
 - optional line wrapping
 - minimal chrome, with close and layout-switch controls where available
 - `nodrag`, `nopan`, and `nowheel` behavior so XYFlow does not consume editor
   interactions
 
-The overlay should not activate `isFullscreenActive`; it is an editing layer, not
-a canvas preview fullscreen mode.
+The overlay should reuse the existing fullscreen UI-hiding infrastructure used by
+surface expand mode. It should set `isFullscreenActive` while open and close the
+sidebar so the rest of the Patchies UI is hidden during focused editing.
 
 ### Sidebar
 

--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -65,6 +65,9 @@ nodeType, title, mode }` in a shared store.
   the current code field in overlay mode.
 - The user's default editor layout decides whether opening a visual node editor
   starts inline or opens the overlay directly.
+- `Shift+click` on the visual node code edit action opens the alternate layout
+  for that invocation: inline defaults open overlay, and overlay defaults open
+  inline.
 - While a detached editor is active for a node field, the inline editor for that
   same field is hidden or replaced with a compact "editing elsewhere" affordance.
 - Closing detached mode clears the active target and allows the inline editor to

--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -1,0 +1,213 @@
+# 148. Code Editor Detached Layouts
+
+## Goal
+
+Add shared detached layouts for node code editors so Patchies can support live
+coding workflows where code is large, focused, and optionally overlaid on top of
+the background output.
+
+This changes the mental model of `CodeEditor.svelte` from "the node's editor" to
+"one editor accessor for a code field." The durable source of truth remains the
+node data field, usually `node.data.code`, while inline, overlay, and sidebar
+editors are different views that can edit the same field.
+
+## Motivation
+
+Live coding performances often make the code itself part of the visual output:
+large text, custom typography, and editor UI that sits front-and-center instead
+of beside a small node preview.
+
+Patchies currently renders most code editors inline with the node, usually to the
+right of the preview or object body. That layout is good for patch building, but
+it is cramped for performance, screen sharing, and focused editing.
+
+Detached editor layouts should support:
+
+- a transparent "Zen" overlay above the background output
+- a focused sidebar editor that uses the existing `SidebarPanel` system
+- future display-only or performance-oriented code views
+
+## Source Of Truth
+
+Node data remains the source of truth for editable code.
+
+```typescript
+interface CodeEditorTarget {
+  nodeId: string;
+  dataKey: string; // usually "code", but also "expr", "prompt", etc.
+  language: SupportedLanguage;
+  nodeType?: string;
+  title?: string;
+  mode: 'overlay' | 'sidebar';
+}
+```
+
+All editor accessors read from and write to the active node's `data[dataKey]`
+through the same node data update path used by inline editors.
+
+`CodeEditor.svelte` should stay a reusable CodeMirror wrapper. It owns
+CodeMirror view creation, local editor events, error decorations, keybindings,
+and commit events, but it does not own the durable code value.
+
+## Behavior
+
+- Only one detached editor target is active at a time.
+- Opening detached mode for a node stores `{ nodeId, dataKey, language,
+  nodeType, title, mode }` in a shared store.
+- While a detached editor is active for a node field, the inline editor for that
+  same field is hidden or replaced with a compact "editing elsewhere" affordance.
+- Closing detached mode clears the active target and allows the inline editor to
+  render normally again.
+- Editing in detached mode updates `node.data[dataKey]` continuously, matching
+  current inline editor behavior.
+- Blur commits still emit the existing `codeCommit` event so undo/redo records a
+  single focused editing session.
+- `Shift-Enter` should run the same node action as the inline editor where the
+  node provides one.
+- Deleting the target node closes detached mode.
+- If the target node's data changes externally, the detached editor receives the
+  new value through the existing `value` prop sync path.
+
+## Layouts
+
+### Overlay
+
+The overlay editor is rendered once near the canvas shell, above the background
+output and above `SvelteFlow`.
+
+Expected presentation:
+
+- transparent editor background
+- large configurable font size
+- optional line wrapping
+- minimal chrome, with close and layout-switch controls
+- `nodrag`, `nopan`, and `nowheel` behavior so XYFlow does not consume editor
+  interactions
+
+The overlay should not activate `isFullscreenActive`; it is an editing layer, not
+a canvas preview fullscreen mode.
+
+### Sidebar
+
+Add a `code` view to `SidebarView` and render a code editor panel inside
+`SidebarPanel`.
+
+The sidebar editor uses the same active target store. Switching a target to
+sidebar mode should open the sidebar, select the `code` tab, and render the
+editor there.
+
+Sidebar mode is useful for focused editing without covering the background
+output.
+
+## Architecture
+
+### Store
+
+Create a dedicated store under `src/stores/`, for example
+`code-editor-layout.store.ts`.
+
+Responsibilities:
+
+- hold the active `CodeEditorTarget | null`
+- expose helpers such as `openOverlay(target)`, `openSidebar(target)`, `close()`
+- expose `isDetachedTarget(nodeId, dataKey)` so node components can hide their
+  inline editor when needed
+- avoid localStorage initially; layout state is session UI state, not patch data
+
+### Shared Shells
+
+Add dedicated presentation components:
+
+- `DetachedCodeEditorOverlay.svelte`
+- `SidebarCodeEditorView.svelte`
+
+Both components resolve the active node and code value from the canvas state,
+then pass normal props into `CodeEditor.svelte`.
+
+### Inline Integration
+
+Node components should not duplicate detached-editor logic. Prefer a small helper
+or wrapper around existing code-editor render paths so common nodes can ask:
+
+```typescript
+const isEditingElsewhere = isDetachedTarget(nodeId, dataKey);
+```
+
+For the first pass, wire the behavior through the common code-editor layouts
+before handling one-off custom nodes.
+
+## Undo And Concurrency
+
+Use option 1: do not allow two visible editor accessors for the same node field.
+
+When detached mode is active for a node field, hide the inline editor for that
+field. This avoids cursor synchronization, double focus state, and ambiguous blur
+commits.
+
+Undo/redo should continue to use the existing `codeCommit` event emitted by
+`CodeEditor.svelte` on blur. Because only one accessor is visible for a field,
+each focused editing session maps cleanly to one undo command.
+
+## Run Action
+
+The main unknown is how consistently node-specific run behavior is exposed today.
+Some nodes pass local `onrun` callbacks directly into `CodeEditor.svelte`.
+
+Implementation should avoid hardcoding run behavior in the detached editor. Good
+options:
+
+1. Register an optional run callback in the active target when opening detached
+   mode.
+2. Route run requests through a node-level service if one already exists or is
+   introduced later.
+3. Omit detached `Shift-Enter` from the first prototype for node types where the
+   run action is not available.
+
+The first implementation can support run for common code layouts first, then
+expand coverage as node-specific paths are traced.
+
+## Scope
+
+First pass:
+
+- shared active detached-editor target store
+- overlay editor for common CodeMirror-backed code nodes
+- hide inline editor while detached overlay is active
+- close behavior when target node is removed
+- preserve undo/redo commit behavior
+
+Follow-up:
+
+- sidebar `code` tab
+- layout switch between overlay and sidebar
+- typography controls for performance mode
+- persisted user preferences for font size, line wrapping, and chrome density
+- broader support for node-specific run callbacks
+
+## Files Likely Touched
+
+- `ui/src/lib/components/CodeEditor.svelte`
+- `ui/src/lib/components/FlowCanvasInner.svelte`
+- `ui/src/lib/components/sidebar/SidebarPanel.svelte`
+- `ui/src/stores/ui.store.ts`
+- `ui/src/stores/code-editor-layout.store.ts`
+- common node layout components such as `CodeBlockBase.svelte` and
+  `ObjectPreviewLayout.svelte`
+
+## Testing
+
+Unit or component coverage should verify:
+
+- opening detached mode stores the correct active target
+- closing detached mode clears the target
+- inline editor is hidden for the active detached node field
+- editing through detached mode updates the node data field
+- blur emits a single undo/redo commit for the edited field
+- deleting the target node closes detached mode
+
+Manual verification should cover:
+
+- overlay editor renders above background output
+- editor wheel and drag interactions do not pan or zoom the canvas
+- large font and transparent background remain readable over visual output
+- sidebar mode can edit the same node field without changing patch data shape

--- a/ui/src/lib/canvas/use-detached-code-editor-overlay.svelte.ts
+++ b/ui/src/lib/canvas/use-detached-code-editor-overlay.svelte.ts
@@ -1,0 +1,121 @@
+import type { Edge, Node } from '@xyflow/svelte';
+import { fromStore } from 'svelte/store';
+import { GLSystem } from '$lib/canvas/GLSystem';
+import {
+  activeCodeEditorTarget,
+  closeCodeEditorOverlay
+} from '../../stores/code-editor-layout.store';
+import { overrideOutputNodeId } from '../../stores/renderer.store';
+
+interface DetachedCodeEditorOverlayOptions {
+  getNodes: () => Node[];
+  setNodes: (nodes: Node[]) => void;
+  getEdges: () => Edge[];
+  glSystem: GLSystem;
+}
+
+function hasBgOutOutput(nodes: Node[], edges: Edge[]): boolean {
+  const bgOutNodeIds = new Set(
+    nodes.filter((node) => node.type === 'bg.out').map((node) => node.id)
+  );
+
+  return edges.some((edge) => bgOutNodeIds.has(edge.target) || edge.target.startsWith('bg.out'));
+}
+
+export function useDetachedCodeEditorOverlay({
+  getNodes,
+  setNodes,
+  getEdges,
+  glSystem
+}: DetachedCodeEditorOverlayOptions) {
+  let temporaryOutputNodeId = $state<string | null>(null);
+
+  const activeTarget = fromStore(activeCodeEditorTarget);
+  const outputOverride = fromStore(overrideOutputNodeId);
+
+  const node = $derived.by(() => {
+    const target = activeTarget.current;
+    if (!target) return undefined;
+
+    return getNodes().find((candidate) => candidate.id === target.nodeId);
+  });
+
+  const value = $derived.by(() => {
+    const target = activeTarget.current;
+    if (!target || !node) return '';
+
+    const nextValue = node.data?.[target.dataKey];
+    return typeof nextValue === 'string' ? nextValue : '';
+  });
+
+  function clearTemporaryOutput() {
+    if (temporaryOutputNodeId && outputOverride.current === temporaryOutputNodeId) {
+      overrideOutputNodeId.set(null);
+      glSystem.setOverrideOutputNode(null);
+    }
+
+    temporaryOutputNodeId = null;
+  }
+
+  function updateValue(nextValue: string) {
+    const target = activeTarget.current;
+    if (!target) return;
+
+    setNodes(
+      getNodes().map((candidate) =>
+        candidate.id === target.nodeId
+          ? {
+              ...candidate,
+              data: {
+                ...candidate.data,
+                [target.dataKey]: nextValue
+              }
+            }
+          : candidate
+      )
+    );
+  }
+
+  $effect(() => {
+    const target = activeTarget.current;
+    if (!target) return;
+
+    const targetExists = getNodes().some((candidate) => candidate.id === target.nodeId);
+
+    if (!targetExists) {
+      closeCodeEditorOverlay();
+    }
+  });
+
+  $effect(() => {
+    const target = activeTarget.current;
+
+    if (!target) {
+      clearTemporaryOutput();
+      return;
+    }
+
+    if (temporaryOutputNodeId && temporaryOutputNodeId !== target.nodeId) {
+      clearTemporaryOutput();
+    }
+
+    if (temporaryOutputNodeId) return;
+    if (outputOverride.current !== null) return;
+    if (hasBgOutOutput(getNodes(), getEdges())) return;
+
+    temporaryOutputNodeId = target.nodeId;
+
+    overrideOutputNodeId.set(target.nodeId);
+    glSystem.setOverrideOutputNode(target.nodeId);
+  });
+
+  return {
+    get node() {
+      return node;
+    },
+    get value() {
+      return value;
+    },
+    updateValue
+  };
+}

--- a/ui/src/lib/components/CanvasPreviewLayout.svelte
+++ b/ui/src/lib/components/CanvasPreviewLayout.svelte
@@ -4,6 +4,7 @@
   import type { SettingsSchema } from '$lib/settings';
   import type { ExtraMenuItem } from './ObjectPreviewOverflowMenu.svelte';
   import { previewBackgroundColor } from '../../stores/renderer.store';
+  import type { SupportedLanguage } from '$lib/codemirror/types';
 
   let {
     title,
@@ -34,6 +35,9 @@
     codeEditor,
     console: consoleSnippet,
     editorReady,
+    codeDataKey = 'code',
+    codeLanguage = 'javascript',
+    codePlaceholder = '',
 
     settingsSchema = undefined,
     settingsValues = {},
@@ -72,6 +76,9 @@
     codeEditor: Snippet;
     console?: Snippet;
     editorReady?: boolean;
+    codeDataKey?: string;
+    codeLanguage?: SupportedLanguage;
+    codePlaceholder?: string;
 
     settingsSchema?: SettingsSchema;
     settingsValues?: Record<string, unknown>;
@@ -113,6 +120,9 @@
   {bottomHandle}
   {codeEditor}
   {editorReady}
+  {codeDataKey}
+  {codeLanguage}
+  {codePlaceholder}
   console={consoleSnippet}
   {settingsSchema}
   {settingsValues}

--- a/ui/src/lib/components/DetachedCodeEditorOverlay.svelte
+++ b/ui/src/lib/components/DetachedCodeEditorOverlay.svelte
@@ -10,11 +10,13 @@
   let {
     onClose,
     onrun,
-    codeEditor
+    codeEditor,
+    class: className = ''
   }: {
     onClose: () => void;
     onrun?: () => void;
     codeEditor: Snippet;
+    class?: string;
   } = $props();
 
   let panelBackground = $derived(`rgba(9, 9, 11, ${$overlayEditorTransparency})`);
@@ -40,7 +42,7 @@
 </script>
 
 <div
-  class="detached-code-editor-overlay fixed inset-0 z-[60]"
+  class={['detached-code-editor-overlay fixed inset-0 z-[60]', className]}
   style:background-color={panelBackground}
 >
   <div class="absolute top-6 right-6 z-10 flex gap-1">

--- a/ui/src/lib/components/DetachedCodeEditorOverlay.svelte
+++ b/ui/src/lib/components/DetachedCodeEditorOverlay.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { Play, X } from '@lucide/svelte/icons';
+  import { onDestroy, onMount } from 'svelte';
+  import type { Snippet } from 'svelte';
+  import * as Tooltip from './ui/tooltip';
+  import { overlayEditorTransparency } from '../../stores/editor-layout-settings.store';
+  import { isSidebarOpen } from '../../stores/ui.store';
+  import { isFullscreenActive } from '$lib/canvas/SurfaceOverlay';
+
+  let {
+    onClose,
+    onrun,
+    codeEditor
+  }: {
+    onClose: () => void;
+    onrun?: () => void;
+    codeEditor: Snippet;
+  } = $props();
+
+  let panelBackground = $derived(`rgba(9, 9, 11, ${$overlayEditorTransparency})`);
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Escape' || !event.shiftKey) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    onClose();
+  }
+
+  onMount(() => {
+    isSidebarOpen.set(false);
+    isFullscreenActive.set(true);
+    window.addEventListener('keydown', handleKeydown, { capture: true });
+  });
+
+  onDestroy(() => {
+    window.removeEventListener('keydown', handleKeydown, { capture: true });
+    isFullscreenActive.set(false);
+  });
+</script>
+
+<div
+  class="detached-code-editor-overlay fixed inset-0 z-[60]"
+  style:background-color={panelBackground}
+>
+  <div class="absolute top-6 right-6 z-10 flex gap-1">
+    {#if onrun}
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          <button
+            class="cursor-pointer rounded bg-black/35 p-2 text-zinc-300 transition-colors hover:bg-zinc-800/80 hover:text-zinc-100"
+            onclick={onrun}
+            aria-label="Run code"
+          >
+            <Play class="h-4 w-4" />
+          </button>
+        </Tooltip.Trigger>
+
+        <Tooltip.Content>Run Code</Tooltip.Content>
+      </Tooltip.Root>
+    {/if}
+
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          class="cursor-pointer rounded bg-black/35 p-2 text-zinc-300 transition-colors hover:bg-zinc-800/80 hover:text-zinc-100"
+          onclick={onClose}
+          aria-label="Close expanded editor"
+        >
+          <X class="h-4 w-4" />
+        </button>
+      </Tooltip.Trigger>
+
+      <Tooltip.Content>Close Expanded Editor (Shift+Esc)</Tooltip.Content>
+    </Tooltip.Root>
+  </div>
+
+  <div class="h-full w-full">
+    {@render codeEditor()}
+  </div>
+</div>
+
+<style>
+  :global(.detached-code-editor-overlay .code-editor-container) {
+    width: 100% !important;
+    height: 100% !important;
+    min-height: 0 !important;
+  }
+
+  :global(.detached-code-editor-overlay .cm-editor) {
+    border: none !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    font-size: 28px !important;
+  }
+
+  :global(.detached-code-editor-overlay .cm-editor.cm-focused) {
+    border-color: transparent !important;
+    box-shadow: none !important;
+  }
+
+  :global(.detached-code-editor-overlay .cm-content) {
+    max-width: none !important;
+    max-height: none !important;
+    padding: 48px !important;
+    line-height: 1.55 !important;
+  }
+
+  :global(.detached-code-editor-overlay .cm-line) {
+    padding: 0 8px !important;
+  }
+
+  :global(.detached-code-editor-overlay .cm-scroller) {
+    padding: 8px 0 !important;
+  }
+</style>

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -90,6 +90,7 @@
   import { WorkletDirectChannelService } from '$lib/audio/WorkletDirectChannelService';
   import { buildAudioSourceConnections } from '$lib/composables/checkHandleConnections';
   import { getSurfaceMouseForwardingKey } from '$lib/canvas/surfaceMouseForwarding';
+  import { useDetachedCodeEditorOverlay } from '$lib/canvas/use-detached-code-editor-overlay.svelte';
 
   import { toast } from 'svelte-sonner';
   import { Transport } from '$lib/transport';
@@ -263,48 +264,11 @@
 
   // Get flow utilities for coordinate transformation
   const { screenToFlowPosition, fitView, getViewport, getNode } = useSvelteFlow();
-
-  let detachedCodeEditorNode = $derived.by(() => {
-    const target = $activeCodeEditorTarget;
-    if (!target) return undefined;
-
-    return nodes.find((node) => node.id === target.nodeId);
-  });
-
-  let detachedCodeEditorValue = $derived.by(() => {
-    const target = $activeCodeEditorTarget;
-    const node = detachedCodeEditorNode;
-    if (!target || !node) return '';
-
-    const value = node.data?.[target.dataKey];
-    return typeof value === 'string' ? value : '';
-  });
-
-  function updateDetachedCodeEditorValue(value: string) {
-    const target = $activeCodeEditorTarget;
-    if (!target) return;
-
-    nodes = nodes.map((node) =>
-      node.id === target.nodeId
-        ? {
-            ...node,
-            data: {
-              ...node.data,
-              [target.dataKey]: value
-            }
-          }
-        : node
-    );
-  }
-
-  $effect(() => {
-    const target = $activeCodeEditorTarget;
-    if (!target) return;
-
-    const targetExists = nodes.some((node) => node.id === target.nodeId);
-    if (!targetExists) {
-      closeCodeEditorOverlay();
-    }
+  const detachedCodeEditor = useDetachedCodeEditorOverlay({
+    getNodes: () => nodes,
+    setNodes: (nextNodes) => (nodes = nextNodes),
+    getEdges: () => edges,
+    glSystem
   });
 
   // Viewport culling for preview rendering optimization
@@ -1236,11 +1200,11 @@
     <BackgroundOutputCanvas />
   </div>
 
-  {#if $activeCodeEditorTarget && detachedCodeEditorNode}
-    {#snippet detachedCodeEditor()}
+  {#if $activeCodeEditorTarget && detachedCodeEditor.node}
+    {#snippet detachedCodeEditorSnippet()}
       <CodeEditor
-        value={detachedCodeEditorValue}
-        onchange={updateDetachedCodeEditorValue}
+        value={detachedCodeEditor.value}
+        onchange={detachedCodeEditor.updateValue}
         language={$activeCodeEditorTarget.language}
         nodeType={$activeCodeEditorTarget.nodeType}
         placeholder={$activeCodeEditorTarget.placeholder ?? ''}
@@ -1254,7 +1218,7 @@
     <DetachedCodeEditorOverlay
       onClose={closeCodeEditorOverlay}
       onrun={$activeCodeEditorTarget.onrun}
-      codeEditor={detachedCodeEditor}
+      codeEditor={detachedCodeEditorSnippet}
     />
   {/if}
 

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -12,6 +12,8 @@
   } from '@xyflow/svelte';
   import { onDestroy, onMount, tick } from 'svelte';
   import CommandPalette from './CommandPalette.svelte';
+  import CodeEditor from './CodeEditor.svelte';
+  import DetachedCodeEditorOverlay from './DetachedCodeEditorOverlay.svelte';
   import ObjectBrowserModal from './object-browser/ObjectBrowserModal.svelte';
   import SettingsModal from './settings-modal/SettingsModal.svelte';
   import BottomToolbar from './BottomToolbar.svelte';
@@ -93,6 +95,10 @@
   import { Transport } from '$lib/transport';
   import { transportStore } from '../../stores/transport.store';
   import { allPreviewsDisabled } from '../../stores/renderer.store';
+  import {
+    activeCodeEditorTarget,
+    closeCodeEditorOverlay
+  } from '../../stores/code-editor-layout.store';
   import { isFullscreenActive } from '$lib/canvas/SurfaceOverlay';
   import { PREVIEW_ZOOM_LOD_TIERS } from '$workers/rendering/constants';
   import { initializeVFS } from '$lib/vfs';
@@ -257,6 +263,49 @@
 
   // Get flow utilities for coordinate transformation
   const { screenToFlowPosition, fitView, getViewport, getNode } = useSvelteFlow();
+
+  let detachedCodeEditorNode = $derived.by(() => {
+    const target = $activeCodeEditorTarget;
+    if (!target) return undefined;
+
+    return nodes.find((node) => node.id === target.nodeId);
+  });
+
+  let detachedCodeEditorValue = $derived.by(() => {
+    const target = $activeCodeEditorTarget;
+    const node = detachedCodeEditorNode;
+    if (!target || !node) return '';
+
+    const value = node.data?.[target.dataKey];
+    return typeof value === 'string' ? value : '';
+  });
+
+  function updateDetachedCodeEditorValue(value: string) {
+    const target = $activeCodeEditorTarget;
+    if (!target) return;
+
+    nodes = nodes.map((node) =>
+      node.id === target.nodeId
+        ? {
+            ...node,
+            data: {
+              ...node.data,
+              [target.dataKey]: value
+            }
+          }
+        : node
+    );
+  }
+
+  $effect(() => {
+    const target = $activeCodeEditorTarget;
+    if (!target) return;
+
+    const targetExists = nodes.some((node) => node.id === target.nodeId);
+    if (!targetExists) {
+      closeCodeEditorOverlay();
+    }
+  });
 
   // Viewport culling for preview rendering optimization
   const viewport = useViewport();
@@ -1186,6 +1235,29 @@
   <div class="pointer-events-none absolute inset-0 z-0">
     <BackgroundOutputCanvas />
   </div>
+
+  {#if $activeCodeEditorTarget && detachedCodeEditorNode}
+    {#snippet detachedCodeEditor()}
+      <CodeEditor
+        value={detachedCodeEditorValue}
+        onchange={updateDetachedCodeEditorValue}
+        language={$activeCodeEditorTarget.language}
+        nodeType={$activeCodeEditorTarget.nodeType}
+        placeholder={$activeCodeEditorTarget.placeholder ?? ''}
+        class="nodrag nopan nowheel h-full w-full resize-none"
+        onrun={$activeCodeEditorTarget.onrun}
+        nodeId={$activeCodeEditorTarget.nodeId}
+        dataKey={$activeCodeEditorTarget.dataKey}
+      />
+    {/snippet}
+
+    <DetachedCodeEditorOverlay
+      onClose={closeCodeEditorOverlay}
+      onrun={$activeCodeEditorTarget.onrun}
+      codeEditor={detachedCodeEditor}
+    />
+  {/if}
+
   <!-- Sidebar (Files / Presets) -->
   <SidebarPanel
     bind:open={$isSidebarOpen}

--- a/ui/src/lib/components/ObjectPreviewContextMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewContextMenu.svelte
@@ -51,7 +51,7 @@
     showSettings: boolean;
     onSettingsToggle: () => void;
     /** Provided when code editor is NOT the primary button — adds an "Edit code" entry. */
-    onCodeToggle?: () => void;
+    onCodeToggle?: (event: MouseEvent) => void;
     onExpandToggle?: () => void;
     isExpanded?: boolean;
     onBgOutputToggle: () => void;

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-  import { Code, Loader, Play, Settings as SettingsIcon, Terminal, X } from '@lucide/svelte/icons';
+  import {
+    Code,
+    Expand,
+    Loader,
+    Play,
+    Settings as SettingsIcon,
+    Terminal,
+    X
+  } from '@lucide/svelte/icons';
   import { onMount, type Snippet } from 'svelte';
   import * as Tooltip from './ui/tooltip';
   import * as ContextMenu from './ui/context-menu';
@@ -9,11 +17,18 @@
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings';
   import type { ExtraMenuItem } from './ObjectPreviewOverflowMenu.svelte';
+  import type { SupportedLanguage } from '$lib/codemirror/types';
   import { outputTarget } from '../../stores/canvas.store';
   import { transportStore } from '../../stores/transport.store';
   import { isSidebarOpen, sidebarView } from '../../stores/ui.store';
   import { helpViewStore } from '../../stores/help-view.store';
   import { overrideOutputNodeId, previewBackgroundColor } from '../../stores/renderer.store';
+  import {
+    activeCodeEditorTarget,
+    closeCodeEditorOverlay,
+    openCodeEditorOverlay
+  } from '../../stores/code-editor-layout.store';
+  import { defaultEditorLayout } from '../../stores/editor-layout-settings.store';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { CanvasPreviewExpandController } from '$lib/canvas/CanvasPreviewExpandController';
   import { SurfaceListeners } from '$lib/canvas/SurfaceListeners';
@@ -23,6 +38,7 @@
   import { useIncludeProcessing } from '$lib/canvas/use-include-processing.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { NodePrimaryButtonUpdateEvent, PrimaryButton } from '$lib/eventbus/events';
+  import { match } from 'ts-pattern';
 
   let previewContainer: HTMLDivElement | null = null;
   const { getNode, getNodes, updateNodeData } = useSvelteFlow();
@@ -47,6 +63,9 @@
     codeEditor,
     console: consoleSnippet,
     editorReady,
+    codeDataKey = 'code',
+    codeLanguage = 'javascript',
+    codePlaceholder = '',
 
     settingsSchema = undefined,
     settingsValues = {},
@@ -73,6 +92,9 @@
     codeEditor: Snippet;
     console?: Snippet;
     editorReady?: boolean;
+    codeDataKey?: string;
+    codeLanguage?: SupportedLanguage;
+    codePlaceholder?: string;
 
     previewWidth?: number;
 
@@ -233,6 +255,29 @@
     showExpandOption && nodeId !== undefined && $outputTarget === 'background'
   );
 
+  let isCodeEditorDetached = $derived(
+    nodeId !== undefined &&
+      $activeCodeEditorTarget?.nodeId === nodeId &&
+      $activeCodeEditorTarget.dataKey === codeDataKey
+  );
+
+  function openExpandedCodeEditor() {
+    if (!nodeId) return;
+
+    openCodeEditorOverlay({
+      nodeId,
+      dataKey: codeDataKey,
+      language: codeLanguage,
+      nodeType: objectType,
+      title,
+      placeholder: codePlaceholder,
+      onrun: onrun ? handleRun : undefined
+    });
+
+    showEditor = false;
+    showSettings = false;
+  }
+
   function handleBgOutputToggle() {
     if (!nodeId) return;
 
@@ -288,7 +333,7 @@
     }
   }
 
-  const toggleCode = () => {
+  function toggleInlineCode() {
     showEditor = !showEditor;
 
     if (showEditor) {
@@ -296,7 +341,21 @@
     }
 
     measureContainerWidth();
-  };
+  }
+
+  function handleCodeOpen() {
+    match($defaultEditorLayout)
+      .with('overlay', () => {
+        if (!showEditor && !isCodeEditorDetached) {
+          openExpandedCodeEditor();
+        } else {
+          toggleInlineCode();
+        }
+      })
+      .otherwise(() => {
+        toggleInlineCode();
+      });
+  }
 </script>
 
 <div class={['relative flex gap-x-3', className]}>
@@ -326,7 +385,7 @@
                   showSettings = !showSettings;
                   if (showSettings) showEditor = false;
                 }}
-                onCodeToggle={resolvedPrimary === 'code' ? undefined : toggleCode}
+                onCodeToggle={resolvedPrimary === 'code' ? undefined : handleCodeOpen}
                 onExpandToggle={canExpand ? handleExpandToggle : undefined}
                 {isExpanded}
                 onBgOutputToggle={handleBgOutputToggle}
@@ -341,11 +400,7 @@
                     <button
                       class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
                       aria-label="Edit code"
-                      onclick={() => {
-                        showEditor = !showEditor;
-                        if (showEditor) showSettings = false;
-                        measureContainerWidth();
-                      }}
+                      onclick={handleCodeOpen}
                     >
                       <Code class="h-4 w-4 text-zinc-300" />
                     </button>
@@ -425,9 +480,7 @@
         if (showSettings) showEditor = false;
       }}
       onCodeToggle={() => {
-        showEditor = !showEditor;
-        if (showEditor) showSettings = false;
-        measureContainerWidth();
+        handleCodeOpen();
       }}
       onExpandToggle={canExpand ? handleExpandToggle : undefined}
       {isExpanded}
@@ -451,7 +504,7 @@
     </div>
   {/if}
 
-  {#if showEditor}
+  {#if showEditor || isCodeEditorDetached}
     <div class="absolute" style="left: {editorLeftPos}px;">
       {#if editorReady !== false}
         <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
@@ -485,7 +538,23 @@
           <Tooltip.Root>
             <Tooltip.Trigger>
               <button
-                onclick={() => (showEditor = false)}
+                onclick={openExpandedCodeEditor}
+                class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+                aria-label="Open expanded editor"
+              >
+                <Expand class="h-4 w-4 text-zinc-300" />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>Open Expanded Editor</Tooltip.Content>
+          </Tooltip.Root>
+
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                onclick={() => {
+                  showEditor = false;
+                  if (isCodeEditorDetached) closeCodeEditorOverlay();
+                }}
                 class="cursor-pointer rounded p-1 hover:bg-zinc-700"
               >
                 <X class="h-4 w-4 text-zinc-300" />
@@ -496,14 +565,31 @@
         </div>
       {/if}
 
-      <div class="rounded-lg border border-zinc-600 bg-zinc-900 shadow-xl">
-        <div class="flex flex-col">
-          {@render codeEditor()}
+      {#if isCodeEditorDetached}
+        <div class="rounded-lg border border-zinc-600 bg-zinc-900 px-4 py-3 shadow-xl">
+          <div class="flex min-w-[260px] items-center justify-between gap-3">
+            <div>
+              <div class="text-xs font-medium text-zinc-200">Editing in expanded view</div>
+              <div class="mt-0.5 text-[11px] text-zinc-500">Close it to return inline.</div>
+            </div>
+            <button
+              class="cursor-pointer rounded border border-zinc-700 px-2 py-1 text-xs text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+              onclick={closeCodeEditorOverlay}
+            >
+              Return
+            </button>
+          </div>
         </div>
-      </div>
+      {:else}
+        <div class="rounded-lg border border-zinc-600 bg-zinc-900 shadow-xl">
+          <div class="flex flex-col">
+            {@render codeEditor()}
+          </div>
+        </div>
 
-      {#if consoleSnippet}
-        {@render consoleSnippet()}
+        {#if consoleSnippet}
+          {@render consoleSnippet()}
+        {/if}
       {/if}
     </div>
   {/if}

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -28,7 +28,10 @@
     closeCodeEditorOverlay,
     openCodeEditorOverlay
   } from '../../stores/code-editor-layout.store';
-  import { defaultEditorLayout } from '../../stores/editor-layout-settings.store';
+  import {
+    defaultEditorLayout,
+    getEditorOpenLayout
+  } from '../../stores/editor-layout-settings.store';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { CanvasPreviewExpandController } from '$lib/canvas/CanvasPreviewExpandController';
   import { SurfaceListeners } from '$lib/canvas/SurfaceListeners';
@@ -343,17 +346,29 @@
     measureContainerWidth();
   }
 
-  function handleCodeOpen() {
-    match($defaultEditorLayout)
+  function openInlineCodeEditor() {
+    if (isCodeEditorDetached) {
+      closeCodeEditorOverlay();
+    }
+
+    showEditor = true;
+    showSettings = false;
+    measureContainerWidth();
+  }
+
+  function handleCodeOpen(event?: MouseEvent) {
+    const layout = getEditorOpenLayout($defaultEditorLayout, event?.shiftKey ?? false);
+
+    match(layout)
       .with('overlay', () => {
-        if (!showEditor && !isCodeEditorDetached) {
-          openExpandedCodeEditor();
+        openExpandedCodeEditor();
+      })
+      .with('inline', () => {
+        if (event?.shiftKey) {
+          openInlineCodeEditor();
         } else {
           toggleInlineCode();
         }
-      })
-      .otherwise(() => {
-        toggleInlineCode();
       });
   }
 </script>
@@ -479,9 +494,7 @@
         showSettings = !showSettings;
         if (showSettings) showEditor = false;
       }}
-      onCodeToggle={() => {
-        handleCodeOpen();
-      }}
+      onCodeToggle={handleCodeOpen}
       onExpandToggle={canExpand ? handleExpandToggle : undefined}
       {isExpanded}
       onBgOutputToggle={handleBgOutputToggle}

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -369,7 +369,8 @@
         } else {
           toggleInlineCode();
         }
-      });
+      })
+      .exhaustive();
   }
 </script>
 
@@ -569,6 +570,7 @@
                   if (isCodeEditorDetached) closeCodeEditorOverlay();
                 }}
                 class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+                aria-label="Close editor"
               >
                 <X class="h-4 w-4 text-zinc-300" />
               </button>

--- a/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
@@ -61,7 +61,7 @@
     previewVisible?: boolean;
     onSettingsToggle?: () => void;
     /** Provided when code editor is NOT the primary button — adds an "Edit code" entry to the menu. */
-    onCodeToggle?: () => void;
+    onCodeToggle?: (event: MouseEvent) => void;
     onExpandToggle?: () => void;
     isExpanded?: boolean;
     onBgOutputToggle?: () => void;

--- a/ui/src/lib/components/nodes/CanvasDom.svelte
+++ b/ui/src/lib/components/nodes/CanvasDom.svelte
@@ -499,6 +499,7 @@
 <CanvasPreviewLayout
   title={data.title ?? 'canvas.dom'}
   objectType="canvas.dom"
+  codePlaceholder="Write your Canvas API code here..."
   {nodeId}
   onrun={runCode}
   onPlaybackToggle={togglePlayback}

--- a/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
+++ b/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
@@ -350,6 +350,8 @@
 <CanvasPreviewLayout
   title={shaderName ?? data.title ?? 'glsl'}
   objectType="glsl"
+  codeLanguage="glsl"
+  codePlaceholder="Write your GLSL fragment shader here..."
   {nodeId}
   onrun={updateShader}
   onPlaybackToggle={togglePause}

--- a/ui/src/lib/components/nodes/HydraNode.svelte
+++ b/ui/src/lib/components/nodes/HydraNode.svelte
@@ -296,6 +296,7 @@
 <CanvasPreviewLayout
   title={data.title ?? 'hydra'}
   objectType="hydra"
+  codePlaceholder="Write your Hydra code here..."
   {nodeId}
   onrun={updateHydra}
   onPlaybackToggle={togglePause}

--- a/ui/src/lib/components/nodes/JSCanvasNode.svelte
+++ b/ui/src/lib/components/nodes/JSCanvasNode.svelte
@@ -269,6 +269,7 @@
 <CanvasPreviewLayout
   title={data.title ?? 'canvas'}
   objectType="canvas"
+  codePlaceholder="Write your Canvas API code here..."
   {nodeId}
   onrun={updateCanvas}
   onPlaybackToggle={togglePlayback}

--- a/ui/src/lib/components/nodes/ReglNode.svelte
+++ b/ui/src/lib/components/nodes/ReglNode.svelte
@@ -279,6 +279,7 @@
 <CanvasPreviewLayout
   title={data.title ?? 'regl'}
   objectType="regl"
+  codePlaceholder="Write your regl code here..."
   {nodeId}
   onrun={updateRegl}
   bind:previewCanvas

--- a/ui/src/lib/components/nodes/ShaderParkNode.svelte
+++ b/ui/src/lib/components/nodes/ShaderParkNode.svelte
@@ -576,6 +576,7 @@
 <CanvasPreviewLayout
   title={shaderParkTitle ?? data.title ?? 'shaderpark'}
   objectType="shaderpark"
+  codePlaceholder="Write Shader Park code here..."
   {nodeId}
   onrun={updateShaderPark}
   bind:previewCanvas

--- a/ui/src/lib/components/nodes/StrudelNode.svelte
+++ b/ui/src/lib/components/nodes/StrudelNode.svelte
@@ -531,15 +531,11 @@
     border-radius: 0 !important;
     box-shadow: none !important;
     font-size: 28px !important;
-    outline: none !important;
   }
 
   :global(.strudel-detached-editor .strudel-editor-shell .cm-focused) {
-    outline: none !important;
-  }
-
-  :global(.strudel-detached-editor .strudel-editor-shell *:focus) {
-    outline: none !important;
+    outline: 2px solid rgb(212 212 216);
+    outline-offset: -2px;
   }
 
   :global(.strudel-detached-editor .strudel-editor-shell .cm-content) {

--- a/ui/src/lib/components/nodes/StrudelNode.svelte
+++ b/ui/src/lib/components/nodes/StrudelNode.svelte
@@ -527,6 +527,15 @@
     border-radius: 0 !important;
     box-shadow: none !important;
     font-size: 28px !important;
+    outline: none !important;
+  }
+
+  :global(.strudel-detached-editor .strudel-editor-shell .cm-focused) {
+    outline: none !important;
+  }
+
+  :global(.strudel-detached-editor .strudel-editor-shell *:focus) {
+    outline: none !important;
   }
 
   :global(.strudel-detached-editor .strudel-editor-shell .cm-content) {

--- a/ui/src/lib/components/nodes/StrudelNode.svelte
+++ b/ui/src/lib/components/nodes/StrudelNode.svelte
@@ -417,7 +417,7 @@
           class={[
             'nodrag nopan transition-opacity',
             isDetached
-              ? 'strudel-detached-editor fixed inset-0 z-[60] flex items-stretch justify-stretch backdrop-blur-md'
+              ? 'strudel-detached-editor fixed inset-0 z-[60] flex items-stretch justify-stretch'
               : 'flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 p-1',
             !isDetached && (hasError ? 'border-red-500' : 'border-transparent'),
             muted ? 'opacity-40' : 'opacity-100'

--- a/ui/src/lib/components/nodes/StrudelNode.svelte
+++ b/ui/src/lib/components/nodes/StrudelNode.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Ellipsis, Link, Play, Square, Terminal, VolumeX } from '@lucide/svelte/icons';
+  import { Ellipsis, Expand, Link, Play, Square, Terminal, VolumeX, X } from '@lucide/svelte/icons';
   import { useSvelteFlow } from '@xyflow/svelte';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
@@ -16,6 +16,15 @@
   import { AudioService } from '$lib/audio/v2/AudioService';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import * as Popover from '$lib/components/ui/popover';
+  import { portal } from '$lib/dom/portal';
+  import { isFullscreenActive } from '$lib/canvas/SurfaceOverlay';
+  import { isSidebarOpen } from '../../../stores/ui.store';
+  import {
+    activeDetachedStrudelNodeId,
+    closeDetachedStrudelEditor,
+    openDetachedStrudelEditor
+  } from '../../../stores/detached-strudel-editor.store';
+  import { overlayEditorTransparency } from '../../../stores/editor-layout-settings.store';
 
   // Get node data from XY Flow - nodes receive their data as props
   let {
@@ -209,6 +218,13 @@
   const consoleLeftPos = $derived(editorContainerWidth + consoleGap);
   const syncTransport = $derived(data.syncTransport ?? false);
   const muted = $derived(data.muted ?? false);
+  const isDetached = $derived($activeDetachedStrudelNodeId === nodeId);
+
+  const detachedPortalTarget = $derived(
+    isDetached && typeof document !== 'undefined' ? document.body : null
+  );
+
+  const detachedBackground = $derived(`rgba(9, 9, 11, ${$overlayEditorTransparency})`);
   const tracker = useNodeDataTracker(nodeId);
 
   function setSyncTransport(value: boolean) {
@@ -243,6 +259,45 @@
       transportSync.subscribe();
     } else {
       transportSync.unsubscribe();
+    }
+  });
+
+  function openExpandedEditor() {
+    openDetachedStrudelEditor(nodeId);
+
+    menuOpen = false;
+  }
+
+  function closeExpandedEditor() {
+    closeDetachedStrudelEditor();
+  }
+
+  $effect(() => {
+    if (!isDetached) return;
+
+    isSidebarOpen.set(false);
+    isFullscreenActive.set(true);
+
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || !event.shiftKey) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      closeExpandedEditor();
+    };
+
+    window.addEventListener('keydown', handleKeydown, { capture: true });
+
+    return () => {
+      window.removeEventListener('keydown', handleKeydown, { capture: true });
+      isFullscreenActive.set(false);
+    };
+  });
+
+  onDestroy(() => {
+    if (isDetached) {
+      closeDetachedStrudelEditor();
     }
   });
 </script>
@@ -312,6 +367,14 @@
 
               <button
                 class="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-300 hover:bg-zinc-700"
+                onclick={openExpandedEditor}
+              >
+                <Expand class="h-4 w-4" />
+                Expand Editor
+              </button>
+
+              <button
+                class="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-300 hover:bg-zinc-700"
                 onclick={() => {
                   setSyncTransport(!syncTransport);
                   menuOpen = false;
@@ -350,14 +413,67 @@
 
         <div
           bind:this={editorContainer}
+          use:portal={detachedPortalTarget}
           class={[
-            'nodrag nopan flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 p-1 transition-opacity',
-            hasError ? 'border-red-500' : 'border-transparent',
+            'nodrag nopan transition-opacity',
+            isDetached
+              ? 'strudel-detached-editor fixed inset-0 z-[60] flex items-stretch justify-stretch backdrop-blur-md'
+              : 'flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 p-1',
+            !isDetached && (hasError ? 'border-red-500' : 'border-transparent'),
             muted ? 'opacity-40' : 'opacity-100'
           ]}
-          style={data.styles?.container}
+          style={isDetached
+            ? `${data.styles?.container ?? ''};background-color:${detachedBackground};`
+            : (data.styles?.container ?? '')}
         >
-          <div class="nodrag nowheel max-h-[600px] max-w-[800px] overflow-auto">
+          {#if isDetached}
+            <div class="absolute top-6 right-6 z-10 flex gap-1">
+              {#if isInitialized && !syncTransport}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    {#if isPlaying}
+                      <button
+                        class="cursor-pointer rounded bg-black/35 p-2 text-zinc-300 transition-colors hover:bg-zinc-800/80 hover:text-zinc-100"
+                        onclick={stop}
+                        aria-label="Stop Strudel"
+                      >
+                        <Square class="h-4 w-4" />
+                      </button>
+                    {:else}
+                      <button
+                        class="cursor-pointer rounded bg-black/35 p-2 text-zinc-300 transition-colors hover:bg-zinc-800/80 hover:text-zinc-100"
+                        onclick={evaluate}
+                        aria-label="Run Strudel"
+                      >
+                        <Play class="h-4 w-4" />
+                      </button>
+                    {/if}
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>{isPlaying ? 'Stop' : 'Run Strudel'}</Tooltip.Content>
+                </Tooltip.Root>
+              {/if}
+
+              <Tooltip.Root>
+                <Tooltip.Trigger>
+                  <button
+                    class="cursor-pointer rounded bg-black/35 p-2 text-zinc-300 transition-colors hover:bg-zinc-800/80 hover:text-zinc-100"
+                    onclick={closeExpandedEditor}
+                    aria-label="Close expanded Strudel editor"
+                  >
+                    <X class="h-4 w-4" />
+                  </button>
+                </Tooltip.Trigger>
+                <Tooltip.Content>Close Expanded Editor (Shift+Esc)</Tooltip.Content>
+              </Tooltip.Root>
+            </div>
+          {/if}
+
+          <div
+            class={[
+              'strudel-editor-shell nodrag nowheel overflow-auto',
+              isDetached ? 'h-full w-full' : 'max-h-[600px] max-w-[800px]'
+            ]}
+          >
             <StrudelEditor
               {code}
               fontFamily={data.fontFamily}
@@ -396,3 +512,33 @@
     />
   </div>
 </div>
+
+<style>
+  :global(.strudel-editor-shell .cm-editor) {
+    height: 100%;
+  }
+
+  :global(.strudel-editor-shell .cm-content) {
+    max-width: none !important;
+  }
+
+  :global(.strudel-detached-editor .strudel-editor-shell .cm-editor) {
+    border: none !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    font-size: 28px !important;
+  }
+
+  :global(.strudel-detached-editor .strudel-editor-shell .cm-content) {
+    padding: 48px !important;
+    line-height: 1.55 !important;
+  }
+
+  :global(.strudel-detached-editor .strudel-editor-shell .cm-line) {
+    padding: 0 8px !important;
+  }
+
+  :global(.strudel-detached-editor .strudel-editor-shell .cm-scroller) {
+    padding: 8px 0 !important;
+  }
+</style>

--- a/ui/src/lib/components/nodes/StrudelNode.svelte
+++ b/ui/src/lib/components/nodes/StrudelNode.svelte
@@ -418,7 +418,7 @@
             'nodrag nopan transition-opacity',
             isDetached
               ? 'strudel-detached-editor fixed inset-0 z-[60] flex items-stretch justify-stretch'
-              : 'flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 p-1',
+              : 'flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 p-2',
             !isDetached && (hasError ? 'border-red-500' : 'border-transparent'),
             muted ? 'opacity-40' : 'opacity-100'
           ]}
@@ -520,6 +520,10 @@
 
   :global(.strudel-editor-shell .cm-content) {
     max-width: none !important;
+  }
+
+  :global(.strudel-editor-shell .cm-gutters) {
+    display: none !important;
   }
 
   :global(.strudel-detached-editor .strudel-editor-shell .cm-editor) {

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -678,6 +678,7 @@
 <CanvasPreviewLayout
   title={data.title ?? 'surface'}
   objectType="surface"
+  codePlaceholder="Write your surface interaction code here..."
   {nodeId}
   onrun={runCode}
   onPlaybackToggle={togglePlayback}

--- a/ui/src/lib/components/nodes/SwissGLNode.svelte
+++ b/ui/src/lib/components/nodes/SwissGLNode.svelte
@@ -223,6 +223,7 @@
 <CanvasPreviewLayout
   title="swgl"
   objectType="swgl"
+  codePlaceholder="Write your SwissGL code here..."
   {nodeId}
   onrun={updateSwissGL}
   onPlaybackToggle={togglePause}

--- a/ui/src/lib/components/nodes/TextmodeDom.svelte
+++ b/ui/src/lib/components/nodes/TextmodeDom.svelte
@@ -421,6 +421,7 @@
 <CanvasPreviewLayout
   title={data.title ?? 'textmode.dom'}
   objectType="textmode.dom"
+  codePlaceholder="Write your Textmode.js code here..."
   {nodeId}
   onrun={runCode}
   onPlaybackToggle={togglePlayback}

--- a/ui/src/lib/components/nodes/TextmodeNode.svelte
+++ b/ui/src/lib/components/nodes/TextmodeNode.svelte
@@ -262,6 +262,7 @@
 <CanvasPreviewLayout
   title={data.title ?? 'textmode'}
   objectType="textmode"
+  codePlaceholder="Write your Textmode.js code here..."
   {nodeId}
   onrun={updateTextmode}
   bind:previewCanvas

--- a/ui/src/lib/components/nodes/ThreeDom.svelte
+++ b/ui/src/lib/components/nodes/ThreeDom.svelte
@@ -488,6 +488,7 @@
 <CanvasPreviewLayout
   title={data.title ?? 'three.dom'}
   objectType="three.dom"
+  codePlaceholder="Write your Three.js code here..."
   {nodeId}
   onrun={runCode}
   onPlaybackToggle={togglePlayback}

--- a/ui/src/lib/components/nodes/ThreeNode.svelte
+++ b/ui/src/lib/components/nodes/ThreeNode.svelte
@@ -301,6 +301,7 @@
 <CanvasPreviewLayout
   title={data.title ?? 'three'}
   objectType="three"
+  codePlaceholder="Write your Three.js code here..."
   {nodeId}
   onrun={updateThree}
   bind:previewCanvas

--- a/ui/src/lib/components/settings-modal/categories/EditorSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/EditorSettings.svelte
@@ -56,7 +56,7 @@
       step="5"
       value={overlayTransparencyPercent}
       oninput={handleTransparencyInput}
-      class="h-1.5 w-28 cursor-pointer accent-orange-500"
+      class="h-1.5 w-28 cursor-pointer accent-zinc-500"
       aria-label="Overlay editor transparency"
     />
     <span class="w-9 text-right font-mono text-xs text-zinc-400">{overlayTransparencyPercent}%</span

--- a/ui/src/lib/components/settings-modal/categories/EditorSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/EditorSettings.svelte
@@ -1,9 +1,66 @@
 <script lang="ts">
   import SettingRow from '../SettingRow.svelte';
+  import SettingDropdown from '../SettingDropdown.svelte';
   import SettingToggle from '../SettingToggle.svelte';
+  import {
+    defaultEditorLayout,
+    overlayEditorTransparency,
+    setDefaultEditorLayout,
+    setOverlayEditorTransparency,
+    type EditorLayoutPreference
+  } from '../../../../stores/editor-layout-settings.store';
   import { useVimInEditor } from '../../../../stores/editor.store';
   import { setVimMode } from '$lib/utils/settings-actions';
+
+  const editorLayoutOptions: { value: EditorLayoutPreference; label: string }[] = [
+    { value: 'inline', label: 'Inline' },
+    { value: 'overlay', label: 'Overlay' }
+  ];
+
+  let overlayTransparencyPercent = $derived(Math.round($overlayEditorTransparency * 100));
+
+  function handleLayoutChange(value: string) {
+    if (value === 'inline' || value === 'overlay') {
+      setDefaultEditorLayout(value);
+    }
+  }
+
+  function handleTransparencyInput(event: Event) {
+    const target = event.target as HTMLInputElement;
+    setOverlayEditorTransparency(Number(target.value) / 100);
+  }
 </script>
+
+<SettingRow
+  title="Default editor layout"
+  description="Choose how visual code objects open their editor."
+>
+  <SettingDropdown
+    value={$defaultEditorLayout}
+    options={editorLayoutOptions}
+    onchange={handleLayoutChange}
+  />
+</SettingRow>
+
+<SettingRow
+  title="Overlay transparency"
+  description="Adjust the Zen editor panel background opacity."
+>
+  <div class="flex items-center gap-3">
+    <input
+      type="range"
+      min="0"
+      max="100"
+      step="5"
+      value={overlayTransparencyPercent}
+      oninput={handleTransparencyInput}
+      class="h-1.5 w-28 cursor-pointer accent-orange-500"
+      aria-label="Overlay editor transparency"
+    />
+    <span class="w-9 text-right font-mono text-xs text-zinc-400">{overlayTransparencyPercent}%</span
+    >
+  </div>
+</SettingRow>
 
 <SettingRow title="Vim mode" description="Enable Vim keybindings in code editors (requires reload)">
   <SettingToggle checked={$useVimInEditor} onchange={setVimMode} />

--- a/ui/src/lib/components/settings-modal/categories/EditorSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/EditorSettings.svelte
@@ -10,6 +10,7 @@
     type EditorLayoutPreference
   } from '../../../../stores/editor-layout-settings.store';
   import { useVimInEditor } from '../../../../stores/editor.store';
+
   import { setVimMode } from '$lib/utils/settings-actions';
 
   const editorLayoutOptions: { value: EditorLayoutPreference; label: string }[] = [
@@ -27,6 +28,7 @@
 
   function handleTransparencyInput(event: Event) {
     const target = event.target as HTMLInputElement;
+
     setOverlayEditorTransparency(Number(target.value) / 100);
   }
 </script>

--- a/ui/src/lib/dom/portal.ts
+++ b/ui/src/lib/dom/portal.ts
@@ -1,0 +1,28 @@
+import type { Action } from 'svelte/action';
+
+export const portal: Action<HTMLElement, HTMLElement | null | undefined> = (node, target) => {
+  const parent = node.parentNode;
+  const marker = document.createComment('portal');
+
+  parent?.insertBefore(marker, node);
+
+  function move(nextTarget: HTMLElement | null | undefined) {
+    if (nextTarget) {
+      nextTarget.appendChild(node);
+    } else {
+      marker.parentNode?.insertBefore(node, marker);
+    }
+  }
+
+  move(target);
+
+  return {
+    update(nextTarget) {
+      move(nextTarget);
+    },
+    destroy() {
+      marker.parentNode?.insertBefore(node, marker);
+      marker.remove();
+    }
+  };
+};

--- a/ui/src/stores/code-editor-layout.store.test.ts
+++ b/ui/src/stores/code-editor-layout.store.test.ts
@@ -1,0 +1,37 @@
+import { get } from 'svelte/store';
+import { describe, expect, it } from 'vitest';
+
+import {
+  activeCodeEditorTarget,
+  closeCodeEditorOverlay,
+  isDetachedCodeEditorTarget,
+  openCodeEditorOverlay
+} from './code-editor-layout.store';
+
+describe('code editor layout store', () => {
+  it('tracks the active overlay target and clears it', () => {
+    openCodeEditorOverlay({
+      nodeId: 'node-1',
+      dataKey: 'code',
+      language: 'javascript',
+      nodeType: 'canvas',
+      title: 'canvas'
+    });
+
+    expect(get(activeCodeEditorTarget)).toEqual({
+      nodeId: 'node-1',
+      dataKey: 'code',
+      language: 'javascript',
+      nodeType: 'canvas',
+      title: 'canvas',
+      mode: 'overlay'
+    });
+    expect(isDetachedCodeEditorTarget('node-1', 'code')).toBe(true);
+    expect(isDetachedCodeEditorTarget('node-1', 'expr')).toBe(false);
+
+    closeCodeEditorOverlay();
+
+    expect(get(activeCodeEditorTarget)).toBeNull();
+    expect(isDetachedCodeEditorTarget('node-1', 'code')).toBe(false);
+  });
+});

--- a/ui/src/stores/code-editor-layout.store.ts
+++ b/ui/src/stores/code-editor-layout.store.ts
@@ -1,0 +1,33 @@
+import { get, writable } from 'svelte/store';
+import type { SupportedLanguage } from '$lib/codemirror/types';
+
+export interface CodeEditorTarget {
+  nodeId: string;
+  dataKey: string;
+  language: SupportedLanguage;
+  nodeType?: string;
+  title?: string;
+  placeholder?: string;
+  onrun?: () => void;
+  mode: 'overlay' | 'sidebar';
+}
+
+export type OpenCodeEditorOverlayTarget = Omit<CodeEditorTarget, 'mode'>;
+
+export const activeCodeEditorTarget = writable<CodeEditorTarget | null>(null);
+
+export function openCodeEditorOverlay(target: OpenCodeEditorOverlayTarget): void {
+  activeCodeEditorTarget.set({ ...target, mode: 'overlay' });
+}
+
+export function closeCodeEditorOverlay(): void {
+  activeCodeEditorTarget.set(null);
+}
+
+export function isDetachedCodeEditorTarget(nodeId: string | undefined, dataKey: string): boolean {
+  if (!nodeId) return false;
+
+  const target = get(activeCodeEditorTarget);
+
+  return target?.nodeId === nodeId && target.dataKey === dataKey;
+}

--- a/ui/src/stores/detached-strudel-editor.store.test.ts
+++ b/ui/src/stores/detached-strudel-editor.store.test.ts
@@ -1,0 +1,24 @@
+import { get } from 'svelte/store';
+import { describe, expect, it } from 'vitest';
+
+import {
+  activeDetachedStrudelNodeId,
+  closeDetachedStrudelEditor,
+  isDetachedStrudelEditor,
+  openDetachedStrudelEditor
+} from './detached-strudel-editor.store';
+
+describe('detached strudel editor store', () => {
+  it('tracks the active detached strudel node', () => {
+    openDetachedStrudelEditor('strudel-1');
+
+    expect(get(activeDetachedStrudelNodeId)).toBe('strudel-1');
+    expect(isDetachedStrudelEditor('strudel-1')).toBe(true);
+    expect(isDetachedStrudelEditor('strudel-2')).toBe(false);
+
+    closeDetachedStrudelEditor();
+
+    expect(get(activeDetachedStrudelNodeId)).toBeNull();
+    expect(isDetachedStrudelEditor('strudel-1')).toBe(false);
+  });
+});

--- a/ui/src/stores/detached-strudel-editor.store.ts
+++ b/ui/src/stores/detached-strudel-editor.store.ts
@@ -1,0 +1,17 @@
+import { get, writable } from 'svelte/store';
+
+export const activeDetachedStrudelNodeId = writable<string | null>(null);
+
+export function openDetachedStrudelEditor(nodeId: string): void {
+  activeDetachedStrudelNodeId.set(nodeId);
+}
+
+export function closeDetachedStrudelEditor(): void {
+  activeDetachedStrudelNodeId.set(null);
+}
+
+export function isDetachedStrudelEditor(nodeId: string | undefined): boolean {
+  if (!nodeId) return false;
+
+  return get(activeDetachedStrudelNodeId) === nodeId;
+}

--- a/ui/src/stores/detached-strudel-editor.store.ts
+++ b/ui/src/stores/detached-strudel-editor.store.ts
@@ -1,4 +1,5 @@
 import { get, writable } from 'svelte/store';
+import { match } from 'ts-pattern';
 
 export const activeDetachedStrudelNodeId = writable<string | null>(null);
 
@@ -11,7 +12,7 @@ export function closeDetachedStrudelEditor(): void {
 }
 
 export function isDetachedStrudelEditor(nodeId: string | undefined): boolean {
-  if (!nodeId) return false;
-
-  return get(activeDetachedStrudelNodeId) === nodeId;
+  return match(nodeId)
+    .with(undefined, () => false)
+    .otherwise((n) => get(activeDetachedStrudelNodeId) === n);
 }

--- a/ui/src/stores/editor-layout-settings.store.test.ts
+++ b/ui/src/stores/editor-layout-settings.store.test.ts
@@ -1,0 +1,44 @@
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  defaultEditorLayout,
+  overlayEditorTransparency,
+  setDefaultEditorLayout,
+  setOverlayEditorTransparency
+} from './editor-layout-settings.store';
+
+describe('editor layout settings store', () => {
+  beforeEach(() => {
+    const items = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      clear: () => items.clear(),
+      getItem: (key: string) => items.get(key) ?? null,
+      removeItem: (key: string) => items.delete(key),
+      setItem: (key: string, value: string) => items.set(key, value)
+    });
+
+    localStorage.clear();
+    setDefaultEditorLayout('inline');
+    setOverlayEditorTransparency(0.72);
+  });
+
+  it('persists the default editor layout preference', () => {
+    setDefaultEditorLayout('overlay');
+
+    expect(get(defaultEditorLayout)).toBe('overlay');
+    expect(localStorage.getItem('editor.defaultLayout')).toBe('overlay');
+  });
+
+  it('clamps and persists overlay transparency', () => {
+    setOverlayEditorTransparency(2);
+
+    expect(get(overlayEditorTransparency)).toBe(1);
+    expect(localStorage.getItem('editor.overlayTransparency')).toBe('1');
+
+    setOverlayEditorTransparency(-1);
+
+    expect(get(overlayEditorTransparency)).toBe(0);
+    expect(localStorage.getItem('editor.overlayTransparency')).toBe('0');
+  });
+});

--- a/ui/src/stores/editor-layout-settings.store.test.ts
+++ b/ui/src/stores/editor-layout-settings.store.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   defaultEditorLayout,
+  getEditorOpenLayout,
   overlayEditorTransparency,
   setDefaultEditorLayout,
   setOverlayEditorTransparency
@@ -40,5 +41,13 @@ describe('editor layout settings store', () => {
 
     expect(get(overlayEditorTransparency)).toBe(0);
     expect(localStorage.getItem('editor.overlayTransparency')).toBe('0');
+  });
+
+  it('resolves shift-click alternate editor layouts', () => {
+    expect(getEditorOpenLayout('inline', false)).toBe('inline');
+    expect(getEditorOpenLayout('inline', true)).toBe('overlay');
+    expect(getEditorOpenLayout('overlay', false)).toBe('overlay');
+    expect(getEditorOpenLayout('overlay', true)).toBe('inline');
+    expect(getEditorOpenLayout('sidebar', true)).toBe('overlay');
   });
 });

--- a/ui/src/stores/editor-layout-settings.store.ts
+++ b/ui/src/stores/editor-layout-settings.store.ts
@@ -1,0 +1,56 @@
+import { writable } from 'svelte/store';
+import { match } from 'ts-pattern';
+
+export type EditorLayoutPreference = 'inline' | 'overlay' | 'sidebar';
+
+const DEFAULT_EDITOR_LAYOUT_KEY = 'editor.defaultLayout';
+const OVERLAY_TRANSPARENCY_KEY = 'editor.overlayTransparency';
+
+const DEFAULT_EDITOR_LAYOUT: EditorLayoutPreference = 'inline';
+const DEFAULT_OVERLAY_TRANSPARENCY = 0.72;
+
+export const defaultEditorLayout = writable<EditorLayoutPreference>(readDefaultEditorLayout());
+export const overlayEditorTransparency = writable<number>(readOverlayTransparency());
+
+function readDefaultEditorLayout(): EditorLayoutPreference {
+  if (typeof localStorage === 'undefined') return DEFAULT_EDITOR_LAYOUT;
+
+  return match(localStorage.getItem(DEFAULT_EDITOR_LAYOUT_KEY))
+    .with('inline', () => 'inline' as const)
+    .with('overlay', () => 'overlay' as const)
+    .with('sidebar', () => 'sidebar' as const)
+    .otherwise(() => DEFAULT_EDITOR_LAYOUT);
+}
+
+function clampTransparency(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_OVERLAY_TRANSPARENCY;
+
+  return Math.min(1, Math.max(0, value));
+}
+
+function readOverlayTransparency(): number {
+  if (typeof localStorage === 'undefined') return DEFAULT_OVERLAY_TRANSPARENCY;
+
+  const stored = localStorage.getItem(OVERLAY_TRANSPARENCY_KEY);
+  if (stored === null) return DEFAULT_OVERLAY_TRANSPARENCY;
+
+  return clampTransparency(Number(stored));
+}
+
+export function setDefaultEditorLayout(value: EditorLayoutPreference): void {
+  defaultEditorLayout.set(value);
+
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(DEFAULT_EDITOR_LAYOUT_KEY, value);
+  }
+}
+
+export function setOverlayEditorTransparency(value: number): void {
+  const next = clampTransparency(value);
+
+  overlayEditorTransparency.set(next);
+
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(OVERLAY_TRANSPARENCY_KEY, String(next));
+  }
+}

--- a/ui/src/stores/editor-layout-settings.store.ts
+++ b/ui/src/stores/editor-layout-settings.store.ts
@@ -2,6 +2,7 @@ import { writable } from 'svelte/store';
 import { match } from 'ts-pattern';
 
 export type EditorLayoutPreference = 'inline' | 'overlay' | 'sidebar';
+export type EditorOpenLayout = 'inline' | 'overlay';
 
 const DEFAULT_EDITOR_LAYOUT_KEY = 'editor.defaultLayout';
 const OVERLAY_TRANSPARENCY_KEY = 'editor.overlayTransparency';
@@ -53,4 +54,20 @@ export function setOverlayEditorTransparency(value: number): void {
   if (typeof localStorage !== 'undefined') {
     localStorage.setItem(OVERLAY_TRANSPARENCY_KEY, String(next));
   }
+}
+
+export function getEditorOpenLayout(
+  defaultLayout: EditorLayoutPreference,
+  useAlternateLayout: boolean
+): EditorOpenLayout {
+  const preferredLayout = match(defaultLayout)
+    .with('overlay', () => 'overlay' as const)
+    .otherwise(() => 'inline' as const);
+
+  if (!useAlternateLayout) return preferredLayout;
+
+  return match(preferredLayout)
+    .with('inline', () => 'overlay' as const)
+    .with('overlay', () => 'inline' as const)
+    .exhaustive();
 }

--- a/ui/src/stores/editor-layout-settings.store.ts
+++ b/ui/src/stores/editor-layout-settings.store.ts
@@ -64,10 +64,10 @@ export function getEditorOpenLayout(
     .with('overlay', () => 'overlay' as const)
     .otherwise(() => 'inline' as const);
 
-  if (!useAlternateLayout) return preferredLayout;
-
-  return match(preferredLayout)
-    .with('inline', () => 'overlay' as const)
-    .with('overlay', () => 'inline' as const)
+  return match([useAlternateLayout, preferredLayout])
+    .with([false, 'inline'], () => 'inline' as const)
+    .with([false, 'overlay'], () => 'overlay' as const)
+    .with([true, 'inline'], () => 'overlay' as const)
+    .with([true, 'overlay'], () => 'inline' as const)
     .exhaustive();
 }

--- a/ui/static/content/objects/strudel.md
+++ b/ui/static/content/objects/strudel.md
@@ -35,6 +35,37 @@ is controlled by the transport bar instead of per-node controls.
 You can create multiple `strudel` objects, but only **one** plays at a time.
 Use `bang` or `run` messages to switch playback between them.
 
+## Styling The Editor
+
+Send style messages into a `strudel` object to tune its editor for live coding.
+This is useful when the editor is expanded over the background output.
+
+Create a `js` object, connect it to `strudel`, and run:
+
+```javascript
+send({
+  type: 'setFontFamily',
+  value: 'Monaco, Menlo, Ubuntu Mono, Consolas, source-code-pro, monospace'
+})
+
+send({
+  type: 'setFontSize',
+  value: 25
+})
+
+send({
+  type: 'setStyles',
+  value: {
+    container: `
+      background: rgba(0, 0, 0, 0.6);
+      backdrop-filter: blur(10px);
+      padding: 20px 10px;
+      border: none;
+    `
+  }
+})
+```
+
 ## Examples
 
 Try [funk42 preset by froos](/?id=zntnikb36c47eaw) for a


### PR DESCRIPTION
Adds a fullscreen overlay "zen mode" CodeMirror code editor layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fullscreen/detached code editor overlay with Shift+Escape to close and a Run/Close toolbar
  * Per-node editor placeholders and language hints for clearer inline editors
  * “Return”/expand controls to switch between inline and detached editing

* **Settings**
  * “Default editor layout” preference (inline/overlay/sidebar)
  * “Overlay transparency” slider to adjust detached background opacity

* **Documentation**
  * Design spec for detached code editor layouts and behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->