### PR TITLE
feat(three): make orbit controls resettable by context menu item

### DIFF
--- a/docs/design-docs/specs/141-three-worker-interaction-controls.md
+++ b/docs/design-docs/specs/141-three-worker-interaction-controls.md
@@ -51,6 +51,8 @@ This is not Three.js' DOM `OrbitControls` addon. It is a worker-safe compatibili
 It intentionally does not require `renderer.domElement`, because worker `three` has no real DOM element.
 Constructing `OrbitControls` should automatically send the same interaction updates as `noDrag()` and `noWheel()` so Patchies canvas gestures do not compete with camera drag and wheel zoom.
 
+When worker `OrbitControls` is constructed, the `three` node preview should expose a camera reset action in the shared preview menu model. The action should appear in both the overflow menu and the right-click context menu, because both menus are driven by the same `ObjectPreviewLayout` action list. Choosing it should reset the registered worker controls to their saved state without sending a user patch message to `onMessage`.
+
 ## Initial OrbitControls Compatibility
 
 Support the practical subset first:
@@ -98,6 +100,18 @@ Defer full parity features such as keyboard listeners, touch gestures, damping, 
 Wheel input needs its own render-worker message because it is a discrete event rather than durable frame state. The wheel payload should include pointer coordinates when available, `deltaX`, `deltaY`, and `deltaMode`.
 
 The `surface` node should forward fullscreen and preview wheel events through the same worker paths: `three` receives `sendThreeWheelData`, and Shader Park 3D receives `zoomShaderParkOrbit`.
+
+## Preview Camera Reset
+
+The reset action should be enabled only after user code constructs at least one worker `OrbitControls` instance with `new OrbitControls(camera)`.
+
+Implementation notes:
+
+- The worker renderer should emit an availability update when controls are registered, and clear it before each code re-run.
+- The UI node should keep that availability as transient component state, not persisted node data.
+- The reset command should use a dedicated render-worker message, similar to wheel forwarding, rather than `sendMessageToNode`; reset is an editor control action, not a user patch message.
+- If multiple controls are registered during one run, reset all live controls. `dispose()` should unregister its control instance.
+- Re-running code should drop stale control registrations before executing the new code.
 
 ## Renderer Reuse
 

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -378,6 +378,13 @@ export class GLSystem {
           enabled: data.enabled
         });
       })
+      .with({ type: 'setThreeOrbitControlsAvailable' }, (data) => {
+        this.eventBus.dispatch({
+          type: 'nodeThreeOrbitControlsAvailabilityUpdate',
+          nodeId: data.nodeId,
+          available: data.available
+        });
+      })
       .with({ type: 'setVideoOutputEnabled' }, (data) => {
         this.eventBus.dispatch({
           type: 'nodeVideoOutputEnabledUpdate',
@@ -773,6 +780,10 @@ export class GLSystem {
       nodeId,
       ...event
     });
+  }
+
+  resetThreeOrbitControls(nodeId: string) {
+    this.send('resetThreeOrbitControls', { nodeId });
   }
 
   zoomShaderParkOrbit(nodeId: string, deltaY: number) {

--- a/ui/src/lib/canvas/constants.ts
+++ b/ui/src/lib/canvas/constants.ts
@@ -227,6 +227,7 @@ scene.add(cube)
 function draw() {
   cube.rotation.x += 0.01
   cube.rotation.y += 0.01
+
   renderer.render(scene, camera)
 }`;
 
@@ -284,15 +285,15 @@ export const DEFAULT_TEXTMODE_CODE = `t.setup(() => {
 
 t.draw(() => {
   t.background(0, 0, 0, 0)
-  
+
   const halfCols = t.grid.cols / 1.95
   const halfRows = t.grid.rows / 1.95
-  
+
   for (let y = -halfRows; y < halfRows; y++) {
     for (let x = -halfCols; x < halfCols; x++) {
       const dist = Math.sqrt(x * x + y * y)
       const wave = Math.sin(dist * 0.2 - t.frameCount * 0.1)
-      
+
       t.push()
       t.translate(x, y, 0)
       t.char(wave > 0.5 ? '▓' : wave > 0 ? '▒' : '░')

--- a/ui/src/lib/components/CanvasPreviewLayout.svelte
+++ b/ui/src/lib/components/CanvasPreviewLayout.svelte
@@ -44,6 +44,7 @@
     onSettingsValueChange = undefined,
     onSettingsRevertAll = undefined,
     extraMenuItems = undefined,
+    displayExtraMenuItems = undefined,
     showBgOutputOption = true,
     showExpandOption = true,
     class: className = ''
@@ -85,6 +86,7 @@
     onSettingsValueChange?: (key: string, value: unknown) => void;
     onSettingsRevertAll?: () => void;
     extraMenuItems?: ExtraMenuItem[];
+    displayExtraMenuItems?: ExtraMenuItem[];
     showBgOutputOption?: boolean;
     showExpandOption?: boolean;
     class?: string;
@@ -129,6 +131,7 @@
   {onSettingsValueChange}
   {onSettingsRevertAll}
   {extraMenuItems}
+  {displayExtraMenuItems}
   class={className}
 >
   {#snippet preview()}

--- a/ui/src/lib/components/ObjectPreviewContextMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewContextMenu.svelte
@@ -25,7 +25,8 @@
     onBgOutputToggle,
     onPlaybackToggle,
     onOpenHelp,
-    extraMenuItems
+    extraMenuItems,
+    displayExtraMenuItems
   }: ObjectPreviewMenuProps = $props();
 
   const menuGroups = $derived(
@@ -48,7 +49,8 @@
       onBgOutputToggle,
       onPlaybackToggle,
       onOpenHelp,
-      extraMenuItems
+      extraMenuItems,
+      displayExtraMenuItems
     })
   );
 

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -73,6 +73,7 @@
     onSettingsValueChange = undefined,
     onSettingsRevertAll = undefined,
     extraMenuItems = undefined,
+    displayExtraMenuItems = undefined,
     class: className = ''
   }: {
     title: string;
@@ -104,6 +105,7 @@
     onSettingsValueChange?: (key: string, value: unknown) => void;
     onSettingsRevertAll?: () => void;
     extraMenuItems?: ExtraMenuItem[];
+    displayExtraMenuItems?: ExtraMenuItem[];
     class?: string;
   } = $props();
 
@@ -417,6 +419,7 @@
                 onPlaybackToggle={handlePlaybackToggle}
                 onOpenHelp={handleOpenHelp}
                 {extraMenuItems}
+                {displayExtraMenuItems}
               />
 
               {#if resolvedPrimary === 'code'}
@@ -511,6 +514,7 @@
       onPlaybackToggle={handlePlaybackToggle}
       onOpenHelp={handleOpenHelp}
       {extraMenuItems}
+      {displayExtraMenuItems}
     />
   </ContextMenu.Root>
 

--- a/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
+++ b/ui/src/lib/components/ObjectPreviewOverflowMenu.svelte
@@ -27,7 +27,8 @@
     onBgOutputToggle,
     onPlaybackToggle,
     onOpenHelp,
-    extraMenuItems
+    extraMenuItems,
+    displayExtraMenuItems
   }: ObjectPreviewMenuProps = $props();
 
   const menuGroups = $derived(
@@ -50,7 +51,8 @@
       onBgOutputToggle,
       onPlaybackToggle,
       onOpenHelp,
-      extraMenuItems
+      extraMenuItems,
+      displayExtraMenuItems
     })
   );
 

--- a/ui/src/lib/components/nodes/JSCanvasNode.svelte
+++ b/ui/src/lib/components/nodes/JSCanvasNode.svelte
@@ -122,16 +122,19 @@
 
   function handleTitleUpdate(e: NodeTitleUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     updateNodeData(nodeId, { title: e.title });
   }
 
   function handleHidePortsUpdate(e: NodeHidePortsUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     updateNodeData(nodeId, { hidePorts: e.hidePorts });
   }
 
   function handleInteractionUpdate(e: NodeInteractionUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     if (e.mode === 'drag') dragEnabled = e.enabled;
     else if (e.mode === 'pan') panEnabled = e.enabled;
     else if (e.mode === 'wheel') wheelEnabled = e.enabled;
@@ -144,7 +147,9 @@
 
   function handleVideoOutputEnabledUpdate(e: NodeVideoOutputEnabledUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     videoOutputEnabled = e.videoOutputEnabled;
+
     updateNodeInternals(nodeId);
   }
 

--- a/ui/src/lib/components/nodes/ReglNode.svelte
+++ b/ui/src/lib/components/nodes/ReglNode.svelte
@@ -131,11 +131,13 @@
 
   function handleTitleUpdate(e: NodeTitleUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     updateNodeData(nodeId, { title: e.title });
   }
 
   function handleHidePortsUpdate(e: NodeHidePortsUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     updateNodeData(nodeId, { hidePorts: e.hidePorts });
   }
 
@@ -162,7 +164,9 @@
 
   function handleVideoOutputEnabledUpdate(e: NodeVideoOutputEnabledUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     videoOutputEnabled = e.videoOutputEnabled;
+
     updateNodeInternals(nodeId);
   }
 

--- a/ui/src/lib/components/nodes/ShaderParkNode.svelte
+++ b/ui/src/lib/components/nodes/ShaderParkNode.svelte
@@ -165,17 +165,21 @@
 
   function handleTitleUpdate(e: NodeTitleUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     updateNodeData(nodeId, { title: e.title });
   }
 
   function handleHidePortsUpdate(e: NodeHidePortsUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     updateNodeData(nodeId, { hidePorts: e.hidePorts });
   }
 
   function handleVideoOutputEnabledUpdate(e: NodeVideoOutputEnabledUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     videoOutputEnabled = e.videoOutputEnabled;
+
     updateNodeInternals(nodeId);
   }
 

--- a/ui/src/lib/components/nodes/TextmodeNode.svelte
+++ b/ui/src/lib/components/nodes/TextmodeNode.svelte
@@ -121,16 +121,19 @@
 
   function handleTitleUpdate(e: NodeTitleUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     updateNodeData(nodeId, { title: e.title });
   }
 
   function handleHidePortsUpdate(e: NodeHidePortsUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     updateNodeData(nodeId, { hidePorts: e.hidePorts });
   }
 
   function handleInteractionUpdate(e: NodeInteractionUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     match(e.mode)
       .with('drag', () => (dragEnabled = e.enabled))
       .with('pan', () => (panEnabled = e.enabled))
@@ -145,7 +148,9 @@
 
   function handleVideoOutputEnabledUpdate(e: NodeVideoOutputEnabledUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     videoOutputEnabled = e.videoOutputEnabled;
+
     updateNodeInternals(nodeId);
   }
 

--- a/ui/src/lib/components/nodes/ThreeNode.svelte
+++ b/ui/src/lib/components/nodes/ThreeNode.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { useSvelteFlow, useUpdateNodeInternals } from '@xyflow/svelte';
+  import { RotateCcw } from '@lucide/svelte/icons';
   import { onMount, onDestroy } from 'svelte';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
   import { MessageContext } from '$lib/messages/MessageContext';
@@ -22,6 +23,7 @@
     NodeTitleUpdateEvent,
     NodeHidePortsUpdateEvent,
     NodeInteractionUpdateEvent,
+    NodeThreeOrbitControlsAvailabilityUpdateEvent,
     NodeVideoOutputEnabledUpdateEvent,
     ConsoleOutputEvent
   } from '$lib/eventbus/events';
@@ -32,6 +34,7 @@
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
   import { CanvasMouseHandler } from '$lib/canvas/CanvasMouseHandler';
+  import type { ExtraMenuItem } from '$lib/components/object-preview-menu-actions';
 
   let {
     id: nodeId,
@@ -90,6 +93,7 @@
   let wheelEnabled = $state(true);
   let videoOutputEnabled = $state(true);
   let editorReady = $state(false);
+  let hasOrbitControls = $state(false);
 
   const { updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
@@ -154,11 +158,13 @@
 
   function handleTitleUpdate(e: NodeTitleUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     updateNodeData(nodeId, { title: e.title });
   }
 
   function handleHidePortsUpdate(e: NodeHidePortsUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     updateNodeData(nodeId, { hidePorts: e.hidePorts });
   }
 
@@ -183,9 +189,17 @@
       .exhaustive();
   }
 
+  function handleOrbitControlsAvailabilityUpdate(e: NodeThreeOrbitControlsAvailabilityUpdateEvent) {
+    if (e.nodeId !== nodeId) return;
+
+    hasOrbitControls = e.available;
+  }
+
   function handleVideoOutputEnabledUpdate(e: NodeVideoOutputEnabledUpdateEvent) {
     if (e.nodeId !== nodeId) return;
+
     videoOutputEnabled = e.videoOutputEnabled;
+
     updateNodeInternals(nodeId);
   }
 
@@ -211,6 +225,18 @@
     }
   };
 
+  const displayExtraMenuItems: ExtraMenuItem[] = $derived(
+    hasOrbitControls
+      ? [
+          {
+            label: 'Reset camera',
+            icon: RotateCcw,
+            onclick: () => glSystem.resetThreeOrbitControls(nodeId)
+          }
+        ]
+      : []
+  );
+
   onMount(() => {
     messageContext = new MessageContext(nodeId);
     messageContext.queue.addCallback(handleMessage);
@@ -222,6 +248,10 @@
     glEventBus.addEventListener('nodeTitleUpdate', handleTitleUpdate);
     glEventBus.addEventListener('nodeHidePortsUpdate', handleHidePortsUpdate);
     glEventBus.addEventListener('nodeInteractionUpdate', handleInteractionUpdate);
+    glEventBus.addEventListener(
+      'nodeThreeOrbitControlsAvailabilityUpdate',
+      handleOrbitControlsAvailabilityUpdate
+    );
     glEventBus.addEventListener('nodeVideoOutputEnabledUpdate', handleVideoOutputEnabledUpdate);
 
     // Listen for console output events to capture lineErrors
@@ -257,6 +287,10 @@
       glEventBus.removeEventListener('nodeHidePortsUpdate', handleHidePortsUpdate);
       glEventBus.removeEventListener('nodeInteractionUpdate', handleInteractionUpdate);
       glEventBus.removeEventListener(
+        'nodeThreeOrbitControlsAvailabilityUpdate',
+        handleOrbitControlsAvailabilityUpdate
+      );
+      glEventBus.removeEventListener(
         'nodeVideoOutputEnabledUpdate',
         handleVideoOutputEnabledUpdate
       );
@@ -290,6 +324,7 @@
     try {
       messageContext?.clearTimers();
       audioAnalysisSystem?.disableFFT(nodeId);
+      hasOrbitControls = false;
 
       glSystem.upsertNode(nodeId, 'three', { code: data.code, _runRevision: Date.now() });
     } catch (error) {
@@ -327,6 +362,7 @@
       glSystem.sendSettingsValueChanged(nodeId, key, value);
     }
   }}
+  {displayExtraMenuItems}
 >
   {#snippet topHandle()}
     {#each Array.from({ length: videoInletCount }, (_, index) => index) as index (index)}

--- a/ui/src/lib/components/object-preview-menu-actions.test.ts
+++ b/ui/src/lib/components/object-preview-menu-actions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RotateCcw } from '@lucide/svelte/icons';
+import { getObjectPreviewMenuGroups } from './object-preview-menu-actions';
+
+describe('object preview menu actions', () => {
+  it('includes extra menu items in the shared top action group', () => {
+    const resetCamera = vi.fn();
+
+    const groups = getObjectPreviewMenuGroups({
+      onOpenHelp: vi.fn(),
+      extraMenuItems: [
+        {
+          label: 'Reset camera',
+          icon: RotateCcw,
+          onclick: resetCamera
+        }
+      ]
+    });
+
+    const resetAction = groups
+      .find((group) => group.id === 'top')
+      ?.actions.find((action) => action.label === 'Reset camera');
+
+    expect(resetAction).toBeDefined();
+
+    resetAction?.onclick({} as MouseEvent);
+
+    expect(resetCamera).toHaveBeenCalledTimes(1);
+  });
+
+  it('appends display extra menu items to the display action group', () => {
+    const expand = vi.fn();
+    const resetCamera = vi.fn();
+
+    const groups = getObjectPreviewMenuGroups({
+      onOpenHelp: vi.fn(),
+      onExpandToggle: expand,
+      displayExtraMenuItems: [
+        {
+          label: 'Reset camera',
+          icon: RotateCcw,
+          onclick: resetCamera
+        }
+      ]
+    });
+
+    const displayActions = groups.find((group) => group.id === 'display')?.actions;
+
+    expect(displayActions?.map((action) => action.label)).toEqual(['Expand', 'Reset camera']);
+
+    displayActions?.at(-1)?.onclick({} as MouseEvent);
+
+    expect(resetCamera).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/lib/components/object-preview-menu-actions.ts
+++ b/ui/src/lib/components/object-preview-menu-actions.ts
@@ -42,6 +42,7 @@ export interface ObjectPreviewMenuProps {
   onPlaybackToggle?: () => void;
   onOpenHelp: () => void;
   extraMenuItems?: ExtraMenuItem[];
+  displayExtraMenuItems?: ExtraMenuItem[];
 }
 
 export type ObjectPreviewMenuActionVariant = 'default' | 'danger' | 'warning';
@@ -83,7 +84,8 @@ export function getObjectPreviewMenuGroups({
   onBgOutputToggle,
   onPlaybackToggle,
   onOpenHelp,
-  extraMenuItems
+  extraMenuItems,
+  displayExtraMenuItems
 }: ObjectPreviewMenuProps): ObjectPreviewMenuGroup[] {
   const topActions: ObjectPreviewMenuAction[] = [];
 
@@ -165,6 +167,16 @@ export function getObjectPreviewMenuGroups({
       label: previewVisible ? 'Hide preview' : 'Show preview',
       icon: previewVisible ? EyeOff : Eye,
       onclick: () => onPreviewToggle()
+    });
+  }
+
+  for (const [index, item] of displayExtraMenuItems?.entries() ?? []) {
+    displayActions.push({
+      id: `display-extra-${index}`,
+      label: item.label,
+      icon: item.icon,
+      onclick: () => item.onclick(),
+      variant: item.variant
     });
   }
 

--- a/ui/src/lib/eventbus/events.ts
+++ b/ui/src/lib/eventbus/events.ts
@@ -11,6 +11,7 @@ export type PatchiesEvent =
   | NodeRunOnMountUpdateEvent
   | NodeHidePortsUpdateEvent
   | NodeInteractionUpdateEvent
+  | NodeThreeOrbitControlsAvailabilityUpdateEvent
   | NodeVideoOutputEnabledUpdateEvent
   | NodeMouseScopeUpdateEvent
   | NodePrimaryButtonUpdateEvent
@@ -112,6 +113,12 @@ export interface NodeInteractionUpdateEvent {
   nodeId: string;
   mode: NodeInteractionMode;
   enabled: boolean;
+}
+
+export interface NodeThreeOrbitControlsAvailabilityUpdateEvent {
+  type: 'nodeThreeOrbitControlsAvailabilityUpdate';
+  nodeId: string;
+  available: boolean;
 }
 
 export interface NodeVideoOutputEnabledUpdateEvent {

--- a/ui/src/lib/rendering/types.ts
+++ b/ui/src/lib/rendering/types.ts
@@ -275,6 +275,11 @@ export type RenderWorkerMessage =
       enabled: boolean;
     }
   | {
+      type: 'setThreeOrbitControlsAvailable';
+      nodeId: string;
+      available: boolean;
+    }
+  | {
       type: 'previewFrameCaptured';
       success: boolean;
       nodeId: string;

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -1440,6 +1440,10 @@ export class FBORenderer {
     this.threeByNode.get(nodeId)?.handleWheelData(event);
   }
 
+  resetThreeOrbitControls(nodeId: string) {
+    this.threeByNode.get(nodeId)?.resetOrbitControls();
+  }
+
   zoomShaderParkOrbit(nodeId: string, deltaY: number) {
     this.shaderParkThreeByNode.get(nodeId)?.zoom(deltaY);
   }

--- a/ui/src/workers/rendering/renderWorker.ts
+++ b/ui/src/workers/rendering/renderWorker.ts
@@ -55,6 +55,7 @@ self.onmessage = (event) => {
         deltaMode: data.deltaMode
       })
     )
+    .with('resetThreeOrbitControls', () => fboRenderer.resetThreeOrbitControls(data.nodeId))
     .with('setOutputSize', () => fboRenderer.setOutputSize(data.width, data.height))
     .with('setBackgroundSize', () => fboRenderer.setBackgroundSize(data.width, data.height))
     .with('setBitmap', () => fboRenderer.setBitmap(data.nodeId, data.bitmap))

--- a/ui/src/workers/rendering/threeRenderer.ts
+++ b/ui/src/workers/rendering/threeRenderer.ts
@@ -7,6 +7,7 @@ import { BaseWorkerRenderer, type BaseRendererConfig } from './BaseWorkerRendere
 import {
   WorkerThreeInteraction,
   createWorkerOrbitControlsClass,
+  type WorkerOrbitControlsRegistration,
   type WorkerWheelEvent
 } from './workerThreeInteraction';
 
@@ -36,6 +37,7 @@ export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
   // Three.js textures wrapping regl textures
   private threeInputTextures: import('three').Texture[] = [];
   private interaction = new WorkerThreeInteraction();
+  private orbitControls = new Set<WorkerOrbitControlsRegistration>();
 
   private constructor(
     config: ThreeRendererConfig,
@@ -167,6 +169,7 @@ export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
 
     this.resetState();
     this.interaction.clearCallbacks();
+    this.clearOrbitControls();
 
     // Cancel any existing animation frame
     if (this.animationId !== null) {
@@ -183,7 +186,7 @@ export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
         THREE,
         this.interaction,
         () => this.renderer.outputSize,
-        () => this.disablePatchCanvasCameraInteractions()
+        (controls) => this.registerOrbitControls(controls)
       );
 
       const extraContext = {
@@ -269,6 +272,46 @@ export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
     this.setInteraction('wheel', false);
   }
 
+  private registerOrbitControls(controls: WorkerOrbitControlsRegistration) {
+    this.disablePatchCanvasCameraInteractions();
+
+    const wasEmpty = this.orbitControls.size === 0;
+    this.orbitControls.add(controls);
+
+    if (wasEmpty) {
+      this.setOrbitControlsAvailable(true);
+    }
+
+    return () => {
+      this.orbitControls.delete(controls);
+
+      if (this.orbitControls.size === 0) {
+        this.setOrbitControlsAvailable(false);
+      }
+    };
+  }
+
+  private clearOrbitControls() {
+    if (this.orbitControls.size === 0) return;
+
+    this.orbitControls.clear();
+    this.setOrbitControlsAvailable(false);
+  }
+
+  private setOrbitControlsAvailable(available: boolean) {
+    self.postMessage({
+      type: 'setThreeOrbitControlsAvailable',
+      nodeId: this.config.nodeId,
+      available
+    });
+  }
+
+  resetOrbitControls() {
+    for (const controls of this.orbitControls) {
+      controls.reset();
+    }
+  }
+
   destroy() {
     if (this.animationId !== null) {
       cancelAnimationFrame(this.animationId);
@@ -276,6 +319,7 @@ export class ThreeRenderer extends BaseWorkerRenderer<ThreeRendererConfig> {
     }
 
     this.renderTarget?.dispose();
+    this.clearOrbitControls();
 
     this.threeWebGLRenderer = null;
     this.renderTarget = null;

--- a/ui/src/workers/rendering/workerThreeInteraction.test.ts
+++ b/ui/src/workers/rendering/workerThreeInteraction.test.ts
@@ -69,6 +69,54 @@ describe('worker three interaction', () => {
     expect(onRegister).toHaveBeenCalledTimes(1);
   });
 
+  it('passes a resettable OrbitControls instance to the registration callback', () => {
+    const interaction = new WorkerThreeInteraction();
+    const registeredControls: Array<{ reset: () => void }> = [];
+
+    const OrbitControls = createWorkerOrbitControlsClass(
+      THREE,
+      interaction,
+      () => [100, 100],
+      (controls) => {
+        registeredControls.push(controls);
+      }
+    );
+
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+    camera.position.set(0, 0, 3);
+    const controls = new OrbitControls(camera);
+
+    controls.rotateLeft(Math.PI / 4);
+    controls.update();
+
+    expect(camera.position.x).not.toBeCloseTo(0);
+
+    registeredControls[0].reset();
+
+    expect(camera.position.x).toBeCloseTo(0);
+    expect(camera.position.y).toBeCloseTo(0);
+    expect(camera.position.z).toBeCloseTo(3);
+  });
+
+  it('unregisters OrbitControls when disposed', () => {
+    const interaction = new WorkerThreeInteraction();
+    const unregister = vi.fn();
+
+    const OrbitControls = createWorkerOrbitControlsClass(
+      THREE,
+      interaction,
+      () => [100, 100],
+      () => unregister
+    );
+
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+    const controls = new OrbitControls(camera);
+
+    controls.dispose();
+
+    expect(unregister).toHaveBeenCalledTimes(1);
+  });
+
   it('mimics OrbitControls right-button panning', () => {
     const interaction = new WorkerThreeInteraction();
 

--- a/ui/src/workers/rendering/workerThreeInteraction.ts
+++ b/ui/src/workers/rendering/workerThreeInteraction.ts
@@ -36,6 +36,10 @@ type OrbitSnapshot = {
   zoom?: number;
 };
 
+export type WorkerOrbitControlsRegistration = {
+  reset: () => void;
+};
+
 export class WorkerThreeInteraction {
   readonly mouse = {
     x: 0,
@@ -177,7 +181,7 @@ export function createWorkerOrbitControlsClass(
   THREE: ThreeModule,
   interaction: WorkerThreeInteraction,
   getSize: () => [number, number],
-  onRegister?: () => void
+  onRegister?: (controls: WorkerOrbitControlsRegistration) => void | (() => void)
 ) {
   return class OrbitControls {
     enabled = true;
@@ -203,6 +207,7 @@ export function createWorkerOrbitControlsClass(
     private position0: Vector3;
     private target0: Vector3;
     private zoom0: number;
+    private unregister: (() => void) | void;
 
     constructor(public object: ControlledCamera) {
       this.target = new THREE.Vector3();
@@ -216,7 +221,7 @@ export function createWorkerOrbitControlsClass(
       this.target0 = this.target.clone();
       this.zoom0 = 'zoom' in object ? object.zoom : 1;
 
-      onRegister?.();
+      this.unregister = onRegister?.(this);
       this.update();
     }
 
@@ -243,7 +248,10 @@ export function createWorkerOrbitControlsClass(
       return changed;
     }
 
-    dispose() {}
+    dispose() {
+      this.unregister?.();
+      this.unregister = undefined;
+    }
 
     saveState() {
       this.position0.copy(this.object.position);


### PR DESCRIPTION
Add menu item to reset orbit control camera when `OrbitControl(camera)` is bound

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added camera reset functionality for Three.js orbit controls, accessible via a new "Reset camera" menu item in both the overflow menu and right-click context menu. The reset action is enabled when orbit controls are active.

* **Tests**
  * Added test coverage for camera reset menu actions and orbit controls registration lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->