### PR TITLE
Sidebar code editor layout

### DIFF
--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -64,7 +64,7 @@ nodeType, title, mode }` in a shared store.
 - Code editor chrome in `CanvasPreviewLayout` exposes an expand action that opens
   the current code field in overlay mode.
 - The user's default editor layout decides whether opening a visual node editor
-  starts inline or opens the overlay directly.
+  starts inline, opens the overlay, or opens the sidebar editor directly.
 - `Shift+click` on the visual node code edit action opens the alternate layout
   for that invocation: inline defaults open overlay, and overlay defaults open
   inline.
@@ -123,11 +123,8 @@ sidebar mode should open the sidebar, select the `code` tab, and render the
 editor there.
 
 Sidebar mode is useful for focused editing without covering the background
-output.
-
-Sidebar mode is not part of the first implementation. The type and settings
-should leave room for it, but the first shipped behavior only needs inline and
-overlay.
+output. Unlike overlay mode, opening the sidebar editor should not create a
+temporary background output override.
 
 ## Settings
 
@@ -135,12 +132,8 @@ Add editor layout preferences to `SettingsModal.svelte`.
 
 Initial settings:
 
-- Default editor layout: `Inline` or `Overlay`
+- Default editor layout: `Inline`, `Overlay`, or `Sidebar`
 - Overlay editor transparency
-
-Future setting:
-
-- `Sidebar` default layout, once the sidebar code view exists
 
 Settings should live in a dedicated store under `src/stores/`, not directly in
 the settings modal component. The default editor layout is user preference state,
@@ -169,15 +162,13 @@ Responsibilities:
 - hold the default editor layout preference
 - hold the overlay transparency preference
 - persist user preferences to localStorage
-- leave room for `sidebar` as a future layout value without showing it in the
-  first dropdown
 
 ### Shared Shells
 
 Add dedicated presentation components:
 
 - `DetachedCodeEditorOverlay.svelte`
-- `SidebarCodeEditorView.svelte` in a follow-up
+- `SidebarCodeEditorView.svelte`
 
 Both components resolve the active node and code value from the canvas state,
 then pass normal props into `CodeEditor.svelte`.
@@ -236,7 +227,9 @@ First pass:
 
 - shared active detached-editor target store
 - overlay editor for `CanvasPreviewLayout` consumers
-- Settings modal option for default editor layout: `Inline` or `Overlay`
+- sidebar editor for `CanvasPreviewLayout` consumers
+- Settings modal option for default editor layout: `Inline`, `Overlay`, or
+  `Sidebar`
 - Settings modal option for overlay editor transparency
 - hide inline editor while detached overlay is active
 - compact inline affordance showing that the editor is open in expanded view
@@ -245,7 +238,6 @@ First pass:
 
 Follow-up:
 
-- sidebar `code` tab
 - layout switch between overlay and sidebar
 - typography controls for performance mode beyond the first overlay defaults
 - persisted user preferences for font size, line wrapping, and chrome density

--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -28,10 +28,11 @@ Detached editor layouts should support:
 - future display-only or performance-oriented code views
 
 The first implementation focuses on visual code nodes that already use
-`CanvasPreviewLayout`, plus JS-style code block nodes that share
-`CodeBlockBase`. Expression-style nodes such as `CommonExprLayout` do not need
-detached editing initially because their inline editors are already compact and
-the code is less likely to be part of a performance visual.
+`CanvasPreviewLayout`, JS-style code block nodes that share `CodeBlockBase`, and
+simple DSP code nodes that share `SimpleDspLayout`. Expression-style nodes such
+as `CommonExprLayout` do not need detached editing initially because their inline
+editors are already compact and the code is less likely to be part of a
+performance visual.
 
 ## Source Of Truth
 
@@ -227,8 +228,10 @@ run path is traced.
 First pass:
 
 - shared active detached-editor target store
-- overlay editor for `CanvasPreviewLayout` and `CodeBlockBase` consumers
-- sidebar editor for `CanvasPreviewLayout` and `CodeBlockBase` consumers
+- overlay editor for `CanvasPreviewLayout`, `CodeBlockBase`, and
+  `SimpleDspLayout` consumers
+- sidebar editor for `CanvasPreviewLayout`, `CodeBlockBase`, and
+  `SimpleDspLayout` consumers
 - Settings modal option for default editor layout: `Inline`, `Overlay`, or
   `Sidebar`
 - Settings modal option for overlay editor transparency

--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -28,9 +28,10 @@ Detached editor layouts should support:
 - future display-only or performance-oriented code views
 
 The first implementation focuses on visual code nodes that already use
-`CanvasPreviewLayout`. Expression-style nodes such as `CommonExprLayout` do not
-need detached editing initially because their inline editors are already compact
-and the code is less likely to be part of a performance visual.
+`CanvasPreviewLayout`, plus JS-style code block nodes that share
+`CodeBlockBase`. Expression-style nodes such as `CommonExprLayout` do not need
+detached editing initially because their inline editors are already compact and
+the code is less likely to be part of a performance visual.
 
 ## Source Of Truth
 
@@ -226,8 +227,8 @@ run path is traced.
 First pass:
 
 - shared active detached-editor target store
-- overlay editor for `CanvasPreviewLayout` consumers
-- sidebar editor for `CanvasPreviewLayout` consumers
+- overlay editor for `CanvasPreviewLayout` and `CodeBlockBase` consumers
+- sidebar editor for `CanvasPreviewLayout` and `CodeBlockBase` consumers
 - Settings modal option for default editor layout: `Inline`, `Overlay`, or
   `Sidebar`
 - Settings modal option for overlay editor transparency

--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -69,7 +69,7 @@ nodeType, title, mode }` in a shared store.
   starts inline, opens the overlay, or opens the sidebar editor directly.
 - `Shift+click` on the visual node code edit action opens the alternate layout
   for that invocation: inline defaults open overlay, and overlay defaults open
-  inline.
+  inline, while sidebar defaults open overlay.
 - Strudel editor views hide line-number gutters in both inline and detached
   layouts so pattern code stays visually central.
 - While a detached editor is active for a node field, the inline editor for that

--- a/ui/src/lib/canvas/use-detached-code-editor-overlay.svelte.ts
+++ b/ui/src/lib/canvas/use-detached-code-editor-overlay.svelte.ts
@@ -95,6 +95,11 @@ export function useDetachedCodeEditorOverlay({
       return;
     }
 
+    if (target.mode !== 'overlay') {
+      clearTemporaryOutput();
+      return;
+    }
+
     if (temporaryOutputNodeId && temporaryOutputNodeId !== target.nodeId) {
       clearTemporaryOutput();
     }
@@ -104,7 +109,6 @@ export function useDetachedCodeEditorOverlay({
     if (hasBgOutOutput(getNodes(), getEdges())) return;
 
     temporaryOutputNodeId = target.nodeId;
-
     overrideOutputNodeId.set(target.nodeId);
     glSystem.setOverrideOutputNode(target.nodeId);
   });

--- a/ui/src/lib/code-editor/open-editor-layout.test.ts
+++ b/ui/src/lib/code-editor/open-editor-layout.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { openEditorLayout } from './open-editor-layout';
+import type { EditorLayoutPreference } from '../../stores/editor-layout-settings.store';
+
+function createHandlers() {
+  return {
+    openInline: vi.fn(),
+    toggleInline: vi.fn(),
+    openOverlay: vi.fn(),
+    openSidebar: vi.fn()
+  };
+}
+
+function callsFor(defaultLayout: EditorLayoutPreference, useAlternateLayout: boolean) {
+  const handlers = createHandlers();
+
+  openEditorLayout({
+    defaultLayout,
+    useAlternateLayout,
+    ...handlers
+  });
+
+  return handlers;
+}
+
+describe('openEditorLayout', () => {
+  it('uses the default layout for plain clicks', () => {
+    expect(callsFor('inline', false).toggleInline).toHaveBeenCalledOnce();
+    expect(callsFor('overlay', false).openOverlay).toHaveBeenCalledOnce();
+    expect(callsFor('sidebar', false).openSidebar).toHaveBeenCalledOnce();
+  });
+
+  it('uses the alternate layout for shift clicks', () => {
+    expect(callsFor('inline', true).openOverlay).toHaveBeenCalledOnce();
+    expect(callsFor('overlay', true).openInline).toHaveBeenCalledOnce();
+    expect(callsFor('sidebar', true).openOverlay).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/lib/code-editor/open-editor-layout.ts
+++ b/ui/src/lib/code-editor/open-editor-layout.ts
@@ -1,0 +1,37 @@
+import { match } from 'ts-pattern';
+import {
+  getEditorOpenLayout,
+  type EditorLayoutPreference
+} from '../../stores/editor-layout-settings.store';
+
+interface OpenEditorLayoutOptions {
+  defaultLayout: EditorLayoutPreference;
+  useAlternateLayout: boolean;
+  openInline: () => void;
+  toggleInline: () => void;
+  openOverlay: () => void;
+  openSidebar: () => void;
+}
+
+export function openEditorLayout({
+  defaultLayout,
+  useAlternateLayout,
+  openInline,
+  toggleInline,
+  openOverlay,
+  openSidebar
+}: OpenEditorLayoutOptions): void {
+  const layout = getEditorOpenLayout(defaultLayout, useAlternateLayout);
+
+  match(layout)
+    .with('inline', () => {
+      if (useAlternateLayout) {
+        openInline();
+      } else {
+        toggleInline();
+      }
+    })
+    .with('overlay', openOverlay)
+    .with('sidebar', openSidebar)
+    .exhaustive();
+}

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -1200,7 +1200,7 @@
     <BackgroundOutputCanvas />
   </div>
 
-  {#if $activeCodeEditorTarget && detachedCodeEditor.node}
+  {#if $activeCodeEditorTarget?.mode === 'overlay' && detachedCodeEditor.node}
     {#snippet detachedCodeEditorSnippet()}
       <CodeEditor
         value={detachedCodeEditor.value}
@@ -1234,6 +1234,14 @@
     {getGraphSummary}
     {getViewportSummary}
     {hasGeminiApiKey}
+    codeEditorTarget={$activeCodeEditorTarget?.mode === 'sidebar' && detachedCodeEditor.node
+      ? $activeCodeEditorTarget
+      : undefined}
+    codeEditorValue={detachedCodeEditor.value}
+    onCodeEditorChange={detachedCodeEditor.updateValue}
+    codeEditorTitle={$activeCodeEditorTarget?.title}
+    onCloseCodeEditor={closeCodeEditorOverlay}
+    onRunCodeEditor={$activeCodeEditorTarget?.onrun}
   />
 
   <!-- Main content area -->

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -26,7 +26,8 @@
   import {
     activeCodeEditorTarget,
     closeCodeEditorOverlay,
-    openCodeEditorOverlay
+    openCodeEditorOverlay,
+    openCodeEditorSidebar
   } from '../../stores/code-editor-layout.store';
   import {
     defaultEditorLayout,
@@ -281,6 +282,23 @@
     showSettings = false;
   }
 
+  function openSidebarCodeEditor() {
+    if (!nodeId) return;
+
+    openCodeEditorSidebar({
+      nodeId,
+      dataKey: codeDataKey,
+      language: codeLanguage,
+      nodeType: objectType,
+      title,
+      placeholder: codePlaceholder,
+      onrun: onrun ? handleRun : undefined
+    });
+
+    showEditor = false;
+    showSettings = false;
+  }
+
   function handleBgOutputToggle() {
     if (!nodeId) return;
 
@@ -362,6 +380,9 @@
     match(layout)
       .with('overlay', () => {
         openExpandedCodeEditor();
+      })
+      .with('sidebar', () => {
+        openSidebarCodeEditor();
       })
       .with('inline', () => {
         if (event?.shiftKey) {
@@ -518,7 +539,7 @@
     </div>
   {/if}
 
-  {#if showEditor || isCodeEditorDetached}
+  {#if showEditor && !isCodeEditorDetached}
     <div class="absolute" style="left: {editorLeftPos}px;">
       {#if editorReady !== false}
         <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
@@ -580,31 +601,14 @@
         </div>
       {/if}
 
-      {#if isCodeEditorDetached}
-        <div class="rounded-lg border border-zinc-600 bg-zinc-900 px-4 py-3 shadow-xl">
-          <div class="flex min-w-[260px] items-center justify-between gap-3">
-            <div>
-              <div class="text-xs font-medium text-zinc-200">Editing in expanded view</div>
-              <div class="mt-0.5 text-[11px] text-zinc-500">Close it to return inline.</div>
-            </div>
-            <button
-              class="cursor-pointer rounded border border-zinc-700 px-2 py-1 text-xs text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
-              onclick={closeCodeEditorOverlay}
-            >
-              Return
-            </button>
-          </div>
+      <div class="rounded-lg border border-zinc-600 bg-zinc-900 shadow-xl">
+        <div class="flex flex-col">
+          {@render codeEditor()}
         </div>
-      {:else}
-        <div class="rounded-lg border border-zinc-600 bg-zinc-900 shadow-xl">
-          <div class="flex flex-col">
-            {@render codeEditor()}
-          </div>
-        </div>
+      </div>
 
-        {#if consoleSnippet}
-          {@render consoleSnippet()}
-        {/if}
+      {#if consoleSnippet}
+        {@render consoleSnippet()}
       {/if}
     </div>
   {/if}

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -568,6 +568,7 @@
                 <Expand class="h-4 w-4 text-zinc-300" />
               </button>
             </Tooltip.Trigger>
+
             <Tooltip.Content>Open Expanded Editor</Tooltip.Content>
           </Tooltip.Root>
 
@@ -584,6 +585,7 @@
                 <X class="h-4 w-4 text-zinc-300" />
               </button>
             </Tooltip.Trigger>
+
             <Tooltip.Content>Close Editor</Tooltip.Content>
           </Tooltip.Root>
         </div>

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -29,10 +29,8 @@
     openCodeEditorOverlay,
     openCodeEditorSidebar
   } from '../../stores/code-editor-layout.store';
-  import {
-    defaultEditorLayout,
-    getEditorOpenLayout
-  } from '../../stores/editor-layout-settings.store';
+  import { defaultEditorLayout } from '../../stores/editor-layout-settings.store';
+  import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { CanvasPreviewExpandController } from '$lib/canvas/CanvasPreviewExpandController';
   import { SurfaceListeners } from '$lib/canvas/SurfaceListeners';
@@ -42,7 +40,6 @@
   import { useIncludeProcessing } from '$lib/canvas/use-include-processing.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { NodePrimaryButtonUpdateEvent, PrimaryButton } from '$lib/eventbus/events';
-  import { match } from 'ts-pattern';
 
   let previewContainer: HTMLDivElement | null = null;
   const { getNode, getNodes, updateNodeData } = useSvelteFlow();
@@ -375,23 +372,14 @@
   }
 
   function handleCodeOpen(event?: MouseEvent) {
-    const layout = getEditorOpenLayout($defaultEditorLayout, event?.shiftKey ?? false);
-
-    match(layout)
-      .with('overlay', () => {
-        openExpandedCodeEditor();
-      })
-      .with('sidebar', () => {
-        openSidebarCodeEditor();
-      })
-      .with('inline', () => {
-        if (event?.shiftKey) {
-          openInlineCodeEditor();
-        } else {
-          toggleInlineCode();
-        }
-      })
-      .exhaustive();
+    openEditorLayout({
+      defaultLayout: $defaultEditorLayout,
+      useAlternateLayout: event?.shiftKey ?? false,
+      openInline: openInlineCodeEditor,
+      toggleInline: toggleInlineCode,
+      openOverlay: openExpandedCodeEditor,
+      openSidebar: openSidebarCodeEditor
+    });
   }
 </script>
 

--- a/ui/src/lib/components/nodes/CodeBlockBase.svelte
+++ b/ui/src/lib/components/nodes/CodeBlockBase.svelte
@@ -584,7 +584,7 @@
         </Tooltip.Root>
       </div>
 
-      <div class="rounded-lg border border-zinc-600 bg-zinc-900 shadow-xl">
+      <div class="min-w-72 rounded-lg border border-zinc-600 bg-zinc-900 shadow-xl">
         <CodeEditor
           value={code}
           onchange={(newCode) => {
@@ -596,7 +596,7 @@
           {language}
           {nodeType}
           placeholder={editorPlaceholder}
-          class="nodrag h-64 w-full resize-none"
+          class="nodrag h-64 w-full min-w-72 resize-none"
           onrun={executeCode}
           {lineErrors}
           {nodeId}

--- a/ui/src/lib/components/nodes/CodeBlockBase.svelte
+++ b/ui/src/lib/components/nodes/CodeBlockBase.svelte
@@ -566,6 +566,7 @@
                 <Expand class="h-4 w-4 text-zinc-300" />
               </button>
             </Tooltip.Trigger>
+
             <Tooltip.Content>Open Expanded Editor</Tooltip.Content>
           </Tooltip.Root>
         {/if}
@@ -580,6 +581,7 @@
               <X class="h-4 w-4 text-zinc-300" />
             </button>
           </Tooltip.Trigger>
+
           <Tooltip.Content>Close Editor</Tooltip.Content>
         </Tooltip.Root>
       </div>

--- a/ui/src/lib/components/nodes/CodeBlockBase.svelte
+++ b/ui/src/lib/components/nodes/CodeBlockBase.svelte
@@ -5,6 +5,7 @@
     Package,
     Pause,
     Play,
+    Expand,
     Settings as SettingsIcon,
     Terminal,
     X
@@ -25,6 +26,14 @@
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings';
   import * as Tooltip from '$lib/components/ui/tooltip';
+  import {
+    activeCodeEditorTarget,
+    closeCodeEditorOverlay,
+    openCodeEditorOverlay,
+    openCodeEditorSidebar
+  } from '../../../stores/code-editor-layout.store';
+  import { defaultEditorLayout } from '../../../stores/editor-layout-settings.store';
+  import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
 
   let contentContainer: HTMLDivElement | null = null;
   let consoleRef: VirtualConsole | null = $state(null);
@@ -135,6 +144,9 @@
 
   const code = $derived(data.code || '');
   let previousExecuteCode = $state<number | undefined>(undefined);
+  let isCodeEditorDetached = $derived(
+    $activeCodeEditorTarget?.nodeId === nodeId && $activeCodeEditorTarget.dataKey === 'code'
+  );
 
   // Track error line numbers for code highlighting
   let lineErrors = $state<Record<number, string[]> | undefined>(undefined);
@@ -245,8 +257,67 @@
     contentWidth = contentContainer.offsetWidth;
   }
 
-  function toggleEditor() {
+  function toggleInlineEditor() {
     showEditor = !showEditor;
+
+    if (showEditor) {
+      showSettings = false;
+    }
+  }
+
+  function openInlineEditor() {
+    if (isCodeEditorDetached) {
+      closeCodeEditorOverlay();
+    }
+
+    showEditor = true;
+    showSettings = false;
+  }
+
+  function openExpandedCodeEditor() {
+    openCodeEditorOverlay({
+      nodeId,
+      dataKey: 'code',
+      language,
+      nodeType,
+      title: (supportsLibraries && data.libraryName) || data.title || nodeLabel,
+      placeholder: editorPlaceholder,
+      onrun: executeCode
+    });
+
+    showEditor = false;
+    showSettings = false;
+  }
+
+  function openSidebarCodeEditor() {
+    openCodeEditorSidebar({
+      nodeId,
+      dataKey: 'code',
+      language,
+      nodeType,
+      title: (supportsLibraries && data.libraryName) || data.title || nodeLabel,
+      placeholder: editorPlaceholder,
+      onrun: executeCode
+    });
+
+    showEditor = false;
+    showSettings = false;
+  }
+
+  function handleCodeOpen(event?: MouseEvent) {
+    if (supportsLibraries && data.libraryName) {
+      openInlineEditor();
+      return;
+    }
+
+    openEditorLayout({
+      defaultLayout: $defaultEditorLayout,
+      useAlternateLayout: event?.shiftKey ?? false,
+      openInline: openInlineEditor,
+      toggleInline: toggleInlineEditor,
+      openOverlay: openExpandedCodeEditor,
+      openSidebar: openSidebarCodeEditor
+    });
   }
 
   function runOrStop() {
@@ -271,7 +342,7 @@
 
   function handleDoubleClickOnRun() {
     if (supportsLibraries && data.libraryName) {
-      toggleEditor();
+      toggleInlineEditor();
     }
   }
 
@@ -296,12 +367,8 @@
     return baseWidth + Math.max(Math.max(totalInlets, 2), Math.max(outletCount, 2)) * inletWidth;
   });
 
-  const toggleCode = () => {
-    toggleEditor();
-
-    if (showEditor) {
-      showSettings = false;
-    }
+  const toggleCode = (event?: MouseEvent) => {
+    handleCodeOpen(event);
   };
 </script>
 
@@ -367,11 +434,7 @@
               <Tooltip.Trigger>
                 <button
                   class="cursor-pointer rounded p-1 hover:bg-zinc-700"
-                  onclick={() => {
-                    toggleEditor();
-
-                    if (showEditor) showSettings = false;
-                  }}
+                  onclick={handleCodeOpen}
                   aria-label="Edit code"
                 >
                   <Code class="h-4 w-4 text-zinc-300" />
@@ -489,15 +552,36 @@
     </div>
   </div>
 
-  {#if showEditor}
+  {#if showEditor && !isCodeEditorDetached}
     <div class="absolute" style="left: {contentWidth + 10}px">
       <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
-        <button
-          onclick={() => (showEditor = false)}
-          class="cursor-pointer rounded p-1 hover:bg-zinc-700"
-        >
-          <X class="h-4 w-4 text-zinc-300" />
-        </button>
+        {#if !(supportsLibraries && data.libraryName)}
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                onclick={openExpandedCodeEditor}
+                class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+                aria-label="Open expanded editor"
+              >
+                <Expand class="h-4 w-4 text-zinc-300" />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>Open Expanded Editor</Tooltip.Content>
+          </Tooltip.Root>
+        {/if}
+
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button
+              onclick={() => (showEditor = false)}
+              class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+              aria-label="Close editor"
+            >
+              <X class="h-4 w-4 text-zinc-300" />
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>Close Editor</Tooltip.Content>
+        </Tooltip.Root>
       </div>
 
       <div class="rounded-lg border border-zinc-600 bg-zinc-900 shadow-xl">

--- a/ui/src/lib/components/nodes/CodeBlockOverflowMenu.svelte
+++ b/ui/src/lib/components/nodes/CodeBlockOverflowMenu.svelte
@@ -17,7 +17,7 @@
     onConsoleToggle: () => void;
     onSettingsToggle: () => void;
     /** Provided when code editor is NOT the primary button — adds an "Edit code" entry. */
-    onCodeToggle?: () => void;
+    onCodeToggle?: (event: MouseEvent) => void;
     settingsSchema: SettingsSchema;
   } = $props();
 </script>

--- a/ui/src/lib/components/nodes/SimpleDspLayout.svelte
+++ b/ui/src/lib/components/nodes/SimpleDspLayout.svelte
@@ -366,13 +366,13 @@
         </Tooltip.Root>
       </div>
 
-      <div class="rounded-lg border border-zinc-600 bg-zinc-900 shadow-xl">
+      <div class="min-w-72 rounded-lg border border-zinc-600 bg-zinc-900 shadow-xl">
         <CodeEditor
           value={code}
           onchange={handleCodeChangeInternal}
           language="javascript"
           {nodeType}
-          class="nodrag h-64 w-full resize-none"
+          class="nodrag h-64 w-full min-w-72 resize-none"
           onrun={onRun}
           {lineErrors}
           {nodeId}

--- a/ui/src/lib/components/nodes/SimpleDspLayout.svelte
+++ b/ui/src/lib/components/nodes/SimpleDspLayout.svelte
@@ -200,6 +200,7 @@
                   onclick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
+
                     toggleSettings();
                   }}
                   aria-label="Settings"
@@ -335,6 +336,7 @@
                 <Terminal class="h-4 w-4 text-zinc-300" />
               </button>
             </Tooltip.Trigger>
+
             <Tooltip.Content>Toggle Console</Tooltip.Content>
           </Tooltip.Root>
         {/if}
@@ -349,6 +351,7 @@
               <Expand class="h-4 w-4 text-zinc-300" />
             </button>
           </Tooltip.Trigger>
+
           <Tooltip.Content>Open Expanded Editor</Tooltip.Content>
         </Tooltip.Root>
 

--- a/ui/src/lib/components/nodes/SimpleDspLayout.svelte
+++ b/ui/src/lib/components/nodes/SimpleDspLayout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Code, Play, Settings, Terminal, X } from '@lucide/svelte/icons';
+  import { Code, Expand, Play, Settings, Terminal, X } from '@lucide/svelte/icons';
   import { useUpdateNodeInternals } from '@xyflow/svelte';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import { onMount, onDestroy, type Snippet } from 'svelte';
@@ -9,6 +9,14 @@
   import * as Tooltip from '$lib/components/ui/tooltip';
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings';
+  import {
+    activeCodeEditorTarget,
+    closeCodeEditorOverlay,
+    openCodeEditorOverlay,
+    openCodeEditorSidebar
+  } from '../../../stores/code-editor-layout.store';
+  import { defaultEditorLayout } from '../../../stores/editor-layout-settings.store';
+  import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
 
   let {
     nodeId,
@@ -65,6 +73,9 @@
   const messageInletCount = $derived(data.messageInletCount || 0);
   const messageOutletCount = $derived(data.messageOutletCount || 0);
   const displayTitle = $derived(data.title || nodeName);
+  const isCodeEditorDetached = $derived(
+    $activeCodeEditorTarget?.nodeId === nodeId && $activeCodeEditorTarget.dataKey === 'code'
+  );
 
   // Update content width when title changes
   $effect(() => {
@@ -107,9 +118,57 @@
     contentWidth = contentContainer.offsetWidth;
   }
 
-  function toggleEditor() {
+  function toggleInlineEditor() {
     showEditor = !showEditor;
     if (showEditor) showSettings = false;
+  }
+
+  function openInlineEditor() {
+    if (isCodeEditorDetached) {
+      closeCodeEditorOverlay();
+    }
+
+    showEditor = true;
+    showSettings = false;
+  }
+
+  function openExpandedCodeEditor() {
+    openCodeEditorOverlay({
+      nodeId,
+      dataKey: 'code',
+      language: 'javascript',
+      nodeType,
+      title: displayTitle,
+      onrun: onRun
+    });
+
+    showEditor = false;
+    showSettings = false;
+  }
+
+  function openSidebarCodeEditor() {
+    openCodeEditorSidebar({
+      nodeId,
+      dataKey: 'code',
+      language: 'javascript',
+      nodeType,
+      title: displayTitle,
+      onrun: onRun
+    });
+
+    showEditor = false;
+    showSettings = false;
+  }
+
+  function handleCodeOpen(event?: MouseEvent) {
+    openEditorLayout({
+      defaultLayout: $defaultEditorLayout,
+      useAlternateLayout: event?.shiftKey ?? false,
+      openInline: openInlineEditor,
+      toggleInline: toggleInlineEditor,
+      openOverlay: openExpandedCodeEditor,
+      openSidebar: openSidebarCodeEditor
+    });
   }
 
   function toggleSettings() {
@@ -134,30 +193,40 @@
           {@render actionButtons?.()}
 
           {#if settingsSchema && settingsSchema.length > 0}
-            <button
-              class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
-              onclick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                toggleSettings();
-              }}
-              title="Settings"
-            >
-              <Settings class="h-4 w-4 text-zinc-300" />
-            </button>
+            <Tooltip.Root>
+              <Tooltip.Trigger>
+                <button
+                  class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
+                  onclick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    toggleSettings();
+                  }}
+                  aria-label="Settings"
+                >
+                  <Settings class="h-4 w-4 text-zinc-300" />
+                </button>
+              </Tooltip.Trigger>
+              <Tooltip.Content>{showSettings ? 'Hide Settings' : 'Settings'}</Tooltip.Content>
+            </Tooltip.Root>
           {/if}
 
-          <button
-            class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
-            onclick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              toggleEditor();
-            }}
-            title="Edit code"
-          >
-            <Code class="h-4 w-4 text-zinc-300" />
-          </button>
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
+                onclick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleCodeOpen(e);
+                }}
+                aria-label="Edit code"
+              >
+                <Code class="h-4 w-4 text-zinc-300" />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>Edit Code</Tooltip.Content>
+          </Tooltip.Root>
         </div>
       </div>
 
@@ -197,7 +266,7 @@
           ondblclick={(e) => {
             e.stopPropagation();
             e.preventDefault();
-            toggleEditor();
+            openInlineEditor();
           }}
           title="Double click to edit code"
         >
@@ -237,12 +306,16 @@
     </div>
   </div>
 
-  {#if showEditor}
+  {#if showEditor && !isCodeEditorDetached}
     <div class="absolute" style="left: {contentWidth + 10}px">
       <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
         <Tooltip.Root>
           <Tooltip.Trigger>
-            <button onclick={onRun} class="rounded p-1 hover:bg-zinc-700">
+            <button
+              onclick={onRun}
+              class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+              aria-label="Run code"
+            >
               <Play class="h-4 w-4 text-zinc-300" />
             </button>
           </Tooltip.Trigger>
@@ -252,18 +325,45 @@
         </Tooltip.Root>
 
         {#if consoleSnippet}
-          <button
-            title="Toggle console"
-            class="rounded p-1 hover:bg-zinc-700"
-            onclick={onToggleConsole}
-          >
-            <Terminal class="h-4 w-4 text-zinc-300" />
-          </button>
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+                onclick={onToggleConsole}
+                aria-label="Toggle console"
+              >
+                <Terminal class="h-4 w-4 text-zinc-300" />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>Toggle Console</Tooltip.Content>
+          </Tooltip.Root>
         {/if}
 
-        <button onclick={() => (showEditor = false)} class="rounded p-1 hover:bg-zinc-700">
-          <X class="h-4 w-4 text-zinc-300" />
-        </button>
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button
+              onclick={openExpandedCodeEditor}
+              class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+              aria-label="Open expanded editor"
+            >
+              <Expand class="h-4 w-4 text-zinc-300" />
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>Open Expanded Editor</Tooltip.Content>
+        </Tooltip.Root>
+
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button
+              onclick={() => (showEditor = false)}
+              class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+              aria-label="Close editor"
+            >
+              <X class="h-4 w-4 text-zinc-300" />
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>Close Editor</Tooltip.Content>
+        </Tooltip.Root>
       </div>
 
       <div class="rounded-lg border border-zinc-600 bg-zinc-900 shadow-xl">

--- a/ui/src/lib/components/settings-modal/categories/EditorSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/EditorSettings.svelte
@@ -15,13 +15,14 @@
 
   const editorLayoutOptions: { value: EditorLayoutPreference; label: string }[] = [
     { value: 'inline', label: 'Inline' },
-    { value: 'overlay', label: 'Overlay' }
+    { value: 'overlay', label: 'Overlay' },
+    { value: 'sidebar', label: 'Sidebar' }
   ];
 
   let overlayTransparencyPercent = $derived(Math.round($overlayEditorTransparency * 100));
 
   function handleLayoutChange(value: string) {
-    if (value === 'inline' || value === 'overlay') {
+    if (value === 'inline' || value === 'overlay' || value === 'sidebar') {
       setDefaultEditorLayout(value);
     }
   }

--- a/ui/src/lib/components/sidebar/SidebarCodeEditorView.svelte
+++ b/ui/src/lib/components/sidebar/SidebarCodeEditorView.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import { Play, X } from '@lucide/svelte/icons';
+  import * as Tooltip from '$lib/components/ui/tooltip';
+  import CodeEditor from '$lib/components/CodeEditor.svelte';
+  import type { CodeEditorTarget } from '../../../stores/code-editor-layout.store';
+
+  let {
+    target,
+    value = '',
+    onchange,
+    title,
+    onClose,
+    onrun
+  }: {
+    target?: CodeEditorTarget;
+    value?: string;
+    onchange?: (value: string) => void;
+    title?: string;
+    onClose: () => void;
+    onrun?: () => void;
+  } = $props();
+</script>
+
+<div class="flex h-full min-h-0 flex-col">
+  <div class="flex shrink-0 items-center justify-between gap-3 border-b border-zinc-800 px-3 py-2">
+    <div class="min-w-0">
+      <div class="truncate text-sm font-medium text-zinc-200">{title ?? 'Code'}</div>
+    </div>
+
+    <div class="flex shrink-0 items-center gap-1">
+      {#if onrun}
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button
+              class="cursor-pointer rounded p-1.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+              onclick={onrun}
+              aria-label="Run code"
+            >
+              <Play class="h-4 w-4" />
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>Run Code</Tooltip.Content>
+        </Tooltip.Root>
+      {/if}
+
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          <button
+            class="cursor-pointer rounded p-1.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+            onclick={onClose}
+            aria-label="Close code editor"
+          >
+            <X class="h-4 w-4" />
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Content>Close Editor</Tooltip.Content>
+      </Tooltip.Root>
+    </div>
+  </div>
+
+  <div class="sidebar-code-editor min-h-0 flex-1 overflow-hidden">
+    {#if target}
+      <CodeEditor
+        {value}
+        onchange={onchange ?? (() => {})}
+        language={target.language}
+        nodeType={target.nodeType}
+        placeholder={target.placeholder ?? ''}
+        class="nodrag nopan nowheel h-full w-full resize-none"
+        onrun={target.onrun}
+        nodeId={target.nodeId}
+        dataKey={target.dataKey}
+      />
+    {:else}
+      <div class="flex h-full items-center justify-center px-4 text-center text-sm text-zinc-500">
+        Open a code editor from a visual node.
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  :global(.sidebar-code-editor .code-editor-container) {
+    width: 100% !important;
+    height: 100% !important;
+    min-height: 0 !important;
+  }
+
+  :global(.sidebar-code-editor .cm-editor) {
+    height: 100% !important;
+    border: none !important;
+    border-radius: 0 !important;
+  }
+
+  :global(.sidebar-code-editor .cm-editor.cm-focused) {
+    border-color: transparent !important;
+  }
+
+  :global(.sidebar-code-editor .cm-scroller) {
+    height: 100% !important;
+  }
+</style>

--- a/ui/src/lib/components/sidebar/SidebarPanel.svelte
+++ b/ui/src/lib/components/sidebar/SidebarPanel.svelte
@@ -10,7 +10,8 @@
     Ellipsis,
     Music,
     MessageSquare,
-    Activity
+    Activity,
+    Code
   } from '@lucide/svelte/icons';
 
   import FileTreeView from './FileTreeView.svelte';
@@ -22,6 +23,7 @@
   import SampleSearchView from './SampleSearchView.svelte';
   import ChatSessionsPanel from './ChatSessionsPanel.svelte';
   import ProfilerView from './ProfilerView.svelte';
+  import SidebarCodeEditorView from './SidebarCodeEditorView.svelte';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import * as ContextMenu from '$lib/components/ui/context-menu';
   import * as Popover from '$lib/components/ui/popover';
@@ -39,6 +41,7 @@
     toggleSidebarTab,
     showSidebarTab
   } from '../../../stores/sidebar-visibility.store';
+  import type { CodeEditorTarget } from '../../../stores/code-editor-layout.store';
 
   import type { AiPromptCallbacks } from '$lib/ai/ai-prompt-controller.svelte';
   import type { ChatNode, ChatGraphSummary, ChatViewportSummary } from '$lib/ai/chat/resolver';
@@ -53,7 +56,13 @@
     getNodeById,
     getGraphSummary,
     getViewportSummary,
-    hasGeminiApiKey = false
+    hasGeminiApiKey = false,
+    codeEditorTarget,
+    codeEditorValue,
+    onCodeEditorChange,
+    codeEditorTitle,
+    onCloseCodeEditor,
+    onRunCodeEditor
   }: {
     open: boolean;
     view?: SidebarView;
@@ -65,6 +74,12 @@
     getGraphSummary?: () => ChatGraphSummary;
     getViewportSummary?: () => ChatViewportSummary;
     hasGeminiApiKey?: boolean;
+    codeEditorTarget?: CodeEditorTarget;
+    codeEditorValue?: string;
+    onCodeEditorChange?: (value: string) => void;
+    codeEditorTitle?: string;
+    onCloseCodeEditor?: () => void;
+    onRunCodeEditor?: () => void;
   } = $props();
 
   // All sidebar views
@@ -77,7 +92,8 @@
     { id: 'samples', icon: Music, title: 'Samples' },
     { id: 'chat', icon: MessageSquare, title: 'Chat', aiOnly: true },
     { id: 'preview', icon: AppWindow, title: 'Patch to App', aiOnly: true },
-    { id: 'profiler', icon: Activity, title: 'Profiler' }
+    { id: 'profiler', icon: Activity, title: 'Profiler' },
+    { id: 'code', icon: Code, title: 'Code' }
   ];
 
   const AI_VIEWS: SidebarView[] = ['chat', 'preview'];
@@ -288,7 +304,7 @@
     </div>
 
     {#if view !== 'chat' && view !== 'profiler'}
-      <div class="min-h-0 flex-1 overflow-y-auto">
+      <div class={['min-h-0 flex-1', view === 'code' ? 'overflow-hidden' : 'overflow-y-auto']}>
         {#if view === 'files'}
           <FileTreeView />
         {:else if view === 'presets'}
@@ -303,6 +319,15 @@
           <SampleSearchView />
         {:else if view === 'preview'}
           <AppPreviewView {onRequestApiKey} {onOpenPatchToApp} />
+        {:else if view === 'code'}
+          <SidebarCodeEditorView
+            target={codeEditorTarget}
+            value={codeEditorValue ?? ''}
+            onchange={onCodeEditorChange}
+            title={codeEditorTitle}
+            onClose={onCloseCodeEditor ?? (() => {})}
+            onrun={onRunCodeEditor}
+          />
         {/if}
       </div>
     {/if}

--- a/ui/src/stores/editor-layout-settings.store.test.ts
+++ b/ui/src/stores/editor-layout-settings.store.test.ts
@@ -48,6 +48,7 @@ describe('editor layout settings store', () => {
     expect(getEditorOpenLayout('inline', true)).toBe('overlay');
     expect(getEditorOpenLayout('overlay', false)).toBe('overlay');
     expect(getEditorOpenLayout('overlay', true)).toBe('inline');
+    expect(getEditorOpenLayout('sidebar', false)).toBe('sidebar');
     expect(getEditorOpenLayout('sidebar', true)).toBe('overlay');
   });
 });

--- a/ui/src/stores/editor-layout-settings.store.ts
+++ b/ui/src/stores/editor-layout-settings.store.ts
@@ -2,7 +2,7 @@ import { writable } from 'svelte/store';
 import { match } from 'ts-pattern';
 
 export type EditorLayoutPreference = 'inline' | 'overlay' | 'sidebar';
-export type EditorOpenLayout = 'inline' | 'overlay';
+export type EditorOpenLayout = 'inline' | 'overlay' | 'sidebar';
 
 const DEFAULT_EDITOR_LAYOUT_KEY = 'editor.defaultLayout';
 const OVERLAY_TRANSPARENCY_KEY = 'editor.overlayTransparency';
@@ -60,14 +60,12 @@ export function getEditorOpenLayout(
   defaultLayout: EditorLayoutPreference,
   useAlternateLayout: boolean
 ): EditorOpenLayout {
-  const preferredLayout = match(defaultLayout)
-    .with('overlay', () => 'overlay' as const)
-    .otherwise(() => 'inline' as const);
-
-  return match([useAlternateLayout, preferredLayout])
+  return match([useAlternateLayout, defaultLayout])
     .with([false, 'inline'], () => 'inline' as const)
     .with([false, 'overlay'], () => 'overlay' as const)
+    .with([false, 'sidebar'], () => 'sidebar' as const)
     .with([true, 'inline'], () => 'overlay' as const)
     .with([true, 'overlay'], () => 'inline' as const)
+    .with([true, 'sidebar'], () => 'overlay' as const)
     .exhaustive();
 }

--- a/ui/src/stores/ui.store.ts
+++ b/ui/src/stores/ui.store.ts
@@ -89,7 +89,8 @@ export type SidebarView =
   | 'preview'
   | 'samples'
   | 'chat'
-  | 'profiler';
+  | 'profiler'
+  | 'code';
 
 const storedSidebarView =
   typeof localStorage !== 'undefined' ? localStorage.getItem('patchies-sidebar-view') : null;


### PR DESCRIPTION
Add sidebar-based code editor layout where code editor appears in a sidebar rather than inline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code editor can open in a new Sidebar view and a new "Code" tab in the sidebar.
  * Sidebar is available as a default editor layout option alongside Inline and Overlay.
  * Inline/Overlay/Sidebar open behavior now respects shift-click alternate-layout selection.

* **Bug Fixes**
  * Detached overlay editor no longer applies temporary background output overrides unexpectedly.

* **Documentation**
  * Design spec updated to include sidebar editor behavior and settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->