### PR TITLE
feat(orca): fullscreen overlay and appearance settings

### DIFF
--- a/docs/design-docs/specs/151-orca-detached-fullscreen.md
+++ b/docs/design-docs/specs/151-orca-detached-fullscreen.md
@@ -1,0 +1,72 @@
+# 151. Orca Detached Fullscreen
+
+## Goal
+
+Add an **Expand** action to the `orca` object so its live grid editor can move
+into a fullscreen overlay without creating a second Orca runtime.
+
+Orca is an interactive DOM/canvas editor, not a render-graph preview. The
+fullscreen path should therefore portal the existing Orca wrapper into
+`document.body`, preserving the current `Orca`, `Clock`, `IO`, renderer, cursor,
+selection, and playback state.
+
+## Behavior
+
+- Orca shows an Expand button alongside its existing play and settings controls.
+- Opening fullscreen stores the active Orca node id in session UI state.
+- Only one Orca fullscreen editor is active at a time.
+- The same canvas wrapper is portaled to `document.body`; no duplicate Orca
+  engine or canvas is mounted.
+- Fullscreen mode sets `isFullscreenActive` so the regular `SvelteFlow` canvas
+  and side panels hide behind the overlay.
+- The sidebar closes when Orca enters fullscreen.
+- `Shift+Esc` closes fullscreen mode.
+- Destroying the active Orca node clears the fullscreen state.
+- Pointer coordinate math treats the portaled fullscreen canvas as unscaled DOM,
+  while the inline canvas continues to account for the current XYFlow zoom.
+- Fullscreen mode defaults to a `2.7x` Orca font scale so the grid is readable
+  for an audience.
+- The fullscreen overlay background is pitch black (`#000000`) to match Orca's
+  canvas background.
+- The fullscreen canvas is borderless; the grid itself should be the visual
+  focus.
+- The fullscreen chrome includes play/pause, settings, and close controls.
+- Settings render inside the fullscreen wrapper, anchored under the fullscreen
+  settings button, so they remain visible while the main editor UI is hidden.
+
+## Non-Goals
+
+- Do not render Orca through `SurfaceOverlay`; that path is for render-graph
+  previews and output canvases.
+- Do not mirror the live Orca editor into `/output` in this pass.
+- Do not convert Orca settings to schema-driven `ObjectSettings`; the existing
+  `OrcaSettings` component remains the source for Orca-specific settings UI.
+
+## Implementation Notes
+
+Use the existing generic `portal` action, following the Strudel detached editor
+shape. The fullscreen wrapper should be the owner of Orca's canvas and settings
+panel so moving it does not orphan controls inside a hidden `SvelteFlow` tree.
+
+Mouse coordinate conversion should use a small helper:
+
+```ts
+screenToOrcaGridCell({
+  clientX,
+  clientY,
+  rect,
+  zoom: isDetached ? 1 : viewport.current.zoom,
+  tileWidth,
+  tileHeight
+})
+```
+
+This keeps the XYFlow zoom adjustment in inline mode and removes it once the
+canvas has been portaled outside XYFlow's transformed coordinate space.
+
+## Testing
+
+- Unit test the detached Orca store helpers.
+- Unit test the pointer coordinate helper for inline zoomed and fullscreen
+  unscaled coordinates.
+- Run Svelte/TypeScript checks after wiring the component.

--- a/docs/design-docs/specs/151-orca-detached-fullscreen.md
+++ b/docs/design-docs/specs/151-orca-detached-fullscreen.md
@@ -26,8 +26,11 @@ selection, and playback state.
   while the inline canvas continues to account for the current XYFlow zoom.
 - Fullscreen mode defaults to a `2.7x` Orca font scale so the grid is readable
   for an audience.
-- The fullscreen overlay background is pitch black (`#000000`) to match Orca's
-  canvas background.
+- The fullscreen overlay background uses the same transparency setting as
+  fullscreen CodeMirror overlays, with black as its base color.
+- The fullscreen Orca canvas clears its own black background so background
+  visuals show through the overlay and the grid area does not become darker than
+  the rest of the screen.
 - The fullscreen canvas is borderless; the grid itself should be the visual
   focus.
 - The fullscreen chrome includes play/pause, settings, and close controls.

--- a/docs/design-docs/specs/151-orca-detached-fullscreen.md
+++ b/docs/design-docs/specs/151-orca-detached-fullscreen.md
@@ -31,6 +31,10 @@ selection, and playback state.
 - The fullscreen Orca canvas clears its own black background so background
   visuals show through the overlay and the grid area does not become darker than
   the rest of the screen.
+- Orca settings include a background color input that accepts CSS color strings
+  such as `transparent`, hex colors, and `rgba(...)`. Inline mode defaults to
+  opaque black for the classic Orca view, while fullscreen defaults to
+  `transparent` so background visuals can show through.
 - The fullscreen canvas is borderless; the grid itself should be the visual
   focus.
 - Orca settings include a light/dark foreground mode. Inline mode preserves the

--- a/docs/design-docs/specs/151-orca-detached-fullscreen.md
+++ b/docs/design-docs/specs/151-orca-detached-fullscreen.md
@@ -33,6 +33,9 @@ selection, and playback state.
   the rest of the screen.
 - The fullscreen canvas is borderless; the grid itself should be the visual
   focus.
+- Orca settings include a light/dark foreground mode. Inline mode preserves the
+  current dark foreground default, while fullscreen defaults to light foregrounds
+  for legibility over transparent visuals.
 - The fullscreen chrome includes play/pause, settings, and close controls.
 - Settings render inside the fullscreen wrapper, anchored under the fullscreen
   settings button, so they remain visible while the main editor UI is hidden.

--- a/ui/src/lib/components/nodes/OrcaNode.svelte
+++ b/ui/src/lib/components/nodes/OrcaNode.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Pause, Play, Settings, X } from '@lucide/svelte/icons';
+  import { Expand, Pause, Play, Settings, X } from '@lucide/svelte/icons';
   import OrcaSettings from '../settings/OrcaSettings.svelte';
   import { onMount, onDestroy } from 'svelte';
   import { useSvelteFlow, useViewport } from '@xyflow/svelte';
@@ -20,6 +20,16 @@
   import { transportStore } from '../../../stores/transport.store';
   import { Transport } from '$lib/transport/Transport';
   import * as Tooltip from '$lib/components/ui/tooltip';
+  import { portal } from '$lib/dom/portal';
+  import { isFullscreenActive } from '$lib/canvas/SurfaceOverlay';
+  import { isSidebarOpen } from '../../../stores/ui.store';
+  import {
+    activeDetachedOrcaNodeId,
+    closeDetachedOrcaEditor,
+    openDetachedOrcaEditor
+  } from '../../../stores/detached-orca-editor.store';
+  import { screenToOrcaGridCell } from '$lib/orca/pointer';
+  import { DEFAULT_ORCA_FULLSCREEN_FONT_SIZE, getOrcaDisplayFontSize } from '$lib/orca/layout';
 
   let {
     id: nodeId,
@@ -72,13 +82,25 @@
 
   // Scale factor for font size
   let fontSize = $state(1.0);
+  let fullscreenFontSize = $state(DEFAULT_ORCA_FULLSCREEN_FONT_SIZE);
 
   // Canvas rendering scale
   let canvasDensity = $state(Math.round(window.devicePixelRatio) ?? 1);
 
   // Tile dimensions for mouse interaction
-  let TILE_W = $derived(10 * fontSize);
-  let TILE_H = $derived(15 * fontSize);
+  const isDetached = $derived($activeDetachedOrcaNodeId === nodeId);
+  const displayFontSize = $derived(
+    getOrcaDisplayFontSize({
+      inlineFontSize: fontSize,
+      fullscreenFontSize,
+      isDetached
+    })
+  );
+  let TILE_W = $derived(10 * displayFontSize);
+  let TILE_H = $derived(15 * displayFontSize);
+  const detachedPortalTarget = $derived(
+    isDetached && typeof document !== 'undefined' ? document.body : null
+  );
 
   const COLORS = {
     background: '#000000',
@@ -147,6 +169,10 @@
   });
 
   onDestroy(() => {
+    if (isDetached) {
+      closeDetachedOrcaEditor();
+    }
+
     if (clock) {
       clock.stop();
     }
@@ -207,6 +233,16 @@
 
       isPlaying = !isPlaying;
     }
+  }
+
+  function openExpandedEditor(): void {
+    showSettings = false;
+    openDetachedOrcaEditor(nodeId);
+  }
+
+  function closeExpandedEditor(): void {
+    showSettings = false;
+    closeDetachedOrcaEditor();
   }
 
   function measureWidth() {
@@ -404,10 +440,14 @@
     if (!canvas) return;
 
     const rect = canvas.getBoundingClientRect();
-    const canvasX = (e.clientX - rect.left) / viewport.current.zoom;
-    const canvasY = (e.clientY - rect.top) / viewport.current.zoom;
-    const x = Math.floor(canvasX / TILE_W);
-    const y = Math.floor(canvasY / TILE_H);
+    const { x, y } = screenToOrcaGridCell({
+      clientX: e.clientX,
+      clientY: e.clientY,
+      rect,
+      zoom: isDetached ? 1 : viewport.current.zoom,
+      tileWidth: TILE_W,
+      tileHeight: TILE_H
+    });
 
     if (orca && x >= 0 && x < orca.w && y >= 0 && y < orca.h) {
       cursorX = x;
@@ -423,10 +463,14 @@
     if (!canvas || !mouseFrom) return;
 
     const rect = canvas.getBoundingClientRect();
-    const canvasX = (e.clientX - rect.left) / viewport.current.zoom;
-    const canvasY = (e.clientY - rect.top) / viewport.current.zoom;
-    const x = Math.floor(canvasX / TILE_W);
-    const y = Math.floor(canvasY / TILE_H);
+    const { x, y } = screenToOrcaGridCell({
+      clientX: e.clientX,
+      clientY: e.clientY,
+      rect,
+      zoom: isDetached ? 1 : viewport.current.zoom,
+      tileWidth: TILE_W,
+      tileHeight: TILE_H
+    });
 
     if (orca && x >= 0 && x < orca.w && y >= 0 && y < orca.h) {
       selectionW = x - mouseFrom.x;
@@ -516,7 +560,7 @@
     if (!renderer || !clock) return;
 
     // Update font scale if it changed
-    renderer.updateFontScale(fontSize);
+    renderer.updateFontScale(displayFontSize);
 
     const selection = { x: cursorX, y: cursorY, w: selectionW, h: selectionH };
     renderer.render(cursorX, cursorY, clock.isPaused, showInterface, showGuide, selection);
@@ -569,7 +613,110 @@
       })
       .exhaustive();
   });
+
+  $effect(() => {
+    if (!isDetached) return;
+
+    isSidebarOpen.set(false);
+    isFullscreenActive.set(true);
+    render();
+
+    queueMicrotask(() => {
+      canvas?.focus();
+    });
+
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || !event.shiftKey) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      closeExpandedEditor();
+    };
+
+    window.addEventListener('keydown', handleKeydown, { capture: true });
+
+    return () => {
+      window.removeEventListener('keydown', handleKeydown, { capture: true });
+      isFullscreenActive.set(false);
+      queueMicrotask(() => {
+        measureWidth();
+        render();
+      });
+    };
+  });
 </script>
+
+{#snippet settingsPanel()}
+  <OrcaSettings
+    gridWidth={orca?.w ?? gridWidth}
+    gridHeight={orca?.h ?? gridHeight}
+    {syncTransport}
+    {bpm}
+    transportBpm={$transportStore.bpm}
+    {showInterface}
+    {showGuide}
+    fontSize={displayFontSize}
+    {canvasDensity}
+    onGridWidthChange={(val) => {
+      if (orca) {
+        const oldWidth = orca.w;
+        const oldGrid = orca.s;
+        orca.load(val, orca.h, oldGrid, orca.f);
+        updateNodeData(nodeId, { width: val, grid: orca.s });
+        tracker.commit('width', oldWidth, val);
+        render();
+        measureWidth();
+      }
+    }}
+    onGridHeightChange={(val) => {
+      if (orca) {
+        const oldHeight = orca.h;
+        const oldGrid = orca.s;
+        orca.load(orca.w, val, oldGrid, orca.f);
+        updateNodeData(nodeId, { height: val, grid: orca.s });
+        tracker.commit('height', oldHeight, val);
+        render();
+        measureWidth();
+      }
+    }}
+    onSyncTransportChange={() => {
+      const oldValue = syncTransport;
+      updateNodeData(nodeId, { syncTransport: !syncTransport });
+      tracker.commit('syncTransport', oldValue, !oldValue);
+    }}
+    onBpmChange={(val) => {
+      if (clock) {
+        const oldBpm = bpm;
+        clock.setSpeed(val, val);
+        updateNodeData(nodeId, { bpm: val });
+        tracker.commit('bpm', oldBpm, val);
+      }
+    }}
+    onShowInterfaceChange={(show) => {
+      showInterface = show;
+      render();
+    }}
+    onShowGuideChange={(show) => {
+      showGuide = show;
+      render();
+    }}
+    onFontSizeChange={(size) => {
+      if (isDetached) {
+        fullscreenFontSize = size;
+      } else {
+        fontSize = size;
+      }
+      render();
+      measureWidth();
+    }}
+    onCanvasDensityChange={(density) => {
+      canvasDensity = density;
+      if (renderer) renderer.updateCanvasScale(canvasDensity);
+      render();
+    }}
+  />
+{/snippet}
 
 <div class="relative flex gap-x-3">
   <div class="group relative">
@@ -600,6 +747,19 @@
             <Tooltip.Trigger>
               <button
                 class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
+                onclick={openExpandedEditor}
+                aria-label="Expand Orca"
+              >
+                <Expand class="h-4 w-4 text-zinc-300" />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>Expand Orca</Tooltip.Content>
+          </Tooltip.Root>
+
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                class="cursor-pointer rounded p-1 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 sm:opacity-0"
                 onclick={() => {
                   showSettings = !showSettings;
                   measureWidth();
@@ -622,7 +782,71 @@
           index={0}
           {nodeId}
         />
-        <div class="relative" bind:this={containerElement}>
+        <div
+          class={[
+            'nodrag nopan nowheel',
+            isDetached
+              ? 'fixed inset-0 z-[60] flex items-center justify-center overflow-auto p-12'
+              : 'relative'
+          ]}
+          bind:this={containerElement}
+          use:portal={detachedPortalTarget}
+          style:background-color={isDetached ? '#000000' : undefined}
+        >
+          {#if isDetached}
+            <div class="absolute top-6 right-6 z-10 flex gap-1">
+              {#if !syncTransport}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <button
+                      class="cursor-pointer rounded bg-black/35 p-2 text-zinc-300 transition-colors hover:bg-zinc-800/80 hover:text-zinc-100"
+                      onclick={togglePlay}
+                      aria-label={isPlaying ? 'Pause Orca' : 'Play Orca'}
+                    >
+                      <!-- svelte-ignore svelte_component_deprecated -->
+                      <svelte:component this={isPlaying ? Pause : Play} class="h-4 w-4" />
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>{isPlaying ? 'Pause' : 'Play'}</Tooltip.Content>
+                </Tooltip.Root>
+              {/if}
+
+              <div class="relative">
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <button
+                      class="cursor-pointer rounded bg-black/35 p-2 text-zinc-300 transition-colors hover:bg-zinc-800/80 hover:text-zinc-100"
+                      onclick={() => (showSettings = !showSettings)}
+                      aria-label={showSettings ? 'Hide Orca settings' : 'Show Orca settings'}
+                    >
+                      <Settings class="h-4 w-4" />
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>{showSettings ? 'Hide Settings' : 'Settings'}</Tooltip.Content>
+                </Tooltip.Root>
+
+                {#if showSettings}
+                  <div class="absolute top-11 right-0 z-20">
+                    {@render settingsPanel()}
+                  </div>
+                {/if}
+              </div>
+
+              <Tooltip.Root>
+                <Tooltip.Trigger>
+                  <button
+                    class="cursor-pointer rounded bg-black/35 p-2 text-zinc-300 transition-colors hover:bg-zinc-800/80 hover:text-zinc-100"
+                    onclick={closeExpandedEditor}
+                    aria-label="Close expanded Orca editor"
+                  >
+                    <X class="h-4 w-4" />
+                  </button>
+                </Tooltip.Trigger>
+                <Tooltip.Content>Close Expanded Orca (Shift+Esc)</Tooltip.Content>
+              </Tooltip.Root>
+            </div>
+          {/if}
+
           <canvas
             bind:this={canvas}
             onkeydown={handleKeyDown}
@@ -633,10 +857,12 @@
             role="textbox"
             aria-label="Orca grid editor"
             class={[
-              'nodrag cursor-text rounded-md border focus:outline-none',
-              selected
-                ? 'shadow-glow-md border-zinc-400'
-                : 'hover:shadow-glow-sm border-transparent'
+              'nodrag cursor-text focus:outline-none',
+              isDetached
+                ? 'rounded-none border-0 shadow-none'
+                : selected
+                  ? 'shadow-glow-md rounded-md border border-zinc-400'
+                  : 'hover:shadow-glow-sm rounded-md border border-transparent'
             ].join(' ')}
           ></canvas>
         </div>
@@ -653,78 +879,18 @@
   </div>
 
   <!-- Settings Panel -->
-  {#if showSettings}
+  {#if showSettings && !isDetached}
     <div class="absolute" style="left: {previewContainerWidth + 10}px;">
       <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
-        <button onclick={() => (showSettings = false)} class="rounded p-1 hover:bg-zinc-700">
+        <button
+          onclick={() => (showSettings = false)}
+          class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+        >
           <X class="h-4 w-4 text-zinc-300" />
         </button>
       </div>
 
-      <OrcaSettings
-        gridWidth={orca?.w ?? gridWidth}
-        gridHeight={orca?.h ?? gridHeight}
-        {syncTransport}
-        {bpm}
-        transportBpm={$transportStore.bpm}
-        {showInterface}
-        {showGuide}
-        {fontSize}
-        {canvasDensity}
-        onGridWidthChange={(val) => {
-          if (orca) {
-            const oldWidth = orca.w;
-            const oldGrid = orca.s;
-            orca.load(val, orca.h, oldGrid, orca.f);
-            updateNodeData(nodeId, { width: val, grid: orca.s });
-            tracker.commit('width', oldWidth, val);
-            render();
-            measureWidth();
-          }
-        }}
-        onGridHeightChange={(val) => {
-          if (orca) {
-            const oldHeight = orca.h;
-            const oldGrid = orca.s;
-            orca.load(orca.w, val, oldGrid, orca.f);
-            updateNodeData(nodeId, { height: val, grid: orca.s });
-            tracker.commit('height', oldHeight, val);
-            render();
-            measureWidth();
-          }
-        }}
-        onSyncTransportChange={() => {
-          const oldValue = syncTransport;
-          updateNodeData(nodeId, { syncTransport: !syncTransport });
-          tracker.commit('syncTransport', oldValue, !oldValue);
-        }}
-        onBpmChange={(val) => {
-          if (clock) {
-            const oldBpm = bpm;
-            clock.setSpeed(val, val);
-            updateNodeData(nodeId, { bpm: val });
-            tracker.commit('bpm', oldBpm, val);
-          }
-        }}
-        onShowInterfaceChange={(show) => {
-          showInterface = show;
-          render();
-        }}
-        onShowGuideChange={(show) => {
-          showGuide = show;
-          render();
-        }}
-        onFontSizeChange={(size) => {
-          fontSize = size;
-          render();
-          measureWidth();
-        }}
-        onCanvasDensityChange={(density) => {
-          canvasDensity = density;
-          if (renderer) renderer.updateCanvasScale(canvasDensity);
-          render();
-        }}
-      />
+      {@render settingsPanel()}
     </div>
   {/if}
 </div>

--- a/ui/src/lib/components/nodes/OrcaNode.svelte
+++ b/ui/src/lib/components/nodes/OrcaNode.svelte
@@ -32,6 +32,7 @@
   import { screenToOrcaGridCell } from '$lib/orca/pointer';
   import {
     DEFAULT_ORCA_FULLSCREEN_FONT_SIZE,
+    getOrcaCanvasBackground,
     getOrcaColors,
     getOrcaDisplayFontSize,
     getOrcaDisplayForegroundMode,
@@ -93,6 +94,8 @@
   let fullscreenFontSize = $state(DEFAULT_ORCA_FULLSCREEN_FONT_SIZE);
   let foregroundMode = $state<OrcaForegroundMode>('dark');
   let fullscreenForegroundMode = $state<OrcaForegroundMode>('light');
+  let background = $state('#000000');
+  let fullscreenBackground = $state('transparent');
 
   // Canvas rendering scale
   let canvasDensity = $state(Math.round(window.devicePixelRatio) ?? 1);
@@ -117,6 +120,8 @@
     })
   );
   const colors = $derived(getOrcaColors(displayForegroundMode));
+  const displayBackground = $derived(isDetached ? fullscreenBackground : background);
+  const canvasBackground = $derived(getOrcaCanvasBackground(displayBackground));
   let TILE_W = $derived(10 * displayFontSize);
   let TILE_H = $derived(15 * displayFontSize);
   const detachedPortalTarget = $derived(
@@ -579,7 +584,7 @@
       showInterface,
       showGuide,
       selection,
-      isDetached ? 'transparent' : colors.background
+      canvasBackground
     );
   }
 
@@ -683,6 +688,7 @@
     {showGuide}
     fontSize={displayFontSize}
     foregroundMode={displayForegroundMode}
+    background={displayBackground}
     {canvasDensity}
     onGridWidthChange={(val) => {
       if (orca) {
@@ -741,6 +747,14 @@
         fullscreenForegroundMode = mode;
       } else {
         foregroundMode = mode;
+      }
+      render();
+    }}
+    onBackgroundChange={(nextBackground) => {
+      if (isDetached) {
+        fullscreenBackground = nextBackground;
+      } else {
+        background = nextBackground;
       }
       render();
     }}

--- a/ui/src/lib/components/nodes/OrcaNode.svelte
+++ b/ui/src/lib/components/nodes/OrcaNode.svelte
@@ -28,8 +28,13 @@
     closeDetachedOrcaEditor,
     openDetachedOrcaEditor
   } from '../../../stores/detached-orca-editor.store';
+  import { overlayEditorTransparency } from '../../../stores/editor-layout-settings.store';
   import { screenToOrcaGridCell } from '$lib/orca/pointer';
-  import { DEFAULT_ORCA_FULLSCREEN_FONT_SIZE, getOrcaDisplayFontSize } from '$lib/orca/layout';
+  import {
+    DEFAULT_ORCA_FULLSCREEN_FONT_SIZE,
+    getOrcaDisplayFontSize,
+    getOrcaFullscreenOverlayBackground
+  } from '$lib/orca/layout';
 
   let {
     id: nodeId,
@@ -95,6 +100,9 @@
       fullscreenFontSize,
       isDetached
     })
+  );
+  const fullscreenOverlayBackground = $derived(
+    getOrcaFullscreenOverlayBackground($overlayEditorTransparency)
   );
   let TILE_W = $derived(10 * displayFontSize);
   let TILE_H = $derived(15 * displayFontSize);
@@ -563,7 +571,15 @@
     renderer.updateFontScale(displayFontSize);
 
     const selection = { x: cursorX, y: cursorY, w: selectionW, h: selectionH };
-    renderer.render(cursorX, cursorY, clock.isPaused, showInterface, showGuide, selection);
+    renderer.render(
+      cursorX,
+      cursorY,
+      clock.isPaused,
+      showInterface,
+      showGuide,
+      selection,
+      isDetached ? 'transparent' : COLORS.background
+    );
   }
 
   function increaseBpm(): void {
@@ -791,7 +807,7 @@
           ]}
           bind:this={containerElement}
           use:portal={detachedPortalTarget}
-          style:background-color={isDetached ? '#000000' : undefined}
+          style:background-color={isDetached ? fullscreenOverlayBackground : undefined}
         >
           {#if isDetached}
             <div class="absolute top-6 right-6 z-10 flex gap-1">

--- a/ui/src/lib/components/nodes/OrcaNode.svelte
+++ b/ui/src/lib/components/nodes/OrcaNode.svelte
@@ -32,9 +32,12 @@
   import { screenToOrcaGridCell } from '$lib/orca/pointer';
   import {
     DEFAULT_ORCA_FULLSCREEN_FONT_SIZE,
+    getOrcaColors,
     getOrcaDisplayFontSize,
+    getOrcaDisplayForegroundMode,
     getOrcaFullscreenOverlayBackground
   } from '$lib/orca/layout';
+  import type { OrcaForegroundMode } from '$lib/orca/layout';
 
   let {
     id: nodeId,
@@ -88,6 +91,8 @@
   // Scale factor for font size
   let fontSize = $state(1.0);
   let fullscreenFontSize = $state(DEFAULT_ORCA_FULLSCREEN_FONT_SIZE);
+  let foregroundMode = $state<OrcaForegroundMode>('dark');
+  let fullscreenForegroundMode = $state<OrcaForegroundMode>('light');
 
   // Canvas rendering scale
   let canvasDensity = $state(Math.round(window.devicePixelRatio) ?? 1);
@@ -104,24 +109,19 @@
   const fullscreenOverlayBackground = $derived(
     getOrcaFullscreenOverlayBackground($overlayEditorTransparency)
   );
+  const displayForegroundMode = $derived(
+    getOrcaDisplayForegroundMode({
+      inlineMode: foregroundMode,
+      fullscreenMode: fullscreenForegroundMode,
+      isDetached
+    })
+  );
+  const colors = $derived(getOrcaColors(displayForegroundMode));
   let TILE_W = $derived(10 * displayFontSize);
   let TILE_H = $derived(15 * displayFontSize);
   const detachedPortalTarget = $derived(
     isDetached && typeof document !== 'undefined' ? document.body : null
   );
-
-  const COLORS = {
-    background: '#000000',
-    f_high: '#ffffff',
-    f_med: '#777777',
-    f_low: '#444444',
-    f_inv: '#000000',
-    b_high: '#eeeeee',
-    b_med: '#72dec2',
-    b_low: '#444444',
-    b_inv: '#ffb545',
-    cursor: '#ffb545'
-  };
 
   onMount(() => {
     if (!canvas) return;
@@ -132,7 +132,7 @@
 
     clock = new Clock(orca);
     io = new IO(messageContext);
-    renderer = new OrcaRenderer(canvas, orca, COLORS, fontSize, canvasDensity);
+    renderer = new OrcaRenderer(canvas, orca, colors, fontSize, canvasDensity);
 
     // Connect IO to Orca so operators can access it
     orca.io = io;
@@ -569,6 +569,7 @@
 
     // Update font scale if it changed
     renderer.updateFontScale(displayFontSize);
+    renderer.updateColors(colors);
 
     const selection = { x: cursorX, y: cursorY, w: selectionW, h: selectionH };
     renderer.render(
@@ -578,9 +579,17 @@
       showInterface,
       showGuide,
       selection,
-      isDetached ? 'transparent' : COLORS.background
+      isDetached ? 'transparent' : colors.background
     );
   }
+
+  $effect(() => {
+    if (!renderer) return;
+
+    renderer.updateFontScale(displayFontSize);
+    renderer.updateColors(colors);
+    render();
+  });
 
   function increaseBpm(): void {
     if (clock) {
@@ -673,6 +682,7 @@
     {showInterface}
     {showGuide}
     fontSize={displayFontSize}
+    foregroundMode={displayForegroundMode}
     {canvasDensity}
     onGridWidthChange={(val) => {
       if (orca) {
@@ -725,6 +735,14 @@
       }
       render();
       measureWidth();
+    }}
+    onForegroundModeChange={(mode) => {
+      if (isDetached) {
+        fullscreenForegroundMode = mode;
+      } else {
+        foregroundMode = mode;
+      }
+      render();
     }}
     onCanvasDensityChange={(density) => {
       canvasDensity = density;

--- a/ui/src/lib/components/settings/OrcaSettings.svelte
+++ b/ui/src/lib/components/settings/OrcaSettings.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { OrcaForegroundMode } from '$lib/orca/layout';
+
   let {
     gridWidth,
     gridHeight,
@@ -8,6 +10,7 @@
     showInterface,
     showGuide,
     fontSize,
+    foregroundMode,
     canvasDensity,
     onGridWidthChange,
     onGridHeightChange,
@@ -16,6 +19,7 @@
     onShowInterfaceChange,
     onShowGuideChange,
     onFontSizeChange,
+    onForegroundModeChange,
     onCanvasDensityChange
   }: {
     gridWidth: number;
@@ -26,6 +30,7 @@
     showInterface: boolean;
     showGuide: boolean;
     fontSize: number;
+    foregroundMode: OrcaForegroundMode;
     canvasDensity: number;
     onGridWidthChange: (width: number) => void;
     onGridHeightChange: (height: number) => void;
@@ -34,6 +39,7 @@
     onShowInterfaceChange: (show: boolean) => void;
     onShowGuideChange: (show: boolean) => void;
     onFontSizeChange: (size: number) => void;
+    onForegroundModeChange: (mode: OrcaForegroundMode) => void;
     onCanvasDensityChange: (density: number) => void;
   } = $props();
 </script>
@@ -113,6 +119,17 @@
 
     <div class="space-y-2">
       <div class="text-xs font-medium text-zinc-400">Display Options</div>
+      <label class="flex items-center gap-2 text-xs text-zinc-400">
+        <input
+          type="checkbox"
+          checked={foregroundMode === 'light'}
+          onchange={(e) => onForegroundModeChange(e.currentTarget.checked ? 'light' : 'dark')}
+          class="cursor-pointer rounded"
+        />
+
+        <span>Brighter foreground</span>
+      </label>
+
       <label class="flex items-center gap-2 text-xs text-zinc-400">
         <input
           type="checkbox"

--- a/ui/src/lib/components/settings/OrcaSettings.svelte
+++ b/ui/src/lib/components/settings/OrcaSettings.svelte
@@ -11,6 +11,7 @@
     showGuide,
     fontSize,
     foregroundMode,
+    background,
     canvasDensity,
     onGridWidthChange,
     onGridHeightChange,
@@ -20,6 +21,7 @@
     onShowGuideChange,
     onFontSizeChange,
     onForegroundModeChange,
+    onBackgroundChange,
     onCanvasDensityChange
   }: {
     gridWidth: number;
@@ -31,6 +33,7 @@
     showGuide: boolean;
     fontSize: number;
     foregroundMode: OrcaForegroundMode;
+    background: string;
     canvasDensity: number;
     onGridWidthChange: (width: number) => void;
     onGridHeightChange: (height: number) => void;
@@ -40,6 +43,7 @@
     onShowGuideChange: (show: boolean) => void;
     onFontSizeChange: (size: number) => void;
     onForegroundModeChange: (mode: OrcaForegroundMode) => void;
+    onBackgroundChange: (background: string) => void;
     onCanvasDensityChange: (density: number) => void;
   } = $props();
 </script>
@@ -187,6 +191,16 @@
             +
           </button>
         </div>
+      </label>
+
+      <label class="flex flex-col text-xs text-zinc-400">
+        <span>Background</span>
+        <input
+          value={background}
+          oninput={(e) => onBackgroundChange(e.currentTarget.value)}
+          placeholder="transparent or rgba(0,0,0,.4)"
+          class="mt-1 w-full rounded bg-zinc-800 px-2 py-1 text-xs text-white placeholder:text-zinc-500"
+        />
       </label>
     </div>
   </div>

--- a/ui/src/lib/orca/OrcaRenderer.ts
+++ b/ui/src/lib/orca/OrcaRenderer.ts
@@ -8,19 +8,7 @@
  */
 
 import type { Orca } from './Orca';
-
-interface OrcaColors {
-  background: string;
-  f_high: string;
-  f_med: string;
-  f_low: string;
-  f_inv: string;
-  b_high: string;
-  b_med: string;
-  b_low: string;
-  b_inv: string;
-  cursor: string;
-}
+import { getOrcaPortForeground, type OrcaColors } from './layout';
 
 export class OrcaRenderer {
   private orca: Orca;
@@ -67,6 +55,10 @@ export class OrcaRenderer {
     this.tileH = 15 * fontScale;
     this.tileWS = Math.floor(this.tileW * this.scale);
     this.tileHS = Math.floor(this.tileH * this.scale);
+  }
+
+  updateColors(colors: OrcaColors): void {
+    this.colors = colors;
   }
 
   findPorts(): void {
@@ -393,15 +385,15 @@ export class OrcaRenderer {
       // type 0: operator (already handled by uppercase check below)
       // type 1: haste port (inputs at negative positions)
       if (portType === 1) {
-        return { fg: this.colors.b_med };
+        return { fg: getOrcaPortForeground(this.colors, portType) };
       }
       // type 2: input port
       if (portType === 2) {
-        return { fg: this.colors.b_high };
+        return { fg: getOrcaPortForeground(this.colors, portType) };
       }
       // type 3: output port
       if (portType === 3) {
-        return { bg: this.colors.b_high, fg: this.colors.f_low };
+        return { bg: this.colors.b_high, fg: this.colors.f_on_bg };
       }
     }
 
@@ -411,7 +403,7 @@ export class OrcaRenderer {
       glyph === glyph.toUpperCase() &&
       glyph.toLowerCase() !== glyph.toUpperCase()
     ) {
-      return { bg: this.colors.b_med, fg: this.colors.f_low };
+      return { bg: this.colors.b_med, fg: this.colors.f_on_bg };
     }
 
     // Locked cells

--- a/ui/src/lib/orca/OrcaRenderer.ts
+++ b/ui/src/lib/orca/OrcaRenderer.ts
@@ -230,7 +230,8 @@ export class OrcaRenderer {
     isPaused: boolean,
     showInterface: boolean = false,
     showGuide: boolean = false,
-    selection?: { x: number; y: number; w: number; h: number }
+    selection?: { x: number; y: number; w: number; h: number },
+    background: string = this.colors.background
   ): void {
     // Update ports map
     this.findPorts();
@@ -252,9 +253,13 @@ export class OrcaRenderer {
       this.ctx.font = `${this.tileHS * 0.75}px monospace`;
     }
 
-    // Clear canvas
-    this.ctx.fillStyle = this.colors.background;
-    this.ctx.fillRect(0, 0, width, height);
+    // Clear canvas. Fullscreen mode can request a transparent grid background
+    // so visuals behind the overlay show through evenly.
+    this.ctx.clearRect(0, 0, width, height);
+    if (background !== 'transparent') {
+      this.ctx.fillStyle = background;
+      this.ctx.fillRect(0, 0, width, height);
+    }
 
     // Calculate selection bounds
     let selMinX = cursorX,

--- a/ui/src/lib/orca/layout.test.ts
+++ b/ui/src/lib/orca/layout.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { DEFAULT_ORCA_FULLSCREEN_FONT_SIZE, getOrcaDisplayFontSize } from './layout';
+import {
+  DEFAULT_ORCA_FULLSCREEN_FONT_SIZE,
+  getOrcaDisplayFontSize,
+  getOrcaFullscreenOverlayBackground
+} from './layout';
 
 describe('getOrcaDisplayFontSize', () => {
   it('keeps the inline font size outside fullscreen mode', () => {
@@ -17,5 +21,11 @@ describe('getOrcaDisplayFontSize', () => {
         isDetached: true
       })
     ).toBe(DEFAULT_ORCA_FULLSCREEN_FONT_SIZE);
+  });
+});
+
+describe('getOrcaFullscreenOverlayBackground', () => {
+  it('uses black with the shared overlay transparency value', () => {
+    expect(getOrcaFullscreenOverlayBackground(0.45)).toBe('rgba(0, 0, 0, 0.45)');
   });
 });

--- a/ui/src/lib/orca/layout.test.ts
+++ b/ui/src/lib/orca/layout.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_ORCA_FULLSCREEN_FONT_SIZE,
   getOrcaColors,
+  getOrcaCanvasBackground,
   getOrcaDisplayFontSize,
   getOrcaDisplayForegroundMode,
   getOrcaFullscreenOverlayBackground,
@@ -30,6 +31,14 @@ describe('getOrcaDisplayFontSize', () => {
 describe('getOrcaFullscreenOverlayBackground', () => {
   it('uses black with the shared overlay transparency value', () => {
     expect(getOrcaFullscreenOverlayBackground(0.45)).toBe('rgba(0, 0, 0, 0.45)');
+  });
+});
+
+describe('getOrcaCanvasBackground', () => {
+  it('uses the user-provided CSS background string', () => {
+    expect(getOrcaCanvasBackground('rgba(0, 0, 0, 0.4)')).toBe('rgba(0, 0, 0, 0.4)');
+    expect(getOrcaCanvasBackground('#00000080')).toBe('#00000080');
+    expect(getOrcaCanvasBackground('transparent')).toBe('transparent');
   });
 });
 

--- a/ui/src/lib/orca/layout.test.ts
+++ b/ui/src/lib/orca/layout.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_ORCA_FULLSCREEN_FONT_SIZE,
+  getOrcaColors,
   getOrcaDisplayFontSize,
-  getOrcaFullscreenOverlayBackground
+  getOrcaDisplayForegroundMode,
+  getOrcaFullscreenOverlayBackground,
+  getOrcaPortForeground
 } from './layout';
 
 describe('getOrcaDisplayFontSize', () => {
@@ -27,5 +30,57 @@ describe('getOrcaDisplayFontSize', () => {
 describe('getOrcaFullscreenOverlayBackground', () => {
   it('uses black with the shared overlay transparency value', () => {
     expect(getOrcaFullscreenOverlayBackground(0.45)).toBe('rgba(0, 0, 0, 0.45)');
+  });
+});
+
+describe('getOrcaDisplayForegroundMode', () => {
+  it('keeps the inline foreground mode outside fullscreen mode', () => {
+    expect(
+      getOrcaDisplayForegroundMode({
+        inlineMode: 'dark',
+        fullscreenMode: 'light',
+        isDetached: false
+      })
+    ).toBe('dark');
+  });
+
+  it('uses the fullscreen foreground mode while detached', () => {
+    expect(
+      getOrcaDisplayForegroundMode({
+        inlineMode: 'dark',
+        fullscreenMode: 'light',
+        isDetached: true
+      })
+    ).toBe('light');
+  });
+});
+
+describe('getOrcaColors', () => {
+  it('keeps the original dark foreground palette', () => {
+    expect(getOrcaColors('dark')).toMatchObject({
+      f_med: '#777777',
+      f_low: '#444444',
+      f_hint: '#444444',
+      b_high: '#eeeeee'
+    });
+  });
+
+  it('uses brighter neutral foregrounds in light mode', () => {
+    expect(getOrcaColors('light')).toMatchObject({
+      f_med: '#d4d4d8',
+      f_low: '#a1a1aa',
+      f_hint: '#ffffff',
+      f_on_bg: '#444444',
+      b_high: '#ffffff'
+    });
+  });
+});
+
+describe('getOrcaPortForeground', () => {
+  it('preserves cyan and white hint colors in light mode', () => {
+    const colors = getOrcaColors('light');
+
+    expect(getOrcaPortForeground(colors, 1)).toBe('#72dec2');
+    expect(getOrcaPortForeground(colors, 2)).toBe('#ffffff');
   });
 });

--- a/ui/src/lib/orca/layout.test.ts
+++ b/ui/src/lib/orca/layout.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_ORCA_FULLSCREEN_FONT_SIZE, getOrcaDisplayFontSize } from './layout';
+
+describe('getOrcaDisplayFontSize', () => {
+  it('keeps the inline font size outside fullscreen mode', () => {
+    expect(
+      getOrcaDisplayFontSize({ inlineFontSize: 1.4, fullscreenFontSize: 3, isDetached: false })
+    ).toBe(1.4);
+  });
+
+  it('uses the fullscreen font size while detached', () => {
+    expect(
+      getOrcaDisplayFontSize({
+        inlineFontSize: 1.4,
+        fullscreenFontSize: DEFAULT_ORCA_FULLSCREEN_FONT_SIZE,
+        isDetached: true
+      })
+    ).toBe(DEFAULT_ORCA_FULLSCREEN_FONT_SIZE);
+  });
+});

--- a/ui/src/lib/orca/layout.ts
+++ b/ui/src/lib/orca/layout.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_ORCA_FULLSCREEN_FONT_SIZE = 2.7;
+
+type OrcaDisplayFontSizeOptions = {
+  inlineFontSize: number;
+  fullscreenFontSize: number;
+  isDetached: boolean;
+};
+
+export function getOrcaDisplayFontSize({
+  inlineFontSize,
+  fullscreenFontSize,
+  isDetached
+}: OrcaDisplayFontSizeOptions): number {
+  return isDetached ? fullscreenFontSize : inlineFontSize;
+}

--- a/ui/src/lib/orca/layout.ts
+++ b/ui/src/lib/orca/layout.ts
@@ -1,9 +1,57 @@
 export const DEFAULT_ORCA_FULLSCREEN_FONT_SIZE = 2.7;
 
+export type OrcaForegroundMode = 'dark' | 'light';
+
+export type OrcaColors = {
+  background: string;
+  f_high: string;
+  f_med: string;
+  f_low: string;
+  f_hint: string;
+  f_on_bg: string;
+  f_inv: string;
+  b_high: string;
+  b_med: string;
+  b_low: string;
+  b_inv: string;
+  cursor: string;
+};
+
 type OrcaDisplayFontSizeOptions = {
   inlineFontSize: number;
   fullscreenFontSize: number;
   isDetached: boolean;
+};
+
+type OrcaDisplayForegroundModeOptions = {
+  inlineMode: OrcaForegroundMode;
+  fullscreenMode: OrcaForegroundMode;
+  isDetached: boolean;
+};
+
+const ORCA_DARK_COLORS: OrcaColors = {
+  background: '#000000',
+  f_high: '#ffffff',
+  f_med: '#777777',
+  f_low: '#444444',
+  f_hint: '#444444',
+  f_on_bg: '#444444',
+  f_inv: '#000000',
+  b_high: '#eeeeee',
+  b_med: '#72dec2',
+  b_low: '#444444',
+  b_inv: '#ffb545',
+  cursor: '#ffb545'
+};
+
+const ORCA_LIGHT_COLORS: OrcaColors = {
+  ...ORCA_DARK_COLORS,
+  f_med: '#d4d4d8',
+  f_low: '#a1a1aa',
+  f_hint: '#ffffff',
+  f_on_bg: '#444444',
+  b_high: '#ffffff',
+  b_low: '#d4d4d8'
 };
 
 export function getOrcaDisplayFontSize({
@@ -12,6 +60,25 @@ export function getOrcaDisplayFontSize({
   isDetached
 }: OrcaDisplayFontSizeOptions): number {
   return isDetached ? fullscreenFontSize : inlineFontSize;
+}
+
+export function getOrcaDisplayForegroundMode({
+  inlineMode,
+  fullscreenMode,
+  isDetached
+}: OrcaDisplayForegroundModeOptions): OrcaForegroundMode {
+  return isDetached ? fullscreenMode : inlineMode;
+}
+
+export function getOrcaColors(mode: OrcaForegroundMode): OrcaColors {
+  return mode === 'light' ? ORCA_LIGHT_COLORS : ORCA_DARK_COLORS;
+}
+
+export function getOrcaPortForeground(colors: OrcaColors, portType: number): string {
+  if (portType === 1) return colors.b_med;
+  if (portType === 2) return colors.b_high;
+
+  return colors.f_hint;
 }
 
 export function getOrcaFullscreenOverlayBackground(transparency: number): string {

--- a/ui/src/lib/orca/layout.ts
+++ b/ui/src/lib/orca/layout.ts
@@ -13,3 +13,7 @@ export function getOrcaDisplayFontSize({
 }: OrcaDisplayFontSizeOptions): number {
   return isDetached ? fullscreenFontSize : inlineFontSize;
 }
+
+export function getOrcaFullscreenOverlayBackground(transparency: number): string {
+  return `rgba(0, 0, 0, ${transparency})`;
+}

--- a/ui/src/lib/orca/layout.ts
+++ b/ui/src/lib/orca/layout.ts
@@ -84,3 +84,7 @@ export function getOrcaPortForeground(colors: OrcaColors, portType: number): str
 export function getOrcaFullscreenOverlayBackground(transparency: number): string {
   return `rgba(0, 0, 0, ${transparency})`;
 }
+
+export function getOrcaCanvasBackground(background: string): string {
+  return background.trim() || 'transparent';
+}

--- a/ui/src/lib/orca/pointer.test.ts
+++ b/ui/src/lib/orca/pointer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { screenToOrcaGridCell } from './pointer';
+
+describe('screenToOrcaGridCell', () => {
+  it('accounts for xyflow zoom in inline mode', () => {
+    const cell = screenToOrcaGridCell({
+      clientX: 140,
+      clientY: 90,
+      rect: { left: 100, top: 50 },
+      zoom: 2,
+      tileWidth: 10,
+      tileHeight: 20
+    });
+
+    expect(cell).toEqual({ x: 2, y: 1 });
+  });
+
+  it('uses unscaled coordinates for portaled fullscreen mode', () => {
+    const cell = screenToOrcaGridCell({
+      clientX: 140,
+      clientY: 90,
+      rect: { left: 100, top: 50 },
+      zoom: 1,
+      tileWidth: 10,
+      tileHeight: 20
+    });
+
+    expect(cell).toEqual({ x: 4, y: 2 });
+  });
+});

--- a/ui/src/lib/orca/pointer.ts
+++ b/ui/src/lib/orca/pointer.ts
@@ -1,0 +1,28 @@
+type OrcaGridPointerRect = Pick<DOMRect, 'left' | 'top'>;
+
+type ScreenToOrcaGridCellOptions = {
+  clientX: number;
+  clientY: number;
+  rect: OrcaGridPointerRect;
+  zoom: number;
+  tileWidth: number;
+  tileHeight: number;
+};
+
+export function screenToOrcaGridCell({
+  clientX,
+  clientY,
+  rect,
+  zoom,
+  tileWidth,
+  tileHeight
+}: ScreenToOrcaGridCellOptions): { x: number; y: number } {
+  const scale = zoom || 1;
+  const canvasX = (clientX - rect.left) / scale;
+  const canvasY = (clientY - rect.top) / scale;
+
+  return {
+    x: Math.floor(canvasX / tileWidth),
+    y: Math.floor(canvasY / tileHeight)
+  };
+}

--- a/ui/src/stores/detached-orca-editor.store.test.ts
+++ b/ui/src/stores/detached-orca-editor.store.test.ts
@@ -1,0 +1,24 @@
+import { get } from 'svelte/store';
+import { describe, expect, it } from 'vitest';
+
+import {
+  activeDetachedOrcaNodeId,
+  closeDetachedOrcaEditor,
+  isDetachedOrcaEditor,
+  openDetachedOrcaEditor
+} from './detached-orca-editor.store';
+
+describe('detached orca editor store', () => {
+  it('tracks the active detached orca node', () => {
+    openDetachedOrcaEditor('orca-1');
+
+    expect(get(activeDetachedOrcaNodeId)).toBe('orca-1');
+    expect(isDetachedOrcaEditor('orca-1')).toBe(true);
+    expect(isDetachedOrcaEditor('orca-2')).toBe(false);
+
+    closeDetachedOrcaEditor();
+
+    expect(get(activeDetachedOrcaNodeId)).toBeNull();
+    expect(isDetachedOrcaEditor('orca-1')).toBe(false);
+  });
+});

--- a/ui/src/stores/detached-orca-editor.store.ts
+++ b/ui/src/stores/detached-orca-editor.store.ts
@@ -1,0 +1,18 @@
+import { get, writable } from 'svelte/store';
+import { match } from 'ts-pattern';
+
+export const activeDetachedOrcaNodeId = writable<string | null>(null);
+
+export function openDetachedOrcaEditor(nodeId: string): void {
+  activeDetachedOrcaNodeId.set(nodeId);
+}
+
+export function closeDetachedOrcaEditor(): void {
+  activeDetachedOrcaNodeId.set(null);
+}
+
+export function isDetachedOrcaEditor(nodeId: string | undefined): boolean {
+  return match(nodeId)
+    .with(undefined, () => false)
+    .otherwise((n) => get(activeDetachedOrcaNodeId) === n);
+}

--- a/ui/static/content/objects/orca.md
+++ b/ui/static/content/objects/orca.md
@@ -30,13 +30,45 @@ Enable **Sync to transport** in settings to lock Orca's clock to the global
 [transport](/docs/transport-control). When synced, BPM and play/pause are
 controlled by the transport bar instead of per-node controls.
 
+## Fullscreen
+
+Use the **Expand** button to move the Orca grid into a fullscreen performance
+view. The same live grid is moved out of the canvas editor, so playback,
+selection, cursor position, and edits keep going.
+
+Fullscreen mode is useful for layering Orca over visual output:
+
+- The grid defaults to a larger font size
+- The background defaults to `transparent`
+- **Brighter foreground** makes operators and hints easier to read over visuals
+- **Background** accepts CSS colors like `transparent`, `#00000080`, or
+  `rgba(0, 0, 0, 0.4)`
+
+Press **Shift+Esc** or the close button to leave fullscreen.
+
+## Settings
+
+Use the settings button to tune the grid and performance view:
+
+- **Width / Height**: resize the Orca grid
+- **BPM**: set Orca's local tempo when transport sync is off
+- **Sync to transport**: follow Patchies transport BPM and play state
+- **Brighter foreground**: use brighter text for transparent or visual
+  backgrounds
+- **Show Status Interface**: show the bottom status readout
+- **Show Operator Guide**: show built-in operator hints
+- **Font Size**: scale the grid text
+- **Canvas Density**: adjust canvas pixel density
+- **Background**: set the Orca canvas background using any CSS color string
+
 ## Controls
 
 - Click on the canvas and type characters to edit the grid
 - **Space**: play/pause
 - **Enter** or **Ctrl+F**: advance one frame
 - **Ctrl+Shift+R**: reset frame
-- **Settings button**: update BPM, font size, grid size
+- **Expand button**: open fullscreen mode
+- **Settings button**: update display, clock, and grid settings
 - **`>`**: increase tempo
 - **`<`**: decrease tempo
 


### PR DESCRIPTION
Add fullscreen overlay mode for Orca for live performances 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orca editor can expand into a detached fullscreen overlay with its own toolbar (play/pause, settings, close), independent font scaling, and transparent/borderless grid presentation.
  * Pointer/zoom mapping correctly converts clicks to grid cells in both inline and detached fullscreen modes.
  * New foreground/theme options exposed to settings (e.g., "Brighter foreground") and runtime color updates.

* **Documentation**
  * Added a design spec describing detached fullscreen behavior, controls, and UX rules.

* **Tests**
  * Added unit tests for font sizing, coordinate conversion, color helpers, and detached-editor state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/heypoom/patchies/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->