### PR TITLE
Add fullscreen ChucK editor

### DIFF
--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -29,10 +29,11 @@ Detached editor layouts should support:
 
 The first implementation focuses on visual code nodes that already use
 `CanvasPreviewLayout`, JS-style code block nodes that share `CodeBlockBase`, and
-simple DSP code nodes that share `SimpleDspLayout`. Expression-style nodes such
-as `CommonExprLayout` do not need detached editing initially because their inline
-editors are already compact and the code is less likely to be part of a
-performance visual.
+simple DSP code nodes that share `SimpleDspLayout`. Most expression-style nodes
+such as `CommonExprLayout` do not need detached editing initially because their
+inline editors are already compact. Longer live-coding expression nodes can opt
+in when their `expr` field benefits from the same focused editor, starting with
+`chuck~`.
 
 ## Source Of Truth
 
@@ -239,6 +240,8 @@ First pass:
   `SimpleDspLayout` consumers
 - sidebar editor for `CanvasPreviewLayout`, `CodeBlockBase`, and
   `SimpleDspLayout` consumers
+- opt-in detached editing for longer expression editors such as `chuck~`, using
+  `dataKey: "expr"` and the same node run callback as the inline editor
 - Settings modal option for default editor layout: `Inline`, `Overlay`, or
   `Sidebar`
 - Settings modal option for overlay editor transparency

--- a/ui/src/lib/code-editor/common-expr-editor-target.test.ts
+++ b/ui/src/lib/code-editor/common-expr-editor-target.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createCommonExprEditorTarget } from './common-expr-editor-target';
+
+describe('createCommonExprEditorTarget', () => {
+  it('builds a detached target for expression-backed code editors', () => {
+    const onrun = vi.fn();
+    const customActions = vi.fn() as any;
+    const customSettings = vi.fn() as any;
+
+    expect(
+      createCommonExprEditorTarget({
+        nodeId: 'chuck-1',
+        dataKey: 'expr',
+        language: 'plain',
+        nodeType: 'chuck~',
+        title: 'chuck~',
+        placeholder: 'SinOsc osc => dac;',
+        onrun,
+        customActions,
+        customSettings
+      })
+    ).toEqual({
+      nodeId: 'chuck-1',
+      dataKey: 'expr',
+      language: 'plain',
+      nodeType: 'chuck~',
+      title: 'chuck~',
+      placeholder: 'SinOsc osc => dac;',
+      onrun,
+      customActions,
+      customSettings
+    });
+  });
+});

--- a/ui/src/lib/code-editor/common-expr-editor-target.ts
+++ b/ui/src/lib/code-editor/common-expr-editor-target.ts
@@ -1,0 +1,39 @@
+import type { SupportedLanguage } from '$lib/codemirror/types';
+import type { Snippet } from 'svelte';
+import type { OpenCodeEditorOverlayTarget } from '../../stores/code-editor-layout.store';
+
+interface CommonExprEditorTargetOptions {
+  nodeId: string;
+  dataKey: string;
+  language: SupportedLanguage;
+  nodeType?: string;
+  title?: string;
+  placeholder?: string;
+  onrun?: () => void;
+  customActions?: Snippet;
+  customSettings?: Snippet;
+}
+
+export function createCommonExprEditorTarget({
+  nodeId,
+  dataKey,
+  language,
+  nodeType,
+  title,
+  placeholder,
+  onrun,
+  customActions,
+  customSettings
+}: CommonExprEditorTargetOptions): OpenCodeEditorOverlayTarget {
+  return {
+    nodeId,
+    dataKey,
+    language,
+    nodeType,
+    title,
+    placeholder,
+    onrun,
+    customActions,
+    customSettings
+  };
+}

--- a/ui/src/lib/components/DetachedCodeEditorOverlay.svelte
+++ b/ui/src/lib/components/DetachedCodeEditorOverlay.svelte
@@ -4,7 +4,10 @@
   import type { Snippet } from 'svelte';
   import * as Tooltip from './ui/tooltip';
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
-  import type { CodeEditorTargetSettings } from '../../stores/code-editor-layout.store';
+  import {
+    hasCodeEditorTargetSettings,
+    type CodeEditorTargetSettings
+  } from '../../stores/code-editor-layout.store';
   import { overlayEditorTransparency } from '../../stores/editor-layout-settings.store';
   import { isSidebarOpen } from '../../stores/ui.store';
   import { isFullscreenActive } from '$lib/canvas/SurfaceOverlay';
@@ -14,6 +17,8 @@
     onrun,
     nodeId,
     settings,
+    customActions,
+    customSettings,
     codeEditor,
     class: className = ''
   }: {
@@ -21,12 +26,15 @@
     onrun?: () => void;
     nodeId?: string;
     settings?: CodeEditorTargetSettings;
+    customActions?: Snippet;
+    customSettings?: Snippet;
     codeEditor: Snippet;
     class?: string;
   } = $props();
 
   let panelBackground = $derived(`rgba(9, 9, 11, ${$overlayEditorTransparency})`);
   let showSettings = $state(false);
+  let hasSettings = $derived(hasCodeEditorTargetSettings({ settings, customSettings }));
 
   function handleKeydown(event: KeyboardEvent) {
     if (event.key !== 'Escape' || !event.shiftKey) return;
@@ -53,7 +61,11 @@
   style:background-color={panelBackground}
 >
   <div class="absolute top-6 right-6 z-10 flex gap-1">
-    {#if onrun}
+    {#if customActions}
+      {@render customActions()}
+    {/if}
+
+    {#if onrun && !customActions}
       <Tooltip.Root>
         <Tooltip.Trigger>
           <button
@@ -69,7 +81,7 @@
       </Tooltip.Root>
     {/if}
 
-    {#if settings && settings.schema.length > 0 && nodeId}
+    {#if hasSettings}
       <div class="relative">
         <Tooltip.Root>
           <Tooltip.Trigger>
@@ -87,17 +99,21 @@
 
         {#if showSettings}
           <div class="absolute top-11 right-0">
-            <ObjectSettings
-              {nodeId}
-              schema={settings.schema}
-              values={settings.values}
-              onValueChange={settings.onValueChange}
-              onRevertAll={settings.onRevertAll}
-              settingsPrefix={settings.settingsPrefix}
-              onClose={() => (showSettings = false)}
-              showCloseButton={false}
-              showRevertButton={false}
-            />
+            {#if customSettings}
+              {@render customSettings()}
+            {:else if settings && settings.schema.length > 0 && nodeId}
+              <ObjectSettings
+                {nodeId}
+                schema={settings.schema}
+                values={settings.values}
+                onValueChange={settings.onValueChange}
+                onRevertAll={settings.onRevertAll}
+                settingsPrefix={settings.settingsPrefix}
+                onClose={() => (showSettings = false)}
+                showCloseButton={false}
+                showRevertButton={false}
+              />
+            {/if}
           </div>
         {/if}
       </div>

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -1236,6 +1236,8 @@
       onrun={$activeCodeEditorTarget.onrun}
       nodeId={$activeCodeEditorTarget.nodeId}
       settings={$activeCodeEditorTarget.settings}
+      customActions={$activeCodeEditorTarget.customActions}
+      customSettings={$activeCodeEditorTarget.customSettings}
       codeEditor={detachedCodeEditorSnippet}
     />
   {/if}

--- a/ui/src/lib/components/nodes/ChuckNode.svelte
+++ b/ui/src/lib/components/nodes/ChuckNode.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CirclePlus, Delete, Replace, Settings } from '@lucide/svelte/icons';
+  import { CirclePlus, Delete, Expand, Replace, Settings } from '@lucide/svelte/icons';
   import { useSvelteFlow } from '@xyflow/svelte';
   import { onMount, onDestroy } from 'svelte';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
@@ -203,6 +203,60 @@
   />
 {/snippet}
 
+{#snippet detachedChuckSettings()}
+  <ChuckSettings
+    {shreds}
+    onRemoveShred={removeShred}
+    onStopAll={stopChuck}
+    showCloseButton={false}
+    showHeaderActions={false}
+  />
+{/snippet}
+
+{#snippet detachedChuckActions()}
+  <Tooltip.Root>
+    <Tooltip.Trigger>
+      <button
+        onclick={handleReplace}
+        class="cursor-pointer rounded bg-black/35 p-2 text-zinc-300 transition-colors hover:bg-zinc-800/80 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={isReplaceDisabled}
+        aria-label="Replace ChucK shred"
+      >
+        <Replace class="h-4 w-4" />
+      </button>
+    </Tooltip.Trigger>
+    <Tooltip.Content>Replace (Cmd+Enter)</Tooltip.Content>
+  </Tooltip.Root>
+
+  <Tooltip.Root>
+    <Tooltip.Trigger>
+      <button
+        onclick={handleAddShred}
+        class="cursor-pointer rounded bg-black/35 p-2 text-zinc-300 transition-colors hover:bg-zinc-800/80 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={!data.expr.trim()}
+        aria-label="Add ChucK shred"
+      >
+        <CirclePlus class="h-4 w-4" />
+      </button>
+    </Tooltip.Trigger>
+    <Tooltip.Content>Add Shred (Cmd+\)</Tooltip.Content>
+  </Tooltip.Root>
+
+  <Tooltip.Root>
+    <Tooltip.Trigger>
+      <button
+        onclick={removeChuckCode}
+        class="cursor-pointer rounded bg-black/35 p-2 text-zinc-300 transition-colors hover:bg-zinc-800/80 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={shreds.length === 0}
+        aria-label="Remove ChucK shred"
+      >
+        <Delete class="h-4 w-4" />
+      </button>
+    </Tooltip.Trigger>
+    <Tooltip.Content>Remove (Cmd+Backspace)</Tooltip.Content>
+  </Tooltip.Root>
+{/snippet}
+
 <div class="relative flex gap-x-3">
   <div class="group relative">
     <div class="flex flex-col gap-2" bind:this={contentContainer}>
@@ -252,17 +306,33 @@
           </Tooltip.Root>
         </div>
 
-        <Tooltip.Root>
-          <Tooltip.Trigger>
-            <button
-              class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
-              onclick={() => (showSettings = !showSettings)}
-            >
-              <Settings class="h-4 w-4 text-zinc-300" />
-            </button>
-          </Tooltip.Trigger>
-          <Tooltip.Content>Settings</Tooltip.Content>
-        </Tooltip.Root>
+        <div class="flex gap-1 transition-opacity group-hover:opacity-100 sm:opacity-0">
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                onclick={() => layoutRef?.openExpandedEditor()}
+                class="cursor-pointer rounded p-1 hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={!data.expr.trim()}
+                aria-label="Expand ChucK editor"
+              >
+                <Expand class="h-4 w-4 text-zinc-300" />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>Expand Editor</Tooltip.Content>
+          </Tooltip.Root>
+
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+                onclick={() => (showSettings = !showSettings)}
+              >
+                <Settings class="h-4 w-4 text-zinc-300" />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>Settings</Tooltip.Content>
+          </Tooltip.Root>
+        </div>
       </div>
 
       <div class="chuck-node-container relative">
@@ -282,6 +352,10 @@
           extraExtensions={chuckKeymaps}
           exitOnRun={false}
           onRun={handleReplace}
+          nodeType="chuck~"
+          detachedEditorTitle="chuck~"
+          detachedActions={detachedChuckActions}
+          detachedSettings={detachedChuckSettings}
         />
 
         {@render chuckOutlets()}

--- a/ui/src/lib/components/nodes/ChuckNode.svelte
+++ b/ui/src/lib/components/nodes/ChuckNode.svelte
@@ -326,6 +326,9 @@
               <button
                 class="cursor-pointer rounded p-1 hover:bg-zinc-700"
                 onclick={() => (showSettings = !showSettings)}
+                type="button"
+                aria-label={showSettings ? 'Close settings' : 'Open settings'}
+                aria-pressed={showSettings}
               >
                 <Settings class="h-4 w-4 text-zinc-300" />
               </button>

--- a/ui/src/lib/components/nodes/CommonExprLayout.svelte
+++ b/ui/src/lib/components/nodes/CommonExprLayout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { useSvelteFlow } from '@xyflow/svelte';
+  import type { Snippet } from 'svelte';
   import hljs from 'highlight.js/lib/core';
   import javascript from 'highlight.js/lib/languages/javascript';
   import CodeEditor from '../CodeEditor.svelte';
@@ -7,6 +8,12 @@
   import { EditorView } from 'codemirror';
   import { highlightUiua } from '$lib/uiua/uiua-highlight';
   import type { SupportedLanguage } from '$lib/codemirror/types';
+  import {
+    activeCodeEditorTarget,
+    closeCodeEditorOverlay,
+    openCodeEditorOverlay
+  } from '../../../stores/code-editor-layout.store';
+  import { createCommonExprEditorTarget } from '$lib/code-editor/common-expr-editor-target';
 
   import 'highlight.js/styles/tokyo-night-dark.css';
 
@@ -57,6 +64,10 @@
     hasError = false,
     allowEmptyExpr = false,
     dataKey = 'expr',
+    nodeType = 'expr',
+    detachedEditorTitle = undefined,
+    detachedActions = undefined,
+    detachedSettings = undefined,
     fontSize,
     lineWrap = false,
     children,
@@ -88,6 +99,10 @@
     handles?: any;
     outlets?: any;
     dataKey?: string;
+    nodeType?: string;
+    detachedEditorTitle?: string;
+    detachedActions?: Snippet;
+    detachedSettings?: Snippet;
     lineWrap?: boolean;
     onPreviewMouseOver?: (e: MouseEvent) => void;
     onPreviewMouseOut?: (e: MouseEvent) => void;
@@ -97,6 +112,9 @@
 
   let codeEditorRef: CodeEditor | null = $state(null);
   let originalExpr = expr; // Store original for escape functionality
+  const isCodeEditorDetached = $derived(
+    $activeCodeEditorTarget?.nodeId === nodeId && $activeCodeEditorTarget.dataKey === dataKey
+  );
 
   // Escape HTML for safe display
   function escapeHtml(text: string): string {
@@ -131,6 +149,10 @@
   });
 
   function enterEditingMode() {
+    if (isCodeEditorDetached) {
+      closeCodeEditorOverlay();
+    }
+
     isEditing = true;
     originalExpr = expr;
 
@@ -207,6 +229,24 @@
   export function insertAtCursor(text: string) {
     codeEditorRef?.insertAtCursor(text);
   }
+
+  export function openExpandedEditor() {
+    openCodeEditorOverlay(
+      createCommonExprEditorTarget({
+        nodeId,
+        dataKey,
+        language,
+        nodeType,
+        title: detachedEditorTitle,
+        placeholder,
+        onrun: onRun,
+        customActions: detachedActions,
+        customSettings: detachedSettings
+      })
+    );
+
+    isEditing = false;
+  }
 </script>
 
 <div class="relative">
@@ -216,7 +256,7 @@
         {@render handles?.()}
 
         <div class="relative">
-          {#if isEditing}
+          {#if isEditing && !isCodeEditorDetached}
             <div
               class={[
                 'expr-editor-container nodrag w-full max-w-[400px] min-w-[40px] resize-none rounded-lg border font-mono text-zinc-200',

--- a/ui/src/lib/components/settings/ChuckSettings.svelte
+++ b/ui/src/lib/components/settings/ChuckSettings.svelte
@@ -1,17 +1,22 @@
 <script lang="ts">
   import { Trash, X } from '@lucide/svelte/icons';
   import type { ChuckShred } from '$lib/audio/v2/nodes/ChuckNode';
+  import * as Tooltip from '$lib/components/ui/tooltip';
 
   let {
     shreds,
     onRemoveShred,
     onStopAll,
-    onClose
+    onClose = undefined,
+    showCloseButton = true,
+    showHeaderActions = true
   }: {
     shreds: ChuckShred[];
     onRemoveShred: (shredId: number) => void;
     onStopAll: () => void;
-    onClose: () => void;
+    onClose?: () => void;
+    showCloseButton?: boolean;
+    showHeaderActions?: boolean;
   } = $props();
 
   function handleClick(e: MouseEvent) {
@@ -22,15 +27,29 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div onclick={handleClick}>
-  <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
-    <button onclick={onStopAll} class="rounded p-1 hover:bg-zinc-700">
-      <Trash class="h-4 w-4 text-zinc-300" />
-    </button>
+  {#if showHeaderActions}
+    <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          <button onclick={onStopAll} class="cursor-pointer rounded p-1 hover:bg-zinc-700">
+            <Trash class="h-4 w-4 text-zinc-300" />
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Content>Stop all shreds</Tooltip.Content>
+      </Tooltip.Root>
 
-    <button onclick={onClose} class="rounded p-1 hover:bg-zinc-700">
-      <X class="h-4 w-4 text-zinc-300" />
-    </button>
-  </div>
+      {#if showCloseButton && onClose}
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button onclick={onClose} class="cursor-pointer rounded p-1 hover:bg-zinc-700">
+              <X class="h-4 w-4 text-zinc-300" />
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>Close settings</Tooltip.Content>
+        </Tooltip.Root>
+      {/if}
+    </div>
+  {/if}
 
   <div class="nodrag w-64 rounded-lg border border-zinc-600 bg-zinc-900 p-4 shadow-xl">
     <div class="space-y-4">
@@ -54,16 +73,37 @@
                 </div>
 
                 <div class="absolute top-0 right-0">
-                  <button
-                    onclick={() => onRemoveShred(shred.id)}
-                    class="ml-2 rounded p-1 hover:bg-zinc-700"
-                    title="Remove shred"
-                  >
-                    <X class="h-3 w-3 text-red-400" />
-                  </button>
+                  <Tooltip.Root>
+                    <Tooltip.Trigger>
+                      <button
+                        onclick={() => onRemoveShred(shred.id)}
+                        class="ml-2 cursor-pointer rounded p-1 hover:bg-zinc-700"
+                      >
+                        <X class="h-3 w-3 text-red-400" />
+                      </button>
+                    </Tooltip.Trigger>
+                    <Tooltip.Content>Remove shred</Tooltip.Content>
+                  </Tooltip.Root>
                 </div>
               </div>
             {/each}
+
+            {#if !showHeaderActions}
+              <div class="flex justify-end border-t border-zinc-800 pt-3">
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <button
+                      onclick={onStopAll}
+                      class="flex cursor-pointer items-center gap-1 rounded border border-red-500/30 px-2 py-1 text-xs text-red-300 hover:bg-red-950/40"
+                    >
+                      <Trash class="h-3 w-3" />
+                      Stop all
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>Stop all shreds</Tooltip.Content>
+                </Tooltip.Root>
+              </div>
+            {/if}
           </div>
         {/if}
       </div>

--- a/ui/src/lib/components/settings/ChuckSettings.svelte
+++ b/ui/src/lib/components/settings/ChuckSettings.svelte
@@ -31,7 +31,12 @@
     <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
       <Tooltip.Root>
         <Tooltip.Trigger>
-          <button onclick={onStopAll} class="cursor-pointer rounded p-1 hover:bg-zinc-700">
+          <button
+            onclick={onStopAll}
+            class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+            type="button"
+            aria-label="Stop all shreds"
+          >
             <Trash class="h-4 w-4 text-zinc-300" />
           </button>
         </Tooltip.Trigger>
@@ -41,7 +46,12 @@
       {#if showCloseButton && onClose}
         <Tooltip.Root>
           <Tooltip.Trigger>
-            <button onclick={onClose} class="cursor-pointer rounded p-1 hover:bg-zinc-700">
+            <button
+              onclick={onClose}
+              class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+              type="button"
+              aria-label="Close settings"
+            >
               <X class="h-4 w-4 text-zinc-300" />
             </button>
           </Tooltip.Trigger>
@@ -78,6 +88,8 @@
                       <button
                         onclick={() => onRemoveShred(shred.id)}
                         class="ml-2 cursor-pointer rounded p-1 hover:bg-zinc-700"
+                        type="button"
+                        aria-label={`Remove shred ${shred.id}`}
                       >
                         <X class="h-3 w-3 text-red-400" />
                       </button>

--- a/ui/src/stores/code-editor-layout.store.test.ts
+++ b/ui/src/stores/code-editor-layout.store.test.ts
@@ -4,9 +4,11 @@ import { describe, expect, it } from 'vitest';
 import {
   activeCodeEditorTarget,
   closeCodeEditorOverlay,
+  hasCodeEditorTargetSettings,
   isDetachedCodeEditorTarget,
   openCodeEditorOverlay,
-  openCodeEditorSidebar
+  openCodeEditorSidebar,
+  type CodeEditorTarget
 } from './code-editor-layout.store';
 import { sidebarVisibleTabs } from './sidebar-visibility.store';
 import { isSidebarOpen, sidebarView } from './ui.store';
@@ -63,5 +65,56 @@ describe('code editor layout store', () => {
     expect(get(sidebarVisibleTabs).has('code')).toBe(true);
 
     closeCodeEditorOverlay();
+  });
+
+  it('detects schema and custom settings targets', () => {
+    const baseTarget = {
+      nodeId: 'node-1',
+      dataKey: 'code',
+      language: 'javascript',
+      mode: 'overlay'
+    } satisfies CodeEditorTarget;
+
+    expect(hasCodeEditorTargetSettings(baseTarget)).toBe(false);
+
+    expect(
+      hasCodeEditorTargetSettings({
+        ...baseTarget,
+        settings: {
+          schema: [],
+          values: {},
+          onValueChange: () => {},
+          onRevertAll: () => {}
+        }
+      })
+    ).toBe(false);
+
+    expect(
+      hasCodeEditorTargetSettings({
+        ...baseTarget,
+        settings: {
+          schema: [
+            {
+              key: 'size',
+              label: 'Size',
+              type: 'number',
+              min: 1,
+              max: 10,
+              step: 1
+            }
+          ],
+          values: {},
+          onValueChange: () => {},
+          onRevertAll: () => {}
+        }
+      })
+    ).toBe(true);
+
+    expect(
+      hasCodeEditorTargetSettings({
+        ...baseTarget,
+        customSettings: (() => {}) as any
+      })
+    ).toBe(true);
   });
 });

--- a/ui/src/stores/code-editor-layout.store.ts
+++ b/ui/src/stores/code-editor-layout.store.ts
@@ -1,4 +1,5 @@
 import { get, writable } from 'svelte/store';
+import type { Snippet } from 'svelte';
 import type { SupportedLanguage } from '$lib/codemirror/types';
 import type { SettingsSchema } from '$lib/settings';
 import { isSidebarOpen, sidebarView } from './ui.store';
@@ -21,6 +22,8 @@ export interface CodeEditorTarget {
   placeholder?: string;
   onrun?: () => void;
   settings?: CodeEditorTargetSettings;
+  customActions?: Snippet;
+  customSettings?: Snippet;
   mode: 'overlay' | 'sidebar';
 }
 
@@ -43,6 +46,21 @@ export function openCodeEditorSidebar(target: OpenCodeEditorSidebarTarget): void
 
 export function closeCodeEditorOverlay(): void {
   activeCodeEditorTarget.set(null);
+}
+
+interface CodeEditorTargetSettingsState {
+  settings?: CodeEditorTargetSettings;
+  customSettings?: Snippet;
+}
+
+export function hasCodeEditorTargetSettings(
+  target: CodeEditorTarget | CodeEditorTargetSettingsState | null | undefined
+): boolean {
+  if (!target) return false;
+
+  if (target.customSettings) return true;
+
+  return (target.settings?.schema.length ?? 0) > 0;
 }
 
 export function isDetachedCodeEditorTarget(nodeId: string | undefined, dataKey: string): boolean {

--- a/ui/static/content/objects/chuck~.md
+++ b/ui/static/content/objects/chuck~.md
@@ -21,6 +21,7 @@ textures.
 - **Replace Shred** (`Ctrl/Cmd + Enter`): replaces the most recent shred
 - **Add Shred** (`Ctrl/Cmd + \`): adds a new shred
 - **Remove Shred** (`Ctrl/Cmd + Backspace`): removes the most recent shred
+- **Expand Editor**: opens the ChucK code in the detached overlay editor
 - **Gear button**: see running shreds, remove any with "x"
 
 ## Audio Input


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ChucK nodes now support opening code in a detached editor overlay via an "Expand Editor" action, with customizable actions and settings panels.

* **Tests**
  * Added unit tests for expression editor target creation and settings detection.

* **Documentation**
  * Updated design specifications for detached code editor layout scope.
  * Added documentation for the Expand Editor action.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->