### PR TITLE
feat(output): forward code overlay, surface mouse event and surface bitmap

### DIFF
--- a/docs/design-docs/specs/149-secondary-output-overlays-and-input.md
+++ b/docs/design-docs/specs/149-secondary-output-overlays-and-input.md
@@ -1,0 +1,316 @@
+# 149. Secondary Output Overlays And Input
+
+## Problem
+
+The secondary output route at `/output` is intentionally minimal today. It owns a
+single canvas with a `bitmaprenderer` context and paints `ImageBitmap` frames
+from the main render pipeline.
+
+That works for bare fullscreen output, but it misses performance-oriented
+surfaces that now exist in the main window:
+
+- the detached code editor overlay used for display-first live coding
+- the active `surface` overlay canvas
+- pointer, wheel, and touch input that should drive an active `surface`
+
+The secondary output window should mirror these surfaces without becoming a
+second source of truth for patch state.
+
+## Goals
+
+- Mirror the active detached code editor overlay in `/output`.
+- Keep the mirrored code editor display-only. It must not edit code or own a
+  CodeMirror instance.
+- Mirror the active `surface` overlay as a second bitmap layer above the render
+  pipeline bitmap.
+- Forward pointer, wheel, and touch input from `/output` back to the main window
+  when an active surface wants input.
+- Reuse the existing surface input semantics, including touch-to-mouse and
+  pinch-to-wheel behavior.
+- Keep all graph-aware behavior in the main window.
+
+## Non-Goals
+
+- Do not make the secondary code editor editable.
+- Do not run `surface` user code inside `/output`.
+- Do not duplicate `GLSystem`, `SurfaceMouseForwarder`, SvelteFlow graph state,
+  or JavaScript runner state in the secondary window.
+- Do not route surface overlay bitmap mirroring through the render worker.
+
+## Current Architecture
+
+`/output` receives frames from `IpcSystem.sendRenderOutput()`:
+
+```text
+render worker output bitmap
+  -> GLSystem
+  -> IpcSystem.sendRenderOutput(bitmap)
+  -> /output bitmaprenderer canvas
+```
+
+The output route has no local patch graph, no render system, and no SvelteFlow
+context. That boundary should stay intact.
+
+The main window already owns:
+
+- `activeCodeEditorTarget` and node data for detached editor overlays
+- `SurfaceOverlay`, including the fullscreen overlay canvas
+- `SurfaceNode` callbacks such as `onPointer()`, `onTouch()`, and `onKeyDown()`
+- `SurfaceMouseForwarder`, including graph-aware mouse and wheel target lookup
+
+## Design
+
+### 1. Typed secondary-output IPC
+
+Extend `IpcSystem` from a render-output sender into a small typed bridge between
+the main window and `/output`.
+
+Main to output:
+
+```ts
+type MainToOutputMessage =
+  | { type: 'renderOutput'; bitmap: ImageBitmap }
+  | { type: 'codeOverlayState'; state: CodeOverlayMirrorState | null }
+  | { type: 'surfaceOverlayState'; state: SurfaceOverlayMirrorState | null }
+  | { type: 'surfaceOverlayFrame'; bitmap: ImageBitmap };
+```
+
+Output to main:
+
+```ts
+type OutputToMainMessage =
+  | { type: 'outputReady' }
+  | { type: 'outputSurfacePointer'; event: SurfacePointerPayload }
+  | { type: 'outputSurfaceWheel'; event: SurfaceWheelPayload }
+  | { type: 'outputSurfaceTouch'; touches: SurfaceTouchPayload[] }
+  | { type: 'outputSurfaceLeave' };
+```
+
+The exact types should live near `IpcSystem` so both windows use the same
+contract.
+
+### 2. Layered `/output` route
+
+Replace the single output canvas with layered surfaces:
+
+```text
+base render canvas       bitmaprenderer, existing render pipeline frames
+surface overlay canvas   bitmaprenderer, optional active surface mirror
+code overlay DOM         optional display-only code mirror
+```
+
+The base render canvas remains the lowest layer and keeps the existing
+`object-fit: cover` behavior.
+
+The surface overlay canvas uses the same sizing and cover-fit normalization as
+the base canvas so pointer coordinates map consistently to the render output.
+
+The code overlay DOM should visually match `DetachedCodeEditorOverlay.svelte`:
+
+- same translucent background color
+- same fullscreen padding and CodeMirror-like typography
+- same z-order above output visuals
+- no edit cursor, no text input, and no run or close controls in `/output`
+
+The main window remains responsible for closing, running, and editing.
+
+### 3. Display-only code editor mirror
+
+When the main window has an active detached code editor target in overlay mode,
+it sends a serializable snapshot to `/output`:
+
+```ts
+type CodeOverlayMirrorState = {
+  nodeId: string;
+  dataKey: string;
+  value: string;
+  language: string;
+  fontSizePx: number;
+  transparency: number;
+};
+```
+
+The mirror should render plain highlighted or preformatted code. It should not
+instantiate `CodeEditor.svelte`, because the secondary window is display-only and
+does not need CodeMirror state, completions, undo, focus, or keybindings.
+
+For a first pass, preformatted text with the same layout CSS is acceptable.
+Syntax highlighting can be added later if it can be done without making the
+mirror interactive.
+
+The main window sends `null` when the overlay closes, the target is deleted, or
+the target switches to sidebar mode.
+
+### 4. Surface overlay bitmap mirror
+
+When a surface enters fullscreen mode, the main window keeps running that surface
+exactly as it does today. The active `SurfaceNode` still switches its drawing
+target to `SurfaceOverlay.canvas`, and user code still draws into that
+main-window `HTMLCanvasElement`.
+
+To mirror it to `/output`, the main window snapshots the active surface overlay
+canvas and transfers the result directly to the output window:
+
+```ts
+const bitmap = await createImageBitmap(surfaceOverlay.canvas);
+
+outputWindow.postMessage(
+  { type: 'surfaceOverlayFrame', bitmap },
+  { transfer: [bitmap], targetOrigin: '*' }
+);
+```
+
+The output route paints this bitmap into its surface overlay `bitmaprenderer`
+canvas.
+
+This path is intentionally direct:
+
+```text
+main surface canvas
+  -> createImageBitmap(canvas)
+  -> postMessage transfer
+  -> /output surface overlay canvas
+```
+
+It does not pass through the render worker:
+
+```text
+not: /output -> main -> surface -> render worker -> /output
+```
+
+#### Frame throttling
+
+Surface overlay snapshots should be coalesced:
+
+- at most one `createImageBitmap()` in flight
+- at most one surface overlay frame sent per animation frame
+- no frame sent when no secondary output window is connected
+- no frame sent when no surface is active
+
+`drawMode: 'always'` surfaces can request a mirror frame after each draw loop
+tick. `drawMode: 'interact'` and `drawMode: 'manual'` surfaces can request a
+mirror frame after `triggerDraw()` or `redraw()`.
+
+If `createImageBitmap()` fails, log a debug warning and disable that one mirror
+frame. Cross-origin tainted canvas content is the likely failure case.
+
+### 5. Output surface input forwarding
+
+The output route should only capture input while a mirrored surface is active.
+When active, it normalizes local DOM input to the same 0-1 coordinate space used
+by `SurfaceListeners`.
+
+The output route sends normalized input payloads back to the opener:
+
+```text
+/output pointer, wheel, or touch
+  -> normalized output IPC event
+  -> main window active SurfaceNode
+  -> SurfaceNode dispatchPointer / dispatchWheel / onTouch
+  -> SurfaceMouseForwarder
+  -> GLSystem mouse or wheel APIs
+```
+
+The main window remains canonical for:
+
+- `mouse` state exposed to surface code
+- `onPointer()` callbacks
+- `onTouch()` callbacks
+- forwarded render-node mouse targets
+- Hydra global/local mouse scope
+- Shader Park and Three wheel behavior
+
+This avoids duplicated graph logic in `/output`.
+
+### 6. Shared surface input normalization
+
+The current `SurfaceListeners` class already handles:
+
+- cover-fit coordinate normalization
+- pointer move/down/up
+- wheel events
+- touch-to-mouse conversion
+- delayed first-touch down
+- pinch-to-wheel
+- ignoring touch-origin `PointerEvent`s
+
+To prevent drift, extract the reusable input logic from `SurfaceListeners` into
+a small shared helper that can target either local callbacks or output IPC.
+
+One possible shape:
+
+```ts
+type SurfaceInputSink = {
+  pointer(event: PointerEvent_): void;
+  wheel(event: SurfaceWheelEvent_): void;
+  touch(touches: TouchPoint[]): void;
+  leave(): void;
+};
+
+function attachSurfaceInputListeners(
+  canvas: HTMLCanvasElement,
+  sink: SurfaceInputSink
+): () => void;
+```
+
+`SurfaceListeners` can become a thin wrapper around this helper that preserves
+existing error handling for user callbacks. `/output` can use the same helper
+with a sink that posts normalized IPC messages.
+
+## Ordering
+
+1. Add typed IPC helpers and message definitions.
+2. Convert `/output` to layered canvases plus optional display-only code overlay.
+3. Mirror detached code editor overlay state from main to output.
+4. Mirror active surface overlay bitmap frames from main to output.
+5. Forward normalized surface input from output to main.
+6. Extract shared surface input listener logic and move both main and output
+   input paths onto it.
+
+The input helper extraction can happen before step 5 if that makes testing
+cleaner.
+
+## Testing
+
+Unit tests:
+
+- IPC message reducers update output route state correctly.
+- Display-only code overlay escapes code text and does not expose editable
+  controls.
+- Surface input helper preserves existing touch-to-mouse and pinch-to-wheel
+  behavior.
+- Output-origin surface input messages call the same main-window surface dispatch
+  path as local overlay input.
+
+Manual checks:
+
+- Open `/output`, enable background output, and verify the base bitmap still
+  renders.
+- Open a detached code editor overlay and verify `/output` mirrors it
+  display-only.
+- Enter surface fullscreen and verify `/output` shows the surface overlay above
+  the render output.
+- Drag on the output window and verify `surface` `onPointer()` and mouse-aware
+  render nodes respond.
+- Pinch or wheel on the output window and verify Shader Park or Three zoom
+  behavior matches the main surface overlay.
+- Close or reload either window and verify `outputReady` reattaches the bridge.
+
+## Risks
+
+- `createImageBitmap(HTMLCanvasElement)` is asynchronous and may copy pixels, so
+  unthrottled pointermove mirroring could be expensive.
+- Surface overlay mirroring can fail for tainted canvas content.
+- Display-only code mirror syntax highlighting can drift from CodeMirror if it
+  uses a separate highlighter.
+- Two windows can disagree about viewport size. All mirrored layers must use the
+  same cover-fit coordinate math as the existing output bitmap path.
+
+## Open Questions
+
+- Should the display-only code mirror include syntax highlighting in the first
+  pass, or is matching layout and typography enough?
+- Should `/output` show the detached editor mirror only when output target is
+  `screen`, or any time an output window is connected?
+- Should surface overlay mirroring be disabled automatically for very large
+  output sizes if snapshot cost becomes visible?

--- a/docs/design-docs/specs/149-secondary-output-overlays-and-input.md
+++ b/docs/design-docs/specs/149-secondary-output-overlays-and-input.md
@@ -89,6 +89,18 @@ type OutputToMainMessage =
 The exact types should live near `IpcSystem` so both windows use the same
 contract.
 
+The IPC bridge must only trust the paired same-origin window. The main window
+accepts `/output` messages only when `event.origin` matches the app origin and
+`event.source` is the connected output `Window`. The output route accepts main
+messages only from `window.opener` with the same expected origin. All
+`postMessage` calls use that concrete origin instead of `*`.
+
+Both sides validate runtime message shape before dispatching. Render messages
+must include an `ImageBitmap`, overlay state messages must carry either `null`
+or the expected serializable state shape, and output input messages must include
+the required pointer, wheel, or touch numeric fields before they can reach the
+active `SurfaceNode`.
+
 ### 2. Layered `/output` route
 
 Replace the single output canvas with layered surfaces:
@@ -141,6 +153,11 @@ mirror interactive.
 The main window sends `null` when the overlay closes, the target is deleted, or
 the target switches to sidebar mode.
 
+`FlowCanvasInner.svelte` should not own the reactive details for deciding which
+code overlay state to mirror. Keep that in a dedicated canvas composable so the
+component only passes current nodes, detached-editor state, editor display
+settings, and the IPC sender.
+
 ### 4. Surface overlay bitmap mirror
 
 When a surface enters fullscreen mode, the main window keeps running that surface
@@ -156,7 +173,7 @@ const bitmap = await createImageBitmap(surfaceOverlay.canvas);
 
 outputWindow.postMessage(
   { type: 'surfaceOverlayFrame', bitmap },
-  { transfer: [bitmap], targetOrigin: '*' }
+  { transfer: [bitmap], targetOrigin: window.location.origin }
 );
 ```
 

--- a/ui/src/lib/canvas/IpcSystem.ts
+++ b/ui/src/lib/canvas/IpcSystem.ts
@@ -1,5 +1,6 @@
 import {
   dispatchOutputToMainMessage,
+  hasConnectedOutputWindow,
   type CodeOverlayMirrorState,
   type MainToOutputMessage,
   type OutputSurfaceInputSink,
@@ -75,7 +76,7 @@ export class IpcSystem {
   }
 
   requestSurfaceOverlayFrame(canvas: HTMLCanvasElement) {
-    if (!this.outputWindow) return;
+    if (!this.hasConnectedOutputWindow()) return;
 
     this.pendingSurfaceOverlayCanvas = canvas;
 
@@ -90,7 +91,7 @@ export class IpcSystem {
       this.pendingSurfaceOverlayCanvas = null;
 
       if (nextCanvas) {
-        void this.sendSurfaceOverlayFrame(nextCanvas);
+        this.sendSurfaceOverlayFrame(nextCanvas);
       }
     });
   }
@@ -103,8 +104,12 @@ export class IpcSystem {
     this.outputWindow = window.open('/output', '_blank');
   }
 
+  hasConnectedOutputWindow() {
+    return hasConnectedOutputWindow(this.outputWindow);
+  }
+
   private async sendSurfaceOverlayFrame(canvas: HTMLCanvasElement) {
-    if (this.surfaceFrameInFlight || !this.outputWindow) return;
+    if (this.surfaceFrameInFlight || !this.hasConnectedOutputWindow()) return;
 
     this.surfaceFrameInFlight = true;
 

--- a/ui/src/lib/canvas/IpcSystem.ts
+++ b/ui/src/lib/canvas/IpcSystem.ts
@@ -1,10 +1,10 @@
 import {
   dispatchOutputToMainMessage,
   hasConnectedOutputWindow,
+  isOutputToMainMessage,
   type CodeOverlayMirrorState,
   type MainToOutputMessage,
   type OutputSurfaceInputSink,
-  type OutputToMainMessage,
   type SurfaceOverlayMirrorState
 } from './secondary-output-ipc';
 
@@ -15,6 +15,7 @@ export class IpcSystem {
 
   public outputWindow: Window | null = null;
 
+  private outputOrigin: string | null = null;
   private outputSurfaceInputSink: OutputSurfaceInputSink | null = null;
   private pendingSurfaceOverlayCanvas: HTMLCanvasElement | null = null;
 
@@ -37,10 +38,19 @@ export class IpcSystem {
   constructor() {
     // Listen for output window announcing itself (handles reloads on either side)
     window.addEventListener('message', (event) => {
-      const message = event.data as OutputToMainMessage | undefined;
+      if (event.origin !== window.location.origin) return;
+      if (!isWindowMessageSource(event.source)) return;
 
-      if (message?.type === 'outputReady' && event.source) {
-        this.outputWindow = event.source as Window;
+      if (this.outputWindow && !this.outputWindow.closed && event.source !== this.outputWindow) {
+        return;
+      }
+
+      const message = event.data;
+      if (!isOutputToMainMessage(message)) return;
+
+      if (message.type === 'outputReady') {
+        this.outputWindow = event.source;
+        this.outputOrigin = event.origin;
 
         this.postToOutput({ type: 'codeOverlayState', state: this.lastCodeOverlayState });
         this.postToOutput({ type: 'surfaceOverlayState', state: this.lastSurfaceOverlayState });
@@ -102,6 +112,7 @@ export class IpcSystem {
 
   openOutputWindow() {
     this.outputWindow = window.open('/output', '_blank');
+    this.outputOrigin = window.location.origin;
   }
 
   hasConnectedOutputWindow() {
@@ -132,9 +143,17 @@ export class IpcSystem {
   }
 
   private postToOutput(message: MainToOutputMessage, transfer?: Transferable[]) {
+    if (!this.outputOrigin) return;
+
     this.outputWindow?.postMessage(message, {
       transfer,
-      targetOrigin: '*'
+      targetOrigin: this.outputOrigin
     });
   }
+}
+
+function isWindowMessageSource(source: MessageEventSource | null): source is Window {
+  return (
+    typeof source === 'object' && source !== null && 'postMessage' in source && 'closed' in source
+  );
 }

--- a/ui/src/lib/canvas/IpcSystem.ts
+++ b/ui/src/lib/canvas/IpcSystem.ts
@@ -1,9 +1,26 @@
+import {
+  dispatchOutputToMainMessage,
+  type CodeOverlayMirrorState,
+  type MainToOutputMessage,
+  type OutputSurfaceInputSink,
+  type OutputToMainMessage,
+  type SurfaceOverlayMirrorState
+} from './secondary-output-ipc';
+
 const IPC_CHANNEL = 'patchies-ipc';
 
 export class IpcSystem {
   private static instance: IpcSystem;
 
   public outputWindow: Window | null = null;
+
+  private outputSurfaceInputSink: OutputSurfaceInputSink | null = null;
+  private pendingSurfaceOverlayCanvas: HTMLCanvasElement | null = null;
+
+  private surfaceFrameScheduled = false;
+  private surfaceFrameInFlight = false;
+  private lastCodeOverlayState: CodeOverlayMirrorState | null = null;
+  private lastSurfaceOverlayState: SurfaceOverlayMirrorState | null = null;
 
   static getInstance() {
     if (!IpcSystem.instance) {
@@ -19,9 +36,20 @@ export class IpcSystem {
   constructor() {
     // Listen for output window announcing itself (handles reloads on either side)
     window.addEventListener('message', (event) => {
-      if (event.data.type === 'outputReady' && event.source) {
+      const message = event.data as OutputToMainMessage | undefined;
+
+      if (message?.type === 'outputReady' && event.source) {
         this.outputWindow = event.source as Window;
+
+        this.postToOutput({ type: 'codeOverlayState', state: this.lastCodeOverlayState });
+        this.postToOutput({ type: 'surfaceOverlayState', state: this.lastSurfaceOverlayState });
+
+        return;
       }
+
+      if (!message) return;
+
+      dispatchOutputToMainMessage(message, this.outputSurfaceInputSink);
     });
 
     // Ping any existing output windows to re-announce (handles main page reload)
@@ -31,13 +59,77 @@ export class IpcSystem {
   }
 
   sendRenderOutput(bitmap: ImageBitmap) {
-    this.outputWindow?.postMessage(
-      { type: 'renderOutput', bitmap },
-      { transfer: [bitmap], targetOrigin: '*' }
-    );
+    this.postToOutput({ type: 'renderOutput', bitmap }, [bitmap]);
+  }
+
+  sendCodeOverlayState(state: CodeOverlayMirrorState | null) {
+    this.lastCodeOverlayState = state;
+
+    this.postToOutput({ type: 'codeOverlayState', state });
+  }
+
+  sendSurfaceOverlayState(state: SurfaceOverlayMirrorState | null) {
+    this.lastSurfaceOverlayState = state;
+
+    this.postToOutput({ type: 'surfaceOverlayState', state });
+  }
+
+  requestSurfaceOverlayFrame(canvas: HTMLCanvasElement) {
+    if (!this.outputWindow) return;
+
+    this.pendingSurfaceOverlayCanvas = canvas;
+
+    if (this.surfaceFrameScheduled || this.surfaceFrameInFlight) return;
+
+    this.surfaceFrameScheduled = true;
+
+    requestAnimationFrame(() => {
+      this.surfaceFrameScheduled = false;
+
+      const nextCanvas = this.pendingSurfaceOverlayCanvas;
+      this.pendingSurfaceOverlayCanvas = null;
+
+      if (nextCanvas) {
+        void this.sendSurfaceOverlayFrame(nextCanvas);
+      }
+    });
+  }
+
+  setOutputSurfaceInputSink(sink: OutputSurfaceInputSink | null) {
+    this.outputSurfaceInputSink = sink;
   }
 
   openOutputWindow() {
     this.outputWindow = window.open('/output', '_blank');
+  }
+
+  private async sendSurfaceOverlayFrame(canvas: HTMLCanvasElement) {
+    if (this.surfaceFrameInFlight || !this.outputWindow) return;
+
+    this.surfaceFrameInFlight = true;
+
+    try {
+      const bitmap = await createImageBitmap(canvas);
+
+      this.postToOutput({ type: 'surfaceOverlayFrame', bitmap }, [bitmap]);
+    } catch (error) {
+      console.warn('[IpcSystem] Failed to mirror surface overlay frame', error);
+    } finally {
+      this.surfaceFrameInFlight = false;
+
+      if (this.pendingSurfaceOverlayCanvas) {
+        const nextCanvas = this.pendingSurfaceOverlayCanvas;
+
+        this.pendingSurfaceOverlayCanvas = null;
+        this.requestSurfaceOverlayFrame(nextCanvas);
+      }
+    }
+  }
+
+  private postToOutput(message: MainToOutputMessage, transfer?: Transferable[]) {
+    this.outputWindow?.postMessage(message, {
+      transfer,
+      targetOrigin: '*'
+    });
   }
 }

--- a/ui/src/lib/canvas/SurfaceOverlay.ts
+++ b/ui/src/lib/canvas/SurfaceOverlay.ts
@@ -16,6 +16,12 @@ const DOM_RENDERER_TYPES = new Set(['p5', 'canvas.dom', 'textmode.dom', 'three.d
  */
 export const isFullscreenActive = writable(false);
 
+export type SurfacePresentationMode = 'main' | 'secondary';
+
+export type SurfaceOverlayActivateOptions = {
+  presentation?: SurfacePresentationMode;
+};
+
 export class SurfaceOverlay {
   private static _instance: SurfaceOverlay | null = null;
 
@@ -24,6 +30,7 @@ export class SurfaceOverlay {
   private _activeNodeId: string | null = null;
   private _frozenNodeIds: string[] = [];
   private _badge: HTMLButtonElement | null = null;
+  private _secondarySurfaceVisible = false;
 
   private _onEscape: (e: KeyboardEvent) => void;
   private _onExit: (() => void) | null = null;
@@ -92,7 +99,15 @@ export class SurfaceOverlay {
    * @param nodes - All current patch nodes (to find DOM-renderer nodes to freeze)
    * @param onExit - Callback invoked when user exits via Escape or badge
    */
-  activate(nodeId: string, nodes: { id: string; type?: string }[], onExit: () => void): void {
+  activate(
+    nodeId: string,
+    nodes: { id: string; type?: string }[],
+    onExit: () => void,
+    options: SurfaceOverlayActivateOptions = {}
+  ): void {
+    const presentation = options.presentation ?? 'main';
+    this._secondarySurfaceVisible = false;
+
     // Last activated wins — displace previous
     if (this._activeNodeId && this._activeNodeId !== nodeId) {
       this._deactivateInternal(this._activeNodeId, false);
@@ -100,27 +115,36 @@ export class SurfaceOverlay {
 
     this._activeNodeId = nodeId;
 
-    // Show canvas + enable pointer events
-    this._canvas.style.display = 'block';
-    this._canvas.style.pointerEvents = 'all';
+    // Main presentation shows the overlay in this window. Secondary presentation keeps the
+    // canvas as a hidden drawing target while the /output window owns the visible surface.
+    this._canvas.style.display = presentation === 'main' ? 'block' : 'none';
+    this._canvas.style.pointerEvents = presentation === 'main' ? 'all' : 'none';
 
-    // Freeze DOM-renderer nodes (not the surface node itself)
-    const eventBus = PatchiesEventBus.getInstance();
     this._frozenNodeIds = [];
 
-    for (const node of nodes) {
-      if (node.type && DOM_RENDERER_TYPES.has(node.type) && node.id !== nodeId) {
-        eventBus.dispatch({ type: 'nodeSetPaused', nodeId: node.id, paused: true });
-        this._frozenNodeIds.push(node.id);
+    // Freeze DOM-renderer nodes (not the surface node itself)
+    if (presentation === 'main') {
+      const eventBus = PatchiesEventBus.getInstance();
+
+      for (const node of nodes) {
+        if (node.type && DOM_RENDERER_TYPES.has(node.type) && node.id !== nodeId) {
+          eventBus.dispatch({ type: 'nodeSetPaused', nodeId: node.id, paused: true });
+          this._frozenNodeIds.push(node.id);
+        }
       }
     }
 
     this._onExit = onExit;
 
-    isFullscreenActive.set(true);
-    isSidebarOpen.set(false);
+    if (presentation === 'main') {
+      isFullscreenActive.set(true);
+      isSidebarOpen.set(false);
 
-    this._showBadge(onExit);
+      this._showBadge(onExit);
+    } else {
+      isFullscreenActive.set(false);
+      this._showSecondaryToggleButton();
+    }
   }
 
   /**
@@ -137,6 +161,7 @@ export class SurfaceOverlay {
     if (this._activeNodeId !== nodeId) return;
 
     this._activeNodeId = null;
+    this._secondarySurfaceVisible = false;
 
     this._canvas.style.display = 'none';
     this._canvas.style.pointerEvents = 'none';
@@ -203,6 +228,57 @@ export class SurfaceOverlay {
     document.body.appendChild(badge);
 
     this._badge = badge;
+  }
+
+  private _showSecondaryToggleButton(): void {
+    this._removeBadge();
+
+    const button = document.createElement('button');
+
+    button.type = 'button';
+
+    button.style.cssText = `
+      position: fixed;
+      top: 16px;
+      right: 16px;
+      z-index: 51;
+      background: rgba(0,0,0,0.55);
+      color: rgba(255,255,255,0.72);
+      font-family: ui-monospace, monospace;
+      font-size: 12px;
+      padding: 6px 10px;
+      border-radius: 6px;
+      cursor: pointer;
+      border: 1px solid rgba(255,255,255,0.16);
+      transition: color 0.15s, background 0.15s;
+      user-select: none;
+    `;
+
+    const syncButton = () => {
+      button.textContent = this._secondarySurfaceVisible ? 'Hide surface' : 'Show surface';
+    };
+
+    button.addEventListener('mouseenter', () => {
+      button.style.color = 'rgba(255,255,255,0.95)';
+      button.style.background = 'rgba(0,0,0,0.78)';
+    });
+
+    button.addEventListener('mouseleave', () => {
+      button.style.color = 'rgba(255,255,255,0.72)';
+      button.style.background = 'rgba(0,0,0,0.55)';
+    });
+
+    button.addEventListener('click', () => {
+      this._secondarySurfaceVisible = !this._secondarySurfaceVisible;
+      this._canvas.style.display = this._secondarySurfaceVisible ? 'block' : 'none';
+      this._canvas.style.pointerEvents = this._secondarySurfaceVisible ? 'all' : 'none';
+      syncButton();
+    });
+
+    syncButton();
+    document.body.appendChild(button);
+
+    this._badge = button;
   }
 
   hideBadge(): void {

--- a/ui/src/lib/canvas/secondary-output-ipc.test.ts
+++ b/ui/src/lib/canvas/secondary-output-ipc.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createCodeOverlayMirrorState,
+  dispatchOutputToMainMessage,
+  highlightCodeOverlayValue,
+  syncCanvasSizeToBitmap
+} from './secondary-output-ipc';
+import type { CodeEditorTarget } from '../../stores/code-editor-layout.store';
+
+describe('secondary output IPC', () => {
+  it('creates a serializable display-only code overlay state from an overlay target', () => {
+    const target: CodeEditorTarget = {
+      nodeId: 'node-1',
+      dataKey: 'code',
+      language: 'javascript',
+      nodeType: 'p5',
+      title: 'Sketch',
+      placeholder: 'Write code',
+      onrun: () => {},
+      mode: 'overlay'
+    };
+
+    expect(createCodeOverlayMirrorState(target, 'circle(20, 20, 10)', 28, 0.72)).toEqual({
+      nodeId: 'node-1',
+      dataKey: 'code',
+      value: 'circle(20, 20, 10)',
+      language: 'javascript',
+      nodeType: 'p5',
+      title: 'Sketch',
+      fontSizePx: 28,
+      transparency: 0.72
+    });
+  });
+
+  it('does not mirror sidebar targets', () => {
+    const target: CodeEditorTarget = {
+      nodeId: 'node-1',
+      dataKey: 'code',
+      language: 'javascript',
+      mode: 'sidebar'
+    };
+
+    expect(createCodeOverlayMirrorState(target, 'code', 28, 0.72)).toBeNull();
+  });
+
+  it('routes output surface input messages to the active sink', () => {
+    const events: unknown[] = [];
+    const sink = {
+      pointer: (event: unknown) => events.push(['pointer', event]),
+      wheel: (event: unknown) => events.push(['wheel', event]),
+      touch: (touches: unknown) => events.push(['touch', touches]),
+      leave: () => events.push(['leave'])
+    };
+
+    dispatchOutputToMainMessage(
+      {
+        type: 'outputSurfacePointer',
+        event: { x: 0.25, y: 0.5, pressure: 0, buttons: 1, down: true, type: 'down' }
+      },
+      sink
+    );
+
+    dispatchOutputToMainMessage(
+      {
+        type: 'outputSurfaceWheel',
+        event: { x: 0.25, y: 0.5, deltaX: 0, deltaY: -12, deltaMode: 0 }
+      },
+      sink
+    );
+
+    dispatchOutputToMainMessage(
+      {
+        type: 'outputSurfaceTouch',
+        touches: [{ id: 1, x: 0.25, y: 0.5, pressure: 0.5 }]
+      },
+      sink
+    );
+
+    dispatchOutputToMainMessage({ type: 'outputSurfaceLeave' }, sink);
+
+    expect(events).toEqual([
+      ['pointer', { x: 0.25, y: 0.5, pressure: 0, buttons: 1, down: true, type: 'down' }],
+      ['wheel', { x: 0.25, y: 0.5, deltaX: 0, deltaY: -12, deltaMode: 0 }],
+      ['touch', [{ id: 1, x: 0.25, y: 0.5, pressure: 0.5 }]],
+      ['leave']
+    ]);
+  });
+
+  it('ignores output surface input messages without an active sink', () => {
+    expect(() =>
+      dispatchOutputToMainMessage(
+        {
+          type: 'outputSurfacePointer',
+          event: { x: 0, y: 0, pressure: 0, buttons: 0, down: false, type: 'move' }
+        },
+        null
+      )
+    ).not.toThrow();
+  });
+
+  it('highlights display-only code overlay values while escaping unknown languages', () => {
+    const highlighted = highlightCodeOverlayValue('const value = 1;', 'javascript');
+    const plain = highlightCodeOverlayValue('<script>alert(1)</script>', 'uiua');
+
+    expect(highlighted).toContain('hljs-keyword');
+    expect(plain).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('syncs mirror canvas dimensions to incoming bitmap dimensions', () => {
+    const canvas = { width: 1920, height: 1080 } as HTMLCanvasElement;
+    const bitmap = { width: 1008, height: 654 } as ImageBitmap;
+
+    syncCanvasSizeToBitmap(canvas, bitmap);
+
+    expect(canvas.width).toBe(1008);
+    expect(canvas.height).toBe(654);
+  });
+});

--- a/ui/src/lib/canvas/secondary-output-ipc.test.ts
+++ b/ui/src/lib/canvas/secondary-output-ipc.test.ts
@@ -5,6 +5,7 @@ import {
   dispatchOutputToMainMessage,
   hasConnectedOutputWindow,
   highlightCodeOverlayValue,
+  isMainToOutputMessage,
   syncCanvasSizeToBitmap
 } from './secondary-output-ipc';
 import type { CodeEditorTarget } from '../../stores/code-editor-layout.store';
@@ -113,6 +114,42 @@ describe('secondary output IPC', () => {
         null
       )
     ).not.toThrow();
+  });
+
+  it('rejects malformed output surface input messages before dispatching', () => {
+    const events: unknown[] = [];
+    const sink = {
+      pointer: (event: unknown) => events.push(['pointer', event]),
+      wheel: (event: unknown) => events.push(['wheel', event]),
+      touch: (touches: unknown) => events.push(['touch', touches]),
+      leave: () => events.push(['leave'])
+    };
+
+    dispatchOutputToMainMessage({ type: 'outputSurfacePointer', event: { x: 0.25 } }, sink);
+    dispatchOutputToMainMessage(
+      { type: 'outputSurfaceWheel', event: { x: 0.25, y: 0.5, deltaY: -12 } },
+      sink
+    );
+    dispatchOutputToMainMessage({ type: 'outputSurfaceTouch', touches: [{ id: 1 }] }, sink);
+    dispatchOutputToMainMessage({ type: 'unknown' }, sink);
+
+    expect(events).toEqual([]);
+  });
+
+  it('validates main-to-output message payloads', () => {
+    const bitmap = { width: 1008, height: 654, close: () => {} } as ImageBitmap;
+
+    expect(isMainToOutputMessage({ type: 'renderOutput', bitmap })).toBe(true);
+    expect(isMainToOutputMessage({ type: 'surfaceOverlayFrame', bitmap })).toBe(true);
+    expect(isMainToOutputMessage({ type: 'renderOutput' })).toBe(false);
+    expect(isMainToOutputMessage({ type: 'surfaceOverlayFrame', bitmap: {} })).toBe(false);
+    expect(isMainToOutputMessage({ type: 'codeOverlayState', state: null })).toBe(true);
+    expect(isMainToOutputMessage({ type: 'surfaceOverlayState', state: { active: true } })).toBe(
+      true
+    );
+    expect(isMainToOutputMessage({ type: 'surfaceOverlayState', state: { active: 'yes' } })).toBe(
+      false
+    );
   });
 
   it('highlights display-only code overlay values while escaping unknown languages', () => {

--- a/ui/src/lib/canvas/secondary-output-ipc.test.ts
+++ b/ui/src/lib/canvas/secondary-output-ipc.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createCodeOverlayMirrorState,
   dispatchOutputToMainMessage,
+  hasConnectedOutputWindow,
   highlightCodeOverlayValue,
   syncCanvasSizeToBitmap
 } from './secondary-output-ipc';
@@ -114,5 +115,11 @@ describe('secondary output IPC', () => {
 
     expect(canvas.width).toBe(1008);
     expect(canvas.height).toBe(654);
+  });
+
+  it('treats a non-closed output window as connected', () => {
+    expect(hasConnectedOutputWindow(null)).toBe(false);
+    expect(hasConnectedOutputWindow({ closed: true })).toBe(false);
+    expect(hasConnectedOutputWindow({ closed: false })).toBe(true);
   });
 });

--- a/ui/src/lib/canvas/secondary-output-ipc.test.ts
+++ b/ui/src/lib/canvas/secondary-output-ipc.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   createCodeOverlayMirrorState,
+  createDetachedStrudelCodeOverlayMirrorState,
   dispatchOutputToMainMessage,
   hasConnectedOutputWindow,
   highlightCodeOverlayValue,
@@ -42,6 +43,21 @@ describe('secondary output IPC', () => {
     };
 
     expect(createCodeOverlayMirrorState(target, 'code', 28, 0.72)).toBeNull();
+  });
+
+  it('creates a display-only code overlay state for detached strudel code', () => {
+    expect(
+      createDetachedStrudelCodeOverlayMirrorState('strudel-1', 's("bd sd")', 28, 0.72)
+    ).toEqual({
+      nodeId: 'strudel-1',
+      dataKey: 'code',
+      value: 's("bd sd")',
+      language: 'javascript',
+      nodeType: 'strudel',
+      title: 'strudel',
+      fontSizePx: 28,
+      transparency: 0.72
+    });
   });
 
   it('routes output surface input messages to the active sink', () => {

--- a/ui/src/lib/canvas/secondary-output-ipc.ts
+++ b/ui/src/lib/canvas/secondary-output-ipc.ts
@@ -86,6 +86,24 @@ export function createCodeOverlayMirrorState(
   };
 }
 
+export function createDetachedStrudelCodeOverlayMirrorState(
+  nodeId: string,
+  value: string,
+  fontSizePx: number,
+  transparency: number
+): CodeOverlayMirrorState {
+  return {
+    nodeId,
+    dataKey: 'code',
+    value,
+    language: 'javascript',
+    nodeType: 'strudel',
+    title: 'strudel',
+    fontSizePx,
+    transparency
+  };
+}
+
 export function dispatchOutputToMainMessage(
   message: OutputToMainMessage,
   sink: OutputSurfaceInputSink | null

--- a/ui/src/lib/canvas/secondary-output-ipc.ts
+++ b/ui/src/lib/canvas/secondary-output-ipc.ts
@@ -86,28 +86,27 @@ export function createCodeOverlayMirrorState(
   };
 }
 
-export function createDetachedStrudelCodeOverlayMirrorState(
+export const createDetachedStrudelCodeOverlayMirrorState = (
   nodeId: string,
   value: string,
   fontSizePx: number,
   transparency: number
-): CodeOverlayMirrorState {
-  return {
-    nodeId,
-    dataKey: 'code',
-    value,
-    language: 'javascript',
-    nodeType: 'strudel',
-    title: 'strudel',
-    fontSizePx,
-    transparency
-  };
-}
+): CodeOverlayMirrorState => ({
+  nodeId,
+  dataKey: 'code',
+  value,
+  language: 'javascript',
+  nodeType: 'strudel',
+  title: 'strudel',
+  fontSizePx,
+  transparency
+});
 
 export function dispatchOutputToMainMessage(
-  message: OutputToMainMessage,
+  message: unknown,
   sink: OutputSurfaceInputSink | null
 ): void {
+  if (!isOutputToMainMessage(message)) return;
   if (!sink) return;
 
   if (message.type === 'outputSurfacePointer') {
@@ -119,6 +118,46 @@ export function dispatchOutputToMainMessage(
   } else if (message.type === 'outputSurfaceLeave') {
     sink.leave();
   }
+}
+
+export function isMainToOutputMessage(message: unknown): message is MainToOutputMessage {
+  if (!isRecord(message) || typeof message.type !== 'string') return false;
+
+  if (message.type === 'renderOutput' || message.type === 'surfaceOverlayFrame') {
+    return isImageBitmapLike(message.bitmap);
+  }
+
+  if (message.type === 'codeOverlayState') {
+    return message.state === null || isCodeOverlayMirrorState(message.state);
+  }
+
+  if (message.type === 'surfaceOverlayState') {
+    return message.state === null || isSurfaceOverlayMirrorState(message.state);
+  }
+
+  return false;
+}
+
+export function isOutputToMainMessage(message: unknown): message is OutputToMainMessage {
+  if (!isRecord(message) || typeof message.type !== 'string') return false;
+
+  if (message.type === 'outputReady' || message.type === 'outputSurfaceLeave') {
+    return true;
+  }
+
+  if (message.type === 'outputSurfacePointer') {
+    return isPointerEventPayload(message.event);
+  }
+
+  if (message.type === 'outputSurfaceWheel') {
+    return isWheelEventPayload(message.event);
+  }
+
+  if (message.type === 'outputSurfaceTouch') {
+    return Array.isArray(message.touches) && message.touches.every(isTouchPointPayload);
+  }
+
+  return false;
 }
 
 export function highlightCodeOverlayValue(value: string, language: SupportedLanguage): string {
@@ -141,17 +180,67 @@ export function syncCanvasSizeToBitmap(canvas: HTMLCanvasElement, bitmap: ImageB
   }
 }
 
-export function hasConnectedOutputWindow(
+export const hasConnectedOutputWindow = (
   outputWindow: Pick<Window, 'closed'> | null | undefined
-): boolean {
-  return outputWindow !== null && outputWindow !== undefined && !outputWindow.closed;
-}
+): boolean => outputWindow !== null && outputWindow !== undefined && !outputWindow.closed;
 
-function escapeHtml(value: string): string {
-  return value
+const escapeHtml = (value: string): string =>
+  value
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
-}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === 'string';
+
+const isImageBitmapLike = (value: unknown): value is ImageBitmap =>
+  isRecord(value) &&
+  isFiniteNumber(value.width) &&
+  isFiniteNumber(value.height) &&
+  typeof value.close === 'function';
+
+const isCodeOverlayMirrorState = (value: unknown): value is CodeOverlayMirrorState =>
+  isRecord(value) &&
+  typeof value.nodeId === 'string' &&
+  typeof value.dataKey === 'string' &&
+  typeof value.value === 'string' &&
+  typeof value.language === 'string' &&
+  isOptionalString(value.nodeType) &&
+  isOptionalString(value.title) &&
+  isFiniteNumber(value.fontSizePx) &&
+  isFiniteNumber(value.transparency);
+
+const isSurfaceOverlayMirrorState = (value: unknown): value is SurfaceOverlayMirrorState =>
+  isRecord(value) && typeof value.active === 'boolean';
+
+const isPointerEventPayload = (value: unknown): value is PointerEvent_ =>
+  isRecord(value) &&
+  isFiniteNumber(value.x) &&
+  isFiniteNumber(value.y) &&
+  isFiniteNumber(value.pressure) &&
+  isFiniteNumber(value.buttons) &&
+  typeof value.down === 'boolean' &&
+  typeof value.type === 'string';
+
+const isWheelEventPayload = (value: unknown): value is SurfaceWheelEvent_ =>
+  isRecord(value) &&
+  isFiniteNumber(value.x) &&
+  isFiniteNumber(value.y) &&
+  isFiniteNumber(value.deltaX) &&
+  isFiniteNumber(value.deltaY) &&
+  isFiniteNumber(value.deltaMode);
+
+const isTouchPointPayload = (value: unknown): value is TouchPoint =>
+  isRecord(value) &&
+  isFiniteNumber(value.id) &&
+  isFiniteNumber(value.x) &&
+  isFiniteNumber(value.y) &&
+  isFiniteNumber(value.pressure);

--- a/ui/src/lib/canvas/secondary-output-ipc.ts
+++ b/ui/src/lib/canvas/secondary-output-ipc.ts
@@ -123,6 +123,12 @@ export function syncCanvasSizeToBitmap(canvas: HTMLCanvasElement, bitmap: ImageB
   }
 }
 
+export function hasConnectedOutputWindow(
+  outputWindow: Pick<Window, 'closed'> | null | undefined
+): boolean {
+  return outputWindow !== null && outputWindow !== undefined && !outputWindow.closed;
+}
+
 function escapeHtml(value: string): string {
   return value
     .replaceAll('&', '&amp;')

--- a/ui/src/lib/canvas/secondary-output-ipc.ts
+++ b/ui/src/lib/canvas/secondary-output-ipc.ts
@@ -1,0 +1,133 @@
+import hljs from 'highlight.js/lib/core';
+import glsl from 'highlight.js/lib/languages/glsl';
+import javascript from 'highlight.js/lib/languages/javascript';
+import markdown from 'highlight.js/lib/languages/markdown';
+import plaintext from 'highlight.js/lib/languages/plaintext';
+import python from 'highlight.js/lib/languages/python';
+import ruby from 'highlight.js/lib/languages/ruby';
+import wasm from 'highlight.js/lib/languages/wasm';
+import x86asm from 'highlight.js/lib/languages/x86asm';
+import type { SupportedLanguage } from '$lib/codemirror/types';
+import type { CodeEditorTarget } from '../../stores/code-editor-layout.store';
+import type { PointerEvent_, SurfaceWheelEvent_, TouchPoint } from './SurfaceListeners';
+
+hljs.registerLanguage('glsl', glsl);
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('markdown', markdown);
+hljs.registerLanguage('plain', plaintext);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('ruby', ruby);
+hljs.registerLanguage('wasm', wasm);
+hljs.registerLanguage('x86asm', x86asm);
+
+const HIGHLIGHT_LANGUAGE_BY_EDITOR_LANGUAGE: Partial<Record<SupportedLanguage, string>> = {
+  assembly: 'x86asm',
+  glsl: 'glsl',
+  javascript: 'javascript',
+  markdown: 'markdown',
+  plain: 'plain',
+  python: 'python',
+  ruby: 'ruby',
+  wgsl: 'glsl'
+};
+
+export type CodeOverlayMirrorState = {
+  nodeId: string;
+  dataKey: string;
+  value: string;
+  language: SupportedLanguage;
+  nodeType?: string;
+  title?: string;
+  fontSizePx: number;
+  transparency: number;
+};
+
+export type SurfaceOverlayMirrorState = {
+  active: boolean;
+};
+
+export type MainToOutputMessage =
+  | { type: 'renderOutput'; bitmap: ImageBitmap }
+  | { type: 'codeOverlayState'; state: CodeOverlayMirrorState | null }
+  | { type: 'surfaceOverlayState'; state: SurfaceOverlayMirrorState | null }
+  | { type: 'surfaceOverlayFrame'; bitmap: ImageBitmap };
+
+export type OutputToMainMessage =
+  | { type: 'outputReady' }
+  | { type: 'outputSurfacePointer'; event: PointerEvent_ }
+  | { type: 'outputSurfaceWheel'; event: SurfaceWheelEvent_ }
+  | { type: 'outputSurfaceTouch'; touches: TouchPoint[] }
+  | { type: 'outputSurfaceLeave' };
+
+export type OutputSurfaceInputSink = {
+  pointer(event: PointerEvent_): void;
+  wheel(event: SurfaceWheelEvent_): void;
+  touch(touches: TouchPoint[]): void;
+  leave(): void;
+};
+
+export function createCodeOverlayMirrorState(
+  target: CodeEditorTarget | null,
+  value: string,
+  fontSizePx: number,
+  transparency: number
+): CodeOverlayMirrorState | null {
+  if (target?.mode !== 'overlay') return null;
+
+  return {
+    nodeId: target.nodeId,
+    dataKey: target.dataKey,
+    value,
+    language: target.language,
+    nodeType: target.nodeType,
+    title: target.title,
+    fontSizePx,
+    transparency
+  };
+}
+
+export function dispatchOutputToMainMessage(
+  message: OutputToMainMessage,
+  sink: OutputSurfaceInputSink | null
+): void {
+  if (!sink) return;
+
+  if (message.type === 'outputSurfacePointer') {
+    sink.pointer(message.event);
+  } else if (message.type === 'outputSurfaceWheel') {
+    sink.wheel(message.event);
+  } else if (message.type === 'outputSurfaceTouch') {
+    sink.touch(message.touches);
+  } else if (message.type === 'outputSurfaceLeave') {
+    sink.leave();
+  }
+}
+
+export function highlightCodeOverlayValue(value: string, language: SupportedLanguage): string {
+  const highlightLanguage = HIGHLIGHT_LANGUAGE_BY_EDITOR_LANGUAGE[language];
+
+  if (!highlightLanguage || !hljs.getLanguage(highlightLanguage)) {
+    return escapeHtml(value);
+  }
+
+  return hljs.highlight(value, { language: highlightLanguage, ignoreIllegals: true }).value;
+}
+
+export function syncCanvasSizeToBitmap(canvas: HTMLCanvasElement, bitmap: ImageBitmap): void {
+  if (canvas.width !== bitmap.width) {
+    canvas.width = bitmap.width;
+  }
+
+  if (canvas.height !== bitmap.height) {
+    canvas.height = bitmap.height;
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}

--- a/ui/src/lib/canvas/use-secondary-output-code-overlay.svelte.ts
+++ b/ui/src/lib/canvas/use-secondary-output-code-overlay.svelte.ts
@@ -1,0 +1,81 @@
+import type { Node } from '@xyflow/svelte';
+import type { CodeEditorTarget } from '../../stores/code-editor-layout.store';
+import {
+  createCodeOverlayMirrorState,
+  createDetachedStrudelCodeOverlayMirrorState,
+  type CodeOverlayMirrorState
+} from './secondary-output-ipc';
+
+type SecondaryOutputCodeOverlayOptions = {
+  getNodes: () => Node[];
+  getActiveDetachedStrudelNodeId: () => string | null;
+  getActiveCodeEditorTarget: () => CodeEditorTarget | null;
+  getDetachedCodeEditorValue: () => string;
+  getFontSizePx: () => number;
+  getTransparency: () => number;
+  sendCodeOverlayState: (state: CodeOverlayMirrorState | null) => void;
+};
+
+type SecondaryOutputCodeOverlayStateOptions = {
+  nodes: Node[];
+  activeDetachedStrudelNodeId: string | null;
+  activeCodeEditorTarget: CodeEditorTarget | null;
+  detachedCodeEditorValue: string;
+  fontSizePx: number;
+  transparency: number;
+};
+
+export function useSecondaryOutputCodeOverlay({
+  getNodes,
+  getActiveDetachedStrudelNodeId,
+  getActiveCodeEditorTarget,
+  getDetachedCodeEditorValue,
+  getFontSizePx,
+  getTransparency,
+  sendCodeOverlayState
+}: SecondaryOutputCodeOverlayOptions) {
+  $effect(() => {
+    sendCodeOverlayState(
+      getSecondaryOutputCodeOverlayState({
+        nodes: getNodes(),
+        activeDetachedStrudelNodeId: getActiveDetachedStrudelNodeId(),
+        activeCodeEditorTarget: getActiveCodeEditorTarget(),
+        detachedCodeEditorValue: getDetachedCodeEditorValue(),
+        fontSizePx: getFontSizePx(),
+        transparency: getTransparency()
+      })
+    );
+  });
+}
+
+export function getSecondaryOutputCodeOverlayState({
+  nodes,
+  activeDetachedStrudelNodeId,
+  activeCodeEditorTarget,
+  detachedCodeEditorValue,
+  fontSizePx,
+  transparency
+}: SecondaryOutputCodeOverlayStateOptions): CodeOverlayMirrorState | null {
+  const detachedStrudelNode =
+    activeDetachedStrudelNodeId === null
+      ? undefined
+      : nodes.find((node) => node.id === activeDetachedStrudelNodeId);
+
+  const detachedStrudelCode = detachedStrudelNode?.data?.code;
+
+  if (activeDetachedStrudelNodeId && typeof detachedStrudelCode === 'string') {
+    return createDetachedStrudelCodeOverlayMirrorState(
+      activeDetachedStrudelNodeId,
+      detachedStrudelCode,
+      fontSizePx,
+      transparency
+    );
+  }
+
+  return createCodeOverlayMirrorState(
+    activeCodeEditorTarget,
+    detachedCodeEditorValue,
+    fontSizePx,
+    transparency
+  );
+}

--- a/ui/src/lib/canvas/use-secondary-output-code-overlay.test.ts
+++ b/ui/src/lib/canvas/use-secondary-output-code-overlay.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import type { Node } from '@xyflow/svelte';
+import type { CodeEditorTarget } from '../../stores/code-editor-layout.store';
+import { getSecondaryOutputCodeOverlayState } from './use-secondary-output-code-overlay.svelte';
+
+describe('secondary output code overlay composable', () => {
+  it('mirrors detached Strudel code ahead of the active code editor target', () => {
+    const nodes = [
+      {
+        id: 'strudel-1',
+        type: 'strudel',
+        position: { x: 0, y: 0 },
+        data: { code: 's("bd")' }
+      }
+    ] satisfies Node[];
+    const activeCodeEditorTarget: CodeEditorTarget = {
+      nodeId: 'p5-1',
+      dataKey: 'code',
+      language: 'javascript',
+      mode: 'overlay'
+    };
+
+    expect(
+      getSecondaryOutputCodeOverlayState({
+        nodes,
+        activeDetachedStrudelNodeId: 'strudel-1',
+        activeCodeEditorTarget,
+        detachedCodeEditorValue: 'circle(20, 20, 10)',
+        fontSizePx: 32,
+        transparency: 0.6
+      })
+    ).toEqual({
+      nodeId: 'strudel-1',
+      dataKey: 'code',
+      value: 's("bd")',
+      language: 'javascript',
+      nodeType: 'strudel',
+      title: 'strudel',
+      fontSizePx: 32,
+      transparency: 0.6
+    });
+  });
+
+  it('falls back to the active editor overlay state when there is no detached Strudel code', () => {
+    const activeCodeEditorTarget: CodeEditorTarget = {
+      nodeId: 'p5-1',
+      dataKey: 'code',
+      language: 'javascript',
+      mode: 'overlay',
+      nodeType: 'p5',
+      title: 'p5'
+    };
+
+    expect(
+      getSecondaryOutputCodeOverlayState({
+        nodes: [],
+        activeDetachedStrudelNodeId: null,
+        activeCodeEditorTarget,
+        detachedCodeEditorValue: 'circle(20, 20, 10)',
+        fontSizePx: 28,
+        transparency: 0.72
+      })
+    ).toEqual({
+      nodeId: 'p5-1',
+      dataKey: 'code',
+      value: 'circle(20, 20, 10)',
+      language: 'javascript',
+      nodeType: 'p5',
+      title: 'p5',
+      fontSizePx: 28,
+      transparency: 0.72
+    });
+  });
+
+  it('returns null when no code overlay should be mirrored', () => {
+    expect(
+      getSecondaryOutputCodeOverlayState({
+        nodes: [],
+        activeDetachedStrudelNodeId: null,
+        activeCodeEditorTarget: null,
+        detachedCodeEditorValue: '',
+        fontSizePx: 28,
+        transparency: 0.72
+      })
+    ).toBeNull();
+  });
+});

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -91,6 +91,7 @@
   import { buildAudioSourceConnections } from '$lib/composables/checkHandleConnections';
   import { getSurfaceMouseForwardingKey } from '$lib/canvas/surfaceMouseForwarding';
   import { useDetachedCodeEditorOverlay } from '$lib/canvas/use-detached-code-editor-overlay.svelte';
+  import { createCodeOverlayMirrorState } from '$lib/canvas/secondary-output-ipc';
 
   import { toast } from 'svelte-sonner';
   import { Transport } from '$lib/transport';
@@ -101,6 +102,7 @@
     closeCodeEditorOverlay
   } from '../../stores/code-editor-layout.store';
   import { editorFullscreenFontSize } from '../../stores/editor.store';
+  import { overlayEditorTransparency } from '../../stores/editor-layout-settings.store';
   import { isFullscreenActive } from '$lib/canvas/SurfaceOverlay';
   import { PREVIEW_ZOOM_LOD_TIERS } from '$workers/rendering/constants';
   import { initializeVFS } from '$lib/vfs';
@@ -270,6 +272,17 @@
     setNodes: (nextNodes) => (nodes = nextNodes),
     getEdges: () => edges,
     glSystem
+  });
+
+  $effect(() => {
+    const state = createCodeOverlayMirrorState(
+      $activeCodeEditorTarget,
+      detachedCodeEditor.value,
+      $editorFullscreenFontSize,
+      $overlayEditorTransparency
+    );
+
+    glSystem.ipcSystem.sendCodeOverlayState(state);
   });
 
   // Viewport culling for preview rendering optimization

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -91,7 +91,10 @@
   import { buildAudioSourceConnections } from '$lib/composables/checkHandleConnections';
   import { getSurfaceMouseForwardingKey } from '$lib/canvas/surfaceMouseForwarding';
   import { useDetachedCodeEditorOverlay } from '$lib/canvas/use-detached-code-editor-overlay.svelte';
-  import { createCodeOverlayMirrorState } from '$lib/canvas/secondary-output-ipc';
+  import {
+    createCodeOverlayMirrorState,
+    createDetachedStrudelCodeOverlayMirrorState
+  } from '$lib/canvas/secondary-output-ipc';
 
   import { toast } from 'svelte-sonner';
   import { Transport } from '$lib/transport';
@@ -103,6 +106,7 @@
   } from '../../stores/code-editor-layout.store';
   import { editorFullscreenFontSize } from '../../stores/editor.store';
   import { overlayEditorTransparency } from '../../stores/editor-layout-settings.store';
+  import { activeDetachedStrudelNodeId } from '../../stores/detached-strudel-editor.store';
   import { isFullscreenActive } from '$lib/canvas/SurfaceOverlay';
   import { PREVIEW_ZOOM_LOD_TIERS } from '$workers/rendering/constants';
   import { initializeVFS } from '$lib/vfs';
@@ -275,12 +279,27 @@
   });
 
   $effect(() => {
-    const state = createCodeOverlayMirrorState(
-      $activeCodeEditorTarget,
-      detachedCodeEditor.value,
-      $editorFullscreenFontSize,
-      $overlayEditorTransparency
-    );
+    const detachedStrudelNode =
+      $activeDetachedStrudelNodeId === null
+        ? undefined
+        : nodes.find((node) => node.id === $activeDetachedStrudelNodeId);
+
+    const detachedStrudelCode = detachedStrudelNode?.data?.code;
+
+    const state =
+      $activeDetachedStrudelNodeId && typeof detachedStrudelCode === 'string'
+        ? createDetachedStrudelCodeOverlayMirrorState(
+            $activeDetachedStrudelNodeId,
+            detachedStrudelCode,
+            $editorFullscreenFontSize,
+            $overlayEditorTransparency
+          )
+        : createCodeOverlayMirrorState(
+            $activeCodeEditorTarget,
+            detachedCodeEditor.value,
+            $editorFullscreenFontSize,
+            $overlayEditorTransparency
+          );
 
     glSystem.ipcSystem.sendCodeOverlayState(state);
   });

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -91,10 +91,7 @@
   import { buildAudioSourceConnections } from '$lib/composables/checkHandleConnections';
   import { getSurfaceMouseForwardingKey } from '$lib/canvas/surfaceMouseForwarding';
   import { useDetachedCodeEditorOverlay } from '$lib/canvas/use-detached-code-editor-overlay.svelte';
-  import {
-    createCodeOverlayMirrorState,
-    createDetachedStrudelCodeOverlayMirrorState
-  } from '$lib/canvas/secondary-output-ipc';
+  import { useSecondaryOutputCodeOverlay } from '$lib/canvas/use-secondary-output-code-overlay.svelte';
 
   import { toast } from 'svelte-sonner';
   import { Transport } from '$lib/transport';
@@ -278,30 +275,14 @@
     glSystem
   });
 
-  $effect(() => {
-    const detachedStrudelNode =
-      $activeDetachedStrudelNodeId === null
-        ? undefined
-        : nodes.find((node) => node.id === $activeDetachedStrudelNodeId);
-
-    const detachedStrudelCode = detachedStrudelNode?.data?.code;
-
-    const state =
-      $activeDetachedStrudelNodeId && typeof detachedStrudelCode === 'string'
-        ? createDetachedStrudelCodeOverlayMirrorState(
-            $activeDetachedStrudelNodeId,
-            detachedStrudelCode,
-            $editorFullscreenFontSize,
-            $overlayEditorTransparency
-          )
-        : createCodeOverlayMirrorState(
-            $activeCodeEditorTarget,
-            detachedCodeEditor.value,
-            $editorFullscreenFontSize,
-            $overlayEditorTransparency
-          );
-
-    glSystem.ipcSystem.sendCodeOverlayState(state);
+  useSecondaryOutputCodeOverlay({
+    getNodes: () => nodes,
+    getActiveDetachedStrudelNodeId: () => $activeDetachedStrudelNodeId,
+    getActiveCodeEditorTarget: () => $activeCodeEditorTarget,
+    getDetachedCodeEditorValue: () => detachedCodeEditor.value,
+    getFontSizePx: () => $editorFullscreenFontSize,
+    getTransparency: () => $overlayEditorTransparency,
+    sendCodeOverlayState: (state) => glSystem.ipcSystem.sendCodeOverlayState(state)
   });
 
   // Viewport culling for preview rendering optimization

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -28,7 +28,8 @@
   import {
     SurfaceListeners,
     type PointerEvent_,
-    type SurfaceWheelEvent_
+    type SurfaceWheelEvent_,
+    type TouchPoint
   } from '$lib/canvas/SurfaceListeners';
   import { shouldShowHandles } from '../../../stores/ui.store';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
@@ -154,6 +155,7 @@
   function clearCanvas() {
     if (activeCanvas && activeCtx) {
       activeCtx.clearRect(0, 0, activeCanvas.width, activeCanvas.height);
+      requestSurfaceOverlayMirrorFrame();
     }
   }
 
@@ -263,6 +265,16 @@
     }
   }
 
+  function dispatchTouch(touches: TouchPoint[]) {
+    if (!touchCallback) return;
+
+    try {
+      touchCallback(touches);
+    } catch (err) {
+      handleCodeError(err, data.code, nodeId, customConsole, SURFACE_WRAPPER_OFFSET);
+    }
+  }
+
   function setMouseForwarding(rules?: SurfaceMouseForwardingRules) {
     mouseForwarder.setForwardingRules(rules);
 
@@ -285,7 +297,15 @@
 
   // ── Bitmap output ────────────────────────────────────────────────────────
 
+  function requestSurfaceOverlayMirrorFrame() {
+    if (!isFullscreen || !activeCanvas) return;
+
+    glSystem.ipcSystem.requestSurfaceOverlayFrame(activeCanvas);
+  }
+
   function sendBitmap() {
+    requestSurfaceOverlayMirrorFrame();
+
     if (!activeCanvas) return;
     if (!videoOutputEnabled) return;
     if (!glSystem.hasOutgoingVideoConnections(nodeId)) return;
@@ -355,6 +375,17 @@
     const nodes = getNodes().map((n) => ({ id: n.id, type: n.type }));
 
     overlay.activate(nodeId, nodes, () => exitSurface());
+    glSystem.ipcSystem.sendSurfaceOverlayState({ active: true });
+    glSystem.ipcSystem.setOutputSurfaceInputSink({
+      pointer: (event) => dispatchPointer(event.x, event.y, event.buttons, event.type),
+      wheel: (event) =>
+        dispatchWheel(event.x, event.y, event.deltaX, event.deltaY, event.deltaMode),
+      touch: (touches) => dispatchTouch(touches),
+      leave: () => {
+        mouse.down = false;
+        mouse.buttons = 0;
+      }
+    });
     mouseForwarder.refreshForwardingTargets();
     mouseForwarder.forceHydraScope('global');
 
@@ -382,7 +413,7 @@
     document.addEventListener('keyup', handleKeyUp);
 
     // Re-run code with overlay canvas
-    runCode();
+    void runCode().then(() => requestSurfaceOverlayMirrorFrame());
   }
 
   function exitSurface() {
@@ -390,6 +421,8 @@
     isFullscreen = false;
 
     SurfaceOverlay.getInstance().deactivate(nodeId);
+    glSystem.ipcSystem.sendSurfaceOverlayState(null);
+    glSystem.ipcSystem.setOutputSurfaceInputSink(null);
     mouseForwarder.forceHydraScope('local');
 
     // Restore window dimensions for preview mode

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -136,6 +136,7 @@
   } | null = null;
 
   let resizeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
   const debouncedHandleWindowResize = () => {
     // Resize canvas immediately so the draw loop sends correctly-sized bitmaps
     // to the GLSL renderer (which resizes its output synchronously on resize).
@@ -155,6 +156,7 @@
   function clearCanvas() {
     if (activeCanvas && activeCtx) {
       activeCtx.clearRect(0, 0, activeCanvas.width, activeCanvas.height);
+
       requestSurfaceOverlayMirrorFrame();
     }
   }
@@ -373,8 +375,9 @@
 
     const overlay = SurfaceOverlay.getInstance();
     const nodes = getNodes().map((n) => ({ id: n.id, type: n.type }));
+    const presentation = glSystem.ipcSystem.hasConnectedOutputWindow() ? 'secondary' : 'main';
 
-    overlay.activate(nodeId, nodes, () => exitSurface());
+    overlay.activate(nodeId, nodes, () => exitSurface(), { presentation });
     glSystem.ipcSystem.sendSurfaceOverlayState({ active: true });
     glSystem.ipcSystem.setOutputSurfaceInputSink({
       pointer: (event) => dispatchPointer(event.x, event.y, event.buttons, event.type),
@@ -398,19 +401,24 @@
     activeCanvas = overlay.canvas;
     activeCtx = overlay.ctx;
 
-    // Swap pointer listeners
+    // Swap pointer listeners. Secondary presentation starts hidden, but the main-window toggle
+    // can reveal this same canvas for direct local interaction.
     previewListeners.detach();
     overlayListeners.attach(overlay.canvas, listenerOpts());
 
-    // Stop thumbnail loop (XYFlow is hidden anyway)
+    // Stop thumbnail loop while the surface draws to the overlay canvas.
     stopThumbnailLoop();
 
-    // Attach keyboard listeners
-    const handleKeyDown = (e: KeyboardEvent) => keyboardCallbacks.onKeyDown?.(e);
-    const handleKeyUp = (e: KeyboardEvent) => keyboardCallbacks.onKeyUp?.(e);
-    keyboardListenerHandlers = { keydown: handleKeyDown, keyup: handleKeyUp };
-    document.addEventListener('keydown', handleKeyDown);
-    document.addEventListener('keyup', handleKeyUp);
+    // Attach keyboard listeners only when this window is the presentation surface.
+    if (presentation === 'main') {
+      const handleKeyDown = (e: KeyboardEvent) => keyboardCallbacks.onKeyDown?.(e);
+      const handleKeyUp = (e: KeyboardEvent) => keyboardCallbacks.onKeyUp?.(e);
+
+      keyboardListenerHandlers = { keydown: handleKeyDown, keyup: handleKeyUp };
+
+      document.addEventListener('keydown', handleKeyDown);
+      document.addEventListener('keyup', handleKeyUp);
+    }
 
     // Re-run code with overlay canvas
     void runCode().then(() => requestSurfaceOverlayMirrorFrame());

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -378,7 +378,9 @@
     const presentation = glSystem.ipcSystem.hasConnectedOutputWindow() ? 'secondary' : 'main';
 
     overlay.activate(nodeId, nodes, () => exitSurface(), { presentation });
+
     glSystem.ipcSystem.sendSurfaceOverlayState({ active: true });
+
     glSystem.ipcSystem.setOutputSurfaceInputSink({
       pointer: (event) => dispatchPointer(event.x, event.y, event.buttons, event.type),
       wheel: (event) =>
@@ -389,6 +391,7 @@
         mouse.buttons = 0;
       }
     });
+
     mouseForwarder.refreshForwardingTargets();
     mouseForwarder.forceHydraScope('global');
 
@@ -429,6 +432,7 @@
     isFullscreen = false;
 
     SurfaceOverlay.getInstance().deactivate(nodeId);
+
     glSystem.ipcSystem.sendSurfaceOverlayState(null);
     glSystem.ipcSystem.setOutputSurfaceInputSink(null);
     mouseForwarder.forceHydraScope('local');
@@ -700,6 +704,9 @@
     // Deactivate overlay if this node was active
     if (isFullscreen) {
       SurfaceOverlay.getInstance().deactivate(nodeId);
+
+      glSystem.ipcSystem.sendSurfaceOverlayState(null);
+      glSystem.ipcSystem.setOutputSurfaceInputSink(null);
     }
 
     eventBus.removeEventListener('consoleOutput', handleConsoleOutput);

--- a/ui/src/routes/output/+page.svelte
+++ b/ui/src/routes/output/+page.svelte
@@ -3,9 +3,10 @@
   import { SurfaceListeners } from '$lib/canvas/SurfaceListeners';
   import {
     highlightCodeOverlayValue,
+    isMainToOutputMessage,
     syncCanvasSizeToBitmap,
     type CodeOverlayMirrorState,
-    type MainToOutputMessage
+    type OutputToMainMessage
   } from '$lib/canvas/secondary-output-ipc';
 
   let outputCanvas: HTMLCanvasElement;
@@ -15,6 +16,7 @@
   let codeOverlayState = $state<CodeOverlayMirrorState | null>(null);
   let surfaceOverlayActive = $state(false);
   let surfaceListeners = new SurfaceListeners();
+  let expectedOrigin: string | null = null;
 
   let codeOverlayBackground = $derived(
     codeOverlayState ? `rgba(9, 9, 11, ${codeOverlayState.transparency})` : 'transparent'
@@ -27,7 +29,9 @@
   );
 
   function announceReady() {
-    window.opener?.postMessage({ type: 'outputReady' }, '*');
+    if (!expectedOrigin) return;
+
+    window.opener?.postMessage({ type: 'outputReady' }, expectedOrigin);
   }
 
   function resizeCanvases() {
@@ -43,16 +47,16 @@
   function attachSurfaceInput() {
     surfaceListeners.attach(surfaceCanvas, {
       onPointer: (event) => {
-        window.opener?.postMessage({ type: 'outputSurfacePointer', event }, '*');
+        postToOpener({ type: 'outputSurfacePointer', event });
       },
       onWheel: (event) => {
-        window.opener?.postMessage({ type: 'outputSurfaceWheel', event }, '*');
+        postToOpener({ type: 'outputSurfaceWheel', event });
       },
       onTouch: (touches) => {
-        window.opener?.postMessage({ type: 'outputSurfaceTouch', touches }, '*');
+        postToOpener({ type: 'outputSurfaceTouch', touches });
       },
       onLeave: () => {
-        window.opener?.postMessage({ type: 'outputSurfaceLeave' }, '*');
+        postToOpener({ type: 'outputSurfaceLeave' });
       },
       code: '',
       nodeId: 'secondary-output-surface',
@@ -65,13 +69,26 @@
     surfaceListeners.detach();
   }
 
+  function postToOpener(message: OutputToMainMessage) {
+    if (!expectedOrigin) return;
+
+    window.opener?.postMessage(message, expectedOrigin);
+  }
+
   onMount(() => {
+    expectedOrigin = getExpectedOrigin();
+
     resizeCanvases();
 
     outputBitmapContext = outputCanvas.getContext('bitmaprenderer')!;
     surfaceBitmapContext = surfaceCanvas.getContext('bitmaprenderer')!;
 
-    const handleMessage = (event: MessageEvent<MainToOutputMessage>) => {
+    const handleMessage = (event: MessageEvent<unknown>) => {
+      if (event.origin !== expectedOrigin) return;
+      if (event.source !== window.opener) return;
+
+      if (!isMainToOutputMessage(event.data)) return;
+
       if (event.data.type === 'renderOutput') {
         syncCanvasSizeToBitmap(outputCanvas, event.data.bitmap);
         outputBitmapContext.transferFromImageBitmap(event.data.bitmap);
@@ -99,17 +116,35 @@
 
     // Listen for ping from main page (handles main page reload)
     const channel = new BroadcastChannel('patchies-ipc');
+
     channel.addEventListener('message', (event) => {
-      if (event.data.type === 'ping') announceReady();
+      if (event.data.type === 'ping') {
+        announceReady();
+      }
     });
 
     return () => {
       window.removeEventListener('message', handleMessage);
       window.removeEventListener('resize', resizeCanvases);
+
       detachSurfaceInput();
       channel.close();
     };
   });
+
+  function getExpectedOrigin() {
+    try {
+      const referrerOrigin = new URL(document.referrer).origin;
+
+      if (referrerOrigin === window.location.origin) {
+        return referrerOrigin;
+      }
+    } catch {
+      // Fall back to the app origin when the output page has no referrer.
+    }
+
+    return window.location.origin;
+  }
 </script>
 
 <div class="secondary-output-root">

--- a/ui/src/routes/output/+page.svelte
+++ b/ui/src/routes/output/+page.svelte
@@ -1,28 +1,98 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { SurfaceListeners } from '$lib/canvas/SurfaceListeners';
+  import {
+    highlightCodeOverlayValue,
+    syncCanvasSizeToBitmap,
+    type CodeOverlayMirrorState,
+    type MainToOutputMessage
+  } from '$lib/canvas/secondary-output-ipc';
 
-  let canvas: HTMLCanvasElement;
-  let bitmapRendererContext: ImageBitmapRenderingContext;
+  let outputCanvas: HTMLCanvasElement;
+  let surfaceCanvas: HTMLCanvasElement;
+  let outputBitmapContext: ImageBitmapRenderingContext;
+  let surfaceBitmapContext: ImageBitmapRenderingContext;
+  let codeOverlayState = $state<CodeOverlayMirrorState | null>(null);
+  let surfaceOverlayActive = $state(false);
+  let surfaceListeners = new SurfaceListeners();
+
+  let codeOverlayBackground = $derived(
+    codeOverlayState ? `rgba(9, 9, 11, ${codeOverlayState.transparency})` : 'transparent'
+  );
+  let codeOverlayFontSize = $derived(`${codeOverlayState?.fontSizePx ?? 28}px`);
+  let highlightedCode = $derived(
+    codeOverlayState
+      ? highlightCodeOverlayValue(codeOverlayState.value, codeOverlayState.language)
+      : ''
+  );
 
   function announceReady() {
     window.opener?.postMessage({ type: 'outputReady' }, '*');
   }
 
-  onMount(() => {
-    canvas.width = window.visualViewport?.width ?? window.innerWidth;
-    canvas.height = window.visualViewport?.height ?? window.innerHeight;
-    canvas.style.width = `100%`;
-    canvas.style.height = `100%`;
-    canvas.style.minHeight = '100vh';
-    canvas.style.objectFit = 'cover';
+  function resizeCanvases() {
+    const width = window.visualViewport?.width ?? window.innerWidth;
+    const height = window.visualViewport?.height ?? window.innerHeight;
 
-    bitmapRendererContext = canvas.getContext('bitmaprenderer')!;
+    outputCanvas.width = width;
+    outputCanvas.height = height;
+    surfaceCanvas.width = width;
+    surfaceCanvas.height = height;
+  }
 
-    window.addEventListener('message', (event) => {
-      if (event.data.type === 'renderOutput') {
-        bitmapRendererContext.transferFromImageBitmap(event.data.bitmap);
-      }
+  function attachSurfaceInput() {
+    surfaceListeners.attach(surfaceCanvas, {
+      onPointer: (event) => {
+        window.opener?.postMessage({ type: 'outputSurfacePointer', event }, '*');
+      },
+      onWheel: (event) => {
+        window.opener?.postMessage({ type: 'outputSurfaceWheel', event }, '*');
+      },
+      onTouch: (touches) => {
+        window.opener?.postMessage({ type: 'outputSurfaceTouch', touches }, '*');
+      },
+      onLeave: () => {
+        window.opener?.postMessage({ type: 'outputSurfaceLeave' }, '*');
+      },
+      code: '',
+      nodeId: 'secondary-output-surface',
+      customConsole: {} as never,
+      wrapperOffset: 0
     });
+  }
+
+  function detachSurfaceInput() {
+    surfaceListeners.detach();
+  }
+
+  onMount(() => {
+    resizeCanvases();
+
+    outputBitmapContext = outputCanvas.getContext('bitmaprenderer')!;
+    surfaceBitmapContext = surfaceCanvas.getContext('bitmaprenderer')!;
+
+    const handleMessage = (event: MessageEvent<MainToOutputMessage>) => {
+      if (event.data.type === 'renderOutput') {
+        syncCanvasSizeToBitmap(outputCanvas, event.data.bitmap);
+        outputBitmapContext.transferFromImageBitmap(event.data.bitmap);
+      } else if (event.data.type === 'codeOverlayState') {
+        codeOverlayState = event.data.state;
+      } else if (event.data.type === 'surfaceOverlayState') {
+        surfaceOverlayActive = event.data.state?.active ?? false;
+
+        if (surfaceOverlayActive) {
+          attachSurfaceInput();
+        } else {
+          detachSurfaceInput();
+        }
+      } else if (event.data.type === 'surfaceOverlayFrame') {
+        syncCanvasSizeToBitmap(surfaceCanvas, event.data.bitmap);
+        surfaceBitmapContext.transferFromImageBitmap(event.data.bitmap);
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    window.addEventListener('resize', resizeCanvases);
 
     // Announce to opener so it can re-capture the window reference after reloads
     announceReady();
@@ -33,8 +103,134 @@
       if (event.data.type === 'ping') announceReady();
     });
 
-    return () => channel.close();
+    return () => {
+      window.removeEventListener('message', handleMessage);
+      window.removeEventListener('resize', resizeCanvases);
+      detachSurfaceInput();
+      channel.close();
+    };
   });
 </script>
 
-<canvas id="output" bind:this={canvas}></canvas>
+<div class="secondary-output-root">
+  <canvas id="output" class="output-layer" bind:this={outputCanvas}></canvas>
+  <canvas
+    id="surface-output"
+    class="output-layer surface-layer"
+    class:active={surfaceOverlayActive}
+    bind:this={surfaceCanvas}
+  ></canvas>
+
+  {#if codeOverlayState}
+    <div
+      class="detached-code-editor-overlay code-overlay-mirror"
+      style:background-color={codeOverlayBackground}
+      style:font-size={codeOverlayFontSize}
+      aria-label={codeOverlayState.title ?? 'Code overlay'}
+    >
+      <pre><code class="hljs">{@html highlightedCode}</code></pre>
+    </div>
+  {/if}
+</div>
+
+<style>
+  :global(html),
+  :global(body) {
+    margin: 0;
+    overflow: hidden;
+    background: #000;
+  }
+
+  .secondary-output-root {
+    position: fixed;
+    inset: 0;
+    min-height: 100vh;
+    overflow: hidden;
+    background: #000;
+  }
+
+  .output-layer {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    min-height: 100vh;
+    object-fit: cover;
+  }
+
+  .surface-layer {
+    display: none;
+    pointer-events: none;
+  }
+
+  .surface-layer.active {
+    display: block;
+    pointer-events: auto;
+  }
+
+  .code-overlay-mirror {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    pointer-events: none;
+    color: rgb(212 212 216);
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+      monospace;
+    line-height: 1.55;
+  }
+
+  .code-overlay-mirror pre {
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    overflow: auto;
+    padding: 56px;
+    white-space: pre;
+  }
+
+  .code-overlay-mirror code {
+    display: block;
+  }
+
+  .code-overlay-mirror :global(.hljs-keyword),
+  .code-overlay-mirror :global(.hljs-built_in),
+  .code-overlay-mirror :global(.hljs-type),
+  .code-overlay-mirror :global(.hljs-literal) {
+    color: #c792ea;
+  }
+
+  .code-overlay-mirror :global(.hljs-string),
+  .code-overlay-mirror :global(.hljs-regexp),
+  .code-overlay-mirror :global(.hljs-symbol) {
+    color: #c3e88d;
+  }
+
+  .code-overlay-mirror :global(.hljs-number),
+  .code-overlay-mirror :global(.hljs-attr),
+  .code-overlay-mirror :global(.hljs-variable),
+  .code-overlay-mirror :global(.hljs-template-variable) {
+    color: #f78c6c;
+  }
+
+  .code-overlay-mirror :global(.hljs-title),
+  .code-overlay-mirror :global(.hljs-name),
+  .code-overlay-mirror :global(.hljs-selector-id),
+  .code-overlay-mirror :global(.hljs-selector-class) {
+    color: #82aaff;
+  }
+
+  .code-overlay-mirror :global(.hljs-comment),
+  .code-overlay-mirror :global(.hljs-quote) {
+    color: #697098;
+    font-style: italic;
+  }
+
+  .code-overlay-mirror :global(.hljs-meta),
+  .code-overlay-mirror :global(.hljs-tag),
+  .code-overlay-mirror :global(.hljs-deletion),
+  .code-overlay-mirror :global(.hljs-addition) {
+    color: #89ddff;
+  }
+</style>


### PR DESCRIPTION
Forwards the code editor overlay, surface mouse event and surface bitmap between the secondary output screen and the primary control screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secondary output windows now show layered mirrored content: rendered output, optional surface overlay, and a detached code overlay; input (pointer/wheel/touch/leave) from secondary windows is forwarded back to the main window.
  * Surface presentation supports main vs. secondary modes with independent visibility toggles and input behavior.

* **Tests**
  * Added tests covering IPC message validation, overlay state mirroring, input dispatching, bitmap/frame handling, and code highlighting behavior.

* **Documentation**
  * Added a design specification detailing secondary output behavior, IPC contracts, and implementation/testing guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->