### PR TITLE
Add experimental html-in-canvas support to dom and vue

### DIFF
--- a/docs/design-docs/specs/100-html-in-canvas-dom-prototype.md
+++ b/docs/design-docs/specs/100-html-in-canvas-dom-prototype.md
@@ -1,0 +1,53 @@
+# 100. HTML-in-Canvas DOM Prototype
+
+**Status**: Prototype
+
+---
+
+## Overview
+
+This prototype explores whether Chromium's experimental HTML-in-Canvas API can turn Patchies `dom` nodes into optional video sources while keeping their main-thread DOM interactivity.
+
+The first pass proved the `dom` path is feasible. The shared HTML-in-Canvas plumbing should now live in a small library so `dom` and `vue` can use the same capture, sizing, video registration, and worker-transfer behavior.
+
+---
+
+## Goals
+
+- Add an opt-in `htmlCanvas.videoOutput()` API to the `dom` and `vue` objects.
+- Add independent `htmlCanvas.canvasLayer()` and `htmlCanvas.glslLayer()` APIs to the `dom` and `vue` objects for local main-thread post-processing that does not register video output.
+- Preserve existing `dom` and `vue` behavior unless the user opts in.
+- Share HTML-in-Canvas lifecycle code between objects instead of duplicating it.
+- Render the DOM root into a `layoutsubtree` canvas with `drawElementImage()`.
+- Capture the DOM root as a transferable `ElementImage` and draw it in the render worker.
+- Surface whether the current browser supports the experimental API.
+
+---
+
+## Non-Goals
+
+- No compatibility fallback that emulates HTML-in-Canvas with `html2canvas` or SVG.
+
+---
+
+## Proposed Runtime Shape
+
+When `htmlCanvas.videoOutput()` is called, the node registers as an external `img` video source, shows a video outlet, and wraps the user root in a `<canvas layoutsubtree>`. `htmlCanvas.videoOutput()` uses the current Patchies render output size by default, `htmlCanvas.videoOutput(false)` disables the output, and `htmlCanvas.videoOutput({ size: "free" })` lets the DOM content choose its own source size before Patchies fits it into the render output.
+
+The user's root element must be a direct child of the canvas because `drawElementImage()` and `captureElementImage()` require that relationship. The canvas `paint` handler draws the root, applies the returned transform to the root for hit testing and accessibility alignment, captures the root as an `ElementImage`, and transfers that snapshot to the render worker. The worker draws the snapshot into an `OffscreenCanvas`, converts it to an `ImageBitmap`, and reuses the existing external texture upload path.
+
+Browsers without `layoutsubtree`, `requestPaint()`, `captureElementImage()`, and `drawElementImage()` support should log a clear warning and leave the node usable as a normal DOM interface.
+
+`dom` and `vue` should each keep ownership of their own code execution lifecycle. The shared library should only own HTML-in-Canvas concerns: API option parsing, support checks, size resolution, canvas paint setup, ElementImage capture, GL video source registration, and cleanup.
+
+`htmlCanvas.canvasLayer(callback)` is independent from `htmlCanvas.videoOutput()`. It uses a local `<canvas layoutsubtree>` to draw the live DOM/Vue root with `drawElementImage()`, then runs the callback on the main thread with the same 2D canvas context plus `{ width, height, displayWidth, displayHeight, pixelRatio, time, delta }`. It should size from the live node surface, not from Patchies' render output size, and it should never register with the render worker or add a video outlet. `htmlCanvas.canvasLayer(false)` disables the local postprocess layer.
+
+`htmlCanvas.glslLayer(fragmentShader)` uses the WebGL HTML-in-Canvas path from the WICG proposal. It creates a WebGL context on the local `layoutsubtree` canvas, uploads the live DOM/Vue root into `sampler2D source` via `texElementImage2D()`, and draws a fullscreen fragment shader using `mainImage(out vec4 fragColor, in vec2 fragCoord)`. `htmlCanvas.canvasLayer()` and `htmlCanvas.glslLayer()` are mutually exclusive because a canvas can only have one context type.
+
+---
+
+## Open Questions
+
+- Does the current Chromium implementation reliably paint Shadow DOM content when the direct child is a shadow host?
+- Should this become an option on `dom`/`vue`, or separate `dom.video`/`vue.video` objects?
+- Does the worker-side `OffscreenCanvasRenderingContext2D.drawElementImage()` path avoid the expensive `createImageBitmap(canvas)` cost enough to justify making this a supported feature?

--- a/ui/src/lib/ai/object-prompts/dom.ts
+++ b/ui/src/lib/ai/object-prompts/dom.ts
@@ -8,6 +8,9 @@ DOM manipulation node with direct JavaScript access to a root div element. Conta
 - root: HTMLDivElement - the container element you can manipulate
 - width, height: Container dimensions (undefined if fluid, set after setSize)
 - setSize(w, h): Set fixed container dimensions
+- htmlCanvas.videoOutput(options): Experimental API that exposes the DOM node as a video source using Chromium's experimental HTML-in-Canvas flag; call htmlCanvas.videoOutput() to match the render output size, htmlCanvas.videoOutput(false) to disable, or htmlCanvas.videoOutput({ size: "free" }) to let the DOM content choose its own source size before Patchies fits it into the render output; mutually exclusive with canvasLayer and glslLayer
+- htmlCanvas.canvasLayer(callback): Experimental API that locally post-processes the live DOM interface with a 2D canvas and Chromium's experimental HTML-in-Canvas flag without adding video output; callback receives (ctx, { width, height, displayWidth, displayHeight, pixelRatio, time, delta }); call htmlCanvas.canvasLayer(false) to disable; mutually exclusive with videoOutput and glslLayer
+- htmlCanvas.glslLayer(fragmentShader): Experimental API that locally post-processes the live DOM interface with a WebGL2 GLSL ES 3 fragment shader and source sampler; use texture(source, uv), mainImage(out vec4 fragColor, in vec2 fragCoord), source, iResolution, iTime, iTimeDelta, and iFrame; supports #include directives; mutually exclusive with videoOutput and canvasLayer
 - setHidePorts(hide): Hide/show ports
 - noDrag(), noPan(), noWheel(), noInteract() - Interaction control (whole node)
 - tailwind(enabled): Enable/disable Tailwind CSS (enabled by default)

--- a/ui/src/lib/ai/object-prompts/vue.ts
+++ b/ui/src/lib/ai/object-prompts/vue.ts
@@ -8,6 +8,9 @@ Vue 3 reactive components with Composition API. Container is fluid-sized by defa
 - root: HTMLDivElement - the container element to mount your Vue app
 - width, height: Container dimensions (undefined if fluid, set after setSize)
 - setSize(w, h): Set fixed container dimensions
+- htmlCanvas.videoOutput(options): Experimental API that exposes the Vue node as a video source using Chromium's experimental HTML-in-Canvas flag; call htmlCanvas.videoOutput() to match the render output size, htmlCanvas.videoOutput(false) to disable, or htmlCanvas.videoOutput({ size: "free" }) to let the Vue content choose its own source size before Patchies fits it into the render output; mutually exclusive with canvasLayer and glslLayer
+- htmlCanvas.canvasLayer(callback): Experimental API that locally post-processes the live Vue interface with a 2D canvas and Chromium's experimental HTML-in-Canvas flag without adding video output; callback receives (ctx, { width, height, displayWidth, displayHeight, pixelRatio, time, delta }); call htmlCanvas.canvasLayer(false) to disable; mutually exclusive with videoOutput and glslLayer
+- htmlCanvas.glslLayer(fragmentShader): Experimental API that locally post-processes the live Vue interface with a WebGL2 GLSL ES 3 fragment shader and source sampler; use texture(source, uv), mainImage(out vec4 fragColor, in vec2 fragCoord), source, iResolution, iTime, iTimeDelta, and iFrame; supports #include directives; mutually exclusive with videoOutput and canvasLayer
 - setHidePorts(hide): Hide/show ports
 - noDrag(), noPan(), noWheel(), noInteract() - Interaction control (whole node)
 - tailwind(enabled): Enable/disable Tailwind CSS (enabled by default)

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -1,5 +1,6 @@
 import { buildRenderGraph, type REdge, type RNode } from '$lib/rendering/graphUtils';
 import type { FBOFormat, RenderGraph, RenderNode, RenderWorkerMessage } from '$lib/rendering/types';
+import type { ElementImageLike } from '$lib/html-in-canvas/html-canvas-video-output';
 import RenderWorker from '$workers/rendering/renderWorker?worker';
 
 import * as ohash from 'ohash';
@@ -954,6 +955,19 @@ export class GLSystem {
         bitmap
       },
       { transfer: [bitmap] }
+    );
+  }
+
+  setElementImage(nodeId: string, elementImage: ElementImageLike, width: number, height: number) {
+    this.renderWorker.postMessage(
+      {
+        type: 'setElementImage',
+        nodeId,
+        elementImage,
+        width,
+        height
+      },
+      { transfer: [elementImage as unknown as Transferable] }
     );
   }
 

--- a/ui/src/lib/canvas/shadertoy-draw.ts
+++ b/ui/src/lib/canvas/shadertoy-draw.ts
@@ -3,7 +3,7 @@ import type { GLUniformDef } from '../../types/uniform-config';
 import { validateShader, type LineErrors } from './shader-validator';
 
 // Render a simple quad for a vertex shader.
-const VERTEX_SHADER = `#version 300 es
+export const SHADERTOY_VERTEX_SHADER = `#version 300 es
   precision highp float;
   in vec2 position;
 	out vec2 uv;
@@ -23,6 +23,43 @@ const PLACEHOLDER_MAIN_IMAGE = `
 const PLACEHOLDER_MAIN_IMAGE_MRT = `
 	void mainImage(in vec2 fragCoord) {}
 `;
+
+export function buildShaderToyFragmentShader({
+  code,
+  mrtCount = 1,
+  extraUniforms = '',
+  fragCoordExpression = 'gl_FragCoord.xy'
+}: {
+  code: string;
+  /** Number of MRT color attachments. 1 = standard single-output mode. */
+  mrtCount?: number;
+  extraUniforms?: string;
+  fragCoordExpression?: string;
+}) {
+  const isMRT = mrtCount > 1;
+  const extraUniformBlock = extraUniforms ? `${extraUniforms}\n` : '';
+
+  return `#version 300 es
+    precision highp float;
+
+    uniform vec3 iResolution;
+    uniform float iTime;
+    uniform vec4 iMouse;
+    uniform vec4 iDate;
+    uniform float iTimeDelta;
+    uniform int iFrame;
+    ${extraUniformBlock}
+
+		in vec2 uv;
+		${isMRT ? '' : 'out vec4 fragColor;'}
+
+    ${code ?? (isMRT ? PLACEHOLDER_MAIN_IMAGE_MRT : PLACEHOLDER_MAIN_IMAGE)}
+
+    void main() {
+      ${isMRT ? `mainImage(${fragCoordExpression});` : `fragColor = vec4(0.0);\n      mainImage(fragColor, ${fragCoordExpression});`}
+    }
+  `;
+}
 
 type UserUniformInputs = Record<string, (_: regl.DefaultContext, props: Props) => void>;
 
@@ -62,37 +99,17 @@ export function createShaderToyDrawCommand({
   mrtCount?: number;
   onError?: (error: Error & { lineErrors?: LineErrors }) => void;
 }): regl.DrawCommand | null {
-  const isMRT = mrtCount > 1;
-
   // Fragment shader with ShaderToy-compatible uniforms and textures.
   // In MRT mode the user declares their own layout(location=N) out variables and
   // mainImage only receives fragCoord — no fragColor injection.
-  const fragmentShader = `#version 300 es
-    precision highp float;
-
-    uniform vec3 iResolution;
-    uniform float iTime;
-    uniform vec4 iMouse;
-    uniform vec4 iDate;
-    uniform float iTimeDelta;
-    uniform int iFrame;
-
-		in vec2 uv;
-		${isMRT ? '' : 'out vec4 fragColor;'}
-
-    ${code ?? (isMRT ? PLACEHOLDER_MAIN_IMAGE_MRT : PLACEHOLDER_MAIN_IMAGE)}
-
-    void main() {
-      ${isMRT ? 'mainImage(gl_FragCoord.xy);' : 'fragColor = vec4(0.0);\n      mainImage(fragColor, gl_FragCoord.xy);'}
-    }
-  `;
+  const fragmentShader = buildShaderToyFragmentShader({ code, mrtCount });
 
   // Count preamble lines (everything before user code insertion)
   // Lines: #version, precision, blank, 5 uniforms, blank, in + optional out, blank = 13 lines
   const PREAMBLE_LINES = 13;
 
   // Validate both shaders before passing to regl
-  const vertexValidation = validateShader(gl, VERTEX_SHADER, gl.VERTEX_SHADER);
+  const vertexValidation = validateShader(gl, SHADERTOY_VERTEX_SHADER, gl.VERTEX_SHADER);
   if (!vertexValidation.valid) {
     const error = new Error(vertexValidation.error || 'Vertex shader compilation failed');
     onError?.(error);
@@ -129,7 +146,7 @@ export function createShaderToyDrawCommand({
   try {
     return regl({
       frag: fragmentShader,
-      vert: VERTEX_SHADER,
+      vert: SHADERTOY_VERTEX_SHADER,
       framebuffer,
 
       attributes: {

--- a/ui/src/lib/codemirror/glsl-in-js.test.ts
+++ b/ui/src/lib/codemirror/glsl-in-js.test.ts
@@ -54,6 +54,14 @@ describe('glsl in js mixed parsing', () => {
     );
   });
 
+  it('detects htmlCanvas.glslLayer template strings as GLSL shader bodies', () => {
+    expect(
+      findTemplateStrings(
+        'htmlCanvas.glslLayer(`void mainImage(out vec4 fragColor, in vec2 fragCoord) { fragColor = texture(source, fragCoord); }`);'
+      )
+    ).toEqual([true]);
+  });
+
   it('keeps unrelated function template strings in JavaScript mode', () => {
     expect(findTemplateStrings('let f = String.raw`not glsl`;')).toEqual([false]);
     expect(findTemplateStrings('let f = shaderParkHelper(`not glsl`);')).toEqual([false]);
@@ -63,6 +71,10 @@ describe('glsl in js mixed parsing', () => {
     expect(getGlslInJsCompletionLabels('setFunction({ glsl: `vec2 p = u')).toContain('uv');
     expect(getGlslInJsCompletionLabels('glsl({ FP: `RGBA = tex')).toContain('texture');
     expect(getGlslInJsCompletionLabels('let sdf = glslSDF(`return l')).toContain('length');
+
+    expect(getGlslInJsCompletionLabels('htmlCanvas.glslLayer(`fragColor = tex')).toContain(
+      'texture'
+    );
   });
 
   it('does not offer GLSL completions in normal template strings or interpolations', () => {

--- a/ui/src/lib/codemirror/glsl-in-js.ts
+++ b/ui/src/lib/codemirror/glsl-in-js.ts
@@ -11,6 +11,9 @@ const GLSL_TAG = new Set(['glsl']);
 // Shader Park GLSL extension helpers take full GLSL shader strings.
 const GLSL_CALLS = new Set(['glslFunc', 'glslFuncES3', 'glslSDF']);
 
+// Namespaced APIs whose first argument is a full GLSL shader string.
+const GLSL_MEMBER_CALLS = new Set(['htmlCanvas.glslLayer']);
+
 // Object property keys whose template string values are GLSL shader source:
 // REGL: frag/vert, Hydra: glsl, SwissGL: FP/VP
 const GLSL_PROPERTY_KEYS = new Set(['frag', 'vert', 'glsl', 'FP', 'VP']);
@@ -28,17 +31,18 @@ export function isGlslTemplateString(
     return !!tag && GLSL_TAG.has(input.read(tag.from, tag.to));
   }
 
-  // glslFunc(`...`), glslFuncES3(`...`), glslSDF(`...`)
+  // glslFunc(`...`), glslFuncES3(`...`), glslSDF(`...`), htmlCanvas.glslLayer(`...`)
   if (parent.name === 'ArgList') {
     const call = parent.parent;
     const callee = call?.firstChild;
+    const calleeText = callee ? input.read(callee.from, callee.to) : '';
 
     return (
       !!call &&
       call.name === 'CallExpression' &&
       !!callee &&
-      callee.name === 'VariableName' &&
-      GLSL_CALLS.has(input.read(callee.from, callee.to))
+      ((callee.name === 'VariableName' && GLSL_CALLS.has(calleeText)) ||
+        GLSL_MEMBER_CALLS.has(calleeText))
     );
   }
 

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -135,6 +135,29 @@ const patchiesAPICompletions: Completion[] = [
     apply: 'setHidePorts(true)'
   },
   {
+    label: 'htmlCanvas.videoOutput',
+    type: 'function',
+    detail: '(options?: boolean | { size: "free" }) => boolean',
+    info: "Render a dom/vue node through Chromium's experimental HTML-in-Canvas API and expose a video output. Mutually exclusive with htmlCanvas.canvasLayer() and htmlCanvas.glslLayer().",
+    apply: 'htmlCanvas.videoOutput()'
+  },
+  {
+    label: 'htmlCanvas.canvasLayer',
+    type: 'function',
+    detail: '((ctx: CanvasRenderingContext2D, frame: HtmlLayerFrame) => void) | false => boolean',
+    info: 'Locally post-process a dom/vue node with a 2D canvas. Mutually exclusive with htmlCanvas.videoOutput() and htmlCanvas.glslLayer().',
+    apply:
+      'htmlCanvas.canvasLayer((ctx, frame) => {\n  // draw over or post-process the live UI pixels\n})'
+  },
+  {
+    label: 'htmlCanvas.glslLayer',
+    type: 'function',
+    detail: '(fragmentShader: string | false) => boolean',
+    info: 'Locally post-process a dom/vue node with a WebGL2 GLSL ES 3 fragment shader and source sampler. Mutually exclusive with htmlCanvas.videoOutput() and htmlCanvas.canvasLayer().',
+    apply:
+      'htmlCanvas.glslLayer(`\nvoid mainImage(out vec4 fragColor, in vec2 fragCoord) {\n  vec2 uv = fragCoord / iResolution.xy;\n  fragColor = texture(source, uv);\n}\n`)'
+  },
+  {
     label: 'setTextureFormat',
     type: 'function',
     detail: "('rgba8' | 'rgba16f' | 'rgba32f') => void",
@@ -445,6 +468,9 @@ const topLevelOnlyFunctions = new Set([
   'activate',
   'deactivate',
   'hideExitButton',
+  'htmlCanvas.videoOutput',
+  'htmlCanvas.canvasLayer',
+  'htmlCanvas.glslLayer',
   'redraw',
   'setAudioPortCount',
   'setCanvasSize',
@@ -584,6 +610,9 @@ const nodeSpecificFunctions: Record<string, string[]> = {
     'three',
     'three.dom'
   ],
+  'htmlCanvas.videoOutput': ['dom', 'vue'],
+  'htmlCanvas.canvasLayer': ['dom', 'vue'],
+  'htmlCanvas.glslLayer': ['dom', 'vue'],
   setTextureFormat: ['hydra', 'canvas', 'three', 'regl', 'swgl', 'textmode'],
   setResolution: ['hydra', 'canvas', 'three', 'regl', 'swgl', 'textmode'],
   setPrimaryButton: ['js', 'worker', 'p5', 'hydra', 'canvas', 'regl', 'swgl', 'textmode', 'three'],

--- a/ui/src/lib/components/nodes/DomNode.svelte
+++ b/ui/src/lib/components/nodes/DomNode.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+  import { useUpdateNodeInternals } from '@xyflow/svelte';
   import DomRuntimeNode from './DomRuntimeNode.svelte';
   import type { CreateDomRuntimeRoot } from './DomRuntimeNode.svelte';
   import { DOM_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
   import type { SettingsSchema } from '$lib/settings';
-
-  const createRuntimeRoot: CreateDomRuntimeRoot = ({ containerRoot }) => ({
-    root: containerRoot
-  });
+  import type { HtmlCanvasNodeOutputState } from '$lib/html-in-canvas/html-canvas-node-output';
+  import type { HtmlGlslLayerNodeOutputState } from '$lib/html-in-canvas/html-glsl-layer-node-output';
+  import type { HtmlLayerNodeOutputState } from '$lib/html-in-canvas/html-layer-node-output';
+  import { createCustomConsole } from '$lib/utils/createCustomConsole';
+  import { outputHeight, outputWidth } from '../../../stores/renderer.store';
+  import { createHtmlCanvasRuntimeAdapter } from './html-canvas-runtime-adapter';
 
   let {
     id,
@@ -29,6 +32,50 @@
     };
     selected?: boolean;
   } = $props();
+
+  const updateNodeInternals = useUpdateNodeInternals();
+  const customConsole = createCustomConsole(id);
+
+  let rootElement = $state<HTMLElement | undefined>();
+  let htmlCanvasElement = $state<HTMLCanvasElement | undefined>();
+  let htmlLayerState = $state<HtmlLayerNodeOutputState>({ enabled: false });
+  let htmlGlslLayerState = $state<HtmlGlslLayerNodeOutputState>({ enabled: false });
+
+  let htmlCanvasState = $state<HtmlCanvasNodeOutputState>({
+    enabled: false,
+    sizeMode: 'output',
+    width: 1,
+    height: 1
+  });
+
+  const htmlCanvasAdapter = createHtmlCanvasRuntimeAdapter({
+    nodeId: id,
+    objectName: 'dom',
+    getRootElement: () => rootElement,
+    getCanvasElement: () => htmlCanvasElement,
+    getExplicitSize: () => ({ width: data.width, height: data.height }),
+    getOutputSize: () => ({ width: $outputWidth, height: $outputHeight }),
+    warn: (message) => customConsole.warn(message),
+    updateNodeInternals: () => updateNodeInternals(id),
+    scheduleRun: () => setTimeout(() => runCode()),
+    onHtmlCanvasStateChange: (state) => (htmlCanvasState = state),
+    onHtmlLayerStateChange: (state) => (htmlLayerState = state),
+    onHtmlGlslLayerStateChange: (state) => (htmlGlslLayerState = state)
+  });
+
+  const createRuntimeRoot: CreateDomRuntimeRoot = ({ containerRoot }) => ({
+    root: containerRoot
+  });
+
+  let runCode = () => {};
+
+  function cleanupRuntime() {
+    htmlCanvasAdapter.cleanup();
+  }
+
+  $effect(() => {
+    htmlCanvasAdapter.syncVideoOutput();
+  });
 </script>
 
 <DomRuntimeNode
@@ -41,4 +88,17 @@
   consolePlaceholder="DOM output will appear here."
   errorOffset={DOM_WRAPPER_OFFSET}
   {createRuntimeRoot}
+  {cleanupRuntime}
+  beforeRun={htmlCanvasAdapter.beforeRun}
+  afterRun={htmlCanvasAdapter.afterRun}
+  extraContext={() => htmlCanvasAdapter.extraContext}
+  bind:rootElement
+  bind:htmlCanvasElement
+  htmlCanvasRootActive={htmlCanvasState.enabled ||
+    htmlLayerState.enabled ||
+    htmlGlslLayerState.enabled}
+  htmlCanvasEnabled={htmlCanvasState.enabled}
+  htmlCanvasContextMode={htmlCanvasAdapter.getCanvasContextMode()}
+  htmlRootClass={htmlCanvasAdapter.getRootClass()}
+  onRunReady={(handler) => (runCode = handler)}
 />

--- a/ui/src/lib/components/nodes/DomRuntimeNode.svelte
+++ b/ui/src/lib/components/nodes/DomRuntimeNode.svelte
@@ -37,6 +37,8 @@
     customConsole: CustomConsole;
   }) => Promise<DomRuntimeRoot> | DomRuntimeRoot;
 
+  type RuntimeContextOptions = { runCode: () => void };
+
   type DomRuntimeData = {
     title: string;
     code: string;
@@ -61,7 +63,17 @@
     consolePlaceholder,
     errorOffset,
     createRuntimeRoot,
-    cleanupRuntime = () => {}
+    cleanupRuntime = () => {},
+    beforeRun = () => true,
+    afterRun = () => {},
+    extraContext = () => ({}),
+    rootElement = $bindable<HTMLElement | undefined>(),
+    htmlCanvasElement = $bindable<HTMLCanvasElement | undefined>(),
+    htmlCanvasRootActive = false,
+    htmlCanvasEnabled = false,
+    htmlCanvasContextMode = '2d',
+    htmlRootClass = 'h-full w-full',
+    onRunReady = () => {}
   }: {
     id: string;
     data: DomRuntimeData;
@@ -73,6 +85,16 @@
     errorOffset: number;
     createRuntimeRoot: CreateDomRuntimeRoot;
     cleanupRuntime?: () => void;
+    beforeRun?: () => boolean | Promise<boolean>;
+    afterRun?: () => void;
+    extraContext?: (options: RuntimeContextOptions) => Record<string, unknown>;
+    rootElement?: HTMLElement;
+    htmlCanvasElement?: HTMLCanvasElement;
+    htmlCanvasRootActive?: boolean;
+    htmlCanvasEnabled?: boolean;
+    htmlCanvasContextMode?: string;
+    htmlRootClass?: string;
+    onRunReady?: (run: () => void) => void;
   } = $props();
 
   const { updateNodeData } = useSvelteFlow();
@@ -109,6 +131,14 @@
   let inletCount = $derived(data.inletCount ?? 1);
   let outletCount = $derived(data.outletCount ?? 0);
   let previousExecuteCode = $state<number | undefined>(undefined);
+
+  $effect(() => {
+    onRunReady(runCode);
+  });
+
+  $effect(() => {
+    rootElement = rootContainer;
+  });
 
   $effect(() => {
     if (data.executeCode && data.executeCode !== previousExecuteCode) {
@@ -203,11 +233,19 @@
     settingsManager.clearCallbacks();
 
     try {
+      const shouldContinue = await beforeRun();
+
+      if (!shouldContinue) {
+        return;
+      }
+
       const container = createIsolatedContainer(rootContainer);
+
       const runtimeRoot = await createRuntimeRoot({
         containerRoot: container.root,
         customConsole
       });
+
       const processedCode = await jsRunner.preprocessCode(data.code, { nodeId });
 
       if (processedCode === null) {
@@ -240,11 +278,13 @@
             wheelEnabled = false;
           },
           tailwind: container.tailwind,
+          ...extraContext({ runCode }),
           ...(runtimeRoot.extraContext ?? {})
         }
       });
 
       runtimeRoot.handleResult?.(result);
+      afterRun();
     } catch (error) {
       handleCodeError(error, data.code, nodeId, customConsole, errorOffset);
     } finally {
@@ -294,7 +334,7 @@
   onSettingsRevertAll={() => settingsManager.revertAll()}
 >
   {#snippet topHandle()}
-    {#each Array.from({ length: inletCount }) as _, index}
+    {#each Array.from({ length: inletCount }) as _, index (index)}
       <TypedHandle
         port="inlet"
         spec={{ handleId: index }}
@@ -325,18 +365,38 @@
         ? `width: ${previewWidth}px; height: ${previewHeight}px;`
         : ''}
     >
-      <div bind:this={rootContainer} class="h-full w-full"></div>
+      {#if htmlCanvasRootActive}
+        {#key htmlCanvasContextMode}
+          <canvas bind:this={htmlCanvasElement} class="block overflow-hidden">
+            <div bind:this={rootContainer} class={htmlRootClass}></div>
+          </canvas>
+        {/key}
+      {:else}
+        <div bind:this={rootContainer} class="h-full w-full"></div>
+      {/if}
     </div>
   {/snippet}
 
   {#snippet bottomHandle()}
-    {#each Array.from({ length: outletCount }) as _, index}
+    {#if htmlCanvasEnabled}
+      <TypedHandle
+        port="outlet"
+        spec={{ handleType: 'video', handleId: '0' }}
+        title="Video output"
+        total={outletCount + 1}
+        index={0}
+        class={handleClass}
+        {nodeId}
+      />
+    {/if}
+
+    {#each Array.from({ length: outletCount }) as _, index (index)}
       <TypedHandle
         port="outlet"
         spec={{ handleId: index }}
         title={`Outlet ${index}`}
-        total={outletCount}
-        {index}
+        total={htmlCanvasEnabled ? outletCount + 1 : outletCount}
+        index={htmlCanvasEnabled ? index + 1 : index}
         class={handleClass}
         {nodeId}
       />

--- a/ui/src/lib/components/nodes/VueNode.svelte
+++ b/ui/src/lib/components/nodes/VueNode.svelte
@@ -1,13 +1,73 @@
 <script lang="ts">
+  import { useUpdateNodeInternals } from '@xyflow/svelte';
   import DomRuntimeNode from './DomRuntimeNode.svelte';
   import type { CreateDomRuntimeRoot } from './DomRuntimeNode.svelte';
   import { VUE_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
   import type { SettingsSchema } from '$lib/settings';
+  import type { HtmlCanvasNodeOutputState } from '$lib/html-in-canvas/html-canvas-node-output';
+  import type { HtmlGlslLayerNodeOutputState } from '$lib/html-in-canvas/html-glsl-layer-node-output';
+  import type { HtmlLayerNodeOutputState } from '$lib/html-in-canvas/html-layer-node-output';
+  import { createCustomConsole } from '$lib/utils/createCustomConsole';
+  import { outputHeight, outputWidth } from '../../../stores/renderer.store';
+  import { createHtmlCanvasRuntimeAdapter } from './html-canvas-runtime-adapter';
+
+  let {
+    id,
+    data,
+    selected
+  }: {
+    id: string;
+    data: {
+      title: string;
+      code: string;
+      inletCount?: number;
+      outletCount?: number;
+      hidePorts?: boolean;
+      executeCode?: number;
+      showConsole?: boolean;
+      width?: number;
+      height?: number;
+      settingsSchema?: SettingsSchema;
+      settings?: Record<string, unknown>;
+    };
+    selected?: boolean;
+  } = $props();
+
+  const updateNodeInternals = useUpdateNodeInternals();
+  const customConsole = createCustomConsole(id);
 
   let Vue: typeof import('vue') | null = null;
   let currentApp: ReturnType<(typeof import('vue'))['createApp']> | null = null;
+  let rootElement = $state<HTMLElement | undefined>();
+  let htmlCanvasElement = $state<HTMLCanvasElement | undefined>();
+  let htmlLayerState = $state<HtmlLayerNodeOutputState>({ enabled: false });
+  let htmlGlslLayerState = $state<HtmlGlslLayerNodeOutputState>({ enabled: false });
 
-  function cleanupRuntime() {
+  let htmlCanvasState = $state<HtmlCanvasNodeOutputState>({
+    enabled: false,
+    sizeMode: 'output',
+    width: 1,
+    height: 1
+  });
+
+  const htmlCanvasAdapter = createHtmlCanvasRuntimeAdapter({
+    nodeId: id,
+    objectName: 'vue',
+    getRootElement: () => rootElement,
+    getCanvasElement: () => htmlCanvasElement,
+    getExplicitSize: () => ({ width: data.width, height: data.height }),
+    getOutputSize: () => ({ width: $outputWidth, height: $outputHeight }),
+    warn: (message) => customConsole.warn(message),
+    updateNodeInternals: () => updateNodeInternals(id),
+    scheduleRun: () => setTimeout(() => runCode()),
+    onHtmlCanvasStateChange: (state) => (htmlCanvasState = state),
+    onHtmlLayerStateChange: (state) => (htmlLayerState = state),
+    onHtmlGlslLayerStateChange: (state) => (htmlGlslLayerState = state)
+  });
+
+  let runCode = () => {};
+
+  function unmountVueApp() {
     if (currentApp) {
       try {
         currentApp.unmount();
@@ -19,11 +79,21 @@
     }
   }
 
+  function cleanupRuntime() {
+    unmountVueApp();
+    htmlCanvasAdapter.cleanup();
+  }
+
   const createRuntimeRoot: CreateDomRuntimeRoot = async ({ containerRoot, customConsole }) => {
-    cleanupRuntime();
+    unmountVueApp();
 
     const vueRoot = document.createElement('div');
-    vueRoot.className = 'h-full w-full';
+
+    vueRoot.className =
+      htmlCanvasState.enabled || htmlLayerState.enabled || htmlGlslLayerState.enabled
+        ? htmlCanvasAdapter.getRootClass()
+        : 'h-full w-full';
+
     containerRoot.appendChild(vueRoot);
 
     if (!Vue) {
@@ -56,27 +126,9 @@
     };
   };
 
-  let {
-    id,
-    data,
-    selected
-  }: {
-    id: string;
-    data: {
-      title: string;
-      code: string;
-      inletCount?: number;
-      outletCount?: number;
-      hidePorts?: boolean;
-      executeCode?: number;
-      showConsole?: boolean;
-      width?: number;
-      height?: number;
-      settingsSchema?: SettingsSchema;
-      settings?: Record<string, unknown>;
-    };
-    selected?: boolean;
-  } = $props();
+  $effect(() => {
+    htmlCanvasAdapter.syncVideoOutput();
+  });
 </script>
 
 <DomRuntimeNode
@@ -90,4 +142,16 @@
   errorOffset={VUE_WRAPPER_OFFSET}
   {createRuntimeRoot}
   {cleanupRuntime}
+  beforeRun={htmlCanvasAdapter.beforeRun}
+  afterRun={htmlCanvasAdapter.afterRun}
+  extraContext={() => htmlCanvasAdapter.extraContext}
+  bind:rootElement
+  bind:htmlCanvasElement
+  htmlCanvasRootActive={htmlCanvasState.enabled ||
+    htmlLayerState.enabled ||
+    htmlGlslLayerState.enabled}
+  htmlCanvasEnabled={htmlCanvasState.enabled}
+  htmlCanvasContextMode={htmlCanvasAdapter.getCanvasContextMode()}
+  htmlRootClass={htmlCanvasAdapter.getRootClass()}
+  onRunReady={(handler) => (runCode = handler)}
 />

--- a/ui/src/lib/components/nodes/html-canvas-runtime-adapter.ts
+++ b/ui/src/lib/components/nodes/html-canvas-runtime-adapter.ts
@@ -1,0 +1,219 @@
+import { GLSystem } from '$lib/canvas/GLSystem';
+import { HtmlCanvasNodeOutput } from '$lib/html-in-canvas/html-canvas-node-output';
+import type { HtmlCanvasNodeOutputState } from '$lib/html-in-canvas/html-canvas-node-output';
+import {
+  guardHtmlCanvasMode,
+  type HtmlCanvasMode
+} from '$lib/html-in-canvas/html-canvas-mode-guard';
+import { HtmlGlslLayerNodeOutput } from '$lib/html-in-canvas/html-glsl-layer-node-output';
+import type {
+  HtmlGlslLayerNodeOutputState,
+  HtmlGlslLayerOptions
+} from '$lib/html-in-canvas/html-glsl-layer-node-output';
+import { HtmlLayerNodeOutput } from '$lib/html-in-canvas/html-layer-node-output';
+import type {
+  HtmlLayerNodeOutputState,
+  HtmlLayerOptions
+} from '$lib/html-in-canvas/html-layer-node-output';
+
+type ExplicitSize = {
+  width?: number;
+  height?: number;
+};
+
+type OutputSize = {
+  width: number;
+  height: number;
+};
+
+type HtmlCanvasRuntimeAdapterOptions = {
+  nodeId: string;
+  objectName: 'dom' | 'vue';
+  getRootElement: () => HTMLElement | undefined;
+  getCanvasElement: () => HTMLCanvasElement | undefined;
+  getExplicitSize: () => ExplicitSize;
+  getOutputSize: () => OutputSize;
+  warn: (message: string) => void;
+  updateNodeInternals: () => void;
+  scheduleRun: () => void;
+  onHtmlCanvasStateChange: (state: HtmlCanvasNodeOutputState) => void;
+  onHtmlLayerStateChange: (state: HtmlLayerNodeOutputState) => void;
+  onHtmlGlslLayerStateChange: (state: HtmlGlslLayerNodeOutputState) => void;
+};
+
+export function createHtmlCanvasRuntimeAdapter(options: HtmlCanvasRuntimeAdapterOptions) {
+  const htmlCanvasOutput = new HtmlCanvasNodeOutput({
+    nodeId: options.nodeId,
+    objectName: options.objectName,
+    getRootElement: options.getRootElement,
+    getCanvasElement: options.getCanvasElement,
+    getExplicitSize: options.getExplicitSize,
+    getOutputSize: options.getOutputSize,
+    warn: options.warn,
+    updateNodeInternals: options.updateNodeInternals,
+    scheduleRun: options.scheduleRun,
+    onStateChange: options.onHtmlCanvasStateChange,
+    videoGraph: GLSystem.getInstance()
+  });
+
+  const htmlLayerOutput = new HtmlLayerNodeOutput({
+    getRootElement: options.getRootElement,
+    getCanvasElement: options.getCanvasElement,
+    getExplicitSize: options.getExplicitSize,
+    warn: options.warn,
+    scheduleRun: options.scheduleRun,
+    onStateChange: options.onHtmlLayerStateChange
+  });
+
+  const htmlGlslLayerOutput = new HtmlGlslLayerNodeOutput({
+    getRootElement: options.getRootElement,
+    getCanvasElement: options.getCanvasElement,
+    getExplicitSize: options.getExplicitSize,
+    warn: options.warn,
+    scheduleRun: options.scheduleRun,
+    onStateChange: options.onHtmlGlslLayerStateChange,
+    getElementTransform: () => new DOMMatrix()
+  });
+
+  let htmlCanvasModeThisRun: HtmlCanvasMode | null = null;
+  let htmlLayerCalledThisRun = false;
+  let htmlGlslLayerCalledThisRun = false;
+
+  function registerHtmlCanvasMode(mode: HtmlCanvasMode) {
+    const result = guardHtmlCanvasMode({
+      currentMode: htmlCanvasModeThisRun,
+      requestedMode: mode,
+      videoOutputEnabled: htmlCanvasOutput.state.enabled
+    });
+
+    if (result.ok) {
+      htmlCanvasModeThisRun = result.mode;
+
+      return true;
+    }
+
+    options.warn(result.message);
+
+    return false;
+  }
+
+  function setHtmlCanvasVideoOutput(enableOptions?: Parameters<typeof htmlCanvasOutput.enable>[0]) {
+    if (enableOptions !== false && !registerHtmlCanvasMode('videoOutput')) {
+      return false;
+    }
+
+    return htmlCanvasOutput.enable(enableOptions);
+  }
+
+  function setHtmlCanvasLayer(layerOptions: HtmlLayerOptions) {
+    if (
+      layerOptions !== false &&
+      layerOptions !== undefined &&
+      !registerHtmlCanvasMode('canvasLayer')
+    ) {
+      return false;
+    }
+
+    htmlLayerCalledThisRun = true;
+
+    const enabled = htmlLayerOutput.enable(layerOptions);
+
+    if (enabled) {
+      htmlGlslLayerOutput.stop();
+    }
+
+    return enabled;
+  }
+
+  function setHtmlGlslLayer(glslLayerOptions: HtmlGlslLayerOptions) {
+    if (
+      glslLayerOptions !== false &&
+      glslLayerOptions !== undefined &&
+      !registerHtmlCanvasMode('glslLayer')
+    ) {
+      return false;
+    }
+
+    htmlGlslLayerCalledThisRun = true;
+
+    const enabled = htmlGlslLayerOutput.enable(glslLayerOptions);
+
+    if (enabled) {
+      htmlLayerOutput.stop();
+    }
+
+    return enabled;
+  }
+
+  function beforeRun() {
+    htmlCanvasModeThisRun = null;
+    htmlLayerCalledThisRun = false;
+    htmlGlslLayerCalledThisRun = false;
+
+    if (htmlCanvasOutput.state.enabled && !htmlCanvasOutput.setup()) {
+      return false;
+    }
+
+    return true;
+  }
+
+  function afterRun() {
+    if (htmlCanvasOutput.state.enabled) {
+      htmlCanvasOutput.updateSize();
+      htmlCanvasOutput.requestPaint();
+    }
+
+    if (htmlLayerCalledThisRun) {
+      htmlLayerOutput.setup();
+    } else {
+      htmlLayerOutput.stop();
+    }
+
+    if (htmlGlslLayerCalledThisRun) {
+      htmlGlslLayerOutput.setup();
+    } else {
+      htmlGlslLayerOutput.stop();
+    }
+  }
+
+  function getRootClass() {
+    if (htmlCanvasOutput.state.enabled) {
+      return htmlCanvasOutput.getRootClass();
+    }
+
+    const explicitSize = options.getExplicitSize();
+
+    return explicitSize.width !== undefined && explicitSize.height !== undefined
+      ? 'h-full w-full'
+      : 'inline-block';
+  }
+
+  function syncVideoOutput() {
+    if (!htmlCanvasOutput.state.enabled || !options.getCanvasElement()) return;
+
+    htmlCanvasOutput.updateSize();
+    htmlCanvasOutput.requestPaint();
+  }
+
+  function cleanup() {
+    htmlCanvasOutput.destroy();
+    htmlLayerOutput.stop();
+    htmlGlslLayerOutput.stop();
+  }
+
+  return {
+    beforeRun,
+    afterRun,
+    cleanup,
+    syncVideoOutput,
+    getRootClass,
+    getCanvasContextMode: () => (htmlGlslLayerOutput.state.enabled ? 'webgl' : '2d'),
+    extraContext: {
+      htmlCanvas: {
+        videoOutput: setHtmlCanvasVideoOutput,
+        canvasLayer: setHtmlCanvasLayer,
+        glslLayer: setHtmlGlslLayer
+      }
+    }
+  };
+}

--- a/ui/src/lib/docs/topic-titles-manifest.ts
+++ b/ui/src/lib/docs/topic-titles-manifest.ts
@@ -21,6 +21,7 @@ export const TOPIC_TITLES: Record<string, string> = {
   'enabling-ai': 'Enabling AI',
   'glsl-imports': 'GLSL Imports',
   'hot-cold-inlets': 'Hot and Cold Inlets',
+  'html-in-canvas': 'HTML in Canvas',
   'in-app-help': 'Help',
   'javascript-runner': 'JavaScript',
   'js-integrations': 'JS Integrations',

--- a/ui/src/lib/glsl-include/browser-resolver.ts
+++ b/ui/src/lib/glsl-include/browser-resolver.ts
@@ -1,0 +1,36 @@
+/**
+ * Combined GLSL #include resolver for main-thread shader users.
+ */
+
+import { VirtualFilesystem } from '$lib/vfs';
+import { createCachedResolver, type CachedIncludeResolver } from './cache';
+import type { IncludeResolver } from './preprocessor';
+import { resolveNpmPackage } from './npm-resolver';
+
+let sharedResolver: CachedIncludeResolver | null = null;
+
+export function createBrowserResolver(): IncludeResolver {
+  if (sharedResolver) return sharedResolver;
+
+  sharedResolver = createCachedResolver({
+    resolveNpm: resolveNpmPackage,
+    resolveVfs: async (vfsPath) => {
+      const blob = await VirtualFilesystem.getInstance().resolve(vfsPath);
+
+      return blob.text();
+    },
+    resolveUrl: async (url) => {
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch #include "${url}": ${response.status} ${response.statusText}`
+        );
+      }
+
+      return response.text();
+    }
+  });
+
+  return sharedResolver;
+}

--- a/ui/src/lib/html-in-canvas/html-canvas-mode-guard.test.ts
+++ b/ui/src/lib/html-in-canvas/html-canvas-mode-guard.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { guardHtmlCanvasMode } from './html-canvas-mode-guard';
+
+describe('guardHtmlCanvasMode', () => {
+  it('allows the first htmlCanvas mode in a run', () => {
+    expect(
+      guardHtmlCanvasMode({
+        currentMode: null,
+        requestedMode: 'glslLayer',
+        videoOutputEnabled: false
+      })
+    ).toEqual({ ok: true, mode: 'glslLayer' });
+  });
+
+  it('allows repeating the same htmlCanvas mode in a run', () => {
+    expect(
+      guardHtmlCanvasMode({
+        currentMode: 'canvasLayer',
+        requestedMode: 'canvasLayer',
+        videoOutputEnabled: false
+      })
+    ).toEqual({ ok: true, mode: 'canvasLayer' });
+  });
+
+  it('rejects mixing htmlCanvas modes in the same run', () => {
+    expect(
+      guardHtmlCanvasMode({
+        currentMode: 'videoOutput',
+        requestedMode: 'glslLayer',
+        videoOutputEnabled: false
+      })
+    ).toEqual({
+      ok: false,
+      message:
+        'htmlCanvas.glslLayer() cannot be used with htmlCanvas.videoOutput() in the same run. Choose one of htmlCanvas.videoOutput(), htmlCanvas.canvasLayer(), or htmlCanvas.glslLayer().'
+    });
+  });
+
+  it('rejects local layers while video output is already enabled', () => {
+    expect(
+      guardHtmlCanvasMode({
+        currentMode: null,
+        requestedMode: 'canvasLayer',
+        videoOutputEnabled: true
+      })
+    ).toEqual({
+      ok: false,
+      message:
+        'htmlCanvas.canvasLayer() cannot be used while htmlCanvas.videoOutput() is enabled. Call htmlCanvas.videoOutput(false) before enabling a local layer.'
+    });
+  });
+});

--- a/ui/src/lib/html-in-canvas/html-canvas-mode-guard.ts
+++ b/ui/src/lib/html-in-canvas/html-canvas-mode-guard.ts
@@ -1,0 +1,31 @@
+export type HtmlCanvasMode = 'videoOutput' | 'canvasLayer' | 'glslLayer';
+
+export type HtmlCanvasModeGuardResult =
+  | { ok: true; mode: HtmlCanvasMode }
+  | { ok: false; message: string };
+
+export function guardHtmlCanvasMode({
+  currentMode,
+  requestedMode,
+  videoOutputEnabled
+}: {
+  currentMode: HtmlCanvasMode | null;
+  requestedMode: HtmlCanvasMode;
+  videoOutputEnabled: boolean;
+}): HtmlCanvasModeGuardResult {
+  if (requestedMode !== 'videoOutput' && videoOutputEnabled) {
+    return {
+      ok: false,
+      message: `htmlCanvas.${requestedMode}() cannot be used while htmlCanvas.videoOutput() is enabled. Call htmlCanvas.videoOutput(false) before enabling a local layer.`
+    };
+  }
+
+  if (currentMode === null || currentMode === requestedMode) {
+    return { ok: true, mode: requestedMode };
+  }
+
+  return {
+    ok: false,
+    message: `htmlCanvas.${requestedMode}() cannot be used with htmlCanvas.${currentMode}() in the same run. Choose one of htmlCanvas.videoOutput(), htmlCanvas.canvasLayer(), or htmlCanvas.glslLayer().`
+  };
+}

--- a/ui/src/lib/html-in-canvas/html-canvas-node-output.test.ts
+++ b/ui/src/lib/html-in-canvas/html-canvas-node-output.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getHtmlCanvasRootClass, HtmlCanvasNodeOutput } from './html-canvas-node-output';
+import type { HtmlCanvasNodeOutputState } from './html-canvas-node-output';
+import { HtmlGlslLayerNodeOutput } from './html-glsl-layer-node-output';
+import { HtmlLayerNodeOutput } from './html-layer-node-output';
+
+describe('HtmlCanvasNodeOutput', () => {
+  it('chooses root sizing classes for output and free modes', () => {
+    expect(getHtmlCanvasRootClass('output', {})).toBe('h-full w-full');
+    expect(getHtmlCanvasRootClass('free', {})).toBe('inline-block');
+    expect(getHtmlCanvasRootClass('free', { width: 320, height: 180 })).toBe('h-full w-full');
+  });
+
+  it('normalizes htmlCanvas calls, registers video, and notifies the host', () => {
+    const states: HtmlCanvasNodeOutputState[] = [];
+
+    const videoGraph = {
+      upsertNode: vi.fn(),
+      removeNode: vi.fn(),
+      hasOutgoingVideoConnections: vi.fn(() => false),
+      setElementImage: vi.fn()
+    };
+
+    const output = new HtmlCanvasNodeOutput({
+      nodeId: 'node-1',
+      objectName: 'dom',
+      getRootElement: () => undefined,
+      getCanvasElement: () => undefined,
+      getExplicitSize: () => ({}),
+      getOutputSize: () => ({ width: 1280, height: 720 }),
+      warn: vi.fn(),
+      updateNodeInternals: vi.fn(),
+      scheduleRun: vi.fn(),
+      onStateChange: (state) => states.push(state),
+      videoGraph,
+      detectSupport: () => ({ supported: true, missing: [] })
+    });
+
+    expect(output.enable()).toBe(true);
+    expect(states.at(-1)).toMatchObject({ enabled: true, sizeMode: 'output' });
+    expect(videoGraph.upsertNode).toHaveBeenCalledWith('node-1', 'img', {});
+
+    expect(output.enable({ size: 'free' })).toBe(true);
+    expect(states.at(-1)).toMatchObject({ enabled: true, sizeMode: 'free' });
+
+    expect(output.enable(false)).toBe(true);
+    expect(states.at(-1)).toMatchObject({ enabled: false, sizeMode: 'output' });
+    expect(videoGraph.removeNode).toHaveBeenCalledWith('node-1');
+  });
+
+  it('updates canvas size without writing host state on every paint', () => {
+    const onStateChange = vi.fn();
+
+    const videoGraph = {
+      upsertNode: vi.fn(),
+      removeNode: vi.fn(),
+      hasOutgoingVideoConnections: vi.fn(() => false),
+      setElementImage: vi.fn()
+    };
+
+    const output = new HtmlCanvasNodeOutput({
+      nodeId: 'node-1',
+      objectName: 'dom',
+      getRootElement: () =>
+        ({
+          scrollWidth: 120,
+          offsetWidth: 120,
+          scrollHeight: 70,
+          offsetHeight: 70
+        }) as HTMLElement,
+      getCanvasElement: () => undefined,
+      getExplicitSize: () => ({}),
+      getOutputSize: () => ({ width: 1280, height: 720 }),
+      warn: vi.fn(),
+      updateNodeInternals: vi.fn(),
+      scheduleRun: vi.fn(),
+      onStateChange,
+      videoGraph,
+      detectSupport: () => ({ supported: true, missing: [] })
+    });
+
+    output.updateSize();
+
+    expect(output.state).toMatchObject({ width: 1280, height: 720 });
+    expect(onStateChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('HtmlGlslLayerNodeOutput', () => {
+  it('uploads the live root with texElementImage2D before drawing a shader frame', () => {
+    const transform = { toString: () => 'matrix(1, 0, 0, 1, 0, 0)' };
+    const calls: string[] = [];
+
+    const gl = {
+      TEXTURE_2D: 3553,
+      RGBA: 6408,
+      UNSIGNED_BYTE: 5121,
+      TRIANGLES: 4,
+      ARRAY_BUFFER: 34962,
+      STATIC_DRAW: 35044,
+      FLOAT: 5126,
+      TEXTURE0: 33984,
+      COLOR_BUFFER_BIT: 16384,
+      CLAMP_TO_EDGE: 33071,
+      LINEAR: 9729,
+      TEXTURE_MIN_FILTER: 10241,
+      TEXTURE_MAG_FILTER: 10240,
+      TEXTURE_WRAP_S: 10242,
+      TEXTURE_WRAP_T: 10243,
+      VERTEX_SHADER: 35633,
+      FRAGMENT_SHADER: 35632,
+      COMPILE_STATUS: true,
+      LINK_STATUS: true,
+      UNPACK_FLIP_Y_WEBGL: 37440,
+      createTexture: vi.fn(() => ({})),
+      bindTexture: vi.fn(),
+      texParameteri: vi.fn(),
+      pixelStorei: vi.fn(),
+      createShader: vi.fn(() => ({})),
+      shaderSource: vi.fn(),
+      compileShader: vi.fn(),
+      getShaderParameter: vi.fn(() => true),
+      getShaderInfoLog: vi.fn(() => ''),
+      createProgram: vi.fn(() => ({})),
+      attachShader: vi.fn(),
+      linkProgram: vi.fn(),
+      getProgramParameter: vi.fn(() => true),
+      getProgramInfoLog: vi.fn(() => ''),
+      createBuffer: vi.fn(() => ({})),
+      bindBuffer: vi.fn(),
+      bufferData: vi.fn(),
+      getAttribLocation: vi.fn(() => 0),
+      enableVertexAttribArray: vi.fn(),
+      vertexAttribPointer: vi.fn(),
+      getUniformLocation: vi.fn((_: unknown, name: string) => ({ name })),
+      viewport: vi.fn(),
+      clear: vi.fn(),
+      useProgram: vi.fn(),
+      activeTexture: vi.fn(),
+      uniform1i: vi.fn(),
+      uniform1f: vi.fn(),
+      uniform1ui: vi.fn(),
+      uniform3f: vi.fn(),
+      drawArrays: vi.fn(() => calls.push('drawArrays')),
+      texElementImage2D: vi.fn(() => calls.push('texElementImage2D')),
+      getExtension: vi.fn()
+    };
+
+    const attributes = new Map<string, string>();
+    const requestPaint = vi.fn();
+
+    const canvas = {
+      width: 0,
+      height: 0,
+      style: { width: '', height: '' },
+      setAttribute: vi.fn((name: string, value: string) => attributes.set(name, value)),
+      getAttribute: (name: string) => attributes.get(name) ?? null,
+      requestPaint,
+      getContext: vi.fn(() => gl)
+    } as unknown as HTMLCanvasElement;
+
+    const root = {
+      scrollWidth: 160,
+      offsetWidth: 160,
+      scrollHeight: 90,
+      offsetHeight: 90,
+      style: { transform: '' }
+    } as unknown as HTMLElement;
+
+    const layer = new HtmlGlslLayerNodeOutput({
+      getCanvasElement: () => canvas,
+      getRootElement: () => root,
+      getExplicitSize: () => ({ width: 640, height: 480 }),
+      warn: vi.fn(),
+      scheduleRun: vi.fn(),
+      detectSupport: () => ({ supported: true, missing: [] }),
+      requestFrame: vi.fn(() => 1),
+      cancelFrame: vi.fn(),
+      now: () => 100,
+      getPixelRatio: () => 2,
+      getElementTransform: () => transform as DOMMatrix
+    });
+
+    layer.enable(`
+      void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+        fragColor = texture(source, fragCoord / iResolution.xy);
+      }
+    `);
+    layer.setup();
+    layer.paint(116);
+
+    expect(canvas.getAttribute('layoutsubtree')).toBe('');
+    expect(canvas.width).toBe(1280);
+    expect(canvas.height).toBe(960);
+
+    expect(gl.texElementImage2D).toHaveBeenCalledWith(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA,
+      1280,
+      960,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      root
+    );
+
+    expect(calls).toEqual(['texElementImage2D', 'drawArrays']);
+    expect(root.style.transform).toBe('matrix(1, 0, 0, 1, 0, 0)');
+
+    expect(gl.shaderSource).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining(
+        'mainImage(fragColor, vec2(gl_FragCoord.x, iResolution.y - gl_FragCoord.y));'
+      )
+    );
+
+    expect(gl.shaderSource).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('#version 300 es')
+    );
+
+    expect(gl.shaderSource).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('out vec4 fragColor;')
+    );
+
+    requestPaint.mockClear();
+
+    gl.texElementImage2D = vi.fn(() => {
+      throw new DOMException('No cached paint record for element.', 'InvalidStateError');
+    });
+
+    expect(() => layer.paint(132)).not.toThrow();
+    expect(requestPaint).toHaveBeenCalled();
+  });
+
+  it('resolves #include directives before compiling the GLSL layer shader', async () => {
+    const gl = {
+      TEXTURE_2D: 3553,
+      RGBA: 6408,
+      UNSIGNED_BYTE: 5121,
+      TRIANGLES: 4,
+      ARRAY_BUFFER: 34962,
+      STATIC_DRAW: 35044,
+      FLOAT: 5126,
+      TEXTURE0: 33984,
+      COLOR_BUFFER_BIT: 16384,
+      CLAMP_TO_EDGE: 33071,
+      LINEAR: 9729,
+      TEXTURE_MIN_FILTER: 10241,
+      TEXTURE_MAG_FILTER: 10240,
+      TEXTURE_WRAP_S: 10242,
+      TEXTURE_WRAP_T: 10243,
+      VERTEX_SHADER: 35633,
+      FRAGMENT_SHADER: 35632,
+      COMPILE_STATUS: true,
+      LINK_STATUS: true,
+      UNPACK_FLIP_Y_WEBGL: 37440,
+      createTexture: vi.fn(() => ({})),
+      bindTexture: vi.fn(),
+      texParameteri: vi.fn(),
+      pixelStorei: vi.fn(),
+      createShader: vi.fn(() => ({})),
+      shaderSource: vi.fn(),
+      compileShader: vi.fn(),
+      getShaderParameter: vi.fn(() => true),
+      getShaderInfoLog: vi.fn(() => ''),
+      createProgram: vi.fn(() => ({})),
+      attachShader: vi.fn(),
+      linkProgram: vi.fn(),
+      getProgramParameter: vi.fn(() => true),
+      getProgramInfoLog: vi.fn(() => ''),
+      createBuffer: vi.fn(() => ({})),
+      bindBuffer: vi.fn(),
+      bufferData: vi.fn(),
+      getAttribLocation: vi.fn(() => 0),
+      enableVertexAttribArray: vi.fn(),
+      vertexAttribPointer: vi.fn(),
+      getUniformLocation: vi.fn((_: unknown, name: string) => ({ name })),
+      viewport: vi.fn(),
+      clear: vi.fn(),
+      useProgram: vi.fn(),
+      activeTexture: vi.fn(),
+      uniform1i: vi.fn(),
+      uniform1f: vi.fn(),
+      uniform3f: vi.fn(),
+      drawArrays: vi.fn(),
+      texElementImage2D: vi.fn()
+    };
+
+    const canvas = {
+      width: 0,
+      height: 0,
+      style: { width: '', height: '' },
+      setAttribute: vi.fn(),
+      getAttribute: vi.fn(() => ''),
+      requestPaint: vi.fn(),
+      getContext: vi.fn(() => gl)
+    } as unknown as HTMLCanvasElement;
+
+    const root = {
+      scrollWidth: 160,
+      offsetWidth: 160,
+      scrollHeight: 90,
+      offsetHeight: 90,
+      style: { transform: '' }
+    } as unknown as HTMLElement;
+
+    const scheduleRun = vi.fn();
+
+    const layer = new HtmlGlslLayerNodeOutput({
+      getCanvasElement: () => canvas,
+      getRootElement: () => root,
+      getExplicitSize: () => ({ width: 640, height: 480 }),
+      warn: vi.fn(),
+      scheduleRun,
+      detectSupport: () => ({ supported: true, missing: [] }),
+      requestFrame: vi.fn(() => 1),
+      cancelFrame: vi.fn(),
+      now: () => 100,
+      getElementTransform: () => ({ toString: () => 'matrix(1, 0, 0, 1, 0, 0)' }) as DOMMatrix,
+      includeResolver: {
+        resolveNpm: vi.fn(async () => 'float includedValue = 0.75;'),
+        resolveVfs: vi.fn(),
+        resolveUrl: vi.fn()
+      }
+    });
+
+    layer.enable(`
+      #include <test/value>
+      void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+        fragColor = vec4(includedValue);
+      }
+    `);
+
+    layer.setup();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    layer.paint(116);
+
+    expect(scheduleRun).toHaveBeenCalled();
+    expect(gl.shaderSource).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('float includedValue = 0.75;')
+    );
+  });
+});
+
+describe('HtmlLayerNodeOutput', () => {
+  it('draws the live root into a layoutsubtree canvas before running the postprocess callback', () => {
+    const callback = vi.fn();
+    const transform = { toString: () => 'matrix(1, 0, 0, 1, 0, 0)' };
+
+    const context = {
+      clearRect: vi.fn(),
+      setTransform: vi.fn(),
+      drawElementImage: vi.fn(() => transform)
+    };
+
+    const attributes = new Map<string, string>();
+
+    const canvas = {
+      width: 0,
+      height: 0,
+      style: { width: '', height: '' },
+      setAttribute: vi.fn((name: string, value: string) => attributes.set(name, value)),
+      getAttribute: (name: string) => attributes.get(name) ?? null,
+      requestPaint: vi.fn(),
+      getContext: vi.fn(() => context)
+    } as unknown as HTMLCanvasElement;
+
+    const root = {
+      scrollWidth: 160,
+      offsetWidth: 160,
+      scrollHeight: 90,
+      offsetHeight: 90,
+      style: { transform: '' }
+    } as unknown as HTMLElement;
+
+    const layer = new HtmlLayerNodeOutput({
+      getCanvasElement: () => canvas,
+      getRootElement: () => root,
+      getExplicitSize: () => ({ width: 640, height: 480 }),
+      warn: vi.fn(),
+      scheduleRun: vi.fn(),
+      detectSupport: () => ({ supported: true, missing: [] }),
+      requestFrame: vi.fn(() => 1),
+      cancelFrame: vi.fn(),
+      now: () => 100,
+      getPixelRatio: () => 2
+    });
+
+    layer.enable(callback);
+    layer.setup();
+
+    expect(canvas.getAttribute('layoutsubtree')).toBe('');
+    expect(canvas.width).toBe(1280);
+    expect(canvas.height).toBe(960);
+    expect(canvas.style.width).toBe('640px');
+    expect(canvas.style.height).toBe('480px');
+    layer.paint(116);
+
+    expect(context.clearRect).toHaveBeenCalledWith(0, 0, 1280, 960);
+    expect(context.drawElementImage).toHaveBeenCalledWith(root, 0, 0, 1280, 960);
+    expect(context.setTransform).toHaveBeenCalledWith(2, 0, 0, 2, 0, 0);
+    expect(root.style.transform).toBe('matrix(1, 0, 0, 1, 0, 0)');
+
+    expect(callback).toHaveBeenCalledWith(context, {
+      width: 1280,
+      height: 960,
+      displayWidth: 640,
+      displayHeight: 480,
+      pixelRatio: 2,
+      time: 16,
+      delta: 16
+    });
+  });
+});

--- a/ui/src/lib/html-in-canvas/html-canvas-node-output.ts
+++ b/ui/src/lib/html-in-canvas/html-canvas-node-output.ts
@@ -1,0 +1,255 @@
+import { PREVIEW_SCALE_FACTOR } from '$lib/canvas/constants';
+import type { GLSystem } from '$lib/canvas/GLSystem';
+import {
+  captureHtmlCanvasElementImage,
+  configureHtmlCanvasElement,
+  createHtmlCanvasSupport,
+  readHtmlCanvasContentSize,
+  resolveHtmlCanvasConfig,
+  resolveHtmlCanvasSize,
+  requestHtmlCanvasPaint,
+  syncHtmlCanvasSize
+} from './html-canvas-video-output';
+import type { HtmlCanvasOptions, HtmlCanvasSizeMode } from './html-canvas-video-output';
+import type { HtmlCanvasSupport } from './html-canvas-video-output';
+
+export type HtmlCanvasNodeOutputState = {
+  enabled: boolean;
+  sizeMode: HtmlCanvasSizeMode;
+  width: number;
+  height: number;
+};
+
+type ExplicitSize = {
+  width?: number;
+  height?: number;
+};
+
+type OutputSize = {
+  width: number;
+  height: number;
+};
+
+type HtmlCanvasVideoGraph = Pick<
+  GLSystem,
+  'upsertNode' | 'removeNode' | 'hasOutgoingVideoConnections' | 'setElementImage'
+>;
+
+export type HtmlCanvasNodeOutputHost = {
+  nodeId: string;
+  objectName: string;
+  getRootElement: () => HTMLElement | undefined;
+  getCanvasElement: () => HTMLCanvasElement | undefined;
+  getExplicitSize: () => ExplicitSize;
+  getOutputSize: () => OutputSize;
+  warn: (message: string) => void;
+  updateNodeInternals: () => void;
+  scheduleRun: () => void;
+  onStateChange?: (state: HtmlCanvasNodeOutputState) => void;
+  videoGraph: HtmlCanvasVideoGraph;
+  detectSupport?: () => HtmlCanvasSupport;
+};
+
+export function getHtmlCanvasRootClass(sizeMode: HtmlCanvasSizeMode, explicitSize: ExplicitSize) {
+  if (
+    sizeMode === 'output' ||
+    (sizeMode === 'free' && explicitSize.width !== undefined && explicitSize.height !== undefined)
+  ) {
+    return 'h-full w-full';
+  }
+
+  return 'inline-block';
+}
+
+export class HtmlCanvasNodeOutput {
+  private enabled = false;
+  private sizeMode: HtmlCanvasSizeMode = 'output';
+  private width = 1;
+  private height = 1;
+  private registered = false;
+  private videoGraph: HtmlCanvasVideoGraph;
+
+  constructor(private host: HtmlCanvasNodeOutputHost) {
+    this.videoGraph = host.videoGraph;
+  }
+
+  get state(): HtmlCanvasNodeOutputState {
+    return {
+      enabled: this.enabled,
+      sizeMode: this.sizeMode,
+      width: this.width,
+      height: this.height
+    };
+  }
+
+  enable = (options: HtmlCanvasOptions = true) => {
+    const config = resolveHtmlCanvasConfig(options);
+
+    if (config.enabled) {
+      const support = this.detectSupport();
+
+      if (!support.supported) {
+        this.host.warn(
+          `htmlCanvas() requires Chrome's experimental HTML-in-Canvas API. Missing: ${support.missing.join(', ')}`
+        );
+
+        return false;
+      }
+    }
+
+    const enabledChanged = this.enabled !== config.enabled;
+    const modeChanged = this.sizeMode !== config.mode;
+
+    if (enabledChanged || modeChanged) {
+      this.enabled = config.enabled;
+      this.sizeMode = config.mode;
+
+      this.setRegistered(config.enabled);
+      this.emitState();
+
+      this.host.updateNodeInternals();
+      this.host.scheduleRun();
+    }
+
+    return true;
+  };
+
+  getRootClass() {
+    return getHtmlCanvasRootClass(this.sizeMode, this.host.getExplicitSize());
+  }
+
+  updateSize() {
+    const rootElement = this.host.getRootElement();
+    const measured = rootElement ? readHtmlCanvasContentSize(rootElement) : { width: 1, height: 1 };
+    const explicitSize = this.host.getExplicitSize();
+    const outputSize = this.host.getOutputSize();
+
+    const size = resolveHtmlCanvasSize({
+      mode: this.sizeMode,
+      explicitWidth: explicitSize.width,
+      explicitHeight: explicitSize.height,
+      measuredWidth: measured.width,
+      measuredHeight: measured.height,
+      outputWidth: outputSize.width,
+      outputHeight: outputSize.height,
+      scale: PREVIEW_SCALE_FACTOR
+    });
+
+    this.width = size.width;
+    this.height = size.height;
+
+    const canvas = this.host.getCanvasElement();
+
+    if (canvas) {
+      syncHtmlCanvasSize(canvas, size);
+    }
+
+    return size;
+  }
+
+  setup() {
+    const canvas = this.host.getCanvasElement();
+    const rootElement = this.host.getRootElement();
+
+    if (!canvas || !rootElement) return false;
+
+    const ctx = canvas.getContext('2d');
+    const support = createHtmlCanvasSupport({ canvas, context: ctx });
+
+    if (!ctx || !support.supported) {
+      this.host.warn(
+        `htmlCanvas() requires Chrome's experimental HTML-in-Canvas API. Missing: ${support.missing.join(', ')}`
+      );
+
+      this.enable(false);
+
+      return false;
+    }
+
+    configureHtmlCanvasElement(canvas, this.updateSize());
+
+    const htmlCanvas = canvas as HTMLCanvasElement & {
+      onpaint: ((event: Event) => void) | null;
+    };
+
+    const drawContext = ctx as CanvasRenderingContext2D & {
+      drawElementImage: (
+        element: Element,
+        dx: number,
+        dy: number,
+        dw: number,
+        dh: number
+      ) => DOMMatrix;
+    };
+
+    htmlCanvas.onpaint = () => {
+      const { width, height } = this.updateSize();
+
+      ctx.clearRect(0, 0, width, height);
+
+      const transform = drawContext.drawElementImage(rootElement, 0, 0, width, height);
+      rootElement.style.transform = transform.toString();
+
+      this.sendBitmap();
+    };
+
+    this.requestPaint();
+
+    return true;
+  }
+
+  requestPaint() {
+    requestHtmlCanvasPaint(this.host.getCanvasElement());
+  }
+
+  destroy() {
+    this.setRegistered(false);
+  }
+
+  private detectSupport() {
+    if (this.host.detectSupport) {
+      return this.host.detectSupport();
+    }
+
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+
+    return createHtmlCanvasSupport({ canvas, context });
+  }
+
+  private setRegistered(registered: boolean) {
+    if (registered === this.registered) return;
+
+    this.registered = registered;
+
+    if (registered) {
+      this.videoGraph.upsertNode(this.host.nodeId, 'img', {});
+    } else {
+      this.videoGraph.removeNode(this.host.nodeId);
+    }
+  }
+
+  private sendBitmap() {
+    const canvas = this.host.getCanvasElement();
+    const rootElement = this.host.getRootElement();
+
+    if (!canvas || !rootElement) return;
+    if (!this.videoGraph.hasOutgoingVideoConnections(this.host.nodeId)) return;
+
+    const elementImage = captureHtmlCanvasElementImage(canvas, rootElement);
+
+    if (!elementImage) {
+      this.host.warn(
+        "htmlCanvas() could not capture an ElementImage. Is Chrome's experimental HTML-in-Canvas flag enabled?"
+      );
+
+      return;
+    }
+
+    this.videoGraph.setElementImage(this.host.nodeId, elementImage, this.width, this.height);
+  }
+
+  private emitState() {
+    this.host.onStateChange?.(this.state);
+  }
+}

--- a/ui/src/lib/html-in-canvas/html-canvas-video-output.test.ts
+++ b/ui/src/lib/html-in-canvas/html-canvas-video-output.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  configureHtmlCanvasElement,
+  captureHtmlCanvasElementImage,
+  createHtmlCanvasSupport,
+  resolveHtmlCanvasConfig,
+  resolveHtmlCanvasSize,
+  requestHtmlCanvasPaint,
+  syncHtmlCanvasSize
+} from './html-canvas-video-output';
+
+function createCanvasStub() {
+  const attributes = new Map<string, string>();
+
+  return {
+    width: 0,
+    height: 0,
+    style: { width: '', height: '' },
+    setAttribute: vi.fn((name: string, value: string) => {
+      attributes.set(name, value);
+    }),
+    getAttribute: (name: string) => attributes.get(name) ?? null
+  } as unknown as HTMLCanvasElement;
+}
+
+describe('html-in-canvas DOM video output helpers', () => {
+  it('detects support from canvas and 2D context capabilities', () => {
+    const support = createHtmlCanvasSupport({
+      canvas: { requestPaint: vi.fn(), captureElementImage: vi.fn() },
+      context: { drawElementImage: vi.fn() }
+    });
+
+    expect(support.supported).toBe(true);
+    expect(support.missing).toEqual([]);
+  });
+
+  it('reports missing capabilities instead of assuming the flagged API exists', () => {
+    const support = createHtmlCanvasSupport({
+      canvas: {},
+      context: {}
+    });
+
+    expect(support.supported).toBe(false);
+    expect(support.missing).toEqual([
+      'HTMLCanvasElement.requestPaint',
+      'HTMLCanvasElement.captureElementImage',
+      'CanvasRenderingContext2D.drawElementImage'
+    ]);
+  });
+
+  it('captures an ElementImage only when captureElementImage is available', () => {
+    const element = {} as Element;
+    const elementImage = { width: 10, height: 20, close: vi.fn() };
+    const canvas = { captureElementImage: vi.fn(() => elementImage) };
+
+    expect(captureHtmlCanvasElementImage(canvas, element)).toBe(elementImage);
+    expect(captureHtmlCanvasElementImage({}, element)).toBeNull();
+    expect(canvas.captureElementImage).toHaveBeenCalledWith(element);
+  });
+
+  it('configures the canvas as a layoutsubtree host with stable sizing', () => {
+    const canvas = createCanvasStub();
+
+    configureHtmlCanvasElement(canvas, { width: 640, height: 360, scale: 4 });
+
+    expect(canvas.getAttribute('layoutsubtree')).toBe('');
+    expect(canvas.width).toBe(640);
+    expect(canvas.height).toBe(360);
+    expect(canvas.style.width).toBe('160px');
+    expect(canvas.style.height).toBe('90px');
+  });
+
+  it('updates canvas dimensions when the output size changes', () => {
+    const canvas = createCanvasStub();
+    expect(syncHtmlCanvasSize(canvas, { width: 800, height: 600, scale: 2 })).toBe(true);
+
+    expect(canvas.width).toBe(800);
+    expect(canvas.height).toBe(600);
+    expect(canvas.style.width).toBe('400px');
+    expect(canvas.style.height).toBe('300px');
+  });
+
+  it('does not rewrite canvas dimensions when the output size is unchanged', () => {
+    const canvas = createCanvasStub();
+    syncHtmlCanvasSize(canvas, { width: 800, height: 600, scale: 2 });
+
+    expect(syncHtmlCanvasSize(canvas, { width: 800, height: 600, scale: 2 })).toBe(false);
+  });
+
+  it('uses measured content size in free mode when no explicit dom size is set', () => {
+    expect(
+      resolveHtmlCanvasSize({
+        mode: 'free',
+        measuredWidth: 120,
+        measuredHeight: 70,
+        outputWidth: 1280,
+        outputHeight: 720,
+        scale: 4
+      })
+    ).toEqual({ width: 480, height: 280, scale: 4 });
+  });
+
+  it('treats explicit dom size as display size in free mode', () => {
+    expect(
+      resolveHtmlCanvasSize({
+        mode: 'free',
+        explicitWidth: 320,
+        explicitHeight: 180,
+        measuredWidth: 120,
+        measuredHeight: 70,
+        scale: 4
+      })
+    ).toEqual({ width: 1280, height: 720, scale: 4 });
+  });
+
+  it('uses the render output size by default', () => {
+    expect(
+      resolveHtmlCanvasSize({
+        outputWidth: 1280,
+        outputHeight: 720,
+        measuredWidth: 120,
+        measuredHeight: 70,
+        scale: 4
+      })
+    ).toEqual({ width: 1280, height: 720, scale: 4 });
+  });
+
+  it('normalizes htmlCanvas API arguments', () => {
+    expect(resolveHtmlCanvasConfig()).toEqual({ enabled: true, mode: 'output' });
+    expect(resolveHtmlCanvasConfig(true)).toEqual({ enabled: true, mode: 'output' });
+    expect(resolveHtmlCanvasConfig(false)).toEqual({ enabled: false, mode: 'output' });
+    expect(resolveHtmlCanvasConfig({ size: 'free' })).toEqual({
+      enabled: true,
+      mode: 'free'
+    });
+  });
+
+  it('requests a paint only when the experimental API is present', () => {
+    const requestPaint = vi.fn();
+
+    requestHtmlCanvasPaint({ requestPaint });
+    requestHtmlCanvasPaint({});
+
+    expect(requestPaint).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/lib/html-in-canvas/html-canvas-video-output.ts
+++ b/ui/src/lib/html-in-canvas/html-canvas-video-output.ts
@@ -1,0 +1,167 @@
+import { getRecord, toPositiveInteger } from './utils';
+export { readHtmlCanvasContentSize } from './utils';
+
+export type HtmlCanvasSupport = {
+  supported: boolean;
+  missing: string[];
+};
+
+export type HtmlCanvasSize = {
+  width: number;
+  height: number;
+  scale: number;
+};
+
+export type HtmlCanvasSizeMode = 'output' | 'free';
+
+export type HtmlCanvasSizeInput = {
+  mode?: HtmlCanvasSizeMode;
+  explicitWidth?: number;
+  explicitHeight?: number;
+  measuredWidth?: number;
+  measuredHeight?: number;
+  outputWidth?: number;
+  outputHeight?: number;
+  scale: number;
+};
+
+export type HtmlCanvasOptions = boolean | { size?: 'free' } | undefined;
+
+export type HtmlCanvasConfig = {
+  enabled: boolean;
+  mode: HtmlCanvasSizeMode;
+};
+
+export type ElementImageLike = {
+  width: number;
+  height: number;
+  close: () => void;
+};
+
+export function createHtmlCanvasSupport({
+  canvas,
+  context
+}: {
+  canvas: unknown;
+  context: unknown;
+}): HtmlCanvasSupport {
+  const missing: string[] = [];
+  const canvasRecord = getRecord(canvas);
+  const contextRecord = getRecord(context);
+
+  if (typeof canvasRecord?.requestPaint !== 'function') {
+    missing.push('HTMLCanvasElement.requestPaint');
+  }
+
+  if (typeof canvasRecord?.captureElementImage !== 'function') {
+    missing.push('HTMLCanvasElement.captureElementImage');
+  }
+
+  if (typeof contextRecord?.drawElementImage !== 'function') {
+    missing.push('CanvasRenderingContext2D.drawElementImage');
+  }
+
+  return {
+    supported: missing.length === 0,
+    missing
+  };
+}
+
+export function configureHtmlCanvasElement(canvas: HTMLCanvasElement, size: HtmlCanvasSize) {
+  canvas.setAttribute('layoutsubtree', '');
+
+  syncHtmlCanvasSize(canvas, size);
+}
+
+export function resolveHtmlCanvasSize({
+  mode = 'output',
+  explicitWidth,
+  explicitHeight,
+  measuredWidth,
+  measuredHeight,
+  outputWidth,
+  outputHeight,
+  scale
+}: HtmlCanvasSizeInput): HtmlCanvasSize {
+  if (mode === 'output') {
+    return {
+      width: toPositiveInteger(outputWidth),
+      height: toPositiveInteger(outputHeight),
+      scale
+    };
+  }
+
+  const displayWidth = explicitWidth ?? measuredWidth;
+  const displayHeight = explicitHeight ?? measuredHeight;
+
+  return {
+    width: toPositiveInteger(displayWidth) * scale,
+    height: toPositiveInteger(displayHeight) * scale,
+    scale
+  };
+}
+
+export function resolveHtmlCanvasConfig(options: HtmlCanvasOptions = true): HtmlCanvasConfig {
+  if (options === false) {
+    return { enabled: false, mode: 'output' };
+  }
+
+  if (typeof options === 'object' && options?.size === 'free') {
+    return { enabled: true, mode: 'free' };
+  }
+
+  return { enabled: true, mode: 'output' };
+}
+
+export function syncHtmlCanvasSize(
+  canvas: HTMLCanvasElement,
+  { width, height, scale }: HtmlCanvasSize
+) {
+  const styleWidth = `${width / scale}px`;
+  const styleHeight = `${height / scale}px`;
+
+  let changed = false;
+
+  if (canvas.width !== width) {
+    canvas.width = width;
+    changed = true;
+  }
+
+  if (canvas.height !== height) {
+    canvas.height = height;
+    changed = true;
+  }
+
+  if (canvas.style.width !== styleWidth) {
+    canvas.style.width = styleWidth;
+    changed = true;
+  }
+
+  if (canvas.style.height !== styleHeight) {
+    canvas.style.height = styleHeight;
+    changed = true;
+  }
+
+  return changed;
+}
+
+export function requestHtmlCanvasPaint(canvas: unknown) {
+  const canvasRecord = getRecord(canvas);
+
+  if (typeof canvasRecord?.requestPaint === 'function') {
+    canvasRecord.requestPaint();
+  }
+}
+
+export function captureHtmlCanvasElementImage(
+  canvas: unknown,
+  element: Element
+): ElementImageLike | null {
+  const canvasRecord = getRecord(canvas);
+
+  if (typeof canvasRecord?.captureElementImage !== 'function') {
+    return null;
+  }
+
+  return canvasRecord.captureElementImage(element) as ElementImageLike;
+}

--- a/ui/src/lib/html-in-canvas/html-glsl-layer-node-output.ts
+++ b/ui/src/lib/html-in-canvas/html-glsl-layer-node-output.ts
@@ -1,0 +1,440 @@
+import { buildShaderToyFragmentShader, SHADERTOY_VERTEX_SHADER } from '$lib/canvas/shadertoy-draw';
+import { createBrowserResolver } from '$lib/glsl-include/browser-resolver';
+import { processIncludes } from '$lib/glsl-include/preprocessor';
+import type { IncludeResolver } from '$lib/glsl-include/preprocessor';
+import {
+  configureHtmlCanvasElement,
+  requestHtmlCanvasPaint,
+  syncHtmlCanvasSize
+} from './html-canvas-video-output';
+import type { HtmlCanvasSize, HtmlCanvasSupport } from './html-canvas-video-output';
+import { getRecord, resolveHtmlLayerSize } from './utils';
+
+export type HtmlGlslLayerOptions = string | false | undefined;
+
+export type HtmlGlslLayerNodeOutputState = {
+  enabled: boolean;
+};
+
+export type HtmlGlslLayerNodeOutputHost = {
+  getRootElement: () => HTMLElement | undefined;
+  getCanvasElement: () => HTMLCanvasElement | undefined;
+  getExplicitSize?: () => { width?: number; height?: number };
+  warn: (message: string) => void;
+  scheduleRun: () => void;
+  onStateChange?: (state: HtmlGlslLayerNodeOutputState) => void;
+  requestFrame?: (callback: FrameRequestCallback) => number;
+  cancelFrame?: (id: number) => void;
+  now?: () => number;
+  getPixelRatio?: () => number;
+  detectSupport?: () => HtmlCanvasSupport;
+  getElementTransform?: (element: Element) => DOMMatrix;
+  includeResolver?: IncludeResolver;
+};
+
+type GlslProgram = {
+  program: WebGLProgram;
+  positionBuffer: WebGLBuffer;
+  sourceTexture: WebGLTexture;
+  positionLocation: number;
+  sourceLocation: WebGLUniformLocation | null;
+  resolutionLocation: WebGLUniformLocation | null;
+  timeLocation: WebGLUniformLocation | null;
+  timeDeltaLocation: WebGLUniformLocation | null;
+  frameLocation: WebGLUniformLocation | null;
+};
+
+function createHtmlGlslLayerSupport({
+  canvas,
+  context
+}: {
+  canvas: unknown;
+  context: unknown;
+}): HtmlCanvasSupport {
+  const missing: string[] = [];
+  const canvasRecord = getRecord(canvas);
+  const contextRecord = getRecord(context);
+
+  if (typeof canvasRecord?.requestPaint !== 'function') {
+    missing.push('HTMLCanvasElement.requestPaint');
+  }
+
+  if (typeof contextRecord?.texElementImage2D !== 'function') {
+    missing.push('WebGL2RenderingContext.texElementImage2D');
+  }
+
+  return {
+    supported: missing.length === 0,
+    missing
+  };
+}
+
+function createShader(gl: WebGL2RenderingContext, type: number, source: string) {
+  const shader = gl.createShader(type);
+  if (!shader) throw new Error('Could not create shader');
+
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    throw new Error(gl.getShaderInfoLog(shader) || 'Shader compile failed');
+  }
+
+  return shader;
+}
+
+const createFragmentShader = (source: string) =>
+  buildShaderToyFragmentShader({
+    code: source,
+    extraUniforms: 'uniform sampler2D source;',
+    fragCoordExpression: 'vec2(gl_FragCoord.x, iResolution.y - gl_FragCoord.y)'
+  });
+
+function createProgram(gl: WebGL2RenderingContext, source: string): GlslProgram {
+  const vertexShader = createShader(gl, gl.VERTEX_SHADER, SHADERTOY_VERTEX_SHADER);
+  const userFragmentShader = createShader(gl, gl.FRAGMENT_SHADER, createFragmentShader(source));
+
+  const program = gl.createProgram();
+  if (!program) throw new Error('Could not create shader program');
+
+  gl.attachShader(program, vertexShader);
+  gl.attachShader(program, userFragmentShader);
+  gl.linkProgram(program);
+
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    throw new Error(gl.getProgramInfoLog(program) || 'Shader link failed');
+  }
+
+  const positionBuffer = gl.createBuffer();
+  const sourceTexture = gl.createTexture();
+
+  if (!positionBuffer || !sourceTexture) {
+    throw new Error('Could not create WebGL resources');
+  }
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]),
+    gl.STATIC_DRAW
+  );
+
+  gl.bindTexture(gl.TEXTURE_2D, sourceTexture);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+  return {
+    program,
+    positionBuffer,
+    sourceTexture,
+    positionLocation: gl.getAttribLocation(program, 'position'),
+    sourceLocation: gl.getUniformLocation(program, 'source'),
+    resolutionLocation: gl.getUniformLocation(program, 'iResolution'),
+    timeLocation: gl.getUniformLocation(program, 'iTime'),
+    timeDeltaLocation: gl.getUniformLocation(program, 'iTimeDelta'),
+    frameLocation: gl.getUniformLocation(program, 'iFrame')
+  };
+}
+
+export class HtmlGlslLayerNodeOutput {
+  private source: string | null = null;
+  private program: GlslProgram | null = null;
+  private resolvedSource: string | null = null;
+  private pendingIncludeSource: string | null = null;
+  private includeRequestId = 0;
+  private frameId: number | null = null;
+  private startedAt = 0;
+  private lastFrameAt = 0;
+  private frame = 0;
+
+  constructor(private host: HtmlGlslLayerNodeOutputHost) {}
+
+  get enabled() {
+    return this.source !== null;
+  }
+
+  get state(): HtmlGlslLayerNodeOutputState {
+    return { enabled: this.enabled };
+  }
+
+  enable = (options: HtmlGlslLayerOptions) => {
+    if (options === false || options === undefined) {
+      const wasEnabled = this.enabled;
+      this.stop();
+      if (wasEnabled) this.host.scheduleRun();
+      return false;
+    }
+
+    const support = this.detectSupport();
+    if (!support.supported) {
+      this.host.warn(
+        `htmlCanvas.glslLayer() requires Chrome's experimental HTML-in-Canvas API. Missing: ${support.missing.join(', ')}`
+      );
+      return false;
+    }
+
+    const wasEnabled = this.enabled;
+    this.source = options;
+    this.program = null;
+    this.resolvedSource = null;
+    this.pendingIncludeSource = null;
+    this.includeRequestId += 1;
+    this.frame = 0;
+    this.startedAt = this.now();
+    this.lastFrameAt = this.startedAt;
+    this.emitState();
+
+    if (!wasEnabled) this.host.scheduleRun();
+
+    return true;
+  };
+
+  stop() {
+    if (this.frameId !== null) {
+      this.cancelFrame(this.frameId);
+      this.frameId = null;
+    }
+
+    const wasEnabled = this.enabled;
+    this.source = null;
+    this.program = null;
+    this.resolvedSource = null;
+    this.pendingIncludeSource = null;
+    this.includeRequestId += 1;
+
+    if (wasEnabled) this.emitState();
+  }
+
+  setup() {
+    const canvas = this.host.getCanvasElement();
+    const rootElement = this.host.getRootElement();
+    if (!this.source || !canvas || !rootElement) return false;
+
+    const gl = canvas.getContext('webgl2') as WebGL2RenderingContext | null;
+    const support = createHtmlGlslLayerSupport({ canvas, context: gl });
+
+    if (!gl || !support.supported) {
+      this.host.warn(
+        `htmlCanvas.glslLayer() requires Chrome's experimental HTML-in-Canvas WebGL API. Missing: ${support.missing.join(', ')}`
+      );
+
+      this.stop();
+
+      return false;
+    }
+
+    configureHtmlCanvasElement(canvas, this.resolveSize(rootElement));
+
+    const htmlCanvas = canvas as HTMLCanvasElement & {
+      onpaint: ((event: Event) => void) | null;
+    };
+
+    htmlCanvas.onpaint = () => this.paint();
+    this.requestPaintLoop();
+
+    try {
+      const source = this.getPreparedSource();
+      if (source) this.program = createProgram(gl, source);
+    } catch (error) {
+      this.host.warn(error instanceof Error ? error.message : String(error));
+      this.stop();
+      return false;
+    }
+
+    return true;
+  }
+
+  paint = (timestamp = this.now()) => {
+    const canvas = this.host.getCanvasElement();
+    const rootElement = this.host.getRootElement();
+    if (!this.source || !canvas || !rootElement) return;
+
+    const gl = canvas.getContext('webgl2') as WebGL2RenderingContext | null;
+    if (!gl) return;
+
+    if (!this.program) {
+      try {
+        const source = this.getPreparedSource();
+        if (!source) return;
+
+        this.program = createProgram(gl, source);
+      } catch (error) {
+        this.host.warn(error instanceof Error ? error.message : String(error));
+        this.stop();
+        return;
+      }
+    }
+
+    const size = this.resolveSize(rootElement);
+    const resized = syncHtmlCanvasSize(canvas, size);
+
+    if (resized) {
+      this.requestPaint();
+      return;
+    }
+
+    gl.bindTexture(gl.TEXTURE_2D, this.program.sourceTexture);
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+
+    try {
+      (
+        gl as WebGL2RenderingContext & {
+          texElementImage2D: (
+            target: number,
+            level: number,
+            internalformat: number,
+            width: number,
+            height: number,
+            format: number,
+            type: number,
+            element: Element
+          ) => void;
+        }
+      ).texElementImage2D(
+        gl.TEXTURE_2D,
+        0,
+        gl.RGBA,
+        size.width,
+        size.height,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        rootElement
+      );
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'InvalidStateError') {
+        this.requestPaint();
+        return;
+      }
+
+      throw error;
+    }
+
+    rootElement.style.transform = this.getTransform(rootElement).toString();
+
+    const elapsed = timestamp - this.startedAt;
+    const delta = timestamp - this.lastFrameAt;
+    this.lastFrameAt = timestamp;
+
+    gl.viewport(0, 0, size.width, size.height);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.useProgram(this.program.program);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.program.positionBuffer);
+    gl.enableVertexAttribArray(this.program.positionLocation);
+    gl.vertexAttribPointer(this.program.positionLocation, 2, gl.FLOAT, false, 0, 0);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.program.sourceTexture);
+
+    if (this.program.sourceLocation) gl.uniform1i(this.program.sourceLocation, 0);
+    if (this.program.resolutionLocation) {
+      gl.uniform3f(
+        this.program.resolutionLocation,
+        size.width,
+        size.height,
+        size.width / size.height
+      );
+    }
+    if (this.program.timeLocation) gl.uniform1f(this.program.timeLocation, elapsed / 1000);
+    if (this.program.timeDeltaLocation) gl.uniform1f(this.program.timeDeltaLocation, delta / 1000);
+    if (this.program.frameLocation) gl.uniform1i(this.program.frameLocation, this.frame);
+
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+    this.frame += 1;
+  };
+
+  requestPaint() {
+    requestHtmlCanvasPaint(this.host.getCanvasElement());
+  }
+
+  private resolveSize(rootElement: HTMLElement): HtmlCanvasSize {
+    return resolveHtmlLayerSize({
+      rootElement,
+      explicitSize: this.host.getExplicitSize?.(),
+      pixelRatio: this.pixelRatio()
+    });
+  }
+
+  private getTransform(element: Element) {
+    return this.host.getElementTransform?.(element) ?? new DOMMatrix();
+  }
+
+  private requestPaintLoop() {
+    this.requestPaint();
+
+    if (this.frameId !== null) this.cancelFrame(this.frameId);
+
+    this.frameId = this.requestFrame(() => {
+      this.frameId = null;
+      this.requestPaintLoop();
+    });
+  }
+
+  private detectSupport() {
+    if (this.host.detectSupport) return this.host.detectSupport();
+
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('webgl2');
+
+    return createHtmlGlslLayerSupport({ canvas, context });
+  }
+
+  private getPreparedSource() {
+    if (!this.source) return null;
+    if (this.resolvedSource) return this.resolvedSource;
+
+    if (!this.source.includes('#include')) {
+      this.resolvedSource = this.source;
+
+      return this.resolvedSource;
+    }
+
+    const requestId = ++this.includeRequestId;
+    const source = this.source;
+    if (this.pendingIncludeSource === source) return null;
+
+    this.pendingIncludeSource = source;
+    const resolver = this.host.includeResolver ?? createBrowserResolver();
+
+    processIncludes(source, resolver).then(
+      (resolved) => {
+        if (requestId !== this.includeRequestId || this.source !== source) return;
+
+        this.resolvedSource = resolved;
+        this.pendingIncludeSource = null;
+        this.program = null;
+        this.host.scheduleRun();
+      },
+      (error) => {
+        if (requestId !== this.includeRequestId || this.source !== source) return;
+
+        this.pendingIncludeSource = null;
+        this.host.warn(error instanceof Error ? error.message : String(error));
+        this.stop();
+      }
+    );
+
+    return null;
+  }
+
+  private requestFrame(callback: FrameRequestCallback) {
+    return this.host.requestFrame?.(callback) ?? requestAnimationFrame(callback);
+  }
+
+  private cancelFrame(id: number) {
+    (this.host.cancelFrame ?? cancelAnimationFrame)(id);
+  }
+
+  private now() {
+    return this.host.now?.() ?? performance.now();
+  }
+
+  private pixelRatio() {
+    return Math.max(1, this.host.getPixelRatio?.() ?? globalThis.devicePixelRatio ?? 1);
+  }
+
+  private emitState() {
+    this.host.onStateChange?.(this.state);
+  }
+}

--- a/ui/src/lib/html-in-canvas/html-layer-node-output.ts
+++ b/ui/src/lib/html-in-canvas/html-layer-node-output.ts
@@ -1,0 +1,258 @@
+import {
+  configureHtmlCanvasElement,
+  requestHtmlCanvasPaint,
+  syncHtmlCanvasSize
+} from './html-canvas-video-output';
+import type { HtmlCanvasSize, HtmlCanvasSupport } from './html-canvas-video-output';
+import { getRecord, resolveHtmlLayerSize } from './utils';
+
+export type HtmlLayerFrame = {
+  width: number;
+  height: number;
+  displayWidth: number;
+  displayHeight: number;
+  pixelRatio: number;
+  time: number;
+  delta: number;
+};
+
+export type HtmlLayerCallback = (ctx: CanvasRenderingContext2D, frame: HtmlLayerFrame) => void;
+export type HtmlLayerOptions = HtmlLayerCallback | false | undefined;
+export type HtmlLayerNodeOutputState = { enabled: boolean };
+
+export type HtmlLayerNodeOutputHost = {
+  getRootElement: () => HTMLElement | undefined;
+  getCanvasElement: () => HTMLCanvasElement | undefined;
+  getExplicitSize?: () => { width?: number; height?: number };
+  warn: (message: string) => void;
+  scheduleRun: () => void;
+  onStateChange?: (state: HtmlLayerNodeOutputState) => void;
+  requestFrame?: (callback: FrameRequestCallback) => number;
+  cancelFrame?: (id: number) => void;
+  now?: () => number;
+  getPixelRatio?: () => number;
+  detectSupport?: () => HtmlCanvasSupport;
+};
+
+type CanvasWithOnPaint = HTMLCanvasElement & { onpaint: ((event: Event) => void) | null };
+
+function createHtmlLayerSupport({
+  canvas,
+  context
+}: {
+  canvas: unknown;
+  context: unknown;
+}): HtmlCanvasSupport {
+  const missing: string[] = [];
+  const canvasRecord = getRecord(canvas);
+  const contextRecord = getRecord(context);
+
+  if (typeof canvasRecord?.requestPaint !== 'function') {
+    missing.push('HTMLCanvasElement.requestPaint');
+  }
+
+  if (typeof contextRecord?.drawElementImage !== 'function') {
+    missing.push('CanvasRenderingContext2D.drawElementImage');
+  }
+
+  return {
+    supported: missing.length === 0,
+    missing
+  };
+}
+
+export class HtmlLayerNodeOutput {
+  private callback: HtmlLayerCallback | null = null;
+  private frameId: number | null = null;
+  private startedAt = 0;
+  private lastFrameAt = 0;
+
+  constructor(private host: HtmlLayerNodeOutputHost) {}
+
+  get enabled() {
+    return this.callback !== null;
+  }
+
+  get state(): HtmlLayerNodeOutputState {
+    return { enabled: this.enabled };
+  }
+
+  enable = (options: HtmlLayerOptions) => {
+    if (options === false || options === undefined) {
+      const wasEnabled = this.enabled;
+      this.stop();
+
+      if (wasEnabled) {
+        this.host.scheduleRun();
+      }
+
+      return false;
+    }
+
+    const support = this.detectSupport();
+
+    if (!support.supported) {
+      this.host.warn(
+        `htmlLayer() requires Chrome's experimental HTML-in-Canvas API. Missing: ${support.missing.join(', ')}`
+      );
+
+      return false;
+    }
+
+    const wasEnabled = this.enabled;
+
+    this.callback = options;
+    this.startedAt = this.now();
+    this.lastFrameAt = this.startedAt;
+    this.emitState();
+
+    if (!wasEnabled) {
+      this.host.scheduleRun();
+    }
+
+    return true;
+  };
+
+  stop() {
+    if (this.frameId !== null) {
+      this.cancelFrame(this.frameId);
+      this.frameId = null;
+    }
+
+    const wasEnabled = this.enabled;
+    this.callback = null;
+
+    if (wasEnabled) {
+      this.emitState();
+    }
+  }
+
+  setup() {
+    const canvas = this.host.getCanvasElement();
+    const rootElement = this.host.getRootElement();
+
+    if (!this.callback || !canvas || !rootElement) return false;
+
+    const ctx = canvas.getContext('2d');
+    const support = createHtmlLayerSupport({ canvas, context: ctx });
+
+    if (!ctx || !support.supported) {
+      this.host.warn(
+        `htmlLayer() requires Chrome's experimental HTML-in-Canvas API. Missing: ${support.missing.join(', ')}`
+      );
+
+      this.stop();
+
+      return false;
+    }
+
+    configureHtmlCanvasElement(canvas, this.resolveSize(rootElement));
+
+    const htmlCanvas = canvas as CanvasWithOnPaint;
+    htmlCanvas.onpaint = () => this.paint();
+
+    this.requestPaintLoop();
+
+    return true;
+  }
+
+  paint = (timestamp = this.now()) => {
+    if (!this.callback) return;
+
+    const canvas = this.host.getCanvasElement();
+    const rootElement = this.host.getRootElement();
+
+    if (!canvas || !rootElement) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const size = this.resolveSize(rootElement);
+    syncHtmlCanvasSize(canvas, size);
+
+    const drawContext = ctx as CanvasRenderingContext2D & {
+      drawElementImage: (
+        element: Element,
+        dx: number,
+        dy: number,
+        dw: number,
+        dh: number
+      ) => DOMMatrix;
+    };
+
+    ctx.clearRect(0, 0, size.width, size.height);
+
+    const transform = drawContext.drawElementImage(rootElement, 0, 0, size.width, size.height);
+    rootElement.style.transform = transform.toString();
+    ctx.setTransform(size.scale, 0, 0, size.scale, 0, 0);
+
+    const frame = {
+      width: size.width,
+      height: size.height,
+      displayWidth: size.width / size.scale,
+      displayHeight: size.height / size.scale,
+      pixelRatio: size.scale,
+      time: timestamp - this.startedAt,
+      delta: timestamp - this.lastFrameAt
+    };
+
+    this.lastFrameAt = timestamp;
+    this.callback(ctx, frame);
+  };
+
+  requestPaint() {
+    requestHtmlCanvasPaint(this.host.getCanvasElement());
+  }
+
+  private resolveSize(rootElement: HTMLElement): HtmlCanvasSize {
+    return resolveHtmlLayerSize({
+      rootElement,
+      explicitSize: this.host.getExplicitSize?.(),
+      pixelRatio: this.pixelRatio()
+    });
+  }
+
+  private requestPaintLoop() {
+    this.requestPaint();
+
+    if (this.frameId !== null) {
+      this.cancelFrame(this.frameId);
+    }
+
+    this.frameId = this.requestFrame(() => {
+      this.frameId = null;
+      this.requestPaintLoop();
+    });
+  }
+
+  private detectSupport() {
+    if (this.host.detectSupport) {
+      return this.host.detectSupport();
+    }
+
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+
+    return createHtmlLayerSupport({ canvas, context });
+  }
+
+  private requestFrame(callback: FrameRequestCallback) {
+    return this.host.requestFrame?.(callback) ?? requestAnimationFrame(callback);
+  }
+
+  private cancelFrame(id: number) {
+    (this.host.cancelFrame ?? cancelAnimationFrame)(id);
+  }
+
+  private now() {
+    return this.host.now?.() ?? performance.now();
+  }
+
+  private pixelRatio() {
+    return Math.max(1, this.host.getPixelRatio?.() ?? globalThis.devicePixelRatio ?? 1);
+  }
+
+  private emitState() {
+    this.host.onStateChange?.(this.state);
+  }
+}

--- a/ui/src/lib/html-in-canvas/utils.ts
+++ b/ui/src/lib/html-in-canvas/utils.ts
@@ -1,0 +1,42 @@
+type Dimension = { width: number; height: number };
+
+export type HtmlLayerSizeInput = {
+  rootElement: HTMLElement;
+  explicitSize?: Partial<Dimension>;
+  pixelRatio: number;
+};
+
+export type HtmlCanvasSizeLike = Dimension & { scale: number };
+
+export const getRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null;
+
+export function toPositiveInteger(value: number | undefined, fallback = 1) {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+
+  return Math.max(1, Math.ceil(value));
+}
+
+export const readHtmlCanvasContentSize = (element: HTMLElement): Dimension => ({
+  width: Math.max(element.scrollWidth, element.offsetWidth),
+  height: Math.max(element.scrollHeight, element.offsetHeight)
+});
+
+export function resolveHtmlLayerSize({
+  rootElement,
+  explicitSize,
+  pixelRatio
+}: HtmlLayerSizeInput): HtmlCanvasSizeLike {
+  const measured = readHtmlCanvasContentSize(rootElement);
+
+  const displayWidth = explicitSize?.width ?? measured.width;
+  const displayHeight = explicitSize?.height ?? measured.height;
+
+  return {
+    width: toPositiveInteger(displayWidth) * pixelRatio,
+    height: toPositiveInteger(displayHeight) * pixelRatio,
+    scale: pixelRatio
+  };
+}

--- a/ui/src/lib/objects/schemas/dom.ts
+++ b/ui/src/lib/objects/schemas/dom.ts
@@ -32,6 +32,9 @@ export const domSchema: ObjectSchema = {
   hasDynamicOutlets: true,
   handlePatterns: {
     inlet: { template: 'in-{index}', description: 'Message inlets (0-indexed)' },
-    outlet: { template: 'out-{index}', description: 'Message outlets (0-indexed)' }
+    outlet: {
+      template: 'out-{index}',
+      description: 'Message outlets (0-indexed); htmlCanvas() adds video-out-0'
+    }
   }
 };

--- a/ui/src/lib/objects/schemas/vue.ts
+++ b/ui/src/lib/objects/schemas/vue.ts
@@ -32,6 +32,9 @@ export const vueSchema: ObjectSchema = {
   hasDynamicOutlets: true,
   handlePatterns: {
     inlet: { template: 'in-{index}', description: 'Message inlets (0-indexed)' },
-    outlet: { template: 'out-{index}', description: 'Message outlets (0-indexed)' }
+    outlet: {
+      template: 'out-{index}',
+      description: 'Message outlets (0-indexed); htmlCanvas() adds video-out-0'
+    }
   }
 };

--- a/ui/src/lib/rendering/types.ts
+++ b/ui/src/lib/rendering/types.ts
@@ -2,6 +2,7 @@ import type regl from 'regl';
 import type { ProfilerCategory, RenderFrameStats, TimingStats } from '$lib/profiler/types';
 import type { GLUniformDef } from '../../types/uniform-config';
 import type { PrimaryButton } from '$lib/eventbus/events';
+import type { ElementImageLike } from '$lib/html-in-canvas/html-canvas-video-output';
 
 export type FBOFormat = 'rgba8' | 'rgba16f' | 'rgba32f';
 
@@ -196,6 +197,13 @@ export type WorkerMessage =
     }
   | { type: 'animationFrame'; outputBitmap: ImageBitmap }
   | { type: 'updateOutput'; buffer: ArrayBuffer }
+  | {
+      type: 'setElementImage';
+      nodeId: string;
+      elementImage: ElementImageLike;
+      width: number;
+      height: number;
+    }
   | {
       type: 'captureWorkerVideoFrames';
       targetNodeId: string;

--- a/ui/src/routes/docs/docs-nav.ts
+++ b/ui/src/routes/docs/docs-nav.ts
@@ -30,7 +30,8 @@ export const topicOrder: Record<string, string[]> = {
     'virtual-filesystem',
     'glsl-imports',
     'data-storage',
-    'network-p2p'
+    'network-p2p',
+    'html-in-canvas'
   ],
   Sidebar: ['manage-files', 'manage-presets', 'manage-saves', 'in-app-help', 'browse-samples'],
   'Timing & Sync': ['audio-reactivity', 'transport-control', 'clock-api', 'parameter-automation'],

--- a/ui/src/workers/rendering/elementImageBitmap.test.ts
+++ b/ui/src/workers/rendering/elementImageBitmap.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderElementImageToBitmap } from './elementImageBitmap';
+
+describe('renderElementImageToBitmap', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('draws a transferable ElementImage into an OffscreenCanvas bitmap', () => {
+    const bitmap = { width: 320, height: 180 };
+    const drawElementImage = vi.fn();
+    const clearRect = vi.fn();
+    const close = vi.fn();
+    const transferToImageBitmap = vi.fn(() => bitmap);
+
+    class OffscreenCanvasStub {
+      width: number;
+      height: number;
+
+      constructor(width: number, height: number) {
+        this.width = width;
+        this.height = height;
+      }
+
+      getContext(kind: string) {
+        return kind === '2d' ? { clearRect, drawElementImage } : null;
+      }
+
+      transferToImageBitmap = transferToImageBitmap;
+    }
+
+    vi.stubGlobal('OffscreenCanvas', OffscreenCanvasStub);
+
+    const elementImage = { width: 320, height: 180, close };
+    const result = renderElementImageToBitmap(elementImage, 320, 180);
+
+    expect(result).toBe(bitmap);
+    expect(clearRect).toHaveBeenCalledWith(0, 0, 320, 180);
+    expect(drawElementImage).toHaveBeenCalledWith(elementImage, 0, 0, 320, 180);
+    expect(transferToImageBitmap).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('closes the ElementImage and returns null when the worker lacks drawElementImage', () => {
+    const close = vi.fn();
+
+    class OffscreenCanvasStub {
+      constructor(_width: number, _height: number) {}
+
+      getContext(kind: string) {
+        return kind === '2d' ? { clearRect: vi.fn() } : null;
+      }
+    }
+
+    vi.stubGlobal('OffscreenCanvas', OffscreenCanvasStub);
+
+    expect(renderElementImageToBitmap({ width: 1, height: 1, close }, 1, 1)).toBeNull();
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/workers/rendering/elementImageBitmap.ts
+++ b/ui/src/workers/rendering/elementImageBitmap.ts
@@ -1,0 +1,33 @@
+import type { ElementImageLike } from '$lib/html-in-canvas/html-canvas-video-output';
+
+type ElementImageContext2D = OffscreenCanvasRenderingContext2D & {
+  drawElementImage?: (
+    elementImage: ElementImageLike,
+    dx: number,
+    dy: number,
+    dw: number,
+    dh: number
+  ) => DOMMatrix;
+};
+
+export function renderElementImageToBitmap(
+  elementImage: ElementImageLike,
+  width: number,
+  height: number
+): ImageBitmap | null {
+  const canvas = new OffscreenCanvas(width, height);
+  const ctx = canvas.getContext('2d') as ElementImageContext2D | null;
+
+  try {
+    if (!ctx || typeof ctx.drawElementImage !== 'function') {
+      return null;
+    }
+
+    ctx.clearRect(0, 0, width, height);
+    ctx.drawElementImage(elementImage, 0, 0, width, height);
+
+    return canvas.transferToImageBitmap();
+  } finally {
+    elementImage.close();
+  }
+}

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -43,6 +43,8 @@ import { JSRunner } from '../../lib/js-runner/JSRunner.js';
 import { RenderingProfiler } from './RenderingProfiler.js';
 import { WorkerProfiler } from '../shared/WorkerProfiler.js';
 import { VideoTextureManager } from './VideoTextureManager.js';
+import { renderElementImageToBitmap } from './elementImageBitmap.js';
+import type { ElementImageLike } from '$lib/html-in-canvas/html-canvas-video-output';
 import { processIncludes } from '$lib/glsl-include/preprocessor';
 import { createWorkerResolver } from '$lib/glsl-include/worker-resolver';
 import { VideoChannelRegistry } from './VideoChannelRegistry.js';
@@ -1961,6 +1963,20 @@ export class FBORenderer {
    */
   setBitmap(nodeId: string, bitmap: ImageBitmap) {
     this.videoTextures.setBitmap(nodeId, bitmap);
+  }
+
+  setElementImage(nodeId: string, elementImage: ElementImageLike, width: number, height: number) {
+    const bitmap = renderElementImageToBitmap(elementImage, width, height);
+
+    if (!bitmap) {
+      console.warn(
+        `[htmlCanvas] Worker cannot draw ElementImage for node ${nodeId}; missing drawElementImage support`
+      );
+
+      return;
+    }
+
+    this.setBitmap(nodeId, bitmap);
   }
 
   setFloatTexture(

--- a/ui/src/workers/rendering/renderWorker.ts
+++ b/ui/src/workers/rendering/renderWorker.ts
@@ -59,6 +59,9 @@ self.onmessage = (event) => {
     .with('setOutputSize', () => fboRenderer.setOutputSize(data.width, data.height))
     .with('setBackgroundSize', () => fboRenderer.setBackgroundSize(data.width, data.height))
     .with('setBitmap', () => fboRenderer.setBitmap(data.nodeId, data.bitmap))
+    .with('setElementImage', () =>
+      fboRenderer.setElementImage(data.nodeId, data.elementImage, data.width, data.height)
+    )
     .with('setFloatTexture', () => {
       const textureData = data.data;
 

--- a/ui/static/content/objects/dom.md
+++ b/ui/static/content/objects/dom.md
@@ -38,7 +38,15 @@ The `root` element runs under an open
 [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Shadow_DOM_API)
 to isolate the DOM tree from the rest of the page.
 
+## HTML-in-Canvas
+
+`dom` supports experimental HTML-in-Canvas APIs for video output and local
+canvas or GLSL layers. See [HTML in Canvas](/docs/html-in-canvas) for
+`htmlCanvas.videoOutput()`, `htmlCanvas.canvasLayer()`, and
+`htmlCanvas.glslLayer()`.
+
 ## See Also
 
 - [vue](/docs/objects/vue) - Vue.js interfaces
+- [HTML in Canvas](/docs/html-in-canvas) - Experimental HTML rendering APIs
 - [JavaScript Runner](/docs/javascript-runner) - messaging API

--- a/ui/static/content/objects/vue.md
+++ b/ui/static/content/objects/vue.md
@@ -48,7 +48,15 @@ The Vue component is mounted under an open
 [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Shadow_DOM_API)
 to isolate the DOM tree from the rest of the page.
 
+## HTML-in-Canvas
+
+`vue` supports experimental HTML in Canvas APIs for video output and local
+canvas or GLSL layers. See [HTML in Canvas](/docs/html-in-canvas) for
+`htmlCanvas.videoOutput()`, `htmlCanvas.canvasLayer()`, and
+`htmlCanvas.glslLayer()`.
+
 ## See Also
 
 - [dom](/docs/objects/dom) - vanilla JS interfaces
+- [HTML in Canvas](/docs/html-in-canvas) - Experimental HTML rendering APIs
 - [JavaScript Runner](/docs/javascript-runner) - messaging API

--- a/ui/static/content/topics/html-in-canvas.md
+++ b/ui/static/content/topics/html-in-canvas.md
@@ -1,0 +1,132 @@
+# HTML in Canvas
+
+HTML-in-Canvas lets `dom` and `vue` objects render live HTML interfaces into a canvas so they can become video sources or receive local canvas and GLSL effects.
+
+> **Experimental**: This uses Chromium's experimental HTML-in-Canvas API. Enable `chrome://flags/#canvas-draw-element` in a Chromium browser.
+
+## How It Works
+
+`dom` and `vue` normally render interactive HTML directly on the Patchies canvas. HTML-in-Canvas wraps that interface in a `layoutsubtree` canvas, then lets Patchies draw or capture the live DOM pixels.
+
+There are two separate use cases:
+
+- `htmlCanvas.videoOutput()` captures the HTML as a transferable `ElementImage` and sends it to the render worker as a video source.
+- `htmlCanvas.canvasLayer()` and `htmlCanvas.glslLayer()` process the live interface locally on the main thread without adding a video outlet.
+
+The local layer APIs keep the original interface clickable. Choose one `htmlCanvas` mode at a time: `videoOutput`, `canvasLayer`, or `glslLayer`. Patchies logs an error if a node tries to enable more than one mode in the same run.
+
+## Video Output
+
+Call `htmlCanvas.videoOutput()` to expose the object as a video source. Patchies captures the root element as a transferable `ElementImage` and draws it in the render worker:
+
+```js
+htmlCanvas.videoOutput();
+setSize(640, 360);
+
+root.innerHTML = '<div class="grid h-full place-items-center text-4xl">hello</div>';
+```
+
+`htmlCanvas.videoOutput()` uses the current Patchies render output size by default. Use `htmlCanvas.videoOutput({ size: "free" })` to let the DOM or Vue content choose its own source size before Patchies fits it into the render output.
+
+`videoOutput` cannot be combined with `canvasLayer` or `glslLayer`.
+
+Disable the video output with:
+
+```js
+htmlCanvas.videoOutput(false);
+```
+
+## Canvas Layer
+
+Call `htmlCanvas.canvasLayer(callback)` to locally post-process the live interface with a 2D canvas. This does not register a video output:
+
+```js
+htmlCanvas.canvasLayer((ctx, frame) => {
+  ctx.fillStyle = 'rgba(255, 0, 0, 0.15)';
+  ctx.fillRect(0, 0, frame.displayWidth, frame.displayHeight);
+});
+```
+
+The callback receives `{ width, height, displayWidth, displayHeight, pixelRatio, time, delta }`.
+
+- `width` and `height` are backing canvas pixels.
+- `displayWidth` and `displayHeight` are CSS pixels.
+- `pixelRatio` is the device pixel ratio used for the backing canvas.
+
+Disable the layer with:
+
+```js
+htmlCanvas.canvasLayer(false);
+```
+
+`canvasLayer` cannot be combined with `videoOutput` or `glslLayer`.
+
+## GLSL Layer
+
+Call `htmlCanvas.glslLayer(fragmentShader)` to locally post-process the live interface with a WebGL2 GLSL ES 3 fragment shader. The live HTML pixels are available as `sampler2D source`:
+
+```js
+htmlCanvas.glslLayer(`
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 uv = fragCoord / iResolution.xy;
+
+  vec4 color = texture(source, uv);
+
+  float wave = sin((uv.y * 28.0) + iTime * 5.0) * 0.012;
+  vec2 warpedUv = uv + vec2(wave, 0.0);
+
+  vec4 warped = texture(source, warpedUv);
+
+  float scanline = 0.92 + 0.08 * sin(fragCoord.y * 1.7);
+  vec3 tint = warped.rgb * vec3(1.12, 0.96, 1.05) * scanline;
+
+  float vignette = smoothstep(0.95, 0.25, distance(uv, vec2(0.5)));
+  
+  fragColor = vec4(tint * vignette, warped.a);
+}
+`);
+```
+
+Built-in uniforms: `source`, `iResolution`, `iTime`, `iTimeDelta`, and `iFrame`.
+
+Use `texture(source, uv)` to sample the live interface. `htmlCanvas.glslLayer()` uses the same ShaderToy-style GLSL wrapper as the `glsl` object, including GLSL ES 3 syntax and `#include` preprocessing.
+
+Disable the layer with:
+
+```js
+htmlCanvas.glslLayer(false);
+```
+
+`glslLayer` cannot be combined with `videoOutput` or `canvasLayer`.
+
+## Vue Example
+
+Use the same `htmlCanvas` APIs before mounting your Vue app:
+
+```js
+htmlCanvas.glslLayer(`
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 uv = fragCoord / iResolution.xy;
+  vec4 color = texture(source, uv);
+  
+  fragColor = vec4(color.rgb * vec3(1.0, 1.15, 1.05), color.a);
+}
+`);
+
+createApp({
+  template: '<button class="p-4">still clickable</button>'
+}).mount(root);
+```
+
+## Browser Support
+
+Without the required Chromium API, Patchies logs a warning and keeps the object in normal DOM or Vue mode.
+
+These APIs are experimental and may change as Chromium's HTML-in-Canvas implementation changes.
+
+## See Also
+
+- [dom](/docs/objects/dom) - Vanilla JavaScript interfaces
+- [vue](/docs/objects/vue) - Vue.js interfaces
+- [GLSL Imports](/docs/glsl-imports) - Shared GLSL `#include` support
+- [Video Chaining](/docs/video-chaining) - Connecting visual objects as video sources


### PR DESCRIPTION
Adds an experimental html-in-canvas support to `dom` and `vue`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental HTML-in-Canvas APIs for `dom` and `vue` nodes with three mutually exclusive modes: video output (export DOM as video source), canvas layer (2D post-processing), and GLSL layer (WebGL2 shader post-processing).

* **Documentation**
  * Added comprehensive HTML-in-Canvas topic documentation.
  * Updated DOM and Vue object documentation with HTML-in-Canvas sections.

* **Developer Experience**
  * Enhanced IDE support with code completions and GLSL syntax highlighting for new APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->