### PR TITLE
feat(patchbay): virtual audio expressions and audio nodes

### DIFF
--- a/docs/design-docs/specs/159-patchbay-virtual-audio-expressions.md
+++ b/docs/design-docs/specs/159-patchbay-virtual-audio-expressions.md
@@ -1,27 +1,29 @@
-# 159. Patchbay Virtual Audio Expressions
+# 159. Patchbay Virtual Audio Processors
 
 ## Status
 
-Prototype extension for the text patchbay object. Implement after the initial text patchbay
-object is stable.
+Prototype extension for the text patchbay object. The initial slice supported virtual `expr~`;
+this revision broadens the same mechanism to a small explicit whitelist of virtual audio effects.
 
 ## Problem
 
-The text patchbay can describe static audio routes, but common audio routing often needs small gain or shaping processors between channels:
+The text patchbay can describe static audio routes, but common audio routing often needs small gain,
+filter, or shaping processors between channels:
 
 ```text
 Feed -> Gain -> Reverb
 ```
 
-Today this requires placing and wiring a visible `expr~` object. For quick patchbay edits, it would be useful to create virtual `expr~` processors directly inside the `[Audio]` section.
+Today this requires placing and wiring visible audio objects. For quick patchbay edits, it should be
+possible to create simple virtual audio processors directly inside the `[Audio]` section.
 
 ## Goals
 
-- Add compact virtual `expr~` processors to audio patchbay routes.
-- Keep the syntax parallel with object aliases, using `Name = expr~ ...`.
-- Support a shorthand for simple one-source expressions. This is the main prototype workflow.
-- Reuse existing `expr~` expression semantics and audio processing where possible.
-- Keep virtual expressions scoped to `[Audio]`.
+- Add compact virtual audio processors to audio patchbay routes.
+- Keep the syntax parallel with object aliases, using `Name = <audio-node> ...`.
+- Keep shorthand math as `expr~` sugar only.
+- Reuse existing audio node creation, object parameter parsing, and connection semantics where possible.
+- Keep virtual processors scoped to `[Audio]`.
 - Avoid changing message and video routing semantics.
 
 ## Non-Goals
@@ -29,45 +31,65 @@ Today this requires placing and wiring a visible `expr~` object. For quick patch
 - Do not support virtual audio processors outside `[Audio]`.
 - Do not add message or video expression processors.
 - Do not invent a new audio expression language.
-- Do not expose a visible `expr~` node on the canvas.
+- Do not expose visible processor nodes on the canvas.
 - Do not require users to declare simple inline expressions before use.
 - Do not support multi-input binding syntax in the prototype.
-- Do not support selecting multiple outlets from a virtual expression in the prototype.
+- Do not support selecting multiple outlets from a virtual processor in the prototype.
+- Do not support source, destination, channel, resource-loading, or UI-managed audio nodes as virtual processors.
+- Do not infer support from every object in the Audio Effects pack; support only the explicit whitelist below.
 
 ## DSL
 
-Virtual audio expressions are declared with an alias name, `=`, the `expr~` keyword, and an expression:
+Virtual audio processors are declared with an alias name, `=`, a supported audio node type, and
+creation arguments:
 
 ```text
 [Audio]
 
 Gain = expr~ s * 0.45
 Feed -> Gain -> Reverb
+
+Filter = lowpass~ 1000 1
+Mic -> Filter -> Out
 ```
 
-The alias resolves as a virtual audio processor, not as a channel. In a route chain, the signal flows through the virtual `expr~` processor and then continues to the next endpoint.
+The alias resolves as a virtual audio processor, not as a channel. In a route chain, the signal
+flows through the hidden processor and then continues to the next endpoint.
 
-Additional examples:
+The prototype supports this explicit whitelist only:
 
 ```text
-Mute = expr~ 0
-Invert = expr~ -s
-SoftClip = expr~ tanh(s * 2)
-
-Feed -> SoftClip -> Out
+expr~
+gain~
+lowpass~
+highpass~
+bandpass~
+notch~
+allpass~
+lowshelf~
+highshelf~
+peaking~
+compressor~
+delay~
 ```
+
+Other audio nodes, including `mic~`, `out~`, `send~`, `recv~`, `soundfile~`, `sampler~`,
+`csound~`, `convolver~`, and `waveshaper~`, should be rejected as unsupported virtual audio
+processors.
 
 ## Expression Inputs
 
-The symbol `s` means the first signal entering the virtual expression processor.
+For virtual `expr~`, the symbol `s` means the first signal entering the virtual expression
+processor.
 
-In the prototype, the virtual expression has one signal inlet. Multiple upstream connections to
-the same virtual expression are mixed by the Web Audio graph and exposed as `s`.
+In the prototype, a virtual processor has one main signal inlet and one signal outlet. Multiple
+upstream connections to the same virtual `expr~` are mixed by the Web Audio graph and exposed as
+`s`.
 
-If multi-input virtual expressions are supported later, later signals should be available as
-`s2`, `s3`, and so on, following the existing `expr~` signal naming style. That later version
-needs explicit inlet-binding syntax; resolved route order should not decide which source becomes
-`s`, `s2`, or `s3`.
+If multi-input virtual expressions are supported later, later signals should be available as `s2`,
+`s3`, and so on, following the existing `expr~` signal naming style. That later version needs
+explicit inlet-binding syntax; resolved route order should not decide which source becomes `s`,
+`s2`, or `s3`.
 
 ## Shorthand
 
@@ -77,16 +99,14 @@ Simple one-source expressions can be written inline:
 Feed * 0.45 -> Reverb
 ```
 
-This is sugar for an anonymous virtual expression between `Feed` and `Reverb`:
+This is sugar for an anonymous virtual `expr~` between `Feed` and `Reverb`:
 
 ```text
 Feed -> expr~ s * 0.45 -> Reverb
 ```
 
 The left endpoint is the source signal. The inline expression operates on that source as `s`.
-
-Shorthand is required in the prototype because it is the fastest path for common patchbay
-edits:
+Shorthand is required in the prototype because it is the fastest path for common patchbay edits:
 
 ```text
 Mic * 0.5 -> Out
@@ -94,30 +114,17 @@ Feed / 2 -> Out
 Feed + 0.1 -> Out
 ```
 
-The prototype should keep shorthand conservative. It should support simple binary expressions
-where the first token is a valid audio route source and the rest of the left side becomes an
-`expr~` body using that source as `s`.
-
-For example:
+Shorthand applies only to `expr~`. Generic audio processors require either a named declaration or
+an explicit route segment:
 
 ```text
-Mic * 0.5 -> Out
+Gain = gain~ 0.5
+Mic -> Gain -> Out
+
+Mic -> lowpass~ 1000 1 -> Out
 ```
 
-normalizes to:
-
-```text
-Mic -> <anonymous expr~ "s * 0.5"> -> Out
-```
-
-More complex processors should use the explicit alias form:
-
-```text
-SoftClip = expr~ tanh(s * 2)
-Mic -> SoftClip -> Out
-```
-
-The prototype should not support full inline `expr~` segments such as:
+The prototype should not support full inline `expr~` route segments such as:
 
 ```text
 Mic -> expr~ s * 0.5 -> Out
@@ -130,17 +137,19 @@ boundaries. Keep it reserved for a later pass.
 
 Within `[Audio]`, bare names in route chains resolve in this order:
 
-1. Virtual audio expression alias.
+1. Virtual audio processor alias.
 2. Object alias.
 3. Channel.
 
-This mirrors the way object aliases are already resolved before channels. Duplicate aliases or declarations in the same audio section should be reported as errors.
+This mirrors the way object aliases are already resolved before channels. Duplicate aliases or
+declarations in the same audio section should be reported as errors.
 
-`expr~` is only active syntax in `[Audio]`. In `[Message]` and `[Video]`, `expr~` should produce a diagnostic if used as a declaration or route segment.
+Virtual audio processor declarations are only active syntax in `[Audio]`. In `[Message]` and
+`[Video]`, supported virtual audio processor declarations should produce diagnostics.
 
 ## Runtime Semantics
 
-Each virtual expression alias compiles to a hidden audio processor equivalent to a configured `expr~` object.
+Each virtual processor compiles to a hidden audio node equivalent to a configured audio object.
 
 For:
 
@@ -155,18 +164,35 @@ the runtime behaves conceptually like:
 recv~ Feed -> expr~ "s * 0.45" -> send~ Reverb
 ```
 
-The virtual processor should not appear as a visible canvas node. It should be owned by the patchbay object and cleaned up when the patchbay code changes or the patchbay node is destroyed.
+For:
+
+```text
+Filter = lowpass~ 1000 1
+Feed -> Filter -> Reverb
+```
+
+the runtime behaves conceptually like:
+
+```text
+recv~ Feed -> lowpass~ 1000 1 -> send~ Reverb
+```
+
+Virtual processor params should use the same object argument parser as `ObjectNode`, so creation
+args match visible object behavior.
+
+The virtual processor should not appear as a visible canvas node. It should be owned by the
+patchbay object and cleaned up when the patchbay code changes or the patchbay node is destroyed.
 
 Generated virtual processor ids should be stable across applies:
 
-- Named aliases use `${patchbayNodeId}:audio-expr:${aliasName}`.
-- Anonymous shorthand expressions use a stable route-local id derived from the normalized
-  route segment, for example `${patchbayNodeId}:audio-expr:inline:${hash(normalizedSegment)}`.
+- Named aliases use `${patchbayNodeId}:audio-virtual:${aliasName}`.
+- Anonymous shorthand expressions use a stable route-local id derived from the normalized route
+  segment, for example `${patchbayNodeId}:audio-virtual:inline:${hash(normalizedSegment)}`.
 
-The expression text can change without changing the node id. This lets the runtime update the
-existing hidden `expr~` node where possible instead of tearing down the whole route.
+The node type and params can change without changing the alias id. The runtime may update an
+existing compatible hidden node where possible, or recreate it when the node type changes.
 
-For a channel-to-channel virtual expression:
+For a channel-to-channel shorthand expression:
 
 ```text
 Mic * 0.5 -> Out
@@ -190,94 +216,106 @@ expands conceptually to:
 obj mic-1 -> expr~ "s * 0.45" -> obj out-2
 ```
 
-The patchbay runtime needs an explicit hidden-audio-node contract, not only edge
-registration. `PatchbayObject` should be able to create or update a hidden `expr~` node, register
-the edges around it, and destroy the hidden node when it is no longer referenced.
+The patchbay runtime needs an explicit hidden-audio-node contract, not only edge registration.
+`PatchbayObject` should be able to create or update a hidden audio node, register the edges around
+it, and destroy the hidden node when it is no longer referenced.
 
 Implementation can add this contract to the patchbay audio runtime, for example:
 
 ```ts
-registerVirtualExpr(routeId, { nodeId, expression });
-unregisterVirtualExpr(routeId);
+registerVirtualAudioNode(routeId, { nodeId, type, params });
+unregisterVirtualAudioNode(routeId);
 ```
 
-or an equivalent API on `AudioService` / `PatchbayAudioIntegration`. The important behavior is
-that hidden `expr~` nodes share the same audio graph update path as visible audio nodes.
+or an equivalent API on `AudioService` / `PatchbayAudioIntegration`. The important behavior is that
+hidden virtual audio nodes share the same audio graph update path as visible audio nodes.
 
-Audio routes that do not involve virtual expressions should keep using the existing patchbay
-audio route behavior.
+Audio routes that do not involve virtual processors should keep using the existing patchbay audio
+route behavior.
 
 ## Parser Requirements
 
 The parser needs to recognize:
 
 - `Name = expr~ <expression>` declarations in `[Audio]`.
+- `Name = <whitelisted-audio-effect> <args...>` declarations in `[Audio]`.
+- Inline explicit whitelisted processor route segments such as `Mic -> lowpass~ 1000 1 -> Out`.
 - Shorthand expressions of the form `<source> <operator/expression> -> <target>`.
 
-Route splitting must avoid treating expression content as endpoints too early. Shorthand parsing should happen before ordinary endpoint validation so `Feed * 0.45` can be normalized into `Feed -> <anonymous expr~>`.
+Route splitting must avoid treating expression content as endpoints too early. Shorthand parsing
+should happen before ordinary endpoint validation so `Feed * 0.45` can be normalized into
+`Feed -> <anonymous expr~>`.
 
 The prototype can limit shorthand to simple binary expressions where the first token is a valid
 source endpoint and the remainder is an expression using that source as `s`.
 
-The parser/analyzer should expose virtual expressions as structured data, not only as rewritten
+The parser/analyzer should expose virtual audio nodes as structured data, not only as rewritten
 channel strings. A useful shape is:
 
 ```ts
-type PatchbayVirtualAudioExpression = {
+type PatchbayVirtualAudioNode = {
   id: string;
   name?: string;
-  expression: string;
+  type: string;
+  rawArgs: string[];
+  params: unknown[];
+  expression?: string;
   line: number;
   anonymous: boolean;
 };
 ```
 
-Audio routes can then reference a virtual expression endpoint, or the analyzer can emit an
-expanded audio-route graph plus the virtual expression table. Prefer the shape that keeps
-diagnostics line-aware and avoids re-parsing route strings in the runtime. The runtime must be
-able to deterministically create the hidden node and register both surrounding edges.
+Audio routes can then reference a virtual audio node endpoint, or the analyzer can emit an expanded
+audio-route graph plus the virtual node table. Prefer the shape that keeps diagnostics line-aware
+and avoids re-parsing route strings in the runtime. The runtime must be able to deterministically
+create the hidden node and register both surrounding edges.
 
 ## Editor Requirements
 
 The editor should distinguish:
 
 - `expr~` as an audio processor keyword.
-- Virtual expression alias names as a distinct audio symbol.
+- Whitelisted virtual processor names as audio processor keywords.
+- Virtual processor alias names as a distinct audio symbol.
 - Expression bodies using the same visual treatment as existing `expr~` expressions when practical.
-- Invalid uses of `expr~` outside `[Audio]`.
+- Invalid uses of virtual processor syntax outside `[Audio]`.
 
-The shorthand form should make the inferred virtual expression easy to understand through hover hints. For example, hovering `* 0.45` could explain that it is treated as `expr~ s * 0.45`.
+The shorthand form should make the inferred virtual expression easy to understand through hover
+hints. For example, hovering `* 0.45` could explain that it is treated as `expr~ s * 0.45`.
 
 ## Diagnostics
 
 The parser or runtime should report errors for:
 
-- `expr~` declarations outside `[Audio]`.
-- Duplicate virtual expression aliases.
-- Expression aliases that collide with `chan` declarations or object aliases.
+- Virtual audio processor declarations outside `[Audio]`.
+- Unsupported virtual audio processor declarations or route segments.
+- Duplicate virtual processor aliases.
+- Processor aliases that collide with `chan` declarations or object aliases.
 - Invalid `expr~` expressions.
 - Shorthand expressions that cannot be normalized safely.
-- Virtual expression aliases used in invalid source or target positions.
+- Virtual processor aliases used in invalid source or target positions.
 - Full inline `expr~` route segments in the prototype.
-- Virtual expressions that produce multiple outlets.
+- Virtual processors that produce multiple outlets.
 
-Expression compile errors should point to the `expr~` declaration or shorthand expression that caused them.
+Expression compile errors should point to the `expr~` declaration or shorthand expression that
+caused them.
 
-Because the existing `expr~` worklet reports compile failures on the audio thread, the
-prototype should also validate expression syntax on the main thread before applying routes.
-Use the same expression parser semantics as `expr~` where practical. If validation succeeds on
-the main thread but the worklet still fails, surface a runtime diagnostic tied to the virtual
-expression line instead of only logging to the console.
+Because the existing `expr~` worklet reports compile failures on the audio thread, the prototype
+should also validate expression syntax on the main thread before applying routes. Use the same
+expression parser semantics as `expr~` where practical. If validation succeeds on the main thread
+but the worklet still fails, surface a runtime diagnostic tied to the virtual expression line
+instead of only logging to the console.
 
 ## Open Questions
 
 - Should multi-input virtual expressions get explicit inlet-binding syntax later?
 - Should virtual `expr~` support multiple outlets, or should one alias always represent one output for patchbay clarity?
 - Should inline full syntax be allowed later, such as `Feed -> expr~ s * 0.45 -> Reverb`, or should all named/full expressions require aliases?
+- Should additional Audio Effects nodes be added after checking their port and side-effect behavior?
 
 ## Prototype Slice
 
-Implement explicit aliases and simple shorthand:
+Implement explicit virtual processors and simple `expr~` shorthand:
 
 ```text
 [Audio]
@@ -285,23 +323,28 @@ Implement explicit aliases and simple shorthand:
 Gain = expr~ s * 0.45
 Feed -> Gain -> Reverb
 
+Filter = lowpass~ 1000 1
+Feed -> Filter -> Reverb
+Feed -> gain~ 0.5 -> Out
+
 Mic * 0.5 -> Out
 ```
 
-Defer full inline `expr~` route segments, explicit multi-input binding, and multi-outlet
-selection until virtual expression lifecycle cleanup, expression diagnostics, and route
-resolution are solid.
+Defer full inline `expr~` route segments, explicit multi-input binding, multi-outlet selection, and
+unlisted audio nodes until virtual processor lifecycle cleanup, diagnostics, and route resolution
+are solid.
 
 Prototype rules:
 
-- Named virtual expressions resolve before object aliases and channels in `[Audio]`.
-- Simple shorthand normalizes into an anonymous virtual expression between the parsed source and
-  target.
-- The first source signal is available as `s`; multiple incoming sources are mixed by the Web
-  Audio connection model and still appear as `s`.
-- Virtual expressions expose one outlet in the patchbay prototype. If the expression body would
-  produce multiple outlets, reject it with a diagnostic.
-- Hidden virtual `expr~` nodes are owned by the patchbay node and destroyed when removed from the
+- Named virtual processors resolve before object aliases and channels in `[Audio]`.
+- Named virtual processors use only the explicit whitelist.
+- Explicit inline virtual processors use only the explicit whitelist.
+- Simple shorthand normalizes into an anonymous virtual `expr~` between the parsed source and target.
+- Shorthand remains `expr~`-only.
+- The first source signal is available as `s`; multiple incoming sources are mixed by the Web Audio
+  connection model and still appear as `s`.
+- Virtual processors expose one outlet in the patchbay prototype.
+- Hidden virtual audio nodes are owned by the patchbay node and destroyed when removed from the
   applied patchbay program or when the patchbay node is destroyed.
 
 ## Testing
@@ -309,16 +352,20 @@ Prototype rules:
 Parser/analyzer tests should cover:
 
 - Explicit `Name = expr~ ...` declarations in `[Audio]`.
+- Explicit `Name = lowpass~ 1000 1` declarations in `[Audio]`.
+- Inline explicit processor route segments such as `Mic -> gain~ 0.5 -> Out`.
+- Diagnostics for unsupported audio nodes such as `convolver~`.
 - Shorthand normalization for `Mic * 0.5 -> Out`.
 - Shorthand with object endpoints where practical, such as `obj mic-1 * 0.5 -> Out`.
-- Diagnostics for `expr~` declarations outside `[Audio]`.
-- Diagnostics for duplicate virtual expression aliases and alias/channel collisions.
+- Diagnostics for virtual processor declarations outside `[Audio]`.
+- Diagnostics for duplicate virtual processor aliases and alias/channel collisions.
 - Diagnostics for invalid expression syntax.
 - Diagnostics for unsupported full inline `expr~` route segments.
 
 Runtime tests should cover:
 
 - A channel-to-channel shorthand expression registers a hidden `expr~` node and two audio edges.
+- A named virtual processor registers a hidden whitelisted audio node with parsed params.
 - A named virtual expression reuses its stable hidden node id across expression updates.
-- Removed virtual expressions unregister edges and destroy hidden nodes.
-- Last valid routes stay active when edited code has virtual-expression diagnostics.
+- Removed virtual processors unregister edges and destroy hidden nodes.
+- Last valid routes stay active when edited code has virtual processor diagnostics.

--- a/docs/design-docs/specs/159-patchbay-virtual-audio-expressions.md
+++ b/docs/design-docs/specs/159-patchbay-virtual-audio-expressions.md
@@ -122,16 +122,11 @@ Gain = gain~ 0.5
 Mic -> Gain -> Out
 
 Mic -> lowpass~ 1000 1 -> Out
-```
-
-The prototype should not support full inline `expr~` route segments such as:
-
-```text
 Mic -> expr~ s * 0.5 -> Out
 ```
 
-That form is harder to parse clearly because route splitting sees `->` before expression
-boundaries. Keep it reserved for a later pass.
+Inline `expr~` route segments are supported when the expression body does not contain `->`.
+Expressions that need more complex route-like syntax should use a named declaration.
 
 ## Name Resolution
 
@@ -310,7 +305,6 @@ instead of only logging to the console.
 
 - Should multi-input virtual expressions get explicit inlet-binding syntax later?
 - Should virtual `expr~` support multiple outlets, or should one alias always represent one output for patchbay clarity?
-- Should inline full syntax be allowed later, such as `Feed -> expr~ s * 0.45 -> Reverb`, or should all named/full expressions require aliases?
 - Should additional Audio Effects nodes be added after checking their port and side-effect behavior?
 
 ## Prototype Slice
@@ -326,19 +320,20 @@ Feed -> Gain -> Reverb
 Filter = lowpass~ 1000 1
 Feed -> Filter -> Reverb
 Feed -> gain~ 0.5 -> Out
+Feed -> expr~ s * 0.5 -> Out
 
 Mic * 0.5 -> Out
 ```
 
-Defer full inline `expr~` route segments, explicit multi-input binding, multi-outlet selection, and
-unlisted audio nodes until virtual processor lifecycle cleanup, diagnostics, and route resolution
-are solid.
+Defer explicit multi-input binding, multi-outlet selection, and unlisted audio nodes until virtual
+processor lifecycle cleanup, diagnostics, and route resolution are solid.
 
 Prototype rules:
 
 - Named virtual processors resolve before object aliases and channels in `[Audio]`.
 - Named virtual processors use only the explicit whitelist.
 - Explicit inline virtual processors use only the explicit whitelist.
+- Explicit inline `expr~` route segments are allowed.
 - Simple shorthand normalizes into an anonymous virtual `expr~` between the parsed source and target.
 - Shorthand remains `expr~`-only.
 - The first source signal is available as `s`; multiple incoming sources are mixed by the Web Audio
@@ -354,13 +349,13 @@ Parser/analyzer tests should cover:
 - Explicit `Name = expr~ ...` declarations in `[Audio]`.
 - Explicit `Name = lowpass~ 1000 1` declarations in `[Audio]`.
 - Inline explicit processor route segments such as `Mic -> gain~ 0.5 -> Out`.
+- Inline explicit expression route segments such as `Mic -> expr~ s * 0.5 -> Out`.
 - Diagnostics for unsupported audio nodes such as `convolver~`.
 - Shorthand normalization for `Mic * 0.5 -> Out`.
 - Shorthand with object endpoints where practical, such as `obj mic-1 * 0.5 -> Out`.
 - Diagnostics for virtual processor declarations outside `[Audio]`.
 - Diagnostics for duplicate virtual processor aliases and alias/channel collisions.
 - Diagnostics for invalid expression syntax.
-- Diagnostics for unsupported full inline `expr~` route segments.
 
 Runtime tests should cover:
 

--- a/docs/design-docs/specs/159-patchbay-virtual-audio-expressions.md
+++ b/docs/design-docs/specs/159-patchbay-virtual-audio-expressions.md
@@ -1,9 +1,10 @@
-# 159. Patchbay Virtual Audio Processors
+# 159. Patchbay Virtual Audio Nodes
 
 ## Status
 
 Prototype extension for the text patchbay object. The initial slice supported virtual `expr~`;
-this revision broadens the same mechanism to a small explicit whitelist of virtual audio effects.
+this revision broadens the same mechanism to a small explicit whitelist of virtual audio sources
+and effects.
 
 ## Problem
 
@@ -19,7 +20,7 @@ possible to create simple virtual audio processors directly inside the `[Audio]`
 
 ## Goals
 
-- Add compact virtual audio processors to audio patchbay routes.
+- Add compact virtual audio nodes to audio patchbay routes.
 - Keep the syntax parallel with object aliases, using `Name = <audio-node> ...`.
 - Keep shorthand math as `expr~` sugar only.
 - Reuse existing audio node creation, object parameter parsing, and connection semantics where possible.
@@ -35,12 +36,12 @@ possible to create simple virtual audio processors directly inside the `[Audio]`
 - Do not require users to declare simple inline expressions before use.
 - Do not support multi-input binding syntax in the prototype.
 - Do not support selecting multiple outlets from a virtual processor in the prototype.
-- Do not support source, destination, channel, resource-loading, or UI-managed audio nodes as virtual processors.
+- Do not support destination, channel, resource-loading, or UI-managed audio nodes as virtual nodes.
 - Do not infer support from every object in the Audio Effects pack; support only the explicit whitelist below.
 
 ## DSL
 
-Virtual audio processors are declared with an alias name, `=`, a supported audio node type, and
+Virtual audio nodes are declared with an alias name, `=`, a supported audio node type, and
 creation arguments:
 
 ```text
@@ -51,15 +52,19 @@ Feed -> Gain -> Reverb
 
 Filter = lowpass~ 1000 1
 Mic -> Filter -> Out
+
+Osc = osc~ 440 sine 0
+Osc -> Out
 ```
 
-The alias resolves as a virtual audio processor, not as a channel. In a route chain, the signal
-flows through the hidden processor and then continues to the next endpoint.
+The alias resolves as a virtual audio node, not as a channel. In a route chain, the signal flows
+through the hidden node and then continues to the next endpoint.
 
 The prototype supports this explicit whitelist only:
 
 ```text
 expr~
+osc~
 gain~
 lowpass~
 highpass~
@@ -75,7 +80,7 @@ delay~
 
 Other audio nodes, including `mic~`, `out~`, `send~`, `recv~`, `soundfile~`, `sampler~`,
 `csound~`, `convolver~`, and `waveshaper~`, should be rejected as unsupported virtual audio
-processors.
+nodes.
 
 ## Expression Inputs
 
@@ -114,7 +119,7 @@ Feed / 2 -> Out
 Feed + 0.1 -> Out
 ```
 
-Shorthand applies only to `expr~`. Generic audio processors require either a named declaration or
+Shorthand applies only to `expr~`. Generic audio nodes require either a named declaration or
 an explicit route segment:
 
 ```text
@@ -123,6 +128,7 @@ Mic -> Gain -> Out
 
 Mic -> lowpass~ 1000 1 -> Out
 Mic -> expr~ s * 0.5 -> Out
+osc~ 440 sine 0 -> Out
 ```
 
 Inline `expr~` route segments are supported when the expression body does not contain `->`.
@@ -144,7 +150,20 @@ Virtual audio processor declarations are only active syntax in `[Audio]`. In `[M
 
 ## Runtime Semantics
 
-Each virtual processor compiles to a hidden audio node equivalent to a configured audio object.
+Each virtual audio node compiles to a hidden audio node equivalent to a configured audio object.
+
+For:
+
+```text
+Osc = osc~ 440 sine 0
+Osc -> Out
+```
+
+the runtime behaves conceptually like:
+
+```text
+osc~ 440 sine 0 -> send~ Out
+```
 
 For:
 
@@ -172,10 +191,10 @@ the runtime behaves conceptually like:
 recv~ Feed -> lowpass~ 1000 1 -> send~ Reverb
 ```
 
-Virtual processor params should use the same object argument parser as `ObjectNode`, so creation
+Virtual audio node params should use the same object argument parser as `ObjectNode`, so creation
 args match visible object behavior.
 
-The virtual processor should not appear as a visible canvas node. It should be owned by the
+The virtual audio node should not appear as a visible canvas node. It should be owned by the
 patchbay object and cleaned up when the patchbay code changes or the patchbay node is destroyed.
 
 Generated virtual processor ids should be stable across applies:
@@ -233,8 +252,9 @@ route behavior.
 The parser needs to recognize:
 
 - `Name = expr~ <expression>` declarations in `[Audio]`.
-- `Name = <whitelisted-audio-effect> <args...>` declarations in `[Audio]`.
-- Inline explicit whitelisted processor route segments such as `Mic -> lowpass~ 1000 1 -> Out`.
+- `Name = <whitelisted-audio-node> <args...>` declarations in `[Audio]`.
+- Inline explicit whitelisted node route segments such as `Mic -> lowpass~ 1000 1 -> Out`.
+- Inline explicit whitelisted source route segments such as `osc~ 440 sine 0 -> Out`.
 - Shorthand expressions of the form `<source> <operator/expression> -> <target>`.
 
 Route splitting must avoid treating expression content as endpoints too early. Shorthand parsing
@@ -270,8 +290,8 @@ create the hidden node and register both surrounding edges.
 The editor should distinguish:
 
 - `expr~` as an audio processor keyword.
-- Whitelisted virtual processor names as audio processor keywords.
-- Virtual processor alias names as a distinct audio symbol.
+- Whitelisted virtual audio node names as audio keywords.
+- Virtual audio node alias names as a distinct audio symbol.
 - Expression bodies using the same visual treatment as existing `expr~` expressions when practical.
 - Invalid uses of virtual processor syntax outside `[Audio]`.
 
@@ -282,9 +302,9 @@ hints. For example, hovering `* 0.45` could explain that it is treated as `expr~
 
 The parser or runtime should report errors for:
 
-- Virtual audio processor declarations outside `[Audio]`.
-- Unsupported virtual audio processor declarations or route segments.
-- Duplicate virtual processor aliases.
+- Virtual audio node declarations outside `[Audio]`.
+- Unsupported virtual audio node declarations or route segments.
+- Duplicate virtual audio node aliases.
 - Processor aliases that collide with `chan` declarations or object aliases.
 - Invalid `expr~` expressions.
 - Shorthand expressions that cannot be normalized safely.
@@ -309,7 +329,7 @@ instead of only logging to the console.
 
 ## Prototype Slice
 
-Implement explicit virtual processors and simple `expr~` shorthand:
+Implement explicit virtual audio nodes and simple `expr~` shorthand:
 
 ```text
 [Audio]
@@ -317,8 +337,12 @@ Implement explicit virtual processors and simple `expr~` shorthand:
 Gain = expr~ s * 0.45
 Feed -> Gain -> Reverb
 
+Osc = osc~ 440 sine 0
+Osc -> Out
+
 Filter = lowpass~ 1000 1
 Feed -> Filter -> Reverb
+osc~ 220 square 0 -> gain~ 0.5 -> Out
 Feed -> gain~ 0.5 -> Out
 Feed -> expr~ s * 0.5 -> Out
 
@@ -326,19 +350,19 @@ Mic * 0.5 -> Out
 ```
 
 Defer explicit multi-input binding, multi-outlet selection, and unlisted audio nodes until virtual
-processor lifecycle cleanup, diagnostics, and route resolution are solid.
+node lifecycle cleanup, diagnostics, and route resolution are solid.
 
 Prototype rules:
 
-- Named virtual processors resolve before object aliases and channels in `[Audio]`.
-- Named virtual processors use only the explicit whitelist.
-- Explicit inline virtual processors use only the explicit whitelist.
+- Named virtual audio nodes resolve before object aliases and channels in `[Audio]`.
+- Named virtual audio nodes use only the explicit whitelist.
+- Explicit inline virtual audio nodes use only the explicit whitelist.
 - Explicit inline `expr~` route segments are allowed.
 - Simple shorthand normalizes into an anonymous virtual `expr~` between the parsed source and target.
 - Shorthand remains `expr~`-only.
 - The first source signal is available as `s`; multiple incoming sources are mixed by the Web Audio
   connection model and still appear as `s`.
-- Virtual processors expose one outlet in the patchbay prototype.
+- Virtual audio nodes expose one outlet in the patchbay prototype.
 - Hidden virtual audio nodes are owned by the patchbay node and destroyed when removed from the
   applied patchbay program or when the patchbay node is destroyed.
 
@@ -348,7 +372,9 @@ Parser/analyzer tests should cover:
 
 - Explicit `Name = expr~ ...` declarations in `[Audio]`.
 - Explicit `Name = lowpass~ 1000 1` declarations in `[Audio]`.
+- Explicit `Name = osc~ 440 sine 0` declarations in `[Audio]`.
 - Inline explicit processor route segments such as `Mic -> gain~ 0.5 -> Out`.
+- Inline explicit source route segments such as `osc~ 440 sine 0 -> Out`.
 - Inline explicit expression route segments such as `Mic -> expr~ s * 0.5 -> Out`.
 - Diagnostics for unsupported audio nodes such as `convolver~`.
 - Shorthand normalization for `Mic * 0.5 -> Out`.
@@ -360,7 +386,7 @@ Parser/analyzer tests should cover:
 Runtime tests should cover:
 
 - A channel-to-channel shorthand expression registers a hidden `expr~` node and two audio edges.
-- A named virtual processor registers a hidden whitelisted audio node with parsed params.
+- A named virtual audio node registers a hidden whitelisted audio node with parsed params.
 - A named virtual expression reuses its stable hidden node id across expression updates.
 - Removed virtual processors unregister edges and destroy hidden nodes.
 - Last valid routes stay active when edited code has virtual processor diagnostics.

--- a/docs/design-docs/specs/159-patchbay-virtual-audio-expressions.md
+++ b/docs/design-docs/specs/159-patchbay-virtual-audio-expressions.md
@@ -197,8 +197,8 @@ the edges around it, and destroy the hidden node when it is no longer referenced
 Implementation can add this contract to the patchbay audio runtime, for example:
 
 ```ts
-registerVirtualExpr(routeId, { nodeId, expression })
-unregisterVirtualExpr(routeId)
+registerVirtualExpr(routeId, { nodeId, expression });
+unregisterVirtualExpr(routeId);
 ```
 
 or an equivalent API on `AudioService` / `PatchbayAudioIntegration`. The important behavior is

--- a/ui/src/lib/audio/expression-processor.ts
+++ b/ui/src/lib/audio/expression-processor.ts
@@ -16,6 +16,14 @@ interface InletValuesMessage {
   values: number[];
 }
 
+interface StopMessage {
+  type: 'stop';
+}
+
+interface StoppedMessage {
+  type: 'stopped';
+}
+
 type ExprDspFn = (
   // s1-s9: samples from each audio input (1-indexed to match $1-$9)
   s1: number,
@@ -55,6 +63,7 @@ type ExprDspFn = (
 class ExpressionProcessor extends AudioWorkletProcessor {
   private evaluators: ExprDspFn[] = [];
   private inletValues: number[] = new Array(10).fill(0);
+  private stopped = false;
 
   // Phasor state: up to 10 independent phasors per expression
   private phasorPhases: number[] = new Array(10).fill(0);
@@ -73,7 +82,9 @@ class ExpressionProcessor extends AudioWorkletProcessor {
     super();
 
     this.port.onmessage = (
-      event: MessageEvent<ExpressionMessage | MultiExpressionMessage | InletValuesMessage>
+      event: MessageEvent<
+        ExpressionMessage | MultiExpressionMessage | InletValuesMessage | StopMessage
+      >
     ) => {
       if (event.data.type === 'set-expression') {
         this.setExpression(event.data.expression);
@@ -81,6 +92,10 @@ class ExpressionProcessor extends AudioWorkletProcessor {
         this.setExpressions(event.data.assignments, event.data.outletExpressions);
       } else if (event.data.type === 'set-inlet-values') {
         this.setInletValues(event.data.values);
+      } else if (event.data.type === 'stop') {
+        this.stopped = true;
+        this.evaluators = [];
+        this.port.postMessage({ type: 'stopped' } satisfies StoppedMessage);
       }
     };
   }
@@ -245,6 +260,8 @@ class ExpressionProcessor extends AudioWorkletProcessor {
   }
 
   process(inputs: Float32Array[][], outputs: Float32Array[][]): boolean {
+    if (this.stopped) return false;
+
     // Keep the expression node alive even without evaluators
     if (this.evaluators.length === 0) {
       // Pass through silence on all outputs

--- a/ui/src/lib/audio/fexpr-processor.ts
+++ b/ui/src/lib/audio/fexpr-processor.ts
@@ -17,6 +17,14 @@ interface InletValuesMessage {
   values: number[];
 }
 
+interface StopMessage {
+  type: 'stop';
+}
+
+interface StoppedMessage {
+  type: 'stopped';
+}
+
 // Function signature for the compiled expression
 // Parameters are passed positionally to avoid object allocation in the hot path
 type FExprDspFn = (
@@ -75,6 +83,7 @@ const MAX_SIGNAL_INLETS = 9;
 class FExprProcessor extends AudioWorkletProcessor {
   private evaluators: FExprDspFn[] = [];
   private inletValues: number[] = new Array(10).fill(0);
+  private stopped = false;
 
   // History buffers for input samples (one per inlet)
   // Circular buffer: historyIndex points to current sample position
@@ -117,7 +126,9 @@ class FExprProcessor extends AudioWorkletProcessor {
     this.rebuildOutputAccessors(1);
 
     this.port.onmessage = (
-      event: MessageEvent<ExpressionMessage | MultiExpressionMessage | InletValuesMessage>
+      event: MessageEvent<
+        ExpressionMessage | MultiExpressionMessage | InletValuesMessage | StopMessage
+      >
     ) => {
       if (event.data.type === 'set-expression') {
         this.setExpression(event.data.expression);
@@ -125,6 +136,10 @@ class FExprProcessor extends AudioWorkletProcessor {
         this.setExpressions(event.data.assignments, event.data.outletExpressions);
       } else if (event.data.type === 'set-inlet-values') {
         this.setInletValues(event.data.values);
+      } else if (event.data.type === 'stop') {
+        this.stopped = true;
+        this.evaluators = [];
+        this.port.postMessage({ type: 'stopped' } satisfies StoppedMessage);
       }
     };
   }
@@ -295,6 +310,8 @@ class FExprProcessor extends AudioWorkletProcessor {
   private static zeroAccessor = () => 0;
 
   process(inputs: Float32Array[][], outputs: Float32Array[][]): boolean {
+    if (this.stopped) return false;
+
     // Keep alive even without evaluators
     if (this.evaluators.length === 0) {
       for (const output of outputs) {

--- a/ui/src/lib/audio/v2/AudioService.ts
+++ b/ui/src/lib/audio/v2/AudioService.ts
@@ -273,15 +273,15 @@ export class AudioService {
     this.patchbay.unregisterEdge(routeId);
   }
 
-  registerPatchbayVirtualExpression(
+  registerPatchbayVirtualAudioNode(
     routeId: string,
-    expression: { nodeId: string; expression: string }
+    node: { nodeId: string; type: string; params: unknown[] }
   ): void {
-    this.patchbay.registerVirtualExpression(routeId, expression);
+    this.patchbay.registerVirtualAudioNode(routeId, node);
   }
 
-  unregisterPatchbayVirtualExpression(routeId: string): void {
-    this.patchbay.unregisterVirtualExpression(routeId);
+  unregisterPatchbayVirtualAudioNode(routeId: string): void {
+    this.patchbay.unregisterVirtualAudioNode(routeId);
   }
 
   /**

--- a/ui/src/lib/audio/v2/AudioService.ts
+++ b/ui/src/lib/audio/v2/AudioService.ts
@@ -273,6 +273,17 @@ export class AudioService {
     this.patchbay.unregisterEdge(routeId);
   }
 
+  registerPatchbayVirtualExpression(
+    routeId: string,
+    expression: { nodeId: string; expression: string }
+  ): void {
+    this.patchbay.registerVirtualExpression(routeId, expression);
+  }
+
+  unregisterPatchbayVirtualExpression(routeId: string): void {
+    this.patchbay.unregisterVirtualExpression(routeId);
+  }
+
   /**
    * Get output volume.
    */

--- a/ui/src/lib/audio/v2/PatchbayAudioIntegration.test.ts
+++ b/ui/src/lib/audio/v2/PatchbayAudioIntegration.test.ts
@@ -56,11 +56,11 @@ describe('PatchbayAudioIntegration', () => {
     expect(disconnect).toHaveBeenCalled();
   });
 
-  it('cleans up a virtual expr node when it is unregistered before async creation finishes', async () => {
+  it('cleans up a virtual audio node when it is unregistered before async creation finishes', async () => {
     let finishCreate!: () => void;
     const destroy = vi.fn();
     const node: AudioNodeV2 = {
-      nodeId: 'patchbay:audio-expr:inline:gain',
+      nodeId: 'patchbay:audio-virtual:inline:gain',
       audioNode: null,
       create: vi.fn(
         () =>
@@ -83,14 +83,15 @@ describe('PatchbayAudioIntegration', () => {
         nodesById.delete(nodeId);
       },
       onEdgesChanged: vi.fn(),
-      createVirtualExpressionNode: () => node
+      createVirtualAudioNode: () => node
     });
 
-    integration.registerVirtualExpression('route-1', {
+    integration.registerVirtualAudioNode('route-1', {
       nodeId: node.nodeId,
-      expression: 's * 0.1'
+      type: 'expr~',
+      params: [null, 's * 0.1']
     });
-    integration.unregisterVirtualExpression('route-1');
+    integration.unregisterVirtualAudioNode('route-1');
 
     expect(nodesById.has(node.nodeId)).toBe(false);
     expect(destroy).toHaveBeenCalledTimes(1);
@@ -100,5 +101,39 @@ describe('PatchbayAudioIntegration', () => {
 
     expect(nodesById.has(node.nodeId)).toBe(false);
     expect(destroy).toHaveBeenCalledTimes(2);
+  });
+
+  it('creates whitelisted virtual audio nodes with parsed params', async () => {
+    const create = vi.fn();
+    const node: AudioNodeV2 = {
+      nodeId: 'patchbay:audio-virtual:Filter',
+      audioNode: null,
+      create
+    };
+    const nodesById = new Map<string, AudioNodeV2>();
+
+    const integration = new PatchbayAudioIntegration({
+      getAudioContext: () => ({}) as unknown as AudioContext,
+      nodesById,
+      removeNodeById(nodeId) {
+        nodesById.delete(nodeId);
+      },
+      onEdgesChanged: vi.fn(),
+      createVirtualAudioNode: (_nodeId, type) => {
+        expect(type).toBe('lowpass~');
+        return node;
+      }
+    });
+
+    integration.registerVirtualAudioNode('route-1', {
+      nodeId: node.nodeId,
+      type: 'lowpass~',
+      params: [null, 1000, 1]
+    });
+
+    await Promise.resolve();
+
+    expect(nodesById.get(node.nodeId)).toBe(node);
+    expect(create).toHaveBeenCalledWith([null, 1000, 1]);
   });
 });

--- a/ui/src/lib/audio/v2/PatchbayAudioIntegration.test.ts
+++ b/ui/src/lib/audio/v2/PatchbayAudioIntegration.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { PatchbayAudioIntegration } from './PatchbayAudioIntegration';
 
+import type { AudioNodeV2 } from './interfaces/audio-nodes';
+
 describe('PatchbayAudioIntegration', () => {
   it('stores patchbay audio edges and notifies when they change', () => {
     const onEdgesChanged = vi.fn();
@@ -52,5 +54,51 @@ describe('PatchbayAudioIntegration', () => {
     expect(removeNodeById).toHaveBeenCalledWith(endpointId);
     expect(nodesById.has(endpointId)).toBe(false);
     expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('cleans up a virtual expr node when it is unregistered before async creation finishes', async () => {
+    let finishCreate!: () => void;
+    const destroy = vi.fn();
+    const node: AudioNodeV2 = {
+      nodeId: 'patchbay:audio-expr:inline:gain',
+      audioNode: null,
+      create: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishCreate = () => {
+              node.audioNode = { disconnect: vi.fn() } as unknown as AudioNode;
+              resolve();
+            };
+          })
+      ),
+      destroy
+    };
+    const nodesById = new Map<string, AudioNodeV2>();
+
+    const integration = new PatchbayAudioIntegration({
+      getAudioContext: () => ({}) as unknown as AudioContext,
+      nodesById,
+      removeNodeById(nodeId) {
+        nodesById.get(nodeId)?.destroy?.();
+        nodesById.delete(nodeId);
+      },
+      onEdgesChanged: vi.fn(),
+      createVirtualExpressionNode: () => node
+    });
+
+    integration.registerVirtualExpression('route-1', {
+      nodeId: node.nodeId,
+      expression: 's * 0.1'
+    });
+    integration.unregisterVirtualExpression('route-1');
+
+    expect(nodesById.has(node.nodeId)).toBe(false);
+    expect(destroy).toHaveBeenCalledTimes(1);
+
+    finishCreate();
+    await Promise.resolve();
+
+    expect(nodesById.has(node.nodeId)).toBe(false);
+    expect(destroy).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/lib/audio/v2/PatchbayAudioIntegration.ts
+++ b/ui/src/lib/audio/v2/PatchbayAudioIntegration.ts
@@ -1,7 +1,6 @@
 import type { Edge } from '@xyflow/svelte';
 
 import type { AudioNodeV2 } from './interfaces/audio-nodes';
-import { ExprNode } from './nodes/ExprNode';
 import { PatchbayAudioEndpoint } from './nodes/PatchbayAudioEndpointNode';
 import { AudioRegistry } from '$lib/registry/AudioRegistry';
 
@@ -120,10 +119,6 @@ export class PatchbayAudioIntegration {
   }
 
   private createVirtualAudioNode(nodeId: string, type: string): AudioNodeV2 | null {
-    if (type === 'expr~') {
-      return new ExprNode(nodeId, this.options.getAudioContext());
-    }
-
     const NodeClass = this.registry.get(type);
     if (!NodeClass) return null;
 

--- a/ui/src/lib/audio/v2/PatchbayAudioIntegration.ts
+++ b/ui/src/lib/audio/v2/PatchbayAudioIntegration.ts
@@ -3,18 +3,29 @@ import type { Edge } from '@xyflow/svelte';
 import type { AudioNodeV2 } from './interfaces/audio-nodes';
 import { ExprNode } from './nodes/ExprNode';
 import { PatchbayAudioEndpoint } from './nodes/PatchbayAudioEndpointNode';
+import { AudioRegistry } from '$lib/registry/AudioRegistry';
 
 type PatchbayAudioIntegrationOptions = {
   getAudioContext: () => AudioContext;
   nodesById: Map<string, AudioNodeV2>;
   removeNodeById: (nodeId: string) => void;
   onEdgesChanged: () => void;
-  createVirtualExpressionNode?: (nodeId: string) => AudioNodeV2;
+  createVirtualAudioNode?: (nodeId: string, type: string) => AudioNodeV2;
+};
+
+type VirtualAudioNodeSpec = {
+  nodeId: string;
+  type: string;
+  params: unknown[];
 };
 
 export class PatchbayAudioIntegration {
+  private registry = AudioRegistry.getInstance();
+
   private edges = new Map<string, Edge>();
-  private virtualExpressionNodeIds = new Map<string, string>();
+
+  private virtualAudioNodeIds = new Map<string, string>();
+  private virtualAudioNodeTypes = new Map<string, string>();
 
   constructor(private options: PatchbayAudioIntegrationOptions) {}
 
@@ -28,37 +39,43 @@ export class PatchbayAudioIntegration {
     this.options.onEdgesChanged();
   }
 
-  registerVirtualExpression(
-    routeId: string,
-    expression: { nodeId: string; expression: string }
-  ): void {
-    const previousNodeId = this.virtualExpressionNodeIds.get(routeId);
+  registerVirtualAudioNode(routeId: string, spec: VirtualAudioNodeSpec): void {
+    const previousNodeId = this.virtualAudioNodeIds.get(routeId);
+    const previousType = this.virtualAudioNodeTypes.get(routeId);
 
-    if (previousNodeId && previousNodeId !== expression.nodeId) {
+    if (previousNodeId && (previousNodeId !== spec.nodeId || previousType !== spec.type)) {
       this.options.removeNodeById(previousNodeId);
     }
 
-    this.virtualExpressionNodeIds.set(routeId, expression.nodeId);
+    this.virtualAudioNodeIds.set(routeId, spec.nodeId);
+    this.virtualAudioNodeTypes.set(routeId, spec.type);
 
-    const existingNode = this.options.nodesById.get(expression.nodeId);
+    const existingNode = this.options.nodesById.get(spec.nodeId);
 
     if (existingNode) {
-      existingNode.send?.('expression', expression.expression);
+      if (spec.type === 'expr~') {
+        existingNode.send?.('expression', spec.params[1]);
+      }
+
       this.options.onEdgesChanged();
+
       return;
     }
 
     const node =
-      this.options.createVirtualExpressionNode?.(expression.nodeId) ??
-      new ExprNode(expression.nodeId, this.options.getAudioContext());
+      this.options.createVirtualAudioNode?.(spec.nodeId, spec.type) ??
+      this.createVirtualAudioNode(spec.nodeId, spec.type);
+
+    if (!node) return;
 
     this.options.nodesById.set(node.nodeId, node);
 
-    Promise.resolve(node.create?.([null, expression.expression])).finally(() => {
-      const activeNodeId = this.virtualExpressionNodeIds.get(routeId);
-      const activeNode = this.options.nodesById.get(expression.nodeId);
+    Promise.resolve(node.create?.(spec.params)).finally(() => {
+      const activeNodeId = this.virtualAudioNodeIds.get(routeId);
+      const activeType = this.virtualAudioNodeTypes.get(routeId);
+      const activeNode = this.options.nodesById.get(spec.nodeId);
 
-      if (activeNodeId !== expression.nodeId || activeNode !== node) {
+      if (activeNodeId !== spec.nodeId || activeType !== spec.type || activeNode !== node) {
         node.destroy?.();
         return;
       }
@@ -67,12 +84,13 @@ export class PatchbayAudioIntegration {
     });
   }
 
-  unregisterVirtualExpression(routeId: string): void {
-    const nodeId = this.virtualExpressionNodeIds.get(routeId);
+  unregisterVirtualAudioNode(routeId: string): void {
+    const nodeId = this.virtualAudioNodeIds.get(routeId);
     if (!nodeId) return;
 
     this.options.removeNodeById(nodeId);
-    this.virtualExpressionNodeIds.delete(routeId);
+    this.virtualAudioNodeIds.delete(routeId);
+    this.virtualAudioNodeTypes.delete(routeId);
     this.options.onEdgesChanged();
   }
 
@@ -84,7 +102,6 @@ export class PatchbayAudioIntegration {
     if (!this.isEndpointId(nodeId) || this.options.nodesById.has(nodeId)) return;
 
     const endpoint = new PatchbayAudioEndpoint(nodeId, this.options.getAudioContext());
-
     this.options.nodesById.set(nodeId, endpoint);
   }
 
@@ -100,5 +117,16 @@ export class PatchbayAudioIntegration {
 
   isEndpointId(nodeId: string): boolean {
     return nodeId.includes(':audio-recv:') || nodeId.includes(':audio-send:');
+  }
+
+  private createVirtualAudioNode(nodeId: string, type: string): AudioNodeV2 | null {
+    if (type === 'expr~') {
+      return new ExprNode(nodeId, this.options.getAudioContext());
+    }
+
+    const NodeClass = this.registry.get(type);
+    if (!NodeClass) return null;
+
+    return new NodeClass(nodeId, this.options.getAudioContext());
   }
 }

--- a/ui/src/lib/audio/v2/PatchbayAudioIntegration.ts
+++ b/ui/src/lib/audio/v2/PatchbayAudioIntegration.ts
@@ -1,6 +1,7 @@
 import type { Edge } from '@xyflow/svelte';
 
 import type { AudioNodeV2 } from './interfaces/audio-nodes';
+import { ExprNode } from './nodes/ExprNode';
 import { PatchbayAudioEndpoint } from './nodes/PatchbayAudioEndpointNode';
 
 type PatchbayAudioIntegrationOptions = {
@@ -12,6 +13,7 @@ type PatchbayAudioIntegrationOptions = {
 
 export class PatchbayAudioIntegration {
   private edges = new Map<string, Edge>();
+  private virtualExpressionNodeIds = new Map<string, string>();
 
   constructor(private options: PatchbayAudioIntegrationOptions) {}
 
@@ -22,6 +24,43 @@ export class PatchbayAudioIntegration {
 
   unregisterEdge(routeId: string): void {
     this.edges.delete(routeId);
+    this.options.onEdgesChanged();
+  }
+
+  registerVirtualExpression(
+    routeId: string,
+    expression: { nodeId: string; expression: string }
+  ): void {
+    const previousNodeId = this.virtualExpressionNodeIds.get(routeId);
+
+    if (previousNodeId && previousNodeId !== expression.nodeId) {
+      this.options.removeNodeById(previousNodeId);
+    }
+
+    this.virtualExpressionNodeIds.set(routeId, expression.nodeId);
+
+    const existingNode = this.options.nodesById.get(expression.nodeId);
+
+    if (existingNode) {
+      existingNode.send?.('expression', expression.expression);
+      this.options.onEdgesChanged();
+      return;
+    }
+
+    const node = new ExprNode(expression.nodeId, this.options.getAudioContext());
+    this.options.nodesById.set(node.nodeId, node);
+
+    Promise.resolve(node.create?.([null, expression.expression])).finally(() => {
+      this.options.onEdgesChanged();
+    });
+  }
+
+  unregisterVirtualExpression(routeId: string): void {
+    const nodeId = this.virtualExpressionNodeIds.get(routeId);
+    if (!nodeId) return;
+
+    this.options.removeNodeById(nodeId);
+    this.virtualExpressionNodeIds.delete(routeId);
     this.options.onEdgesChanged();
   }
 

--- a/ui/src/lib/audio/v2/PatchbayAudioIntegration.ts
+++ b/ui/src/lib/audio/v2/PatchbayAudioIntegration.ts
@@ -9,6 +9,7 @@ type PatchbayAudioIntegrationOptions = {
   nodesById: Map<string, AudioNodeV2>;
   removeNodeById: (nodeId: string) => void;
   onEdgesChanged: () => void;
+  createVirtualExpressionNode?: (nodeId: string) => AudioNodeV2;
 };
 
 export class PatchbayAudioIntegration {
@@ -47,10 +48,21 @@ export class PatchbayAudioIntegration {
       return;
     }
 
-    const node = new ExprNode(expression.nodeId, this.options.getAudioContext());
+    const node =
+      this.options.createVirtualExpressionNode?.(expression.nodeId) ??
+      new ExprNode(expression.nodeId, this.options.getAudioContext());
+
     this.options.nodesById.set(node.nodeId, node);
 
     Promise.resolve(node.create?.([null, expression.expression])).finally(() => {
+      const activeNodeId = this.virtualExpressionNodeIds.get(routeId);
+      const activeNode = this.options.nodesById.get(expression.nodeId);
+
+      if (activeNodeId !== expression.nodeId || activeNode !== node) {
+        node.destroy?.();
+        return;
+      }
+
       this.options.onEdgesChanged();
     });
   }

--- a/ui/src/lib/audio/v2/nodes/ExprNode.test.ts
+++ b/ui/src/lib/audio/v2/nodes/ExprNode.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ExprNode } from './ExprNode';
+import { FExprNode } from './FExprNode';
+
+function createFakeWorkletNode() {
+  return {
+    port: {
+      onmessage: null as ((event: MessageEvent<{ type?: string }>) => void) | null,
+      postMessage: vi.fn(),
+      close: vi.fn()
+    },
+    disconnect: vi.fn()
+  };
+}
+
+describe('ExprNode cleanup', () => {
+  it('stops and releases the worklet when expr~ is destroyed', () => {
+    const node = new ExprNode('expr-1', {} as AudioContext);
+    const worklet = createFakeWorkletNode();
+
+    node.audioNode = worklet as unknown as AudioWorkletNode;
+    node.destroy();
+
+    expect(worklet.port.postMessage).toHaveBeenCalledWith({ type: 'stop' });
+    expect(worklet.disconnect).toHaveBeenCalled();
+    expect(node.audioNode).toBeNull();
+    expect(worklet.port.close).not.toHaveBeenCalled();
+
+    worklet.port.onmessage?.({ data: { type: 'stopped' } } as MessageEvent<{ type?: string }>);
+
+    expect(worklet.port.onmessage).toBeNull();
+    expect(worklet.port.close).toHaveBeenCalled();
+  });
+
+  it('stops and releases the worklet when fexpr~ is destroyed', () => {
+    const node = new FExprNode('fexpr-1', {} as AudioContext);
+    const worklet = createFakeWorkletNode();
+
+    node.audioNode = worklet as unknown as AudioWorkletNode;
+    node.destroy();
+
+    expect(worklet.port.postMessage).toHaveBeenCalledWith({ type: 'stop' });
+    expect(worklet.disconnect).toHaveBeenCalled();
+    expect(node.audioNode).toBeNull();
+    expect(worklet.port.close).not.toHaveBeenCalled();
+
+    worklet.port.onmessage?.({ data: { type: 'stopped' } } as MessageEvent<{ type?: string }>);
+
+    expect(worklet.port.onmessage).toBeNull();
+    expect(worklet.port.close).toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/audio/v2/nodes/ExprNode.ts
+++ b/ui/src/lib/audio/v2/nodes/ExprNode.ts
@@ -4,6 +4,7 @@ import { logger } from '$lib/utils/logger';
 import { handleToPortIndex } from '$lib/utils/get-edge-types';
 import { parseMultiOutletExpressions } from '$lib/utils/expr-parser';
 import { match, P } from 'ts-pattern';
+import { destroyWorkletNode } from './destroy-worklet-node';
 import workletUrl from '../../../audio/expression-processor?worker&url';
 
 const MAX_SIGNAL_INLETS = 9;
@@ -80,8 +81,7 @@ export class ExprNode implements AudioNodeV2 {
 
   private async createWorklet(outletCount: number): Promise<void> {
     if (this.audioNode) {
-      this.audioNode.disconnect();
-      this.audioNode = null;
+      this.destroyWorklet();
     }
 
     try {
@@ -199,7 +199,15 @@ export class ExprNode implements AudioNodeV2 {
   }
 
   destroy(): void {
-    this.audioNode?.disconnect();
+    this.destroyWorklet();
+  }
+
+  private destroyWorklet(): void {
+    const worklet = this.audioNode as AudioWorkletNode | null;
+    if (!worklet) return;
+
+    destroyWorkletNode({ label: 'expr~', node: worklet });
+    this.audioNode = null;
   }
 
   private static moduleReady = false;

--- a/ui/src/lib/audio/v2/nodes/FExprNode.ts
+++ b/ui/src/lib/audio/v2/nodes/FExprNode.ts
@@ -4,6 +4,7 @@ import { logger } from '$lib/utils/logger';
 import { handleToPortIndex } from '$lib/utils/get-edge-types';
 import { parseMultiOutletExpressions } from '$lib/utils/expr-parser';
 import { match, P } from 'ts-pattern';
+import { destroyWorkletNode } from './destroy-worklet-node';
 import workletUrl from '../../../audio/fexpr-processor?worker&url';
 
 const MAX_SIGNAL_INLETS = 9;
@@ -74,8 +75,7 @@ export class FExprNode implements AudioNodeV2 {
 
   private async createWorklet(outletCount: number): Promise<void> {
     if (this.audioNode) {
-      this.audioNode.disconnect();
-      this.audioNode = null;
+      this.destroyWorklet();
     }
 
     try {
@@ -188,7 +188,15 @@ export class FExprNode implements AudioNodeV2 {
   }
 
   destroy(): void {
-    this.audioNode?.disconnect();
+    this.destroyWorklet();
+  }
+
+  private destroyWorklet(): void {
+    const worklet = this.audioNode as AudioWorkletNode | null;
+    if (!worklet) return;
+
+    destroyWorkletNode({ label: 'fexpr~', node: worklet });
+    this.audioNode = null;
   }
 
   private static moduleReady = false;

--- a/ui/src/lib/audio/v2/nodes/OscNode.test.ts
+++ b/ui/src/lib/audio/v2/nodes/OscNode.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { OscNode } from './OscNode';
+
+function createFakeOscillator() {
+  return {
+    frequency: { value: 0 },
+    detune: { value: 0 },
+    type: 'sine',
+    start: vi.fn(),
+    stop: vi.fn(),
+    disconnect: vi.fn(),
+    setPeriodicWave: vi.fn()
+  };
+}
+
+describe('OscNode', () => {
+  it('creates an oscillator from frequency, type, and detune params', () => {
+    const oscillator = createFakeOscillator();
+    const audioContext = {
+      createOscillator: () => oscillator
+    } as unknown as AudioContext;
+    const node = new OscNode('osc-1', audioContext);
+
+    node.create([440, 'sine', 12]);
+
+    expect(oscillator.frequency.value).toBe(440);
+    expect(oscillator.type).toBe('sine');
+    expect(oscillator.detune.value).toBe(12);
+    expect(oscillator.start).toHaveBeenCalledWith(0);
+  });
+});

--- a/ui/src/lib/audio/v2/nodes/OscNode.ts
+++ b/ui/src/lib/audio/v2/nodes/OscNode.ts
@@ -67,10 +67,11 @@ export class OscNode implements AudioNodeV2 {
   }
 
   create(params: unknown[]): void {
-    const [freq, type] = params as [number, OscillatorType];
+    const [freq, type, detune] = params as [number, OscillatorType, number];
 
     this.audioNode.frequency.value = freq ?? 440;
     this.audioNode.type = type ?? 'sine';
+    this.audioNode.detune.value = detune ?? 0;
     this.audioNode.start(0);
   }
 

--- a/ui/src/lib/audio/v2/nodes/destroy-worklet-node.ts
+++ b/ui/src/lib/audio/v2/nodes/destroy-worklet-node.ts
@@ -1,0 +1,50 @@
+import { logger } from '$lib/utils/logger';
+
+type DestroyWorkletNodeOptions = {
+  label: string;
+  node: AudioWorkletNode;
+  fallbackCloseMs?: number;
+};
+
+export function destroyWorkletNode({
+  label,
+  node,
+  fallbackCloseMs = 250
+}: DestroyWorkletNodeOptions): void {
+  const port = node.port;
+  let fallbackCloseTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const closePort = () => {
+    if (fallbackCloseTimer !== null) {
+      clearTimeout(fallbackCloseTimer);
+      fallbackCloseTimer = null;
+    }
+
+    try {
+      port.onmessage = null;
+      port.close?.();
+    } catch (error) {
+      logger.warn(`cannot close ${label} worklet port:`, error);
+    }
+  };
+
+  try {
+    port.onmessage = (event: MessageEvent<{ type?: string }>) => {
+      if (event.data?.type === 'stopped') {
+        closePort();
+      }
+    };
+
+    port.postMessage({ type: 'stop' });
+    fallbackCloseTimer = setTimeout(closePort, fallbackCloseMs);
+  } catch (error) {
+    logger.warn(`cannot stop ${label} worklet:`, error);
+    closePort();
+  }
+
+  try {
+    node.disconnect();
+  } catch (error) {
+    logger.warn(`cannot disconnect ${label} worklet:`, error);
+  }
+}

--- a/ui/src/lib/components/CodeEditor.svelte
+++ b/ui/src/lib/components/CodeEditor.svelte
@@ -443,6 +443,15 @@
           '.cm-patchbay-object-keyword, .cm-patchbay-object-keyword *': {
             color: 'rgb(255, 202, 105) !important'
           },
+          '.cm-patchbay-virtual-expression-name, .cm-patchbay-virtual-expression-name *': {
+            color: 'rgb(156, 255, 192) !important'
+          },
+          '.cm-patchbay-virtual-expression-keyword, .cm-patchbay-virtual-expression-keyword *': {
+            color: 'rgb(81, 255, 144) !important'
+          },
+          '.cm-patchbay-virtual-expression-operator, .cm-patchbay-virtual-expression-operator *': {
+            color: 'rgb(196 181 253) !important'
+          },
           '.cm-patchbay-role-error': {
             color: 'rgb(252 165 165)',
             textDecoration: 'underline wavy rgb(248 113 113)',

--- a/ui/src/lib/components/nodes/PatchbayNode.svelte
+++ b/ui/src/lib/components/nodes/PatchbayNode.svelte
@@ -16,6 +16,10 @@
     getPatchbayObjectKeywordRanges,
     getPatchbayObjectLinkRanges,
     getPatchbayObjectNameRanges,
+    getPatchbayVirtualExpressionAssignmentRanges,
+    getPatchbayVirtualExpressionKeywordRanges,
+    getPatchbayVirtualExpressionNameRanges,
+    getPatchbayVirtualExpressionOperatorRanges,
     patchbayContextualCompletionSource
   } from '$lib/patchbay/codemirror/patchbay.codemirror';
   import { AudioChannelRegistry } from '$lib/audio/AudioChannelRegistry';
@@ -99,6 +103,10 @@
     ...getPatchbayObjectNameRanges(code),
     ...getPatchbayObjectAssignmentRanges(code),
     ...getPatchbayObjectKeywordRanges(code),
+    ...getPatchbayVirtualExpressionNameRanges(code),
+    ...getPatchbayVirtualExpressionAssignmentRanges(code),
+    ...getPatchbayVirtualExpressionKeywordRanges(code),
+    ...getPatchbayVirtualExpressionOperatorRanges(code),
     ...getPatchbayLocalChannelRanges(code),
     ...getPatchbayObjectAliasHintRanges(code),
     ...getPatchbayChannelLinkRanges(code, {

--- a/ui/src/lib/objects/v2/nodes/PatchbayObject.test.ts
+++ b/ui/src/lib/objects/v2/nodes/PatchbayObject.test.ts
@@ -554,10 +554,10 @@ describe('PatchbayObject', () => {
     const destinationNodeId = `recv-audio-${suffix}`;
     const registry = AudioChannelRegistry.getInstance();
     const registeredEdges: Array<{ routeId: string; edge: unknown }> = [];
-    const unregisteredVirtualExpressions: string[] = [];
-    const registeredVirtualExpressions: Array<{
+    const unregisteredVirtualAudioNodes: string[] = [];
+    const registeredVirtualAudioNodes: Array<{
       routeId: string;
-      expression: { nodeId: string; expression: string };
+      node: { nodeId: string; type: string; params: unknown[] };
     }> = [];
 
     const audioRuntime: PatchbayAudioRuntime = {
@@ -565,11 +565,11 @@ describe('PatchbayObject', () => {
         registeredEdges.push({ routeId, edge });
       },
       unregisterEdge() {},
-      registerVirtualExpression(routeId, expression) {
-        registeredVirtualExpressions.push({ routeId, expression });
+      registerVirtualAudioNode(routeId, node) {
+        registeredVirtualAudioNodes.push({ routeId, node });
       },
-      unregisterVirtualExpression(routeId) {
-        unregisteredVirtualExpressions.push(routeId);
+      unregisterVirtualAudioNode(routeId) {
+        unregisteredVirtualAudioNodes.push(routeId);
       }
     };
     const restoreAudioRuntime = setPatchbayAudioRuntime(audioRuntime);
@@ -583,12 +583,13 @@ describe('PatchbayObject', () => {
     `);
 
     expect(object.diagnostics).toEqual([]);
-    expect(registeredVirtualExpressions).toEqual([
+    expect(registeredVirtualAudioNodes).toEqual([
       {
-        routeId: expect.stringContaining('audio-expr'),
-        expression: expect.objectContaining({
-          nodeId: expect.stringContaining(':audio-expr:inline:'),
-          expression: 's * 0.5'
+        routeId: expect.stringContaining('audio-virtual'),
+        node: expect.objectContaining({
+          nodeId: expect.stringContaining(':audio-virtual:inline:'),
+          type: 'expr~',
+          params: [null, 's * 0.5']
         })
       }
     ]);
@@ -596,7 +597,7 @@ describe('PatchbayObject', () => {
       {
         routeId: expect.stringContaining(`${source}->expr~`),
         edge: expect.objectContaining({
-          target: registeredVirtualExpressions[0].expression.nodeId,
+          target: registeredVirtualAudioNodes[0].node.nodeId,
           sourceHandle: 'audio-out',
           targetHandle: 'audio-in-0'
         })
@@ -604,15 +605,15 @@ describe('PatchbayObject', () => {
       {
         routeId: expect.stringContaining(`expr~`),
         edge: expect.objectContaining({
-          source: registeredVirtualExpressions[0].expression.nodeId,
+          source: registeredVirtualAudioNodes[0].node.nodeId,
           targetHandle: 'audio-in'
         })
       }
     ]);
 
     object.destroy();
-    expect(unregisteredVirtualExpressions).toEqual(
-      registeredVirtualExpressions.map(({ routeId }) => routeId)
+    expect(unregisteredVirtualAudioNodes).toEqual(
+      registeredVirtualAudioNodes.map(({ routeId }) => routeId)
     );
 
     restoreAudioRuntime();

--- a/ui/src/lib/objects/v2/nodes/PatchbayObject.test.ts
+++ b/ui/src/lib/objects/v2/nodes/PatchbayObject.test.ts
@@ -621,6 +621,108 @@ describe('PatchbayObject', () => {
     registry.unsubscribe(destination, destinationNodeId);
   });
 
+  it('keeps unchanged virtual audio nodes alive when patchbay code reapplies', () => {
+    const suffix = crypto.randomUUID();
+    const destination = `audio-destination-${suffix}`;
+    const destinationNodeId = `recv-audio-${suffix}`;
+    const registry = AudioChannelRegistry.getInstance();
+    const registeredVirtualAudioNodes: Array<{
+      routeId: string;
+      node: { nodeId: string; type: string; params: unknown[] };
+    }> = [];
+    const unregisteredVirtualAudioNodes: string[] = [];
+
+    const audioRuntime: PatchbayAudioRuntime = {
+      registerEdge() {},
+      unregisterEdge() {},
+      registerVirtualAudioNode(routeId, node) {
+        registeredVirtualAudioNodes.push({ routeId, node });
+      },
+      unregisterVirtualAudioNode(routeId) {
+        unregisteredVirtualAudioNodes.push(routeId);
+      }
+    };
+    const restoreAudioRuntime = setPatchbayAudioRuntime(audioRuntime);
+
+    registry.subscribe(destination, destinationNodeId, 'recv');
+
+    const { object, params } = createPatchbay(`
+      [Audio]
+      Osc = osc~ 440 sine 0
+      Osc -> ${destination}
+    `);
+
+    params[0] = `
+      [Audio]
+      Osc = osc~ 440 sine 0
+      Osc -> ${destination}
+      // comment-only edit
+    `;
+    object.applyCode();
+
+    expect(registeredVirtualAudioNodes).toEqual([
+      {
+        routeId: expect.stringContaining('Osc'),
+        node: expect.objectContaining({
+          nodeId: expect.stringContaining('Osc'),
+          type: 'osc~',
+          params: [440, 'sine', 0]
+        })
+      }
+    ]);
+    expect(unregisteredVirtualAudioNodes).toEqual([]);
+
+    object.destroy();
+    expect(unregisteredVirtualAudioNodes).toEqual(
+      registeredVirtualAudioNodes.map(({ routeId }) => routeId)
+    );
+
+    restoreAudioRuntime();
+    registry.unsubscribe(destination, destinationNodeId);
+  });
+
+  it('unregisters virtual audio nodes removed from patchbay code', () => {
+    const suffix = crypto.randomUUID();
+    const destination = `audio-destination-${suffix}`;
+    const destinationNodeId = `recv-audio-${suffix}`;
+    const registry = AudioChannelRegistry.getInstance();
+    const registeredVirtualAudioNodes: string[] = [];
+    const unregisteredVirtualAudioNodes: string[] = [];
+
+    const audioRuntime: PatchbayAudioRuntime = {
+      registerEdge() {},
+      unregisterEdge() {},
+      registerVirtualAudioNode(routeId) {
+        registeredVirtualAudioNodes.push(routeId);
+      },
+      unregisterVirtualAudioNode(routeId) {
+        unregisteredVirtualAudioNodes.push(routeId);
+      }
+    };
+    const restoreAudioRuntime = setPatchbayAudioRuntime(audioRuntime);
+
+    registry.subscribe(destination, destinationNodeId, 'recv');
+
+    const { object, params } = createPatchbay(`
+      [Audio]
+      Osc = osc~ 440 sine 0
+      Osc -> ${destination}
+    `);
+
+    params[0] = `
+      [Audio]
+    `;
+    object.applyCode();
+
+    expect(unregisteredVirtualAudioNodes).toEqual(registeredVirtualAudioNodes);
+
+    object.destroy();
+    expect(unregisteredVirtualAudioNodes).toEqual(registeredVirtualAudioNodes);
+
+    restoreAudioRuntime();
+    registry.unsubscribe(destination, destinationNodeId);
+  });
+
   it('registers video object endpoints as hidden video edges', () => {
     const suffix = crypto.randomUUID();
     const source = `video-source-${suffix}`;

--- a/ui/src/lib/objects/v2/nodes/PatchbayObject.test.ts
+++ b/ui/src/lib/objects/v2/nodes/PatchbayObject.test.ts
@@ -10,6 +10,7 @@ import { setPatchbayVideoRuntime } from '$lib/patchbay/patchbay-video-runtime';
 import { PatchbayObject } from './PatchbayObject';
 
 import type { ObjectContext } from '../ObjectContext';
+import type { PatchbayAudioRuntime } from '$lib/patchbay/patchbay-audio-runtime';
 
 function createPatchbay(code: string) {
   const params = [code];
@@ -494,14 +495,15 @@ describe('PatchbayObject', () => {
     const registry = AudioChannelRegistry.getInstance();
     const registeredEdges: Array<{ routeId: string; edge: unknown }> = [];
     const unregisteredEdges: string[] = [];
-    const restoreAudioRuntime = setPatchbayAudioRuntime({
+    const audioRuntime: PatchbayAudioRuntime = {
       registerEdge(routeId, edge) {
         registeredEdges.push({ routeId, edge });
       },
       unregisterEdge(routeId) {
         unregisteredEdges.push(routeId);
       }
-    });
+    };
+    const restoreAudioRuntime = setPatchbayAudioRuntime(audioRuntime);
 
     registry.subscribe(source, sourceNodeId, 'send');
 
@@ -542,6 +544,80 @@ describe('PatchbayObject', () => {
     expect(unregisteredEdges).toEqual(registeredEdges.map(({ routeId }) => routeId));
     restoreAudioRuntime();
     registry.unsubscribe(source, sourceNodeId);
+  });
+
+  it('registers audio shorthand expressions as hidden expr nodes between channel endpoints', () => {
+    const suffix = crypto.randomUUID();
+    const source = `audio-source-${suffix}`;
+    const destination = `audio-destination-${suffix}`;
+    const sourceNodeId = `send-audio-${suffix}`;
+    const destinationNodeId = `recv-audio-${suffix}`;
+    const registry = AudioChannelRegistry.getInstance();
+    const registeredEdges: Array<{ routeId: string; edge: unknown }> = [];
+    const unregisteredVirtualExpressions: string[] = [];
+    const registeredVirtualExpressions: Array<{
+      routeId: string;
+      expression: { nodeId: string; expression: string };
+    }> = [];
+
+    const audioRuntime: PatchbayAudioRuntime = {
+      registerEdge(routeId, edge) {
+        registeredEdges.push({ routeId, edge });
+      },
+      unregisterEdge() {},
+      registerVirtualExpression(routeId, expression) {
+        registeredVirtualExpressions.push({ routeId, expression });
+      },
+      unregisterVirtualExpression(routeId) {
+        unregisteredVirtualExpressions.push(routeId);
+      }
+    };
+    const restoreAudioRuntime = setPatchbayAudioRuntime(audioRuntime);
+
+    registry.subscribe(source, sourceNodeId, 'send');
+    registry.subscribe(destination, destinationNodeId, 'recv');
+
+    const { object } = createPatchbay(`
+      [Audio]
+      ${source} * 0.5 -> ${destination}
+    `);
+
+    expect(object.diagnostics).toEqual([]);
+    expect(registeredVirtualExpressions).toEqual([
+      {
+        routeId: expect.stringContaining('audio-expr'),
+        expression: expect.objectContaining({
+          nodeId: expect.stringContaining(':audio-expr:inline:'),
+          expression: 's * 0.5'
+        })
+      }
+    ]);
+    expect(registeredEdges).toEqual([
+      {
+        routeId: expect.stringContaining(`${source}->expr~`),
+        edge: expect.objectContaining({
+          target: registeredVirtualExpressions[0].expression.nodeId,
+          sourceHandle: 'audio-out',
+          targetHandle: 'audio-in-0'
+        })
+      },
+      {
+        routeId: expect.stringContaining(`expr~`),
+        edge: expect.objectContaining({
+          source: registeredVirtualExpressions[0].expression.nodeId,
+          targetHandle: 'audio-in'
+        })
+      }
+    ]);
+
+    object.destroy();
+    expect(unregisteredVirtualExpressions).toEqual(
+      registeredVirtualExpressions.map(({ routeId }) => routeId)
+    );
+
+    restoreAudioRuntime();
+    registry.unsubscribe(source, sourceNodeId);
+    registry.unsubscribe(destination, destinationNodeId);
   });
 
   it('registers video object endpoints as hidden video edges', () => {

--- a/ui/src/lib/objects/v2/nodes/PatchbayObject.ts
+++ b/ui/src/lib/objects/v2/nodes/PatchbayObject.ts
@@ -56,7 +56,7 @@ export class PatchbayObject implements TextObjectV2 {
 
   private activeAudioRoutes = new Map<string, PatchbayRoute>();
   private activeAudioEdges = new Set<string>();
-  private activeAudioVirtualExpressions = new Set<string>();
+  private activeAudioVirtualExpressions = new Map<string, string>();
 
   private activeVideoRoutes = new Map<string, { from: string; to: string }>();
   private activeVideoEdges = new Map<string, string>();
@@ -223,7 +223,9 @@ export class PatchbayObject implements TextObjectV2 {
   }
 
   private applyAudioRoutes(routes: PatchbayRoute[]): void {
-    this.clearAudioRoutes();
+    const desiredVirtualExpressions = new Set<string>();
+
+    this.clearAudioEdgesAndRoutes();
 
     for (const route of routes) {
       if (
@@ -232,7 +234,7 @@ export class PatchbayObject implements TextObjectV2 {
         route.fromVirtualExpression ||
         route.toVirtualExpression
       ) {
-        this.applyAudioObjectRoute(route);
+        this.applyAudioObjectRoute(route, desiredVirtualExpressions);
 
         continue;
       }
@@ -244,6 +246,8 @@ export class PatchbayObject implements TextObjectV2 {
 
       this.activeAudioRoutes.set(endpointId, route);
     }
+
+    this.clearStaleAudioVirtualExpressions(desiredVirtualExpressions);
   }
 
   private applyVideoRoutes(routes: PatchbayRoute[]): void {
@@ -342,15 +346,18 @@ export class PatchbayObject implements TextObjectV2 {
     }
   }
 
-  private applyAudioObjectRoute(route: PatchbayRoute): void {
+  private applyAudioObjectRoute(
+    route: PatchbayRoute,
+    desiredVirtualExpressions: Set<string>
+  ): void {
     const routeId = this.getAudioObjectRouteId(route);
 
     if (route.fromVirtualExpression) {
-      this.registerAudioVirtualExpression(route.fromVirtualExpression);
+      this.registerAudioVirtualExpression(route.fromVirtualExpression, desiredVirtualExpressions);
     }
 
     if (route.toVirtualExpression) {
-      this.registerAudioVirtualExpression(route.toVirtualExpression);
+      this.registerAudioVirtualExpression(route.toVirtualExpression, desiredVirtualExpressions);
     }
 
     const sourceNodeId =
@@ -386,9 +393,22 @@ export class PatchbayObject implements TextObjectV2 {
   }
 
   private registerAudioVirtualExpression(
-    expression: NonNullable<PatchbayRoute['fromVirtualExpression']>
+    expression: NonNullable<PatchbayRoute['fromVirtualExpression']>,
+    desiredVirtualExpressions: Set<string>
   ): void {
-    if (this.activeAudioVirtualExpressions.has(expression.id)) return;
+    desiredVirtualExpressions.add(expression.id);
+
+    const signature = hash({
+      type: expression.type,
+      params: expression.params
+    });
+    const activeSignature = this.activeAudioVirtualExpressions.get(expression.id);
+
+    if (activeSignature === signature) return;
+
+    if (activeSignature) {
+      getPatchbayAudioRuntime().unregisterVirtualAudioNode?.(expression.id);
+    }
 
     getPatchbayAudioRuntime().registerVirtualAudioNode?.(expression.id, {
       nodeId: expression.id,
@@ -396,7 +416,16 @@ export class PatchbayObject implements TextObjectV2 {
       params: expression.params
     });
 
-    this.activeAudioVirtualExpressions.add(expression.id);
+    this.activeAudioVirtualExpressions.set(expression.id, signature);
+  }
+
+  private clearStaleAudioVirtualExpressions(desiredVirtualExpressions: Set<string>): void {
+    for (const routeId of this.activeAudioVirtualExpressions.keys()) {
+      if (desiredVirtualExpressions.has(routeId)) continue;
+
+      getPatchbayAudioRuntime().unregisterVirtualAudioNode?.(routeId);
+      this.activeAudioVirtualExpressions.delete(routeId);
+    }
   }
 
   private collectVideoObjectRoute(
@@ -489,6 +518,16 @@ export class PatchbayObject implements TextObjectV2 {
   }
 
   private clearAudioRoutes(): void {
+    this.clearAudioEdgesAndRoutes();
+
+    for (const routeId of this.activeAudioVirtualExpressions.keys()) {
+      getPatchbayAudioRuntime().unregisterVirtualAudioNode?.(routeId);
+    }
+
+    this.activeAudioVirtualExpressions.clear();
+  }
+
+  private clearAudioEdgesAndRoutes(): void {
     for (const routeId of this.activeAudioEdges) {
       getPatchbayAudioRuntime().unregisterEdge(routeId);
     }
@@ -501,12 +540,6 @@ export class PatchbayObject implements TextObjectV2 {
     }
 
     this.activeAudioRoutes.clear();
-
-    for (const routeId of this.activeAudioVirtualExpressions) {
-      getPatchbayAudioRuntime().unregisterVirtualAudioNode?.(routeId);
-    }
-
-    this.activeAudioVirtualExpressions.clear();
   }
 
   private clearVideoRoutes(): void {

--- a/ui/src/lib/objects/v2/nodes/PatchbayObject.ts
+++ b/ui/src/lib/objects/v2/nodes/PatchbayObject.ts
@@ -241,6 +241,7 @@ export class PatchbayObject implements TextObjectV2 {
 
       this.audioChannelRegistry.subscribe(route.from, endpointId, 'recv');
       this.audioChannelRegistry.subscribe(route.to, endpointId, 'send');
+
       this.activeAudioRoutes.set(endpointId, route);
     }
   }
@@ -389,9 +390,10 @@ export class PatchbayObject implements TextObjectV2 {
   ): void {
     if (this.activeAudioVirtualExpressions.has(expression.id)) return;
 
-    getPatchbayAudioRuntime().registerVirtualExpression?.(expression.id, {
+    getPatchbayAudioRuntime().registerVirtualAudioNode?.(expression.id, {
       nodeId: expression.id,
-      expression: expression.expression
+      type: expression.type,
+      params: expression.params
     });
 
     this.activeAudioVirtualExpressions.add(expression.id);
@@ -501,7 +503,7 @@ export class PatchbayObject implements TextObjectV2 {
     this.activeAudioRoutes.clear();
 
     for (const routeId of this.activeAudioVirtualExpressions) {
-      getPatchbayAudioRuntime().unregisterVirtualExpression?.(routeId);
+      getPatchbayAudioRuntime().unregisterVirtualAudioNode?.(routeId);
     }
 
     this.activeAudioVirtualExpressions.clear();

--- a/ui/src/lib/objects/v2/nodes/PatchbayObject.ts
+++ b/ui/src/lib/objects/v2/nodes/PatchbayObject.ts
@@ -393,6 +393,7 @@ export class PatchbayObject implements TextObjectV2 {
       nodeId: expression.id,
       expression: expression.expression
     });
+
     this.activeAudioVirtualExpressions.add(expression.id);
   }
 

--- a/ui/src/lib/objects/v2/nodes/PatchbayObject.ts
+++ b/ui/src/lib/objects/v2/nodes/PatchbayObject.ts
@@ -56,6 +56,7 @@ export class PatchbayObject implements TextObjectV2 {
 
   private activeAudioRoutes = new Map<string, PatchbayRoute>();
   private activeAudioEdges = new Set<string>();
+  private activeAudioVirtualExpressions = new Set<string>();
 
   private activeVideoRoutes = new Map<string, { from: string; to: string }>();
   private activeVideoEdges = new Map<string, string>();
@@ -225,7 +226,12 @@ export class PatchbayObject implements TextObjectV2 {
     this.clearAudioRoutes();
 
     for (const route of routes) {
-      if (route.fromEndpoint || route.toEndpoint) {
+      if (
+        route.fromEndpoint ||
+        route.toEndpoint ||
+        route.fromVirtualExpression ||
+        route.toVirtualExpression
+      ) {
         this.applyAudioObjectRoute(route);
 
         continue;
@@ -338,31 +344,56 @@ export class PatchbayObject implements TextObjectV2 {
   private applyAudioObjectRoute(route: PatchbayRoute): void {
     const routeId = this.getAudioObjectRouteId(route);
 
+    if (route.fromVirtualExpression) {
+      this.registerAudioVirtualExpression(route.fromVirtualExpression);
+    }
+
+    if (route.toVirtualExpression) {
+      this.registerAudioVirtualExpression(route.toVirtualExpression);
+    }
+
     const sourceNodeId =
-      route.fromEndpoint?.nodeId ?? `${routeId}:audio-recv:${route.from}:audio-send:obj`;
+      route.fromEndpoint?.nodeId ??
+      route.fromVirtualExpression?.id ??
+      `${routeId}:audio-recv:${route.from}:audio-send:obj`;
 
     const targetNodeId =
-      route.toEndpoint?.nodeId ?? `${routeId}:audio-recv:obj:audio-send:${route.to}`;
+      route.toEndpoint?.nodeId ??
+      route.toVirtualExpression?.id ??
+      `${routeId}:audio-recv:obj:audio-send:${route.to}`;
 
     getPatchbayAudioRuntime().registerEdge(routeId, {
       id: routeId,
       source: sourceNodeId,
       target: targetNodeId,
       sourceHandle: route.fromEndpoint?.handle ?? 'audio-out',
-      targetHandle: route.toEndpoint?.handle ?? 'audio-in'
+      targetHandle:
+        route.toEndpoint?.handle ?? (route.toVirtualExpression ? 'audio-in-0' : 'audio-in')
     });
 
     this.activeAudioEdges.add(routeId);
 
-    if (!route.fromEndpoint) {
+    if (!route.fromEndpoint && !route.fromVirtualExpression) {
       this.audioChannelRegistry.subscribe(route.from, sourceNodeId, 'recv');
       this.activeAudioRoutes.set(sourceNodeId, route);
     }
 
-    if (!route.toEndpoint) {
+    if (!route.toEndpoint && !route.toVirtualExpression) {
       this.audioChannelRegistry.subscribe(route.to, targetNodeId, 'send');
       this.activeAudioRoutes.set(targetNodeId, route);
     }
+  }
+
+  private registerAudioVirtualExpression(
+    expression: NonNullable<PatchbayRoute['fromVirtualExpression']>
+  ): void {
+    if (this.activeAudioVirtualExpressions.has(expression.id)) return;
+
+    getPatchbayAudioRuntime().registerVirtualExpression?.(expression.id, {
+      nodeId: expression.id,
+      expression: expression.expression
+    });
+    this.activeAudioVirtualExpressions.add(expression.id);
   }
 
   private collectVideoObjectRoute(
@@ -467,6 +498,12 @@ export class PatchbayObject implements TextObjectV2 {
     }
 
     this.activeAudioRoutes.clear();
+
+    for (const routeId of this.activeAudioVirtualExpressions) {
+      getPatchbayAudioRuntime().unregisterVirtualExpression?.(routeId);
+    }
+
+    this.activeAudioVirtualExpressions.clear();
   }
 
   private clearVideoRoutes(): void {

--- a/ui/src/lib/patchbay/codemirror/patchbay.codemirror.test.ts
+++ b/ui/src/lib/patchbay/codemirror/patchbay.codemirror.test.ts
@@ -590,6 +590,16 @@ describe('patchbaySectionCompletions', () => {
     expect(getPatchbayCompletionLabels('src obj =')).toEqual([]);
     expect(getPatchbayCompletionLabels('slider-43 obj ->')).toEqual([]);
   });
+
+  it('suggests audio processor keywords in audio declarations and route endpoints', () => {
+    expect(getPatchbayCompletionLabels('[Audio]\nGain = e')).toEqual(['expr~']);
+    expect(getPatchbayCompletionLabels('[Audio]\nGain = g')).toEqual(['gain~']);
+    expect(getPatchbayCompletionLabels('[Audio]\nMic -> lo')).toEqual(['lowpass~', 'lowshelf~']);
+    expect(getPatchbayCompletionLabels('[Audio]\nMic -> e')).toEqual([]);
+
+    expect(getPatchbayCompletionLabels('[Message]\nGain = g')).toEqual([]);
+    expect(getPatchbayCompletionLabels('[Video]\nSource -> g')).toEqual([]);
+  });
 });
 
 describe('patchbayContextualCompletions', () => {

--- a/ui/src/lib/patchbay/codemirror/patchbay.codemirror.test.ts
+++ b/ui/src/lib/patchbay/codemirror/patchbay.codemirror.test.ts
@@ -15,6 +15,10 @@ import {
   getPatchbayObjectKeywordRanges,
   getPatchbayObjectLinkRanges,
   getPatchbayObjectNameRanges,
+  getPatchbayVirtualExpressionAssignmentRanges,
+  getPatchbayVirtualExpressionKeywordRanges,
+  getPatchbayVirtualExpressionNameRanges,
+  getPatchbayVirtualExpressionOperatorRanges,
   tokenizePatchbayLine
 } from './patchbay.codemirror';
 
@@ -83,6 +87,15 @@ describe('tokenizePatchbayLine', () => {
       { text: '=', style: 'operator' },
       { text: 'obj', style: 'keyword' },
       { text: 'glsl-34', style: 'variableName' }
+    ]);
+
+    expect(tokenizePatchbayLine('Gainer = expr~ s * 0.8')).toEqual([
+      { text: 'Gainer', style: 'variableName' },
+      { text: '=', style: 'operator' },
+      { text: 'expr~', style: 'keyword' },
+      { text: 's', style: 'variableName' },
+      { text: '*', style: 'operator' },
+      { text: '0.8', style: 'variableName' }
     ]);
   });
 
@@ -390,6 +403,66 @@ Src -> Out`;
         from: 47,
         to: 54,
         className: 'cm-patchbay-object-id'
+      }
+    ]);
+  });
+
+  it('returns green syntax ranges for virtual expr aliases and keywords', () => {
+    const source = `[Audio]
+Gainer = expr~ s * 0.8
+Osc -> Gainer -> Out`;
+
+    expect(getPatchbayVirtualExpressionNameRanges(source)).toEqual([
+      {
+        from: 8,
+        to: 14,
+        className: 'cm-patchbay-virtual-expression-name'
+      },
+      {
+        from: 38,
+        to: 44,
+        className: 'cm-patchbay-virtual-expression-name'
+      }
+    ]);
+
+    expect(getPatchbayVirtualExpressionKeywordRanges(source)).toEqual([
+      {
+        from: 17,
+        to: 22,
+        className: 'cm-patchbay-virtual-expression-keyword'
+      }
+    ]);
+
+    expect(getPatchbayVirtualExpressionAssignmentRanges(source)).toEqual([
+      {
+        from: 15,
+        to: 16,
+        className: 'cm-patchbay-object-assignment'
+      }
+    ]);
+  });
+
+  it('returns purple operator ranges for virtual expr bodies and shorthand', () => {
+    const source = `[Audio]
+Gainer = expr~ s * 0.8
+Offset = expr~ s + 0.1
+Osc * 0.8 -> Out`;
+
+    expect(getPatchbayVirtualExpressionOperatorRanges(source)).toEqual([
+      {
+        from: 25,
+        to: 26,
+        className: 'cm-patchbay-virtual-expression-operator'
+      },
+      {
+        from: 48,
+        to: 49,
+        className: 'cm-patchbay-virtual-expression-operator'
+      },
+      {
+        from: 58,
+        to: 59,
+        className: 'cm-patchbay-virtual-expression-operator'
       }
     ]);
   });

--- a/ui/src/lib/patchbay/codemirror/patchbay.codemirror.test.ts
+++ b/ui/src/lib/patchbay/codemirror/patchbay.codemirror.test.ts
@@ -593,7 +593,9 @@ describe('patchbaySectionCompletions', () => {
 
   it('suggests audio processor keywords in audio declarations and route endpoints', () => {
     expect(getPatchbayCompletionLabels('[Audio]\nGain = e')).toEqual(['expr~']);
+    expect(getPatchbayCompletionLabels('[Audio]\nOsc = o')).toEqual(['obj', 'osc~']);
     expect(getPatchbayCompletionLabels('[Audio]\nGain = g')).toEqual(['gain~']);
+    expect(getPatchbayCompletionLabels('[Audio]\no')).toEqual(['obj', 'osc~']);
     expect(getPatchbayCompletionLabels('[Audio]\nMic -> lo')).toEqual(['lowpass~', 'lowshelf~']);
     expect(getPatchbayCompletionLabels('[Audio]\nMic -> e')).toEqual([]);
 

--- a/ui/src/lib/patchbay/codemirror/patchbay.codemirror.test.ts
+++ b/ui/src/lib/patchbay/codemirror/patchbay.codemirror.test.ts
@@ -97,6 +97,23 @@ describe('tokenizePatchbayLine', () => {
       { text: '*', style: 'operator' },
       { text: '0.8', style: 'variableName' }
     ]);
+
+    expect(tokenizePatchbayLine('Filter = lowpass~ 1000 1')).toEqual([
+      { text: 'Filter', style: 'variableName' },
+      { text: '=', style: 'operator' },
+      { text: 'lowpass~', style: 'keyword' },
+      { text: '1000', style: 'variableName' },
+      { text: '1', style: 'variableName' }
+    ]);
+
+    expect(tokenizePatchbayLine('Mic -> gain~ 0.5 -> Out')).toEqual([
+      { text: 'Mic', style: 'variableName' },
+      { text: '->', style: 'operator' },
+      { text: 'gain~', style: 'keyword' },
+      { text: '0.5', style: 'variableName' },
+      { text: '->', style: 'operator' },
+      { text: 'Out', style: 'variableName' }
+    ]);
   });
 
   it('returns inline ranges for unknown channel diagnostics', () => {

--- a/ui/src/lib/patchbay/codemirror/patchbay.codemirror.ts
+++ b/ui/src/lib/patchbay/codemirror/patchbay.codemirror.ts
@@ -120,21 +120,7 @@ export type PatchbayCompletionData = {
 
 type PatchbayEndpointCompletionRole = 'source' | 'target' | 'both' | 'any';
 
-const commentLinePattern = /^\s*(?:#|\/\/).*/;
-const commentPrefixPattern = /^\s*(?:#|\/\/)/;
-const identifierPattern = /^[A-Za-z0-9_.~/:-]+/;
-const sectionPattern = /^\[(Message|Audio|Video)\]/i;
-const sectionCompletionOptions: Completion[] = [
-  { label: '[Audio]', type: 'namespace', detail: 'Audio routes' },
-  { label: '[Video]', type: 'namespace', detail: 'Video routes' },
-  { label: '[Message]', type: 'namespace', detail: 'Message routes' }
-];
-const objCompletionOption: Completion = {
-  label: 'obj',
-  type: 'keyword',
-  detail: 'object endpoint'
-};
-const virtualAudioProcessorKeywordLabels = [
+const VIRTUAL_AUDIO_PROCESSOR_NODE_TYPES = [
   'expr~',
   'gain~',
   'lowpass~',
@@ -148,8 +134,36 @@ const virtualAudioProcessorKeywordLabels = [
   'compressor~',
   'delay~'
 ] as const;
-const virtualAudioProcessorKeywords = new Set<string>(virtualAudioProcessorKeywordLabels);
-const virtualAudioProcessorCompletionOptions: Completion[] = virtualAudioProcessorKeywordLabels.map(
+
+const VALID_DIAGNOSTICS = [
+  'unknown-channel',
+  'receiver-as-source',
+  'sender-as-target',
+  'unknown-object',
+  'object-port-unavailable',
+  'object-port-out-of-range'
+];
+
+const commentLinePattern = /^\s*(?:#|\/\/).*/;
+const commentPrefixPattern = /^\s*(?:#|\/\/)/;
+const identifierPattern = /^[A-Za-z0-9_.~/:-]+/;
+const sectionPattern = /^\[(Message|Audio|Video)\]/i;
+
+const sectionCompletionOptions: Completion[] = [
+  { label: '[Audio]', type: 'namespace', detail: 'Audio routes' },
+  { label: '[Video]', type: 'namespace', detail: 'Video routes' },
+  { label: '[Message]', type: 'namespace', detail: 'Message routes' }
+];
+
+const objCompletionOption: Completion = {
+  label: 'obj',
+  type: 'keyword',
+  detail: 'object endpoint'
+};
+
+const virtualAudioProcessorKeywords = new Set<string>(VIRTUAL_AUDIO_PROCESSOR_NODE_TYPES);
+
+const virtualAudioProcessorCompletionOptions: Completion[] = VIRTUAL_AUDIO_PROCESSOR_NODE_TYPES.map(
   (label) => ({
     label,
     type: 'keyword',
@@ -188,16 +202,7 @@ export function getPatchbayDiagnosticRanges(
 
   return diagnostics
     .filter(
-      (diagnostic) =>
-        diagnostic.severity === 'error' &&
-        [
-          'unknown-channel',
-          'receiver-as-source',
-          'sender-as-target',
-          'unknown-object',
-          'object-port-unavailable',
-          'object-port-out-of-range'
-        ].includes(diagnostic.code)
+      (diagnostic) => diagnostic.severity === 'error' && VALID_DIAGNOSTICS.includes(diagnostic.code)
     )
     .flatMap((diagnostic) => {
       if (!diagnostic.name) return [];
@@ -233,6 +238,7 @@ export function getPatchbayChannelLinkRanges(
   const objectAliases = getPatchbayObjectAliases(source);
   const rolesBySection = normalizeRolesBySection(registryChannels);
   const ranges: PatchbayChannelLinkRange[] = [];
+
   let currentSection: PatchbaySection | undefined;
 
   source.split(/\r?\n/).forEach((line, lineIndex) => {
@@ -260,10 +266,12 @@ export function getPatchbayChannelLinkRanges(
       }
 
       if (token.style !== 'variableName') continue;
+
       if (skipObjectId) {
         skipObjectId = false;
         continue;
       }
+
       if (!currentSection) continue;
       if (objectAliases.has(getChannelKey(currentSection, token.text))) continue;
       if (localChannels.has(getChannelKey(currentSection, token.text))) continue;
@@ -276,6 +284,7 @@ export function getPatchbayChannelLinkRanges(
       if (!isSender && !isReceiver) continue;
 
       const role = isSender && isReceiver ? 'both' : isSender ? 'sender' : 'receiver';
+
       const roleClass =
         role === 'both'
           ? 'cm-patchbay-bidirectional-channel'
@@ -284,6 +293,7 @@ export function getPatchbayChannelLinkRanges(
             : 'cm-patchbay-receiver-channel';
 
       const from = lineStarts[lineIndex] + column;
+
       ranges.push({
         from,
         to: from + token.text.length,
@@ -326,14 +336,17 @@ export function getPatchbayLocalChannelRanges(source: string): PatchbayLocalChan
       }
 
       if (token.style !== 'variableName') continue;
+
       if (skipObjectId) {
         skipObjectId = false;
         continue;
       }
+
       if (!currentSection) continue;
       if (!localChannels.has(getChannelKey(currentSection, token.text))) continue;
 
       const from = lineStarts[lineIndex] + column;
+
       ranges.push({
         from,
         to: from + token.text.length,
@@ -446,10 +459,12 @@ export function getPatchbayObjectNameRanges(source: string): PatchbayObjectNameR
       }
 
       if (token.style !== 'variableName') continue;
+
       if (skipObjectId) {
         skipObjectId = false;
         continue;
       }
+
       if (!currentSection) continue;
       if (!objectAliases.has(getChannelKey(currentSection, token.text))) continue;
 
@@ -458,6 +473,7 @@ export function getPatchbayObjectNameRanges(source: string): PatchbayObjectNameR
       if (seenRanges.has(rangeKey)) continue;
 
       seenRanges.add(rangeKey);
+
       ranges.push({
         from,
         to: from + token.text.length,
@@ -473,11 +489,13 @@ export function getPatchbayObjectAliasHintRanges(source: string): PatchbayObject
   const lineStarts = getLineStarts(source);
   const objectAliases = getPatchbayObjectAliases(source);
   const ranges: PatchbayObjectAliasHintRange[] = [];
+
   let currentSection: PatchbaySection | undefined;
 
   source.split(/\r?\n/).forEach((line, lineIndex) => {
     const lineTokens = tokenizePatchbayLine(line);
     const section = parseSectionToken(lineTokens[0]);
+
     if (section) {
       currentSection = section;
       return;
@@ -500,6 +518,7 @@ export function getPatchbayObjectAliasHintRanges(source: string): PatchbayObject
       }
 
       if (token.style !== 'variableName') continue;
+
       if (skipObjectId) {
         skipObjectId = false;
         continue;
@@ -509,6 +528,7 @@ export function getPatchbayObjectAliasHintRanges(source: string): PatchbayObject
       if (!nodeId) continue;
 
       const from = lineStarts[lineIndex] + column;
+
       ranges.push({
         from,
         to: from + token.text.length,
@@ -521,20 +541,21 @@ export function getPatchbayObjectAliasHintRanges(source: string): PatchbayObject
   return ranges;
 }
 
-export function getPatchbayObjectIdRanges(source: string): PatchbayObjectIdRange[] {
-  return getPatchbayObjectReferenceTokenRanges(source, 'id', 'cm-patchbay-object-id');
-}
+export const getPatchbayObjectIdRanges = (source: string): PatchbayObjectIdRange[] =>
+  getPatchbayObjectReferenceTokenRanges(source, 'id', 'cm-patchbay-object-id');
 
 export function getPatchbayVirtualExpressionNameRanges(
   source: string
 ): PatchbayVirtualExpressionNameRange[] {
   const lineStarts = getLineStarts(source);
   const aliases = getPatchbayVirtualExpressionAliases(source);
+
   const ranges = getPatchbayVirtualExpressionDeclarationTokenRanges(
     source,
     0,
     'cm-patchbay-virtual-expression-name'
   );
+
   const seenRanges = new Set(ranges.map((range) => `${range.from}:${range.to}`));
   let currentSection: PatchbaySection | undefined;
 
@@ -551,6 +572,7 @@ export function getPatchbayVirtualExpressionNameRanges(
       searchStart = column + token.text.length;
 
       const section = parseSectionToken(token);
+
       if (section) {
         currentSection = section;
         continue;
@@ -576,36 +598,32 @@ export function getPatchbayVirtualExpressionNameRanges(
   return ranges;
 }
 
-export function getPatchbayVirtualExpressionKeywordRanges(
+export const getPatchbayVirtualExpressionKeywordRanges = (
   source: string
-): PatchbayVirtualExpressionKeywordRange[] {
-  return getPatchbayVirtualExpressionDeclarationTokenRanges(
+): PatchbayVirtualExpressionKeywordRange[] =>
+  getPatchbayVirtualExpressionDeclarationTokenRanges(
     source,
     2,
     'cm-patchbay-virtual-expression-keyword'
   );
-}
 
-export function getPatchbayVirtualExpressionAssignmentRanges(
+export const getPatchbayVirtualExpressionAssignmentRanges = (
   source: string
-): PatchbayVirtualExpressionAssignmentRange[] {
-  return getPatchbayVirtualExpressionDeclarationTokenRanges(
-    source,
-    1,
-    'cm-patchbay-object-assignment'
-  );
-}
+): PatchbayVirtualExpressionAssignmentRange[] =>
+  getPatchbayVirtualExpressionDeclarationTokenRanges(source, 1, 'cm-patchbay-object-assignment');
 
 export function getPatchbayVirtualExpressionOperatorRanges(
   source: string
 ): PatchbayVirtualExpressionOperatorRange[] {
   const lineStarts = getLineStarts(source);
   const ranges: PatchbayVirtualExpressionOperatorRange[] = [];
+
   let currentSection: PatchbaySection | undefined;
 
   source.split(/\r?\n/).forEach((line, lineIndex) => {
     const tokens = tokenizePatchbayLine(line);
     const section = parseSectionToken(tokens[0]);
+
     if (section) {
       currentSection = section;
       return;
@@ -867,6 +885,7 @@ function getPatchbayLocalChannels(source: string): Set<string> {
     if (tokens[0]?.text !== 'chan') continue;
 
     const channel = tokens[1];
+
     if (currentSection && channel?.style === 'variableName') {
       channels.add(getChannelKey(currentSection, channel.text));
     }

--- a/ui/src/lib/patchbay/codemirror/patchbay.codemirror.ts
+++ b/ui/src/lib/patchbay/codemirror/patchbay.codemirror.ts
@@ -134,7 +134,7 @@ const objCompletionOption: Completion = {
   type: 'keyword',
   detail: 'object endpoint'
 };
-const virtualAudioProcessorKeywords = new Set([
+const virtualAudioProcessorKeywordLabels = [
   'expr~',
   'gain~',
   'lowpass~',
@@ -147,7 +147,15 @@ const virtualAudioProcessorKeywords = new Set([
   'peaking~',
   'compressor~',
   'delay~'
-]);
+] as const;
+const virtualAudioProcessorKeywords = new Set<string>(virtualAudioProcessorKeywordLabels);
+const virtualAudioProcessorCompletionOptions: Completion[] = virtualAudioProcessorKeywordLabels.map(
+  (label) => ({
+    label,
+    type: 'keyword',
+    detail: label === 'expr~' ? 'virtual expression' : 'virtual audio processor'
+  })
+);
 
 export function tokenizePatchbayLine(line: string): PatchbayLineToken[] {
   const tokens: PatchbayLineToken[] = [];
@@ -954,7 +962,10 @@ export function patchbaySectionCompletions(context: CompletionContext): Completi
   const sectionResult = getPatchbaySectionCompletion(line.from, linePrefix);
   if (sectionResult) return sectionResult;
 
-  return getPatchbayObjectKeywordCompletion(line.from, linePrefix);
+  return (
+    getPatchbayObjectKeywordCompletion(line.from, linePrefix) ??
+    getPatchbayVirtualAudioProcessorKeywordCompletion(context, line.from, linePrefix)
+  );
 }
 
 export function patchbayContextualCompletions(
@@ -1051,6 +1062,7 @@ function getPatchbayObjectIdCompletions(
       const sectionPorts = ports[context.section];
       const inletCount = sectionPorts?.inlets?.length ?? 0;
       const outletCount = sectionPorts?.outlets?.length ?? 0;
+
       const detail =
         inletCount > 0 && outletCount > 0
           ? `${context.section} in/out`
@@ -1087,6 +1099,7 @@ function getPatchbayChannelCompletions(
   const channels = new Map<string, Completion>();
   const localChannels = getPatchbayLocalChannelNames(context.source, context.section);
   const objectAliases = getPatchbayObjectAliasesForSection(context.source, context.section);
+
   const roles = data.channels?.[context.section];
 
   for (const channel of localChannels) {
@@ -1116,9 +1129,11 @@ function getPatchbayChannelCompletions(
   }
 
   const word = context.word.toLowerCase();
+
   const options = [...channels.values()].filter((option) =>
     option.label.toLowerCase().startsWith(word)
   );
+
   if (options.length === 0) return null;
 
   return {
@@ -1158,9 +1173,8 @@ function canCompleteChannelName(beforeWord: string, afterWord: string): boolean 
   return false;
 }
 
-function isObjectAliasCompletion(beforeWord: string): boolean {
-  return /^[^\s=]+\s*=\s*obj\s*$/.test(beforeWord.trim());
-}
+const isObjectAliasCompletion = (beforeWord: string): boolean =>
+  /^[^\s=]+\s*=\s*obj\s*$/.test(beforeWord.trim());
 
 function getEndpointCompletionRole(
   source: string,
@@ -1170,10 +1184,12 @@ function getEndpointCompletionRole(
 ): PatchbayEndpointCompletionRole {
   const hasArrowBefore =
     beforeWord.includes('->') || previousRouteLineWaitsForEndpoint(source, lineNumber);
+
   const hasArrowAfter = afterWord.trimStart().startsWith('->');
 
   if (hasArrowBefore && hasArrowAfter) return 'both';
   if (hasArrowBefore) return 'target';
+
   return 'source';
 }
 
@@ -1182,6 +1198,7 @@ function previousRouteLineWaitsForEndpoint(source: string, lineNumber: number): 
 
   for (let index = lineNumber - 2; index >= 0; index -= 1) {
     const text = lines[index]?.trim() ?? '';
+
     if (text === '' || text.startsWith('[') || text.startsWith('chan ')) return false;
     if (commentPrefixPattern.test(text)) continue;
 
@@ -1240,9 +1257,11 @@ function getPatchbaySectionCompletion(
   if (!match) return null;
 
   const typedText = match[2].toLowerCase();
+
   const options = sectionCompletionOptions.filter((option) =>
     option.label.toLowerCase().startsWith(typedText)
   );
+
   if (options.length === 0) return null;
 
   return {
@@ -1268,6 +1287,48 @@ function getPatchbayObjectKeywordCompletion(
     options: [objCompletionOption],
     validFor: /^obj?$/
   };
+}
+
+function getPatchbayVirtualAudioProcessorKeywordCompletion(
+  context: CompletionContext,
+  lineFrom: number,
+  linePrefix: string
+): CompletionResult | null {
+  const section = getSectionAtPosition(context.state.doc.toString(), context.pos);
+  if (section !== 'audio') return null;
+
+  const match = linePrefix.match(/(?:^|\s)([A-Za-z0-9_.~]*)$/);
+  if (!match) return null;
+
+  const typedText = match[1];
+  const typedStart = linePrefix.length - typedText.length;
+  const beforeTypedText = linePrefix.slice(0, typedStart);
+  const trimmedBefore = beforeTypedText.trimEnd();
+
+  if (!canStartVirtualAudioProcessorEndpoint(trimmedBefore)) return null;
+
+  const includeExpression = trimmedBefore.endsWith('=');
+
+  const options = virtualAudioProcessorCompletionOptions.filter((option) => {
+    if (option.label === 'expr~' && !includeExpression) return false;
+
+    return option.label.toLowerCase().startsWith(typedText.toLowerCase());
+  });
+
+  if (options.length === 0) return null;
+
+  return {
+    from: lineFrom + typedStart,
+    options,
+    validFor: /^[A-Za-z0-9_.~]*$/
+  };
+}
+
+function canStartVirtualAudioProcessorEndpoint(trimmedBefore: string): boolean {
+  if (trimmedBefore.endsWith('=')) return true;
+  if (trimmedBefore === '' || trimmedBefore.endsWith('->')) return true;
+
+  return false;
 }
 
 function canStartObjectEndpoint(linePrefix: string): boolean {

--- a/ui/src/lib/patchbay/codemirror/patchbay.codemirror.ts
+++ b/ui/src/lib/patchbay/codemirror/patchbay.codemirror.ts
@@ -122,6 +122,7 @@ type PatchbayEndpointCompletionRole = 'source' | 'target' | 'both' | 'any';
 
 const VIRTUAL_AUDIO_PROCESSOR_NODE_TYPES = [
   'expr~',
+  'osc~',
   'gain~',
   'lowpass~',
   'highpass~',
@@ -981,8 +982,8 @@ export function patchbaySectionCompletions(context: CompletionContext): Completi
   const sectionResult = getPatchbaySectionCompletion(line.from, linePrefix);
   if (sectionResult) return sectionResult;
 
-  return (
-    getPatchbayObjectKeywordCompletion(line.from, linePrefix) ??
+  return combineCompletionResults(
+    getPatchbayObjectKeywordCompletion(line.from, linePrefix),
     getPatchbayVirtualAudioProcessorKeywordCompletion(context, line.from, linePrefix)
   );
 }
@@ -1305,6 +1306,20 @@ function getPatchbayObjectKeywordCompletion(
     from: lineFrom + typedStart,
     options: [objCompletionOption],
     validFor: /^obj?$/
+  };
+}
+
+function combineCompletionResults(
+  first: CompletionResult | null,
+  second: CompletionResult | null
+): CompletionResult | null {
+  if (!first) return second;
+  if (!second) return first;
+
+  return {
+    from: Math.min(first.from, second.from),
+    options: [...first.options, ...second.options],
+    validFor: first.validFor
   };
 }
 

--- a/ui/src/lib/patchbay/codemirror/patchbay.codemirror.ts
+++ b/ui/src/lib/patchbay/codemirror/patchbay.codemirror.ts
@@ -82,6 +82,30 @@ export type PatchbayObjectAliasHintRange = {
   hoverText: string;
 };
 
+export type PatchbayVirtualExpressionNameRange = {
+  from: number;
+  to: number;
+  className: string;
+};
+
+export type PatchbayVirtualExpressionKeywordRange = {
+  from: number;
+  to: number;
+  className: string;
+};
+
+export type PatchbayVirtualExpressionAssignmentRange = {
+  from: number;
+  to: number;
+  className: string;
+};
+
+export type PatchbayVirtualExpressionOperatorRange = {
+  from: number;
+  to: number;
+  className: string;
+};
+
 export type PatchbayChannelRoles = {
   senders: Set<string>;
   receivers: Set<string>;
@@ -479,6 +503,112 @@ export function getPatchbayObjectIdRanges(source: string): PatchbayObjectIdRange
   return getPatchbayObjectReferenceTokenRanges(source, 'id', 'cm-patchbay-object-id');
 }
 
+export function getPatchbayVirtualExpressionNameRanges(
+  source: string
+): PatchbayVirtualExpressionNameRange[] {
+  const lineStarts = getLineStarts(source);
+  const aliases = getPatchbayVirtualExpressionAliases(source);
+  const ranges = getPatchbayVirtualExpressionDeclarationTokenRanges(
+    source,
+    0,
+    'cm-patchbay-virtual-expression-name'
+  );
+  const seenRanges = new Set(ranges.map((range) => `${range.from}:${range.to}`));
+  let currentSection: PatchbaySection | undefined;
+
+  source.split(/\r?\n/).forEach((line, lineIndex) => {
+    const lineTokens = tokenizePatchbayLine(line);
+    if (isVirtualExpressionDeclarationTokens(lineTokens)) return;
+
+    let searchStart = 0;
+
+    for (const token of lineTokens) {
+      const column = line.indexOf(token.text, searchStart);
+      if (column === -1) continue;
+
+      searchStart = column + token.text.length;
+
+      const section = parseSectionToken(token);
+      if (section) {
+        currentSection = section;
+        continue;
+      }
+
+      if (token.style !== 'variableName') continue;
+      if (!currentSection) continue;
+      if (!aliases.has(getChannelKey(currentSection, token.text))) continue;
+
+      const from = lineStarts[lineIndex] + column;
+      const rangeKey = `${from}:${from + token.text.length}`;
+      if (seenRanges.has(rangeKey)) continue;
+
+      seenRanges.add(rangeKey);
+      ranges.push({
+        from,
+        to: from + token.text.length,
+        className: 'cm-patchbay-virtual-expression-name'
+      });
+    }
+  });
+
+  return ranges;
+}
+
+export function getPatchbayVirtualExpressionKeywordRanges(
+  source: string
+): PatchbayVirtualExpressionKeywordRange[] {
+  return getPatchbayVirtualExpressionDeclarationTokenRanges(
+    source,
+    2,
+    'cm-patchbay-virtual-expression-keyword'
+  );
+}
+
+export function getPatchbayVirtualExpressionAssignmentRanges(
+  source: string
+): PatchbayVirtualExpressionAssignmentRange[] {
+  return getPatchbayVirtualExpressionDeclarationTokenRanges(
+    source,
+    1,
+    'cm-patchbay-object-assignment'
+  );
+}
+
+export function getPatchbayVirtualExpressionOperatorRanges(
+  source: string
+): PatchbayVirtualExpressionOperatorRange[] {
+  const lineStarts = getLineStarts(source);
+  const ranges: PatchbayVirtualExpressionOperatorRange[] = [];
+  let currentSection: PatchbaySection | undefined;
+
+  source.split(/\r?\n/).forEach((line, lineIndex) => {
+    const tokens = tokenizePatchbayLine(line);
+    const section = parseSectionToken(tokens[0]);
+    if (section) {
+      currentSection = section;
+      return;
+    }
+
+    if (currentSection !== 'audio') return;
+
+    const expressionSpan = getVirtualExpressionOperatorSearchSpan(line, tokens);
+    if (!expressionSpan) return;
+
+    for (let column = expressionSpan.from; column < expressionSpan.to; column += 1) {
+      if (!'+-*/'.includes(line[column])) continue;
+
+      const from = lineStarts[lineIndex] + column;
+      ranges.push({
+        from,
+        to: from + 1,
+        className: 'cm-patchbay-virtual-expression-operator'
+      });
+    }
+  });
+
+  return ranges;
+}
+
 function getPatchbayObjectReferenceTokenRanges(
   source: string,
   tokenKind: 'keyword' | 'id',
@@ -537,6 +667,38 @@ function isObjectAliasDeclarationTokens(tokens: PatchbayLineToken[]): boolean {
   );
 }
 
+function isVirtualExpressionDeclarationTokens(tokens: PatchbayLineToken[]): boolean {
+  return (
+    tokens[0]?.style === 'variableName' &&
+    tokens[1]?.text === '=' &&
+    tokens[1]?.style === 'operator' &&
+    tokens[2]?.text === 'expr~' &&
+    tokens[2]?.style === 'keyword'
+  );
+}
+
+function getVirtualExpressionOperatorSearchSpan(
+  line: string,
+  tokens: PatchbayLineToken[]
+): { from: number; to: number } | null {
+  if (isVirtualExpressionDeclarationTokens(tokens)) {
+    const exprIndex = line.indexOf('expr~');
+    return exprIndex === -1 ? null : { from: exprIndex + 'expr~'.length, to: line.length };
+  }
+
+  if (!line.includes('->')) return null;
+  if (tokens[0]?.style !== 'variableName') return null;
+  if (tokens[1]?.style !== 'operator' || tokens[1].text === '->' || tokens[1].text === '=') {
+    return null;
+  }
+
+  const arrowIndex = line.indexOf('->');
+  const sourceIndex = line.indexOf(tokens[0].text);
+  if (sourceIndex === -1 || arrowIndex === -1 || sourceIndex > arrowIndex) return null;
+
+  return { from: sourceIndex + tokens[0].text.length, to: arrowIndex };
+}
+
 function getPatchbayObjectAliasTokenRanges(
   source: string,
   tokenIndex: 0 | 1 | 2 | 3,
@@ -575,6 +737,66 @@ function getPatchbayObjectAliasTokenRanges(
   });
 
   return ranges;
+}
+
+function getPatchbayVirtualExpressionDeclarationTokenRanges(
+  source: string,
+  tokenIndex: 0 | 1 | 2,
+  className: string
+): Array<{ from: number; to: number; className: string }> {
+  const lineStarts = getLineStarts(source);
+  const ranges: Array<{ from: number; to: number; className: string }> = [];
+  let currentSection: PatchbaySection | undefined;
+
+  source.split(/\r?\n/).forEach((line, lineIndex) => {
+    const tokens = tokenizePatchbayLine(line);
+    const section = parseSectionToken(tokens[0]);
+    if (section) {
+      currentSection = section;
+      return;
+    }
+
+    if (currentSection !== 'audio' || !isVirtualExpressionDeclarationTokens(tokens)) {
+      return;
+    }
+
+    const previousToken = tokenIndex > 0 ? tokens[tokenIndex - 1] : undefined;
+    const token = tokens[tokenIndex];
+    const searchStart = previousToken
+      ? line.indexOf(previousToken.text) + previousToken.text.length
+      : 0;
+    const column = line.indexOf(token.text, searchStart);
+    if (column === -1) return;
+
+    const from = lineStarts[lineIndex] + column;
+    ranges.push({
+      from,
+      to: from + token.text.length,
+      className
+    });
+  });
+
+  return ranges;
+}
+
+function getPatchbayVirtualExpressionAliases(source: string): Set<string> {
+  const aliases = new Set<string>();
+  let currentSection: PatchbaySection | undefined;
+
+  for (const line of source.split(/\r?\n/)) {
+    const tokens = tokenizePatchbayLine(line);
+    const section = parseSectionToken(tokens[0]);
+    if (section) {
+      currentSection = section;
+      continue;
+    }
+
+    if (currentSection && isVirtualExpressionDeclarationTokens(tokens)) {
+      aliases.add(getChannelKey(currentSection, tokens[0].text));
+    }
+  }
+
+  return aliases;
 }
 
 function getPatchbayObjectAliases(source: string): Map<string, string> {
@@ -671,11 +893,12 @@ function readPatchbayTokenFromText(text: string): PatchbayLineToken | null {
   const section = text.match(sectionPattern);
   if (section) return { text: section[0], style: 'typeName' };
 
-  const keyword = text.match(/^(chan|obj)\b/);
+  const keyword = text.match(/^(?:chan|obj)\b|^expr~(?=\s|$)/);
   if (keyword) return { text: keyword[0], style: 'keyword' };
 
   if (text.startsWith('->')) return { text: '->', style: 'operator' };
   if (text.startsWith('=')) return { text: '=', style: 'operator' };
+  if (/^[+\-*/]/.test(text)) return { text: text[0], style: 'operator' };
 
   const identifier = text.match(identifierPattern);
   if (identifier) return { text: identifier[0], style: 'variableName' };

--- a/ui/src/lib/patchbay/codemirror/patchbay.codemirror.ts
+++ b/ui/src/lib/patchbay/codemirror/patchbay.codemirror.ts
@@ -134,6 +134,20 @@ const objCompletionOption: Completion = {
   type: 'keyword',
   detail: 'object endpoint'
 };
+const virtualAudioProcessorKeywords = new Set([
+  'expr~',
+  'gain~',
+  'lowpass~',
+  'highpass~',
+  'bandpass~',
+  'notch~',
+  'allpass~',
+  'lowshelf~',
+  'highshelf~',
+  'peaking~',
+  'compressor~',
+  'delay~'
+]);
 
 export function tokenizePatchbayLine(line: string): PatchbayLineToken[] {
   const tokens: PatchbayLineToken[] = [];
@@ -672,7 +686,7 @@ function isVirtualExpressionDeclarationTokens(tokens: PatchbayLineToken[]): bool
     tokens[0]?.style === 'variableName' &&
     tokens[1]?.text === '=' &&
     tokens[1]?.style === 'operator' &&
-    tokens[2]?.text === 'expr~' &&
+    virtualAudioProcessorKeywords.has(tokens[2]?.text ?? '') &&
     tokens[2]?.style === 'keyword'
   );
 }
@@ -893,8 +907,13 @@ function readPatchbayTokenFromText(text: string): PatchbayLineToken | null {
   const section = text.match(sectionPattern);
   if (section) return { text: section[0], style: 'typeName' };
 
-  const keyword = text.match(/^(?:chan|obj)\b|^expr~(?=\s|$)/);
-  if (keyword) return { text: keyword[0], style: 'keyword' };
+  const keyword = text.match(/^(?:chan|obj)\b|^[A-Za-z0-9_.~/:-]+(?=\s|$)/);
+  if (keyword && virtualAudioProcessorKeywords.has(keyword[0])) {
+    return { text: keyword[0], style: 'keyword' };
+  }
+  if (keyword && /^(?:chan|obj)$/.test(keyword[0])) {
+    return { text: keyword[0], style: 'keyword' };
+  }
 
   if (text.startsWith('->')) return { text: '->', style: 'operator' };
   if (text.startsWith('=')) return { text: '=', style: 'operator' };

--- a/ui/src/lib/patchbay/patchbay-audio-runtime.ts
+++ b/ui/src/lib/patchbay/patchbay-audio-runtime.ts
@@ -3,11 +3,11 @@ import type { Edge } from '@xyflow/svelte';
 export type PatchbayAudioRuntime = {
   registerEdge(routeId: string, edge: Edge): void;
   unregisterEdge(routeId: string): void;
-  registerVirtualExpression?(
+  registerVirtualAudioNode?(
     routeId: string,
-    expression: { nodeId: string; expression: string }
+    node: { nodeId: string; type: string; params: unknown[] }
   ): void;
-  unregisterVirtualExpression?(routeId: string): void;
+  unregisterVirtualAudioNode?(routeId: string): void;
 };
 
 const getService = () =>
@@ -20,11 +20,11 @@ const audioServiceRuntime: PatchbayAudioRuntime = {
   unregisterEdge(routeId) {
     getService().then((audio) => audio.unregisterPatchbayAudioEdge(routeId));
   },
-  registerVirtualExpression(routeId, expression) {
-    getService().then((audio) => audio.registerPatchbayVirtualExpression(routeId, expression));
+  registerVirtualAudioNode(routeId, node) {
+    getService().then((audio) => audio.registerPatchbayVirtualAudioNode(routeId, node));
   },
-  unregisterVirtualExpression(routeId) {
-    getService().then((audio) => audio.unregisterPatchbayVirtualExpression(routeId));
+  unregisterVirtualAudioNode(routeId) {
+    getService().then((audio) => audio.unregisterPatchbayVirtualAudioNode(routeId));
   }
 };
 

--- a/ui/src/lib/patchbay/patchbay-audio-runtime.ts
+++ b/ui/src/lib/patchbay/patchbay-audio-runtime.ts
@@ -3,6 +3,11 @@ import type { Edge } from '@xyflow/svelte';
 export type PatchbayAudioRuntime = {
   registerEdge(routeId: string, edge: Edge): void;
   unregisterEdge(routeId: string): void;
+  registerVirtualExpression?(
+    routeId: string,
+    expression: { nodeId: string; expression: string }
+  ): void;
+  unregisterVirtualExpression?(routeId: string): void;
 };
 
 const getService = () =>
@@ -14,6 +19,12 @@ const audioServiceRuntime: PatchbayAudioRuntime = {
   },
   unregisterEdge(routeId) {
     getService().then((audio) => audio.unregisterPatchbayAudioEdge(routeId));
+  },
+  registerVirtualExpression(routeId, expression) {
+    getService().then((audio) => audio.registerPatchbayVirtualExpression(routeId, expression));
+  },
+  unregisterVirtualExpression(routeId) {
+    getService().then((audio) => audio.unregisterPatchbayVirtualExpression(routeId));
   }
 };
 

--- a/ui/src/lib/patchbay/patchbay-parser.test.ts
+++ b/ui/src/lib/patchbay/patchbay-parser.test.ts
@@ -375,6 +375,72 @@ describe('analyzePatchbay', () => {
     ]);
   });
 
+  it('resolves whitelisted audio source aliases as virtual audio nodes', () => {
+    const result = analyzePatchbay(
+      `
+      [Audio]
+      Osc = osc~ 440 sine 0
+      Osc -> Out
+      `,
+      {
+        audioTargets: new Set(['Out'])
+      }
+    );
+
+    expect(result.diagnostics).toEqual([]);
+
+    expect(result.virtualAudioExpressions).toEqual([
+      expect.objectContaining({
+        name: 'Osc',
+        type: 'osc~',
+        rawArgs: ['440', 'sine', '0'],
+        params: [440, 'sine', 0],
+        anonymous: false,
+        line: 3
+      })
+    ]);
+
+    expect(result.audioRoutes).toEqual([
+      expect.objectContaining({
+        from: 'Osc',
+        to: 'Out',
+        fromVirtualExpression: expect.objectContaining({ name: 'Osc', type: 'osc~' })
+      })
+    ]);
+  });
+
+  it('resolves inline whitelisted audio source route segments as anonymous virtual audio nodes', () => {
+    const result = analyzePatchbay(
+      `
+      [Audio]
+      osc~ 440 sine 0 -> Out
+      `,
+      {
+        audioTargets: new Set(['Out'])
+      }
+    );
+
+    expect(result.diagnostics).toEqual([]);
+
+    expect(result.virtualAudioExpressions).toEqual([
+      expect.objectContaining({
+        type: 'osc~',
+        rawArgs: ['440', 'sine', '0'],
+        params: [440, 'sine', 0],
+        anonymous: true,
+        line: 3
+      })
+    ]);
+
+    expect(result.audioRoutes).toEqual([
+      expect.objectContaining({
+        from: expect.stringContaining('osc~'),
+        to: 'Out',
+        fromVirtualExpression: expect.objectContaining({ type: 'osc~', anonymous: true })
+      })
+    ]);
+  });
+
   it('rejects unsupported audio nodes as virtual processors', () => {
     const result = analyzePatchbay(
       `

--- a/ui/src/lib/patchbay/patchbay-parser.test.ts
+++ b/ui/src/lib/patchbay/patchbay-parser.test.ts
@@ -245,6 +245,129 @@ describe('analyzePatchbay', () => {
     ]);
   });
 
+  it('resolves whitelisted audio effect aliases as virtual audio nodes', () => {
+    const result = analyzePatchbay(
+      `
+      [Audio]
+      Filter = lowpass~ 1000 1
+      Mic -> Filter -> Out
+      `,
+      {
+        audioSources: new Set(['Mic']),
+        audioTargets: new Set(['Out'])
+      }
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.virtualAudioExpressions).toEqual([
+      expect.objectContaining({
+        name: 'Filter',
+        type: 'lowpass~',
+        rawArgs: ['1000', '1'],
+        params: [null, 1000, 1],
+        anonymous: false,
+        line: 3
+      })
+    ]);
+    expect(result.audioRoutes).toEqual([
+      expect.objectContaining({
+        from: 'Mic',
+        to: 'Filter',
+        toVirtualExpression: expect.objectContaining({ name: 'Filter', type: 'lowpass~' })
+      }),
+      expect.objectContaining({
+        from: 'Filter',
+        to: 'Out',
+        fromVirtualExpression: expect.objectContaining({ name: 'Filter', type: 'lowpass~' })
+      })
+    ]);
+  });
+
+  it('resolves inline whitelisted audio effect route segments as anonymous virtual audio nodes', () => {
+    const result = analyzePatchbay(
+      `
+      [Audio]
+      Mic -> gain~ 0.5 -> Out
+      `,
+      {
+        audioSources: new Set(['Mic']),
+        audioTargets: new Set(['Out'])
+      }
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.virtualAudioExpressions).toEqual([
+      expect.objectContaining({
+        type: 'gain~',
+        rawArgs: ['0.5'],
+        params: [null, 0.5],
+        anonymous: true,
+        line: 3
+      })
+    ]);
+    expect(result.audioRoutes).toEqual([
+      expect.objectContaining({
+        from: 'Mic',
+        to: expect.stringContaining('gain~'),
+        toVirtualExpression: expect.objectContaining({ type: 'gain~', anonymous: true })
+      }),
+      expect.objectContaining({
+        from: expect.stringContaining('gain~'),
+        to: 'Out',
+        fromVirtualExpression: expect.objectContaining({ type: 'gain~', anonymous: true })
+      })
+    ]);
+  });
+
+  it('rejects unsupported audio nodes as virtual processors', () => {
+    const result = analyzePatchbay(
+      `
+      [Audio]
+      Space = convolver~ impulse.wav
+      Mic -> Space -> Out
+      `,
+      {
+        audioSources: new Set(['Mic']),
+        audioTargets: new Set(['Out'])
+      }
+    );
+
+    expect(result.audioRoutes).toEqual([]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'unsupported-virtual-audio-node',
+        section: 'audio',
+        name: 'Space',
+        line: 3
+      })
+    );
+  });
+
+  it('rejects unsupported inline audio nodes as virtual processors', () => {
+    const result = analyzePatchbay(
+      `
+      [Audio]
+      Mic -> convolver~ impulse.wav -> Out
+      `,
+      {
+        audioSources: new Set(['Mic']),
+        audioTargets: new Set(['Out'])
+      }
+    );
+
+    expect(result.audioRoutes).toEqual([]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        code: 'unsupported-virtual-audio-node',
+        section: 'audio',
+        name: 'convolver~',
+        line: 3
+      })
+    );
+  });
+
   it('reports invalid audio virtual expressions before applying routes', () => {
     const result = analyzePatchbay(
       `

--- a/ui/src/lib/patchbay/patchbay-parser.test.ts
+++ b/ui/src/lib/patchbay/patchbay-parser.test.ts
@@ -169,6 +169,107 @@ describe('analyzePatchbay', () => {
     ]);
   });
 
+  it('normalizes audio shorthand into an anonymous virtual expression', () => {
+    const result = analyzePatchbay(
+      `
+      [Audio]
+      Mic * 0.5 -> Out
+      `,
+      {
+        audioSources: new Set(['Mic']),
+        audioTargets: new Set(['Out'])
+      }
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.virtualAudioExpressions).toEqual([
+      expect.objectContaining({
+        expression: 's * 0.5',
+        anonymous: true,
+        line: 3
+      })
+    ]);
+    expect(result.audioRoutes).toEqual([
+      {
+        from: 'Mic',
+        to: expect.stringContaining('expr~'),
+        toVirtualExpression: expect.objectContaining({
+          expression: 's * 0.5',
+          anonymous: true
+        })
+      },
+      {
+        from: expect.stringContaining('expr~'),
+        to: 'Out',
+        fromVirtualExpression: expect.objectContaining({
+          expression: 's * 0.5',
+          anonymous: true
+        })
+      }
+    ]);
+  });
+
+  it('resolves explicit audio virtual expression aliases before channels', () => {
+    const result = analyzePatchbay(
+      `
+      [Audio]
+      Gain = expr~ s * 0.5
+      Mic -> Gain -> Out
+      `,
+      {
+        audioSources: new Set(['Mic']),
+        audioTargets: new Set(['Out'])
+      }
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.virtualAudioExpressions).toEqual([
+      expect.objectContaining({
+        name: 'Gain',
+        expression: 's * 0.5',
+        anonymous: false,
+        line: 3
+      })
+    ]);
+    expect(result.audioRoutes).toEqual([
+      expect.objectContaining({
+        from: 'Mic',
+        to: 'Gain',
+        toVirtualExpression: expect.objectContaining({ name: 'Gain' })
+      }),
+      expect.objectContaining({
+        from: 'Gain',
+        to: 'Out',
+        fromVirtualExpression: expect.objectContaining({ name: 'Gain' })
+      })
+    ]);
+  });
+
+  it('reports invalid audio virtual expressions before applying routes', () => {
+    const result = analyzePatchbay(
+      `
+      [Audio]
+      Gain = expr~ s *
+      Mic -> Gain -> Out
+      `,
+      {
+        audioSources: new Set(['Mic']),
+        audioTargets: new Set(['Out'])
+      }
+    );
+
+    expect(result.audioRoutes).toEqual([]);
+    expect(result.diagnostics).toMatchObject([
+      {
+        severity: 'error',
+        code: 'invalid-virtual-expression',
+        section: 'audio',
+        name: 'Gain',
+        line: 3
+      }
+    ]);
+  });
+
   it('rejects audio receiver-only channels as route sources', () => {
     const result = analyzePatchbay(
       `

--- a/ui/src/lib/patchbay/patchbay-parser.test.ts
+++ b/ui/src/lib/patchbay/patchbay-parser.test.ts
@@ -14,6 +14,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.messageRoutes).toEqual([
       { from: 'A', to: 'B' },
       { from: 'B', to: 'C' }
@@ -54,6 +55,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.messageRoutes).toEqual([]);
+
     expect(result.diagnostics).toMatchObject([
       {
         severity: 'error',
@@ -76,6 +78,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.messageRoutes).toEqual([]);
+
     expect(result.diagnostics).toMatchObject([
       {
         severity: 'error',
@@ -98,6 +101,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.messageRoutes).toEqual([]);
+
     expect(result.diagnostics).toMatchObject([
       {
         severity: 'error',
@@ -163,6 +167,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.audioRoutes).toEqual([
       { from: 'Mic', to: 'Bus' },
       { from: 'Bus', to: 'Out' }
@@ -182,6 +187,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.virtualAudioExpressions).toEqual([
       expect.objectContaining({
         expression: 's * 0.5',
@@ -189,6 +195,7 @@ describe('analyzePatchbay', () => {
         line: 3
       })
     ]);
+
     expect(result.audioRoutes).toEqual([
       {
         from: 'Mic',
@@ -223,6 +230,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.virtualAudioExpressions).toEqual([
       expect.objectContaining({
         name: 'Gain',
@@ -231,12 +239,14 @@ describe('analyzePatchbay', () => {
         line: 3
       })
     ]);
+
     expect(result.audioRoutes).toEqual([
       expect.objectContaining({
         from: 'Mic',
         to: 'Gain',
         toVirtualExpression: expect.objectContaining({ name: 'Gain' })
       }),
+
       expect.objectContaining({
         from: 'Gain',
         to: 'Out',
@@ -259,6 +269,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.virtualAudioExpressions).toEqual([
       expect.objectContaining({
         name: 'Filter',
@@ -269,12 +280,14 @@ describe('analyzePatchbay', () => {
         line: 3
       })
     ]);
+
     expect(result.audioRoutes).toEqual([
       expect.objectContaining({
         from: 'Mic',
         to: 'Filter',
         toVirtualExpression: expect.objectContaining({ name: 'Filter', type: 'lowpass~' })
       }),
+
       expect.objectContaining({
         from: 'Filter',
         to: 'Out',
@@ -296,6 +309,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.virtualAudioExpressions).toEqual([
       expect.objectContaining({
         type: 'gain~',
@@ -305,16 +319,58 @@ describe('analyzePatchbay', () => {
         line: 3
       })
     ]);
+
     expect(result.audioRoutes).toEqual([
       expect.objectContaining({
         from: 'Mic',
         to: expect.stringContaining('gain~'),
         toVirtualExpression: expect.objectContaining({ type: 'gain~', anonymous: true })
       }),
+
       expect.objectContaining({
         from: expect.stringContaining('gain~'),
         to: 'Out',
         fromVirtualExpression: expect.objectContaining({ type: 'gain~', anonymous: true })
+      })
+    ]);
+  });
+
+  it('resolves inline expr route segments as anonymous virtual audio nodes', () => {
+    const result = analyzePatchbay(
+      `
+      [Audio]
+      Osc -> expr~ s * 0.2 -> Out
+      `,
+      {
+        audioSources: new Set(['Osc']),
+        audioTargets: new Set(['Out'])
+      }
+    );
+
+    expect(result.diagnostics).toEqual([]);
+
+    expect(result.virtualAudioExpressions).toEqual([
+      expect.objectContaining({
+        type: 'expr~',
+        rawArgs: ['s', '*', '0.2'],
+        params: [null, 's * 0.2'],
+        expression: 's * 0.2',
+        anonymous: true,
+        line: 3
+      })
+    ]);
+
+    expect(result.audioRoutes).toEqual([
+      expect.objectContaining({
+        from: 'Osc',
+        to: expect.stringContaining('expr~'),
+        toVirtualExpression: expect.objectContaining({ type: 'expr~', anonymous: true })
+      }),
+
+      expect.objectContaining({
+        from: expect.stringContaining('expr~'),
+        to: 'Out',
+        fromVirtualExpression: expect.objectContaining({ type: 'expr~', anonymous: true })
       })
     ]);
   });
@@ -333,6 +389,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.audioRoutes).toEqual([]);
+
     expect(result.diagnostics).toContainEqual(
       expect.objectContaining({
         severity: 'error',
@@ -357,6 +414,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.audioRoutes).toEqual([]);
+
     expect(result.diagnostics).toContainEqual(
       expect.objectContaining({
         severity: 'error',
@@ -382,6 +440,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.audioRoutes).toEqual([]);
+
     expect(result.diagnostics).toMatchObject([
       {
         severity: 'error',
@@ -406,6 +465,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.audioRoutes).toEqual([]);
+
     expect(result.diagnostics).toMatchObject([
       {
         severity: 'error',
@@ -430,6 +490,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.audioRoutes).toEqual([]);
+
     expect(result.diagnostics).toMatchObject([
       {
         severity: 'error',
@@ -454,6 +515,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.videoRoutes).toEqual([
       { from: 'Camera', to: 'Mix' },
       { from: 'Mix', to: 'Screen' }
@@ -473,6 +535,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.videoRoutes).toEqual([]);
+
     expect(result.diagnostics).toMatchObject([
       {
         severity: 'error',
@@ -497,6 +560,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.videoRoutes).toEqual([]);
+
     expect(result.diagnostics).toMatchObject([
       {
         severity: 'error',
@@ -543,6 +607,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.videoRoutes).toEqual([
       {
         from: 'Camera',
@@ -555,6 +620,7 @@ describe('analyzePatchbay', () => {
         }
       }
     ]);
+
     expect(result.messageRoutes).toEqual([
       {
         from: 'obj slider-1',
@@ -591,6 +657,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.audioRoutes).toEqual([]);
+
     expect(result.diagnostics).toMatchObject([
       {
         severity: 'error',
@@ -632,6 +699,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.videoRoutes).toEqual([
       {
         from: 'Src',
@@ -681,6 +749,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.messageRoutes).toEqual([
       {
         from: 'Src',
@@ -767,6 +836,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.videoRoutes).toEqual([
       {
         from: 'Src',
@@ -817,6 +887,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.messageRoutes).toEqual([
       {
         from: 'Src',
@@ -854,6 +925,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.messageRoutes).toEqual([]);
+
     expect(result.diagnostics).toMatchObject([
       {
         severity: 'error',
@@ -891,6 +963,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.videoRoutes).toEqual([
       {
         from: 'Src',
@@ -970,6 +1043,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.diagnostics).toEqual([]);
+
     expect(result.videoRoutes).toEqual([
       {
         from: 'Src',
@@ -999,6 +1073,7 @@ describe('analyzePatchbay', () => {
     );
 
     expect(result.messageRoutes).toEqual([]);
+
     expect(result.diagnostics).toMatchObject([
       {
         severity: 'error',

--- a/ui/src/lib/patchbay/patchbay-parser.ts
+++ b/ui/src/lib/patchbay/patchbay-parser.ts
@@ -388,6 +388,7 @@ function parseVirtualAudioProcessorDeclaration(
 
   if (type === 'expr~') {
     const validationError = validateVirtualAudioExpression(expression);
+
     if (validationError) {
       diagnostics.push(
         createDiagnostic('error', 'invalid-virtual-expression', line, validationError, {
@@ -567,7 +568,20 @@ function parseVirtualAudioProcessorEndpoint(
   const rawArgs = splitVirtualAudioProcessorArgs(match[2] ?? '');
   const expression = type === 'expr~' ? rawArgs.join(' ').trim() : '';
 
-  if (type === 'expr~') return null;
+  if (type === 'expr~') {
+    if (expression.length === 0) return null;
+
+    const validationError = validateVirtualAudioExpression(expression);
+
+    if (validationError) {
+      diagnostics.push(
+        createDiagnostic('error', 'invalid-virtual-expression', line, validationError, {
+          section,
+          name: rawEndpoint
+        })
+      );
+    }
+  }
 
   const id = `${patchbayIdSeed}:audio-virtual:inline:${hash({
     line,
@@ -620,6 +634,7 @@ function parseAudioShorthandEndpoint(
 
   const expression = `s ${expressionTail}`;
   const validationError = validateVirtualAudioExpression(expression);
+
   if (validationError) {
     diagnostics.push(
       createDiagnostic('error', 'invalid-virtual-expression', line, validationError, {

--- a/ui/src/lib/patchbay/patchbay-parser.ts
+++ b/ui/src/lib/patchbay/patchbay-parser.ts
@@ -1,3 +1,7 @@
+import { hash } from 'ohash';
+import { Parser } from 'expr-eval';
+import { parseMultiOutletExpressions } from '$lib/utils/expr-parser';
+
 export type PatchbaySection = 'message' | 'audio' | 'video';
 
 export type PatchbayRoute = {
@@ -5,6 +9,8 @@ export type PatchbayRoute = {
   to: string;
   fromEndpoint?: PatchbayResolvedObjectEndpoint;
   toEndpoint?: PatchbayResolvedObjectEndpoint;
+  fromVirtualExpression?: PatchbayVirtualAudioExpression;
+  toVirtualExpression?: PatchbayVirtualAudioExpression;
 };
 
 export type PatchbayDiagnosticSeverity = 'error' | 'warning';
@@ -24,7 +30,8 @@ export type PatchbayDiagnosticCode =
   | 'duplicate-alias'
   | 'unknown-object'
   | 'object-port-unavailable'
-  | 'object-port-out-of-range';
+  | 'object-port-out-of-range'
+  | 'invalid-virtual-expression';
 
 export type PatchbayDiagnostic = {
   severity: PatchbayDiagnosticSeverity;
@@ -62,6 +69,22 @@ export type PatchbayObjectEndpointRef = {
   line: number;
 };
 
+export type PatchbayVirtualAudioExpression = {
+  id: string;
+  name?: string;
+  expression: string;
+  raw: string;
+  line: number;
+  anonymous: boolean;
+};
+
+export type PatchbayVirtualAudioExpressionEndpointRef = {
+  kind: 'virtual-audio-expression';
+  expression: PatchbayVirtualAudioExpression;
+  raw: string;
+  line: number;
+};
+
 export type PatchbayChannelEndpointRef = {
   kind: 'channel';
   name: string;
@@ -69,7 +92,10 @@ export type PatchbayChannelEndpointRef = {
   line: number;
 };
 
-export type PatchbayEndpointRef = PatchbayChannelEndpointRef | PatchbayObjectEndpointRef;
+export type PatchbayEndpointRef =
+  | PatchbayChannelEndpointRef
+  | PatchbayObjectEndpointRef
+  | PatchbayVirtualAudioExpressionEndpointRef;
 
 export type PatchbayResolvedObjectEndpoint = {
   kind: 'object';
@@ -83,6 +109,7 @@ export type PatchbayAnalysis = {
   messageRoutes: PatchbayRoute[];
   audioRoutes: PatchbayRoute[];
   videoRoutes: PatchbayRoute[];
+  virtualAudioExpressions: PatchbayVirtualAudioExpression[];
   channels: Record<PatchbaySection, Set<string>>;
 };
 
@@ -90,6 +117,8 @@ type SectionState = {
   declarations: Map<string, number>;
   declarationUseCount: Map<string, number>;
   aliases: Map<string, PatchbayObjectEndpointRef>;
+  virtualAudioExpressions: Map<string, PatchbayVirtualAudioExpression>;
+  anonymousVirtualAudioExpressions: PatchbayVirtualAudioExpression[];
   routes: Array<{ line: number; endpoints: PatchbayEndpointRef[] }>;
 };
 
@@ -114,11 +143,25 @@ const SECTION_NAMES: Record<string, PatchbaySection> = {
 
 const IDENTIFIER_PATTERN = /^[A-Za-z0-9_.~/:-]+$/;
 const OBJECT_ID_PATTERN = /^[A-Za-z0-9_.~/-]+$/;
+const AUDIO_EXPRESSION_PARAMETER_NAMES = [
+  ...Array.from({ length: 9 }, (_, index) => `s${index + 1}`),
+  's',
+  'i',
+  't',
+  'channel',
+  'bufferSize',
+  'samples',
+  'input',
+  'inputs',
+  ...Array.from({ length: 9 }, (_, index) => `x${index + 1}`)
+];
 
 const createSectionState = (): SectionState => ({
   declarations: new Map(),
   declarationUseCount: new Map(),
   aliases: new Map(),
+  virtualAudioExpressions: new Map(),
+  anonymousVirtualAudioExpressions: [],
   routes: []
 });
 
@@ -213,6 +256,81 @@ function parseAliasDeclaration(
   return { name, endpoint };
 }
 
+function parseVirtualAudioExpressionDeclaration(
+  raw: string,
+  line: number,
+  section: PatchbaySection,
+  patchbayIdSeed: string,
+  diagnostics: PatchbayDiagnostic[]
+): { name: string; expression: PatchbayVirtualAudioExpression } | null {
+  const match = raw.match(/^([^=\s]+)\s*=\s*expr~\s+(.+)$/);
+  if (!match) return null;
+
+  const name = match[1].trim();
+  const expression = match[2].trim();
+
+  if (section !== 'audio') {
+    diagnostics.push(
+      createDiagnostic(
+        'error',
+        'invalid-virtual-expression',
+        line,
+        '`expr~` declarations are only supported in [Audio].',
+        { section, name }
+      )
+    );
+
+    return null;
+  }
+
+  if (!IDENTIFIER_PATTERN.test(name)) {
+    diagnostics.push(
+      createDiagnostic('error', 'invalid-identifier', line, `Invalid alias name "${name}".`, {
+        section,
+        name
+      })
+    );
+
+    return null;
+  }
+
+  if (expression.length === 0) {
+    diagnostics.push(
+      createDiagnostic(
+        'error',
+        'invalid-virtual-expression',
+        line,
+        `Virtual expression "${name}" needs an expr~ body.`,
+        { section, name }
+      )
+    );
+
+    return null;
+  }
+
+  const validationError = validateVirtualAudioExpression(expression);
+  if (validationError) {
+    diagnostics.push(
+      createDiagnostic('error', 'invalid-virtual-expression', line, validationError, {
+        section,
+        name
+      })
+    );
+  }
+
+  return {
+    name,
+    expression: {
+      id: `${patchbayIdSeed}:audio-expr:${name}`,
+      name,
+      expression,
+      raw: name,
+      line,
+      anonymous: false
+    }
+  };
+}
+
 function splitRouteContinuation(raw: string): string[] | null {
   if (!raw.startsWith('->')) return null;
 
@@ -229,11 +347,29 @@ function parseEndpointParts(
   parts: string[],
   line: number,
   section: PatchbaySection,
+  state: SectionState,
+  patchbayIdSeed: string,
   diagnostics: PatchbayDiagnostic[]
 ): PatchbayEndpointRef[] | null {
   const endpoints: PatchbayEndpointRef[] = [];
 
-  for (const rawEndpoint of parts) {
+  for (let index = 0; index < parts.length; index += 1) {
+    const rawEndpoint = parts[index];
+    const shorthandEndpoints = parseAudioShorthandEndpoint(
+      rawEndpoint,
+      line,
+      section,
+      index,
+      state,
+      patchbayIdSeed,
+      diagnostics
+    );
+
+    if (shorthandEndpoints) {
+      endpoints.push(...shorthandEndpoints);
+      continue;
+    }
+
     const endpoint = parseEndpoint(rawEndpoint, line);
 
     if (!endpoint || (endpoint.kind === 'channel' && !IDENTIFIER_PATTERN.test(endpoint.name))) {
@@ -254,6 +390,103 @@ function parseEndpointParts(
   }
 
   return endpoints;
+}
+
+function parseAudioShorthandEndpoint(
+  rawEndpoint: string,
+  line: number,
+  section: PatchbaySection,
+  routePartIndex: number,
+  state: SectionState,
+  patchbayIdSeed: string,
+  diagnostics: PatchbayDiagnostic[]
+): PatchbayEndpointRef[] | null {
+  if (section !== 'audio') return null;
+  if (!/\s/.test(rawEndpoint)) return null;
+  if (rawEndpoint.startsWith('obj ')) return null;
+  if (rawEndpoint.startsWith('expr~ ')) return null;
+
+  const match = rawEndpoint.match(/^([A-Za-z0-9_.~/:-]+)\s+(.+)$/);
+  if (!match) return null;
+
+  const source = match[1].trim();
+  const expressionTail = match[2].trim();
+  if (!IDENTIFIER_PATTERN.test(source) || expressionTail.length === 0) return null;
+
+  const expression = `s ${expressionTail}`;
+  const validationError = validateVirtualAudioExpression(expression);
+  if (validationError) {
+    diagnostics.push(
+      createDiagnostic('error', 'invalid-virtual-expression', line, validationError, {
+        section,
+        name: rawEndpoint
+      })
+    );
+  }
+
+  const id = `${patchbayIdSeed}:audio-expr:inline:${hash({
+    line,
+    routePartIndex,
+    source
+  })}`;
+
+  const virtualExpression: PatchbayVirtualAudioExpression = {
+    id,
+    expression,
+    raw: `expr~ ${expression}`,
+    line,
+    anonymous: true
+  };
+
+  state.anonymousVirtualAudioExpressions.push(virtualExpression);
+
+  return [
+    { kind: 'channel', name: source, raw: source, line },
+    {
+      kind: 'virtual-audio-expression',
+      expression: virtualExpression,
+      raw: virtualExpression.raw,
+      line
+    }
+  ];
+}
+
+function validateVirtualAudioExpression(expression: string): string | null {
+  const parsed = parseMultiOutletExpressions(expression);
+
+  if (parsed.outletExpressions.length > 1) {
+    return 'Virtual expr~ expressions in patchbay can only produce one outlet.';
+  }
+
+  try {
+    const parser = new Parser({
+      operators: {
+        add: true,
+        concatenate: true,
+        conditional: true,
+        divide: true,
+        factorial: true,
+        multiply: true,
+        power: true,
+        remainder: true,
+        subtract: true,
+        logical: true,
+        comparison: true,
+        in: true,
+        assignment: true
+      }
+    });
+
+    const renamedExpression = expression.replace(/\n/g, ';').replace(/\$(\d+)/g, 'x$1');
+    const parsedExpression = parser.parse(renamedExpression);
+    parsedExpression.toJSFunction(AUDIO_EXPRESSION_PARAMETER_NAMES.join(','));
+
+    return null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    return `Invalid expr~ expression: ${message}`;
+  }
 }
 
 function hasCycle(routes: PatchbayRoute[]): boolean {
@@ -302,11 +535,16 @@ function analyzeSection(
   const routes: PatchbayRoute[] = [];
   const routeKeys = new Set<string>();
 
-  let hasErrors = false;
+  let hasErrors = diagnostics.some(
+    (diagnostic) => diagnostic.severity === 'error' && diagnostic.section === section
+  );
 
   for (const route of state.routes) {
     for (const endpoint of route.endpoints) {
       const objectEndpoint = getObjectEndpointRef(endpoint, state);
+      const virtualExpressionEndpoint = getVirtualExpressionEndpointRef(endpoint, state);
+
+      if (virtualExpressionEndpoint) continue;
 
       if (objectEndpoint) {
         if (!objects?.has(objectEndpoint.nodeId)) {
@@ -355,6 +593,8 @@ function analyzeSection(
 
       const fromObjectRef = getObjectEndpointRef(fromEndpointRef, state);
       const toObjectRef = getObjectEndpointRef(toEndpointRef, state);
+      const fromVirtualExpression = getVirtualExpressionEndpointRef(fromEndpointRef, state);
+      const toVirtualExpression = getVirtualExpressionEndpointRef(toEndpointRef, state);
 
       const from = fromEndpointRef.raw;
       const to = toEndpointRef.raw;
@@ -379,6 +619,7 @@ function analyzeSection(
         roles &&
         fromEndpointRef.kind === 'channel' &&
         !state.aliases.has(fromEndpointRef.name) &&
+        !state.virtualAudioExpressions.has(fromEndpointRef.name) &&
         !state.declarations.has(fromEndpointRef.name) &&
         knownChannels.has(fromEndpointRef.name) &&
         !roles.sources.has(fromEndpointRef.name)
@@ -400,6 +641,7 @@ function analyzeSection(
         roles &&
         toEndpointRef.kind === 'channel' &&
         !state.aliases.has(toEndpointRef.name) &&
+        !state.virtualAudioExpressions.has(toEndpointRef.name) &&
         !state.declarations.has(toEndpointRef.name) &&
         knownChannels.has(toEndpointRef.name) &&
         !roles.targets.has(toEndpointRef.name)
@@ -440,7 +682,14 @@ function analyzeSection(
       }
 
       routeKeys.add(key);
-      routes.push({ from, to, fromEndpoint, toEndpoint });
+      routes.push({
+        from,
+        to,
+        fromEndpoint,
+        toEndpoint,
+        fromVirtualExpression,
+        toVirtualExpression
+      });
     }
   }
 
@@ -553,13 +802,25 @@ function getObjectEndpointRef(
   state: SectionState
 ): PatchbayObjectEndpointRef | undefined {
   if (endpoint.kind === 'object') return endpoint;
+  if (endpoint.kind !== 'channel') return undefined;
 
   return state.aliases.get(endpoint.name);
 }
 
+function getVirtualExpressionEndpointRef(
+  endpoint: PatchbayEndpointRef,
+  state: SectionState
+): PatchbayVirtualAudioExpression | undefined {
+  if (endpoint.kind === 'virtual-audio-expression') return endpoint.expression;
+  if (endpoint.kind !== 'channel') return undefined;
+
+  return state.virtualAudioExpressions.get(endpoint.name);
+}
+
 export function analyzePatchbay(
   source: string,
-  knownChannels: PatchbayKnownChannels = {}
+  knownChannels: PatchbayKnownChannels = {},
+  patchbayIdSeed = 'patchbay'
 ): PatchbayAnalysis {
   const diagnostics: PatchbayDiagnostic[] = [];
 
@@ -671,7 +932,11 @@ export function analyzePatchbay(
 
       const state = states[currentSection];
 
-      if (state.declarations.has(name) || state.aliases.has(name)) {
+      if (
+        state.declarations.has(name) ||
+        state.aliases.has(name) ||
+        state.virtualAudioExpressions.has(name)
+      ) {
         const duplicateChannelError = createDiagnostic(
           'error',
           'duplicate-channel',
@@ -694,6 +959,45 @@ export function analyzePatchbay(
     if (/^[^=\s]+\s*=/.test(text)) {
       flushPendingRoute();
 
+      if (/^[^=\s]+\s*=\s*expr~(?:\s|$)/.test(text)) {
+        const virtualExpressionDeclaration = parseVirtualAudioExpressionDeclaration(
+          text,
+          line,
+          currentSection,
+          patchbayIdSeed,
+          diagnostics
+        );
+
+        if (!virtualExpressionDeclaration) return;
+
+        const state = states[currentSection];
+
+        if (
+          state.virtualAudioExpressions.has(virtualExpressionDeclaration.name) ||
+          state.aliases.has(virtualExpressionDeclaration.name) ||
+          state.declarations.has(virtualExpressionDeclaration.name)
+        ) {
+          diagnostics.push(
+            createDiagnostic(
+              'error',
+              'duplicate-alias',
+              line,
+              `Duplicate ${currentSection} virtual expression alias "${virtualExpressionDeclaration.name}".`,
+              { section: currentSection, name: virtualExpressionDeclaration.name }
+            )
+          );
+
+          return;
+        }
+
+        state.virtualAudioExpressions.set(
+          virtualExpressionDeclaration.name,
+          virtualExpressionDeclaration.expression
+        );
+
+        return;
+      }
+
       const aliasDeclaration = parseAliasDeclaration(text, line, currentSection, diagnostics);
       if (!aliasDeclaration) return;
 
@@ -701,6 +1005,7 @@ export function analyzePatchbay(
 
       if (
         state.aliases.has(aliasDeclaration.name) ||
+        state.virtualAudioExpressions.has(aliasDeclaration.name) ||
         state.declarations.has(aliasDeclaration.name)
       ) {
         const duplicateAliasError = createDiagnostic(
@@ -744,6 +1049,8 @@ export function analyzePatchbay(
         waitingForEndpoint ? continuationParts.slice(0, -1) : continuationParts,
         line,
         currentSection,
+        states[currentSection],
+        patchbayIdSeed,
         diagnostics
       );
 
@@ -793,7 +1100,14 @@ export function analyzePatchbay(
     const waitingForEndpoint = routeParts.at(-1) === '';
     const endpointParts = waitingForEndpoint ? routeParts.slice(0, -1) : routeParts;
 
-    const endpoints = parseEndpointParts(endpointParts, line, currentSection, diagnostics);
+    const endpoints = parseEndpointParts(
+      endpointParts,
+      line,
+      currentSection,
+      states[currentSection],
+      patchbayIdSeed,
+      diagnostics
+    );
     if (!endpoints) return;
 
     if (pendingRoute?.waitingForEndpoint && pendingRoute.section === currentSection) {
@@ -882,6 +1196,10 @@ export function analyzePatchbay(
     messageRoutes,
     audioRoutes,
     videoRoutes,
+    virtualAudioExpressions: [
+      ...states.audio.virtualAudioExpressions.values(),
+      ...states.audio.anonymousVirtualAudioExpressions
+    ],
     channels: {
       message: new Set(channels.message.keys()),
       audio: new Set(channels.audio.keys()),

--- a/ui/src/lib/patchbay/patchbay-parser.ts
+++ b/ui/src/lib/patchbay/patchbay-parser.ts
@@ -1,6 +1,19 @@
 import { hash } from 'ohash';
 import { Parser } from 'expr-eval';
 import { parseMultiOutletExpressions } from '$lib/utils/expr-parser';
+import { isUnmodifiableType, parseStringParamByType } from '$lib/objects/parse-object-param';
+import { AllpassNode } from '$lib/audio/v2/nodes/AllpassNode';
+import { BandpassNode } from '$lib/audio/v2/nodes/BandpassNode';
+import { CompressorNode } from '$lib/audio/v2/nodes/CompressorNode';
+import { DelayNodeV2 } from '$lib/audio/v2/nodes/DelayNode';
+import { GainNodeV2 } from '$lib/audio/v2/nodes/GainNode';
+import { HighpassNode } from '$lib/audio/v2/nodes/HighpassNode';
+import { HighshelfNode } from '$lib/audio/v2/nodes/HighshelfNode';
+import { LowpassNode } from '$lib/audio/v2/nodes/LowpassNode';
+import { LowshelfNode } from '$lib/audio/v2/nodes/LowshelfNode';
+import { NotchNode } from '$lib/audio/v2/nodes/NotchNode';
+import { PeakingNode } from '$lib/audio/v2/nodes/PeakingNode';
+import type { ObjectInlet } from '$lib/objects/v2/object-metadata';
 
 export type PatchbaySection = 'message' | 'audio' | 'video';
 
@@ -31,7 +44,8 @@ export type PatchbayDiagnosticCode =
   | 'unknown-object'
   | 'object-port-unavailable'
   | 'object-port-out-of-range'
-  | 'invalid-virtual-expression';
+  | 'invalid-virtual-expression'
+  | 'unsupported-virtual-audio-node';
 
 export type PatchbayDiagnostic = {
   severity: PatchbayDiagnosticSeverity;
@@ -72,6 +86,9 @@ export type PatchbayObjectEndpointRef = {
 export type PatchbayVirtualAudioExpression = {
   id: string;
   name?: string;
+  type: string;
+  rawArgs: string[];
+  params: unknown[];
   expression: string;
   raw: string;
   line: number;
@@ -155,6 +172,49 @@ const AUDIO_EXPRESSION_PARAMETER_NAMES = [
   'inputs',
   ...Array.from({ length: 9 }, (_, index) => `x${index + 1}`)
 ];
+const VIRTUAL_AUDIO_PROCESSOR_TYPES = new Set([
+  'expr~',
+  'gain~',
+  'lowpass~',
+  'highpass~',
+  'bandpass~',
+  'notch~',
+  'allpass~',
+  'lowshelf~',
+  'highshelf~',
+  'peaking~',
+  'compressor~',
+  'delay~'
+]);
+const KNOWN_UNSUPPORTED_AUDIO_PROCESSOR_TYPES = new Set([
+  'biquad~',
+  'comb~',
+  'convolver~',
+  'mic~',
+  'out~',
+  'send~',
+  'recv~',
+  'soundfile~',
+  'sampler~',
+  'csound~',
+  'waveshaper~'
+]);
+
+const VIRTUAL_AUDIO_PROCESSOR_INLETS = new Map<string, ObjectInlet[]>(
+  [
+    AllpassNode,
+    BandpassNode,
+    CompressorNode,
+    DelayNodeV2,
+    GainNodeV2,
+    HighpassNode,
+    HighshelfNode,
+    LowpassNode,
+    LowshelfNode,
+    NotchNode,
+    PeakingNode
+  ].map((node) => [node.type, node.inlets ?? []])
+);
 
 const createSectionState = (): SectionState => ({
   declarations: new Map(),
@@ -256,18 +316,20 @@ function parseAliasDeclaration(
   return { name, endpoint };
 }
 
-function parseVirtualAudioExpressionDeclaration(
+function parseVirtualAudioProcessorDeclaration(
   raw: string,
   line: number,
   section: PatchbaySection,
   patchbayIdSeed: string,
   diagnostics: PatchbayDiagnostic[]
 ): { name: string; expression: PatchbayVirtualAudioExpression } | null {
-  const match = raw.match(/^([^=\s]+)\s*=\s*expr~\s+(.+)$/);
+  const match = raw.match(/^([^=\s]+)\s*=\s*([A-Za-z0-9_.~/:-]+)(?:\s+(.+))?$/);
   if (!match) return null;
 
   const name = match[1].trim();
-  const expression = match[2].trim();
+  const type = match[2].trim();
+  const rawArgs = splitVirtualAudioProcessorArgs(match[3] ?? '');
+  const expression = type === 'expr~' ? rawArgs.join(' ').trim() : '';
 
   if (section !== 'audio') {
     diagnostics.push(
@@ -275,7 +337,7 @@ function parseVirtualAudioExpressionDeclaration(
         'error',
         'invalid-virtual-expression',
         line,
-        '`expr~` declarations are only supported in [Audio].',
+        'Virtual audio processor declarations are only supported in [Audio].',
         { section, name }
       )
     );
@@ -294,13 +356,13 @@ function parseVirtualAudioExpressionDeclaration(
     return null;
   }
 
-  if (expression.length === 0) {
+  if (!isSupportedVirtualAudioProcessorType(type)) {
     diagnostics.push(
       createDiagnostic(
         'error',
-        'invalid-virtual-expression',
+        'unsupported-virtual-audio-node',
         line,
-        `Virtual expression "${name}" needs an expr~ body.`,
+        `Unsupported virtual audio processor "${type}".`,
         { section, name }
       )
     );
@@ -308,27 +370,89 @@ function parseVirtualAudioExpressionDeclaration(
     return null;
   }
 
-  const validationError = validateVirtualAudioExpression(expression);
-  if (validationError) {
-    diagnostics.push(
-      createDiagnostic('error', 'invalid-virtual-expression', line, validationError, {
-        section,
-        name
-      })
-    );
+  if (expression.length === 0) {
+    if (type === 'expr~') {
+      diagnostics.push(
+        createDiagnostic(
+          'error',
+          'invalid-virtual-expression',
+          line,
+          `Virtual expression "${name}" needs an expr~ body.`,
+          { section, name }
+        )
+      );
+
+      return null;
+    }
+  }
+
+  if (type === 'expr~') {
+    const validationError = validateVirtualAudioExpression(expression);
+    if (validationError) {
+      diagnostics.push(
+        createDiagnostic('error', 'invalid-virtual-expression', line, validationError, {
+          section,
+          name
+        })
+      );
+    }
   }
 
   return {
     name,
     expression: {
-      id: `${patchbayIdSeed}:audio-expr:${name}`,
+      id: `${patchbayIdSeed}:audio-virtual:${name}`,
       name,
+      type,
+      rawArgs,
+      params: parseVirtualAudioProcessorParams(type, rawArgs),
       expression,
       raw: name,
       line,
       anonymous: false
     }
   };
+}
+
+function splitVirtualAudioProcessorArgs(rawArgs: string): string[] {
+  return rawArgs.trim().length === 0 ? [] : rawArgs.trim().split(/\s+/);
+}
+
+function isSupportedVirtualAudioProcessorType(type: string): boolean {
+  return VIRTUAL_AUDIO_PROCESSOR_TYPES.has(type);
+}
+
+function isKnownUnsupportedAudioProcessorType(type: string): boolean {
+  return KNOWN_UNSUPPORTED_AUDIO_PROCESSOR_TYPES.has(type);
+}
+
+function parseVirtualAudioProcessorParams(type: string, rawArgs: string[]): unknown[] {
+  if (type === 'expr~') return [null, rawArgs.join(' ')];
+
+  const inlets = VIRTUAL_AUDIO_PROCESSOR_INLETS.get(type);
+  if (!inlets) return rawArgs;
+
+  const params: unknown[] = [];
+  let inputInletIndex = 0;
+
+  for (const inlet of inlets) {
+    const skipAsUnmodifiable = isUnmodifiableType(inlet.type) && !inlet.acceptsFloat;
+    if (skipAsUnmodifiable) {
+      params.push(null);
+      continue;
+    }
+
+    if (inputInletIndex >= rawArgs.length) {
+      params.push(inlet.defaultValue ?? null);
+      inputInletIndex += 1;
+      continue;
+    }
+
+    params.push(parseStringParamByType(inlet, rawArgs[inputInletIndex]));
+    inputInletIndex += 1;
+  }
+
+  return params;
 }
 
 function splitRouteContinuation(raw: string): string[] | null {
@@ -355,6 +479,21 @@ function parseEndpointParts(
 
   for (let index = 0; index < parts.length; index += 1) {
     const rawEndpoint = parts[index];
+    const virtualProcessorEndpoint = parseVirtualAudioProcessorEndpoint(
+      rawEndpoint,
+      line,
+      section,
+      index,
+      state,
+      patchbayIdSeed,
+      diagnostics
+    );
+
+    if (virtualProcessorEndpoint) {
+      endpoints.push(virtualProcessorEndpoint);
+      continue;
+    }
+
     const shorthandEndpoints = parseAudioShorthandEndpoint(
       rawEndpoint,
       line,
@@ -392,6 +531,72 @@ function parseEndpointParts(
   return endpoints;
 }
 
+function parseVirtualAudioProcessorEndpoint(
+  rawEndpoint: string,
+  line: number,
+  section: PatchbaySection,
+  routePartIndex: number,
+  state: SectionState,
+  patchbayIdSeed: string,
+  diagnostics: PatchbayDiagnostic[]
+): PatchbayVirtualAudioExpressionEndpointRef | null {
+  if (section !== 'audio') return null;
+  if (rawEndpoint.startsWith('obj ')) return null;
+
+  const match = rawEndpoint.match(/^([A-Za-z0-9_.~/:-]+)\s*(.*)$/);
+  if (!match) return null;
+
+  const type = match[1].trim();
+
+  if (!isSupportedVirtualAudioProcessorType(type)) {
+    if (isKnownUnsupportedAudioProcessorType(type) && /\s/.test(rawEndpoint)) {
+      diagnostics.push(
+        createDiagnostic(
+          'error',
+          'unsupported-virtual-audio-node',
+          line,
+          `Unsupported virtual audio processor "${type}".`,
+          { section, name: type }
+        )
+      );
+    }
+
+    return null;
+  }
+
+  const rawArgs = splitVirtualAudioProcessorArgs(match[2] ?? '');
+  const expression = type === 'expr~' ? rawArgs.join(' ').trim() : '';
+
+  if (type === 'expr~') return null;
+
+  const id = `${patchbayIdSeed}:audio-virtual:inline:${hash({
+    line,
+    routePartIndex,
+    type,
+    rawArgs
+  })}`;
+
+  const virtualExpression: PatchbayVirtualAudioExpression = {
+    id,
+    type,
+    rawArgs,
+    params: parseVirtualAudioProcessorParams(type, rawArgs),
+    expression,
+    raw: rawEndpoint,
+    line,
+    anonymous: true
+  };
+
+  state.anonymousVirtualAudioExpressions.push(virtualExpression);
+
+  return {
+    kind: 'virtual-audio-expression',
+    expression: virtualExpression,
+    raw: virtualExpression.raw,
+    line
+  };
+}
+
 function parseAudioShorthandEndpoint(
   rawEndpoint: string,
   line: number,
@@ -424,7 +629,7 @@ function parseAudioShorthandEndpoint(
     );
   }
 
-  const id = `${patchbayIdSeed}:audio-expr:inline:${hash({
+  const id = `${patchbayIdSeed}:audio-virtual:inline:${hash({
     line,
     routePartIndex,
     source
@@ -432,6 +637,9 @@ function parseAudioShorthandEndpoint(
 
   const virtualExpression: PatchbayVirtualAudioExpression = {
     id,
+    type: 'expr~',
+    rawArgs: [expression],
+    params: parseVirtualAudioProcessorParams('expr~', [expression]),
     expression,
     raw: `expr~ ${expression}`,
     line,
@@ -959,8 +1167,15 @@ export function analyzePatchbay(
     if (/^[^=\s]+\s*=/.test(text)) {
       flushPendingRoute();
 
-      if (/^[^=\s]+\s*=\s*expr~(?:\s|$)/.test(text)) {
-        const virtualExpressionDeclaration = parseVirtualAudioExpressionDeclaration(
+      const processorDeclarationMatch = text.match(/^[^=\s]+\s*=\s*([A-Za-z0-9_.~/:-]+)/);
+      const processorType = processorDeclarationMatch?.[1];
+
+      if (
+        processorType &&
+        (isSupportedVirtualAudioProcessorType(processorType) ||
+          isKnownUnsupportedAudioProcessorType(processorType))
+      ) {
+        const virtualExpressionDeclaration = parseVirtualAudioProcessorDeclaration(
           text,
           line,
           currentSection,

--- a/ui/src/lib/patchbay/patchbay-parser.ts
+++ b/ui/src/lib/patchbay/patchbay-parser.ts
@@ -12,6 +12,7 @@ import { HighshelfNode } from '$lib/audio/v2/nodes/HighshelfNode';
 import { LowpassNode } from '$lib/audio/v2/nodes/LowpassNode';
 import { LowshelfNode } from '$lib/audio/v2/nodes/LowshelfNode';
 import { NotchNode } from '$lib/audio/v2/nodes/NotchNode';
+import { OscNode } from '$lib/audio/v2/nodes/OscNode';
 import { PeakingNode } from '$lib/audio/v2/nodes/PeakingNode';
 import type { ObjectInlet } from '$lib/objects/v2/object-metadata';
 
@@ -174,6 +175,7 @@ const AUDIO_EXPRESSION_PARAMETER_NAMES = [
 ];
 const VIRTUAL_AUDIO_PROCESSOR_TYPES = new Set([
   'expr~',
+  'osc~',
   'gain~',
   'lowpass~',
   'highpass~',
@@ -212,6 +214,7 @@ const VIRTUAL_AUDIO_PROCESSOR_INLETS = new Map<string, ObjectInlet[]>(
     LowpassNode,
     LowshelfNode,
     NotchNode,
+    OscNode,
     PeakingNode
   ].map((node) => [node.type, node.inlets ?? []])
 );

--- a/ui/static/content/objects/patchbay.md
+++ b/ui/static/content/objects/patchbay.md
@@ -139,6 +139,51 @@ Mic -> Reverb -> Out
 
 Audio sent to `Mic` will pass through the virtual `Reverb` channel and arrive at `Out`.
 
+### Virtual Audio Processors
+
+In `[Audio]`, patchbay can create small hidden audio processors between an audio source and
+destination. The examples below assume `Osc` is an object alias and `Out` is an audio receiver
+channel:
+
+```text
+[Audio]
+Osc = obj object-30
+```
+
+Use a named virtual processor when you want to reuse the same processor in multiple routes:
+
+```text
+[Audio]
+Osc = obj object-30
+
+Gain = gain~ 0.06
+Osc -> Gain -> Out
+
+Expr = expr~ s * 0.06
+Osc -> Expr -> Out
+```
+
+Use an inline processor when the processor only belongs to one route:
+
+```text
+[Audio]
+Osc = obj object-30
+
+Osc -> gain~ 0.06 -> Out
+Osc -> expr~ s * 0.06 -> Out
+Osc -> lowpass~ 80 1 -> Out
+```
+
+For simple one-source math, you can use shorthand. This creates an anonymous `expr~` processor
+where the source signal is available as `s`:
+
+```text
+[Audio]
+Osc = obj object-30
+
+Osc * 0.06 -> Out
+```
+
 ## Video Example
 
 Create these objects anywhere in your patch:

--- a/ui/static/content/objects/patchbay.md
+++ b/ui/static/content/objects/patchbay.md
@@ -139,18 +139,21 @@ Mic -> Reverb -> Out
 
 Audio sent to `Mic` will pass through the virtual `Reverb` channel and arrive at `Out`.
 
-### Virtual Audio Processors
+### Virtual Audio Nodes
 
-In `[Audio]`, patchbay can create small hidden audio processors between an audio source and
-destination. The examples below assume `Osc` is an object alias and `Out` is an audio receiver
-channel:
+In `[Audio]`, patchbay can create small hidden audio nodes. The examples below use `Out` as an
+audio receiver channel.
+
+Use a named virtual source when you want patchbay to own the oscillator:
 
 ```text
 [Audio]
-Osc = obj object-30
+Osc = osc~ 440 sine 0
+
+Osc -> Out
 ```
 
-Use a named virtual processor when you want to reuse the same processor in multiple routes:
+You can still alias a visible object with `obj` and route it through named virtual processors:
 
 ```text
 [Audio]
@@ -163,12 +166,13 @@ Expr = expr~ s * 0.06
 Osc -> Expr -> Out
 ```
 
-Use an inline processor when the processor only belongs to one route:
+Use inline nodes when they only belong to one route:
 
 ```text
 [Audio]
 Osc = obj object-30
 
+osc~ 440 sine 0 -> Out
 Osc -> gain~ 0.06 -> Out
 Osc -> expr~ s * 0.06 -> Out
 Osc -> lowpass~ 80 1 -> Out


### PR DESCRIPTION
Support virtual audio expressions via `expr~` and its shorthand format.

Full

```md
[Audio]
Osc = obj object-30
Gain = expr~ s * 0.1
Osc -> Gain -> Out
```

Shorthand

```md
[Audio]
Osc = obj object-30
Osc * 0.1 -> Out
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced virtual audio nodes in patchbay routes (`osc~`, `lowpass~`, `gain~`, etc.)
  * Added shorthand expression syntax for inline audio processing
  * Enhanced editor syntax highlighting and autocompletion for audio expressions
  * Improved audio worklet lifecycle management

* **Documentation**
  * Added guide for virtual audio node declarations and usage patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->