### PR TITLE
feat(p5): add surface mode for p5

### DIFF
--- a/docs/design-docs/specs/100-p5-surface-mode.md
+++ b/docs/design-docs/specs/100-p5-surface-mode.md
@@ -21,6 +21,11 @@ function draw() {
 
 `createSurfaceCanvas()` creates the p5 canvas at the current renderer output size. The user does not also call `createCanvas()`.
 
+Surface-mode p5 also exposes:
+
+- `hideExitButton()` to hide the overlay exit badge.
+- `setMouseForwarding({ enabled, only, except })` to forward p5 mouse and wheel interaction to mouse-aware render nodes while expanded.
+
 ## Preview And Expand Behavior
 
 - Before expansion, the node shows a scaled preview of the surface-sized p5 canvas.
@@ -39,3 +44,4 @@ If a secondary `/output` window is connected, frames may still be mirrored from 
 
 - `createSurfaceCanvas(WEBGL)` should remain possible by forwarding optional renderer arguments to p5.
 - The existing `p5` object remains the only object type; no `surface.p5` object is introduced.
+- Programmatic `activate()` / `deactivate()` is intentionally not part of the p5 surface-mode API for now because p5 setup and canvas creation timing make it less direct than on the `surface` object.

--- a/docs/design-docs/specs/100-p5-surface-mode.md
+++ b/docs/design-docs/specs/100-p5-surface-mode.md
@@ -1,0 +1,41 @@
+# 100. P5 Surface Mode
+
+## Goal
+
+Allow `p5` sketches to run as transparent fullscreen performance overlays without copying their pixels into the normal video rendering chain.
+
+## User API
+
+P5 sketches can call `createSurfaceCanvas()` from `setup()`:
+
+```javascript
+function setup() {
+  createSurfaceCanvas();
+}
+
+function draw() {
+  clear();
+  circle(mouseX, mouseY, 48);
+}
+```
+
+`createSurfaceCanvas()` creates the p5 canvas at the current renderer output size. The user does not also call `createCanvas()`.
+
+## Preview And Expand Behavior
+
+- Before expansion, the node shows a scaled preview of the surface-sized p5 canvas.
+- When `createSurfaceCanvas()` has run, the node menu shows **Expand**.
+- Expanding activates `SurfaceOverlay`, hides the editor, and re-runs the sketch with the p5 canvas mounted into the overlay layer.
+- Collapsing restores the sketch to the inline preview.
+- Surface-mode p5 output is transparent by default when user code uses `clear()` or draws alpha; `background()` remains available when the sketch intentionally covers the scene.
+
+## Rendering Contract
+
+Surface-mode p5 is a DOM overlay presentation, not a normal render-pipeline source. It should not require Hydra-style canvas source chaining or a p5-to-GL bitmap copy for the main fullscreen overlay path.
+
+If a secondary `/output` window is connected, frames may still be mirrored from the p5 canvas to the output window until p5 can run directly in the output context.
+
+## Notes
+
+- `createSurfaceCanvas(WEBGL)` should remain possible by forwarding optional renderer arguments to p5.
+- The existing `p5` object remains the only object type; no `surface.p5` object is introduced.

--- a/docs/design-docs/specs/100-p5-surface-mode.md
+++ b/docs/design-docs/specs/100-p5-surface-mode.md
@@ -23,6 +23,7 @@ function draw() {
 
 Surface-mode p5 also exposes:
 
+- `expandSurface()` and `collapseSurface()` to enter or exit fullscreen surface mode from code.
 - `hideExitButton()` to hide the overlay exit badge.
 - `setMouseForwarding({ enabled, only, except })` to forward p5 mouse and wheel interaction to mouse-aware render nodes while expanded.
 
@@ -44,4 +45,3 @@ If a secondary `/output` window is connected, frames may still be mirrored from 
 
 - `createSurfaceCanvas(WEBGL)` should remain possible by forwarding optional renderer arguments to p5.
 - The existing `p5` object remains the only object type; no `surface.p5` object is introduced.
-- Programmatic `activate()` / `deactivate()` is intentionally not part of the p5 surface-mode API for now because p5 setup and canvas creation timing make it less direct than on the `surface` object.

--- a/docs/design-docs/specs/126-surface-fullscreen-interaction.md
+++ b/docs/design-docs/specs/126-surface-fullscreen-interaction.md
@@ -45,8 +45,8 @@ FBO-renderer nodes (`hydra`, `regl`, `glsl`, `swgl`, `canvas`, `three`, `textmod
 
 **State transitions:**
 
-- `preview` → `fullscreen`: click **Expand** button on node / send `bang` / send `{ type: 'expand' }` / call `activate()`
-- `fullscreen` → `preview`: press **Shift+Escape** / click floating exit badge / send `{ type: 'collapse' }` / call `deactivate()`
+- `preview` → `fullscreen`: click **Expand** button on node / send `bang` / send `{ type: 'expand' }` / call `expandSurface()`
+- `fullscreen` → `preview`: press **Shift+Escape** / click floating exit badge / send `{ type: 'collapse' }` / call `collapseSurface()`
 - `preview` ↔ `stopped`: click **Stop/Play** button on node (pause canvas to save CPU)
 
 Escape always returns to `preview`, never to `stopped`.
@@ -100,18 +100,18 @@ noOutput(); // disable CPU→GPU texture copy (default: enabled, same as canvas.
 CPU→GPU copy is expensive. Call `noOutput()` if you don't need to composite the overlay
 into the FBO pipeline.
 
-### Surface Activation
+### Surface Expansion
 
 ```js
-activate(); // enter fullscreen state: show overlay, hide XYFlow, freeze DOM-renderer nodes
-deactivate(); // return to preview state: remove overlay, restore XYFlow and frozen nodes
+expandSurface(); // enter fullscreen state: show overlay, hide XYFlow, freeze DOM-renderer nodes
+collapseSurface(); // return to preview state: remove overlay, restore XYFlow and frozen nodes
 ```
 
 Messages also trigger these:
 
 ```js
-// bang or { type: 'expand' }   → calls activate()
-// { type: 'collapse' }         → calls deactivate()
+// bang or { type: 'expand' }   → calls expandSurface()
+// { type: 'collapse' }         → calls collapseSurface()
 ```
 
 ### Browser Fullscreen (optional)
@@ -127,12 +127,12 @@ or combine with activation:
 ```js
 recv((msg) => {
   if (msg.type === "live") {
-    activate();
+    expandSurface();
     goFullscreen();
   }
 
   if (msg.type === "exit") {
-    deactivate();
+    collapseSurface();
     exitFullscreen();
   }
 });
@@ -268,7 +268,7 @@ Based on `CanvasDom.svelte` with these differences:
 - `setDrawMode()` added to `extraContext`
 - `onPointer()` / `onTouch()` added to `extraContext`
 - CodeMirror Patchies API completions should expose the documented surface JavaScript API:
-  `onPointer`, `onTouch`, `setDrawMode`, `redraw`, `activate`, `deactivate`,
+  `onPointer`, `onTouch`, `setDrawMode`, `redraw`, `expandSurface`, `collapseSurface`,
   `hideExitButton`, `onKeyDown`, `onKeyUp`, `setMouseForwarding`, and `noOutput`.
 - `pointer` and `touch` message outlets added
 - On mount: calls `SurfaceOverlay.activate(nodeId)`

--- a/docs/design-docs/specs/147-canvas-preview-expand.md
+++ b/docs/design-docs/specs/147-canvas-preview-expand.md
@@ -37,8 +37,8 @@ The shared behavior should live in a small controller under `src/lib/canvas/`
 rather than duplicating surface-specific code in every node component.
 
 `surface` keeps its custom implementation because it draws directly into the
-overlay canvas and exposes surface-specific JavaScript APIs such as `activate()`,
-`deactivate()`, `onTouch()`, and `hideExitButton()`.
+overlay canvas and exposes surface-specific JavaScript APIs such as `expandSurface()`,
+`collapseSurface()`, `onTouch()`, and `hideExitButton()`.
 
 `ObjectPreviewLayout` should own the shared menu action because it already owns
 background-output pinning and the overflow/context menus used by

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "patchies-web",

--- a/ui/src/lib/ai/object-prompts/p5.ts
+++ b/ui/src/lib/ai/object-prompts/p5.ts
@@ -16,10 +16,12 @@ ${esmInstructions}
 - noWheel() - Disable XYFlow canvas wheel zoom when interacting
 - noInteract() - Disable all XYFlow canvas interactions (drag, pan, wheel)
 - noOutput() - Hide video output port (call this when the sketch is self-contained and does not need to feed video to other nodes)
+- createSurfaceCanvas(renderer?) - Create a transparent renderer-output-sized canvas and enable Expand so the p5 sketch can run as a fullscreen surface overlay. Do NOT also call createCanvas() when using this.
 - setPortCount(inlets, outlets) - Set inlet/outlet count (e.g. setPortCount(1, 0) if only an inlet is needed and no message outlet)
 
 **Default behaviors to apply unless there's a reason not to:**
 - Call noOutput() by default unless the sketch is explicitly meant to output video to another node.
+- For fullscreen transparent overlays over Hydra/GLSL/video output, call createSurfaceCanvas() in setup() instead of createCanvas(), and use clear() in draw() so visuals underneath show through.
 - Call noDrag() if the sketch uses mousePressed, mouseDragged, mouseX/mouseY interaction.
 - Call noWheel() if the sketch uses scroll or mouseWheel interaction.
 - Call setPortCount(1, 0) if the sketch only needs to receive messages (inlet) and does not send any output messages.
@@ -31,6 +33,7 @@ ${esmInstructions}
 
 **Canvas size:**
 - Default to 252x164 or similar sizes unless the user specifies a size. Keep canvases small as p5 is CPU-bound and large canvases cause lag.
+- For surface overlays, use createSurfaceCanvas() and do not provide fixed dimensions.
 - NEVER use windowWidth or windowHeight — the node is embedded in a canvas at a small size.
 - Acceptable size range: 200×150 minimum, 1000×1000 maximum. Prefer smaller when possible.
 

--- a/ui/src/lib/ai/object-prompts/p5.ts
+++ b/ui/src/lib/ai/object-prompts/p5.ts
@@ -17,6 +17,7 @@ ${esmInstructions}
 - noInteract() - Disable all XYFlow canvas interactions (drag, pan, wheel)
 - noOutput() - Hide video output port (call this when the sketch is self-contained and does not need to feed video to other nodes)
 - createSurfaceCanvas(renderer?) - Create a transparent renderer-output-sized canvas and enable Expand so the p5 sketch can run as a fullscreen surface overlay. Do NOT also call createCanvas() when using this.
+- expandSurface() / collapseSurface() - In p5 surface mode, enter or exit fullscreen surface mode from code.
 - hideExitButton() - In expanded p5 surface mode, hide the "Exit surface" badge.
 - setMouseForwarding({ enabled?: boolean, only?: string[], except?: string[] }) - In expanded p5 surface mode, forward p5 mouse/wheel interaction to render nodes. Use enabled: false or only: [] to disable.
 - setPortCount(inlets, outlets) - Set inlet/outlet count (e.g. setPortCount(1, 0) if only an inlet is needed and no message outlet)

--- a/ui/src/lib/ai/object-prompts/p5.ts
+++ b/ui/src/lib/ai/object-prompts/p5.ts
@@ -17,11 +17,14 @@ ${esmInstructions}
 - noInteract() - Disable all XYFlow canvas interactions (drag, pan, wheel)
 - noOutput() - Hide video output port (call this when the sketch is self-contained and does not need to feed video to other nodes)
 - createSurfaceCanvas(renderer?) - Create a transparent renderer-output-sized canvas and enable Expand so the p5 sketch can run as a fullscreen surface overlay. Do NOT also call createCanvas() when using this.
+- hideExitButton() - In expanded p5 surface mode, hide the "Exit surface" badge.
+- setMouseForwarding({ enabled?: boolean, only?: string[], except?: string[] }) - In expanded p5 surface mode, forward p5 mouse/wheel interaction to render nodes. Use enabled: false or only: [] to disable.
 - setPortCount(inlets, outlets) - Set inlet/outlet count (e.g. setPortCount(1, 0) if only an inlet is needed and no message outlet)
 
 **Default behaviors to apply unless there's a reason not to:**
 - Call noOutput() by default unless the sketch is explicitly meant to output video to another node.
 - For fullscreen transparent overlays over Hydra/GLSL/video output, call createSurfaceCanvas() in setup() instead of createCanvas(), and use clear() in draw() so visuals underneath show through.
+- In p5 surface mode, use setMouseForwarding() when only some render nodes should receive mouse/wheel interaction, and setMouseForwarding({ enabled: false }) when p5 should consume interaction without driving Hydra/GLSL/Three.
 - Call noDrag() if the sketch uses mousePressed, mouseDragged, mouseX/mouseY interaction.
 - Call noWheel() if the sketch uses scroll or mouseWheel interaction.
 - Call setPortCount(1, 0) if the sketch only needs to receive messages (inlet) and does not send any output messages.

--- a/ui/src/lib/ai/object-prompts/surface.ts
+++ b/ui/src/lib/ai/object-prompts/surface.ts
@@ -14,7 +14,7 @@ Fullscreen interactive canvas overlay for live performance. Captures pointer/tou
 - setDrawMode('always'|'interact'|'manual') — control render loop
 - redraw() — trigger a draw in manual mode
 - setMouseForwarding({ enabled?: boolean, only?: string[], except?: string[] }) — enable/disable or restrict forwarded mouse events by node ID
-- activate() / deactivate() — enter/exit fullscreen from code
+- expandSurface() / collapseSurface() — enter/exit fullscreen from code
 - noOutput() — hide video output port
 
 **Coordinate system:**

--- a/ui/src/lib/canvas/SurfaceOverlay.ts
+++ b/ui/src/lib/canvas/SurfaceOverlay.ts
@@ -17,9 +17,11 @@ const DOM_RENDERER_TYPES = new Set(['p5', 'canvas.dom', 'textmode.dom', 'three.d
 export const isFullscreenActive = writable(false);
 
 export type SurfacePresentationMode = 'main' | 'secondary';
+export type SurfaceOverlayContentMode = 'canvas' | 'custom';
 
 export type SurfaceOverlayActivateOptions = {
   presentation?: SurfacePresentationMode;
+  content?: SurfaceOverlayContentMode;
 };
 
 export class SurfaceOverlay {
@@ -27,10 +29,12 @@ export class SurfaceOverlay {
 
   private _canvas: HTMLCanvasElement;
   private _ctx: CanvasRenderingContext2D;
+  private _customHost: HTMLDivElement;
   private _activeNodeId: string | null = null;
   private _frozenNodeIds: string[] = [];
   private _badge: HTMLButtonElement | null = null;
   private _secondarySurfaceVisible = false;
+  private _contentMode: SurfaceOverlayContentMode = 'canvas';
 
   private _onEscape: (e: KeyboardEvent) => void;
   private _onExit: (() => void) | null = null;
@@ -51,6 +55,12 @@ export class SurfaceOverlay {
 
     document.body.appendChild(this._canvas);
 
+    this._customHost = document.createElement('div');
+    this._customHost.style.cssText =
+      'position: fixed; inset: 0; display: none; z-index: 50; pointer-events: none; width: 100vw; height: 100vh; overflow: hidden;';
+
+    document.body.appendChild(this._customHost);
+
     this._ctx = this._canvas.getContext('2d')!;
     this._resize();
 
@@ -68,6 +78,10 @@ export class SurfaceOverlay {
 
   get canvas(): HTMLCanvasElement {
     return this._canvas;
+  }
+
+  get customHost(): HTMLDivElement {
+    return this._customHost;
   }
 
   get ctx(): CanvasRenderingContext2D {
@@ -106,7 +120,9 @@ export class SurfaceOverlay {
     options: SurfaceOverlayActivateOptions = {}
   ): void {
     const presentation = options.presentation ?? 'main';
+    const content = options.content ?? 'canvas';
     this._secondarySurfaceVisible = false;
+    this._contentMode = content;
 
     // Last activated wins — displace previous
     if (this._activeNodeId && this._activeNodeId !== nodeId) {
@@ -117,8 +133,12 @@ export class SurfaceOverlay {
 
     // Main presentation shows the overlay in this window. Secondary presentation keeps the
     // canvas as a hidden drawing target while the /output window owns the visible surface.
-    this._canvas.style.display = presentation === 'main' ? 'block' : 'none';
-    this._canvas.style.pointerEvents = presentation === 'main' ? 'all' : 'none';
+    const showInMainWindow = presentation === 'main';
+    this._canvas.style.display = showInMainWindow && content === 'canvas' ? 'block' : 'none';
+    this._canvas.style.pointerEvents = showInMainWindow && content === 'canvas' ? 'all' : 'none';
+    this._customHost.style.display = showInMainWindow && content === 'custom' ? 'block' : 'none';
+    this._customHost.style.pointerEvents =
+      showInMainWindow && content === 'custom' ? 'all' : 'none';
 
     this._frozenNodeIds = [];
 
@@ -162,9 +182,13 @@ export class SurfaceOverlay {
 
     this._activeNodeId = null;
     this._secondarySurfaceVisible = false;
+    this._contentMode = 'canvas';
 
     this._canvas.style.display = 'none';
     this._canvas.style.pointerEvents = 'none';
+
+    this._customHost.style.display = 'none';
+    this._customHost.style.pointerEvents = 'none';
 
     if (unfreeze) {
       const eventBus = PatchiesEventBus.getInstance();
@@ -270,8 +294,14 @@ export class SurfaceOverlay {
 
     button.addEventListener('click', () => {
       this._secondarySurfaceVisible = !this._secondarySurfaceVisible;
-      this._canvas.style.display = this._secondarySurfaceVisible ? 'block' : 'none';
-      this._canvas.style.pointerEvents = this._secondarySurfaceVisible ? 'all' : 'none';
+
+      const display = this._secondarySurfaceVisible ? 'block' : 'none';
+      const pointerEvents = this._secondarySurfaceVisible ? 'all' : 'none';
+      const target = this._contentMode === 'custom' ? this._customHost : this._canvas;
+
+      target.style.display = display;
+      target.style.pointerEvents = pointerEvents;
+
       syncButton();
     });
 

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -107,23 +107,37 @@ describe('patchies completions', () => {
         'setDrawMode',
         'redraw',
         'setMouseForwarding',
-        'activate',
-        'deactivate',
+        'expandSurface',
+        'collapseSurface',
         'hideExitButton',
         'noOutput'
       ])
     );
+
+    expect(labels).not.toContain('activate');
+    expect(labels).not.toContain('deactivate');
   });
 
-  it('shows p5 surface mode helper completions without surface activation helpers', () => {
+  it('shows p5 surface mode helper completions with surface expansion helpers', () => {
     const labels = getCompletionLabels('p5', '');
 
     expect(labels).toEqual(
-      expect.arrayContaining(['createSurfaceCanvas', 'hideExitButton', 'setMouseForwarding'])
+      expect.arrayContaining([
+        'createSurfaceCanvas',
+        'hideExitButton',
+        'setMouseForwarding',
+        'expandSurface',
+        'collapseSurface'
+      ])
     );
 
     expect(labels).not.toContain('activate');
     expect(labels).not.toContain('deactivate');
+  });
+
+  it('shows surface expansion helper completions inside callbacks', () => {
+    expect(getCompletionLabels('surface', 'recv(() => { exp')).toContain('expandSurface');
+    expect(getCompletionLabels('p5', 'function mousePressed() { col')).toContain('collapseSurface');
   });
 
   it('shows setSize completions for DOM and Vue nodes', () => {

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -115,6 +115,17 @@ describe('patchies completions', () => {
     );
   });
 
+  it('shows p5 surface mode helper completions without surface activation helpers', () => {
+    const labels = getCompletionLabels('p5', '');
+
+    expect(labels).toEqual(
+      expect.arrayContaining(['createSurfaceCanvas', 'hideExitButton', 'setMouseForwarding'])
+    );
+
+    expect(labels).not.toContain('activate');
+    expect(labels).not.toContain('deactivate');
+  });
+
   it('shows setSize completions for DOM and Vue nodes', () => {
     expect(getCompletionLabels('dom', 'setS')).toContain('setSize');
     expect(getCompletionLabels('vue', 'setS')).toContain('setSize');

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -135,6 +135,11 @@ describe('patchies completions', () => {
     expect(labels).not.toContain('deactivate');
   });
 
+  it('shows p5 surface mode helper completions inside setup', () => {
+    expect(getCompletionLabels('p5', 'function setup() { setM')).toContain('setMouseForwarding');
+    expect(getCompletionLabels('p5', 'function setup() { hide')).toContain('hideExitButton');
+  });
+
   it('shows surface expansion helper completions inside callbacks', () => {
     expect(getCompletionLabels('surface', 'recv(() => { exp')).toContain('expandSurface');
     expect(getCompletionLabels('p5', 'function mousePressed() { col')).toContain('collapseSurface');

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -493,6 +493,14 @@ const topLevelOnlyFunctions = new Set([
   'setVideoCount'
 ]);
 
+const p5FunctionBodySurfaceHelpers = new Set(['hideExitButton', 'setMouseForwarding']);
+
+function isAllowedInFunctionBody(completion: Completion, patchiesContext?: PatchiesContext) {
+  if (!topLevelOnlyFunctions.has(completion.label)) return true;
+
+  return patchiesContext?.nodeType === 'p5' && p5FunctionBodySurfaceHelpers.has(completion.label);
+}
+
 const MOUSE_INTERACTION_JS_NODES = [
   'p5',
   'canvas',
@@ -1082,7 +1090,9 @@ export function createPatchiesCompletionSource(patchiesContext?: PatchiesContext
 
     // Filter out top-level only functions when inside a function body
     if (insideFunction) {
-      options = options.filter((completion) => !topLevelOnlyFunctions.has(completion.label));
+      options = options.filter((completion) =>
+        isAllowedInFunctionBody(completion, patchiesContext)
+      );
     }
 
     // Filter based on node type

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -283,18 +283,18 @@ const patchiesAPICompletions: Completion[] = [
     apply: 'redraw()'
   },
   {
-    label: 'activate',
+    label: 'expandSurface',
     type: 'function',
     detail: '() => void',
     info: 'Enter fullscreen surface mode.',
-    apply: 'activate()'
+    apply: 'expandSurface()'
   },
   {
-    label: 'deactivate',
+    label: 'collapseSurface',
     type: 'function',
     detail: '() => void',
     info: 'Exit fullscreen surface mode.',
-    apply: 'deactivate()'
+    apply: 'collapseSurface()'
   },
   {
     label: 'hideExitButton',
@@ -472,8 +472,6 @@ const topLevelOnlyFunctions = new Set([
   'onMessage',
   'onVideoFrame',
   'recv',
-  'activate',
-  'deactivate',
   'hideExitButton',
   'htmlCanvas.videoOutput',
   'htmlCanvas.canvasLayer',
@@ -573,8 +571,8 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   onTouch: ['surface'],
   setDrawMode: ['surface'],
   redraw: ['surface'],
-  activate: ['surface'],
-  deactivate: ['surface'],
+  expandSurface: ['surface', 'p5'],
+  collapseSurface: ['surface', 'p5'],
   hideExitButton: ['surface', 'p5'],
   setAudioPortCount: ['dsp~'],
   setCanvasSize: ['canvas.dom', 'textmode.dom', 'three.dom'],

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -255,6 +255,13 @@ const patchiesAPICompletions: Completion[] = [
     apply: 'noOutput()'
   },
   {
+    label: 'createSurfaceCanvas',
+    type: 'function',
+    detail: '(renderer?: P2D | WEBGL) => p5.Renderer',
+    info: 'Create a p5 canvas sized for the transparent fullscreen surface overlay and enable the Expand action.',
+    apply: 'createSurfaceCanvas()'
+  },
+  {
     label: 'setMouseForwarding',
     type: 'function',
     detail: '(args?: { enabled?: boolean, only?: string[], except?: string[] }) => void',
@@ -547,6 +554,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   noPan: MOUSE_INTERACTION_JS_NODES,
   noWheel: MOUSE_INTERACTION_JS_NODES,
   noInteract: MOUSE_INTERACTION_JS_NODES,
+  createSurfaceCanvas: ['p5'],
   setMouseForwarding: ['surface'],
   noOutput: [
     'p5',

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -555,7 +555,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   noWheel: MOUSE_INTERACTION_JS_NODES,
   noInteract: MOUSE_INTERACTION_JS_NODES,
   createSurfaceCanvas: ['p5'],
-  setMouseForwarding: ['surface'],
+  setMouseForwarding: ['surface', 'p5'],
   noOutput: [
     'p5',
     'canvas',
@@ -575,7 +575,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   redraw: ['surface'],
   activate: ['surface'],
   deactivate: ['surface'],
-  hideExitButton: ['surface'],
+  hideExitButton: ['surface', 'p5'],
   setAudioPortCount: ['dsp~'],
   setCanvasSize: ['canvas.dom', 'textmode.dom', 'three.dom'],
   setSize: ['dom', 'vue'],

--- a/ui/src/lib/components/nodes/P5CanvasNode.svelte
+++ b/ui/src/lib/components/nodes/P5CanvasNode.svelte
@@ -8,20 +8,17 @@
   import { GLSystem } from '$lib/canvas/GLSystem';
   import ObjectPreviewLayout from '$lib/components/ObjectPreviewLayout.svelte';
   import { shouldShowHandles } from '../../../stores/ui.store';
-  import { PREVIEW_SCALE_FACTOR } from '$lib/canvas/constants';
-  import { SurfaceOverlay } from '$lib/canvas/SurfaceOverlay';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { createCustomConsole } from '$lib/utils/createCustomConsole';
   import { handleCodeError } from '$lib/js-runner/handleCodeError';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { ConsoleOutputEvent } from '$lib/eventbus/events';
-  import type { ExtraMenuItem } from '$lib/components/object-preview-menu-actions';
   import { parseCanvasDimensions, shouldResetP5CanvasSize } from '$lib/p5/component-helpers';
+  import { createP5SurfaceMode } from '$lib/p5/use-p5-surface-mode.svelte';
   import { P5_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
   import { SettingsManager, createSettingsAPI } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
-  import { Expand, Shrink } from '@lucide/svelte/icons';
 
   let consoleRef: VirtualConsole | null = $state(null);
 
@@ -70,7 +67,6 @@
   let videoOutputEnabled = $state(true);
   let errorMessage = $state<string | null>(null);
   let editorReady = $state(false);
-  let isSurfaceExpanded = $state(false);
 
   let previewContainerWidth = $state(0);
   const code = $derived(data.code || '');
@@ -85,18 +81,16 @@
   let clearDimensionsTimeout: ReturnType<typeof setTimeout> | null = null;
   let preservedFrameCanvas: HTMLCanvasElement | null = null;
 
-  const surfaceMenuItems: ExtraMenuItem[] = $derived(
-    data.surfaceMode
-      ? [
-          {
-            label: isSurfaceExpanded ? 'Exit surface' : 'Expand',
-            icon: isSurfaceExpanded ? Shrink : Expand,
-            onclick: () => (isSurfaceExpanded ? exitSurfaceMode() : enterSurfaceMode()),
-            variant: isSurfaceExpanded ? 'danger' : 'default'
-          }
-        ]
-      : []
-  );
+  const surfaceMode = createP5SurfaceMode({
+    nodeId,
+    getNodes,
+    getGlSystem: () => glSystem,
+    getP5Manager: () => p5Manager,
+    getPreviewContainer: () => containerElement ?? null,
+    isSurfaceModeEnabled: () => data.surfaceMode,
+    measureWidth,
+    updateSketch: () => void updateSketch()
+  });
 
   function setCanvasDimensionsFromCode(nextCode = code) {
     const dimensions = parseCanvasDimensions(nextCode);
@@ -167,87 +161,6 @@
     preservedFrameCanvas = canvas;
   }
 
-  function getSurfaceCanvasSize() {
-    const [width, height] = glSystem.outputSize;
-
-    return { width, height };
-  }
-
-  function styleSurfaceCanvas(canvas: HTMLCanvasElement) {
-    const { width, height } = getSurfaceCanvasSize();
-
-    if (isSurfaceExpanded) {
-      const scale = Math.max(window.innerWidth / width, window.innerHeight / height);
-      const displayWidth = width * scale;
-      const displayHeight = height * scale;
-
-      Object.assign(canvas.style, {
-        display: 'block',
-        position: 'absolute',
-        left: `${(window.innerWidth - displayWidth) / 2}px`,
-        top: `${(window.innerHeight - displayHeight) / 2}px`,
-        width: `${displayWidth}px`,
-        height: `${displayHeight}px`,
-        margin: '0',
-        objectFit: 'fill',
-        pointerEvents: 'auto'
-      });
-    } else {
-      Object.assign(canvas.style, {
-        display: 'block',
-        position: 'static',
-        left: '',
-        top: '',
-        width: `${width / PREVIEW_SCALE_FACTOR}px`,
-        height: `${height / PREVIEW_SCALE_FACTOR}px`,
-        margin: '0',
-        objectFit: 'fill',
-        pointerEvents: 'auto'
-      });
-    }
-
-    measureWidth(50);
-  }
-
-  function requestSurfaceOverlayMirrorFrame(canvas: HTMLCanvasElement) {
-    if (!isSurfaceExpanded) return;
-
-    glSystem.ipcSystem.requestSurfaceOverlayFrame(canvas);
-  }
-
-  function enterSurfaceMode() {
-    if (isSurfaceExpanded || !data.surfaceMode || !p5Manager) return;
-
-    isSurfaceExpanded = true;
-
-    const overlay = SurfaceOverlay.getInstance();
-    const nodes = getNodes().map((node) => ({ id: node.id, type: node.type }));
-    const presentation = glSystem.ipcSystem.hasConnectedOutputWindow() ? 'secondary' : 'main';
-
-    overlay.activate(nodeId, nodes, () => exitSurfaceMode(), {
-      presentation,
-      content: 'custom'
-    });
-
-    glSystem.ipcSystem.sendSurfaceOverlayState({ active: true });
-    p5Manager.setContainer(overlay.customHost);
-
-    void updateSketch();
-  }
-
-  function exitSurfaceMode() {
-    if (!isSurfaceExpanded) return;
-
-    isSurfaceExpanded = false;
-
-    SurfaceOverlay.getInstance().deactivate(nodeId);
-    glSystem.ipcSystem.sendSurfaceOverlayState(null);
-
-    p5Manager?.setContainer(containerElement);
-
-    void updateSketch();
-  }
-
   // Create custom console for routing output to VirtualConsole
   const customConsole = createCustomConsole(nodeId);
 
@@ -293,10 +206,7 @@
 
   onDestroy(() => {
     clearPreservedFrameCanvas();
-    if (isSurfaceExpanded) {
-      SurfaceOverlay.getInstance().deactivate(nodeId);
-      glSystem.ipcSystem.sendSurfaceOverlayState(null);
-    }
+    surfaceMode.cleanup();
     p5Manager?.destroy();
     glSystem.removeNode(nodeId);
     messageContext?.destroy();
@@ -412,15 +322,15 @@
           },
           settings: settingsAPI,
           pauseOnMount: onMount && !!data.paused,
-          useViewportMouseScale: !isSurfaceExpanded,
+          useViewportMouseScale: !surfaceMode.isExpanded,
           customConsole,
           onRuntimeError: (error) => handleRuntimeError(error, nextCode),
-          onPreserveFrame: isSurfaceExpanded ? undefined : preserveFrameCanvas,
+          onPreserveFrame: surfaceMode.isExpanded ? undefined : preserveFrameCanvas,
           onFrameReady: () => {
             clearPreservedFrameCanvas();
             setVideoOutputEnabled(nextVideoOutputEnabled);
           },
-          getSurfaceCanvasSize,
+          getSurfaceCanvasSize: surfaceMode.getCanvasSize,
           onSurfaceModeChange: (enabled) => {
             nextSurfaceModeEnabled = enabled;
 
@@ -429,8 +339,8 @@
               setVideoOutputEnabled(false);
             }
           },
-          onSurfaceCanvasCreated: styleSurfaceCanvas,
-          onSurfaceFrame: requestSurfaceOverlayMirrorFrame
+          onSurfaceCanvasCreated: surfaceMode.styleCanvas,
+          onSurfaceFrame: surfaceMode.requestMirrorFrame
         });
 
         p5Manager.shouldSendBitmap = !nextSurfaceModeEnabled;
@@ -439,8 +349,8 @@
           updateNodeData(nodeId, { surfaceMode: nextSurfaceModeEnabled });
         }
 
-        if (!nextSurfaceModeEnabled && isSurfaceExpanded) {
-          exitSurfaceMode();
+        if (!nextSurfaceModeEnabled && surfaceMode.isExpanded) {
+          surfaceMode.exit();
         }
 
         measureWidth(100);
@@ -492,7 +402,7 @@
   settingsValues={data.settings ?? {}}
   onSettingsValueChange={(key, value) => settingsManager.setValue(key, value)}
   onSettingsRevertAll={() => settingsManager.revertAll()}
-  displayExtraMenuItems={surfaceMenuItems}
+  displayExtraMenuItems={surfaceMode.menuItems}
 >
   {#snippet topHandle()}
     {#each Array.from({ length: inletCount }) as _, index (index)}

--- a/ui/src/lib/components/nodes/P5CanvasNode.svelte
+++ b/ui/src/lib/components/nodes/P5CanvasNode.svelte
@@ -289,6 +289,7 @@
       try {
         settingsManager.clearCallbacks();
         p5Manager.shouldSendBitmap = true;
+        surfaceMode.setMouseForwarding();
 
         await p5Manager.updateCode({
           code: nextCode,
@@ -340,7 +341,11 @@
             }
           },
           onSurfaceCanvasCreated: surfaceMode.styleCanvas,
-          onSurfaceFrame: surfaceMode.requestMirrorFrame
+          onSurfaceFrame: surfaceMode.requestMirrorFrame,
+          onSurfacePointer: surfaceMode.forwardPointer,
+          onSurfaceWheel: surfaceMode.forwardWheel,
+          hideExitButton: surfaceMode.hideExitButton,
+          setMouseForwarding: surfaceMode.setMouseForwarding
         });
 
         p5Manager.shouldSendBitmap = !nextSurfaceModeEnabled;

--- a/ui/src/lib/components/nodes/P5CanvasNode.svelte
+++ b/ui/src/lib/components/nodes/P5CanvasNode.svelte
@@ -8,16 +8,20 @@
   import { GLSystem } from '$lib/canvas/GLSystem';
   import ObjectPreviewLayout from '$lib/components/ObjectPreviewLayout.svelte';
   import { shouldShowHandles } from '../../../stores/ui.store';
+  import { PREVIEW_SCALE_FACTOR } from '$lib/canvas/constants';
+  import { SurfaceOverlay } from '$lib/canvas/SurfaceOverlay';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { createCustomConsole } from '$lib/utils/createCustomConsole';
   import { handleCodeError } from '$lib/js-runner/handleCodeError';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { ConsoleOutputEvent } from '$lib/eventbus/events';
+  import type { ExtraMenuItem } from '$lib/components/object-preview-menu-actions';
   import { parseCanvasDimensions, shouldResetP5CanvasSize } from '$lib/p5/component-helpers';
   import { P5_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
   import { SettingsManager, createSettingsAPI } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
+  import { Expand, Shrink } from '@lucide/svelte/icons';
 
   let consoleRef: VirtualConsole | null = $state(null);
 
@@ -36,13 +40,14 @@
       executeCode?: number;
       paused?: boolean;
       showConsole?: boolean;
+      surfaceMode?: boolean;
       settingsSchema?: SettingsSchema;
       settings?: Record<string, unknown>;
     };
     selected: boolean;
   } = $props();
 
-  const { updateNodeData } = useSvelteFlow();
+  const { getNodes, updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
   const viewport = useViewport();
 
@@ -65,6 +70,7 @@
   let videoOutputEnabled = $state(true);
   let errorMessage = $state<string | null>(null);
   let editorReady = $state(false);
+  let isSurfaceExpanded = $state(false);
 
   let previewContainerWidth = $state(0);
   const code = $derived(data.code || '');
@@ -78,6 +84,19 @@
   let preloadCanvasHeight = $state<number | undefined>(0);
   let clearDimensionsTimeout: ReturnType<typeof setTimeout> | null = null;
   let preservedFrameCanvas: HTMLCanvasElement | null = null;
+
+  const surfaceMenuItems: ExtraMenuItem[] = $derived(
+    data.surfaceMode
+      ? [
+          {
+            label: isSurfaceExpanded ? 'Exit surface' : 'Expand',
+            icon: isSurfaceExpanded ? Shrink : Expand,
+            onclick: () => (isSurfaceExpanded ? exitSurfaceMode() : enterSurfaceMode()),
+            variant: isSurfaceExpanded ? 'danger' : 'default'
+          }
+        ]
+      : []
+  );
 
   function setCanvasDimensionsFromCode(nextCode = code) {
     const dimensions = parseCanvasDimensions(nextCode);
@@ -148,6 +167,87 @@
     preservedFrameCanvas = canvas;
   }
 
+  function getSurfaceCanvasSize() {
+    const [width, height] = glSystem.outputSize;
+
+    return { width, height };
+  }
+
+  function styleSurfaceCanvas(canvas: HTMLCanvasElement) {
+    const { width, height } = getSurfaceCanvasSize();
+
+    if (isSurfaceExpanded) {
+      const scale = Math.max(window.innerWidth / width, window.innerHeight / height);
+      const displayWidth = width * scale;
+      const displayHeight = height * scale;
+
+      Object.assign(canvas.style, {
+        display: 'block',
+        position: 'absolute',
+        left: `${(window.innerWidth - displayWidth) / 2}px`,
+        top: `${(window.innerHeight - displayHeight) / 2}px`,
+        width: `${displayWidth}px`,
+        height: `${displayHeight}px`,
+        margin: '0',
+        objectFit: 'fill',
+        pointerEvents: 'auto'
+      });
+    } else {
+      Object.assign(canvas.style, {
+        display: 'block',
+        position: 'static',
+        left: '',
+        top: '',
+        width: `${width / PREVIEW_SCALE_FACTOR}px`,
+        height: `${height / PREVIEW_SCALE_FACTOR}px`,
+        margin: '0',
+        objectFit: 'fill',
+        pointerEvents: 'auto'
+      });
+    }
+
+    measureWidth(50);
+  }
+
+  function requestSurfaceOverlayMirrorFrame(canvas: HTMLCanvasElement) {
+    if (!isSurfaceExpanded) return;
+
+    glSystem.ipcSystem.requestSurfaceOverlayFrame(canvas);
+  }
+
+  function enterSurfaceMode() {
+    if (isSurfaceExpanded || !data.surfaceMode || !p5Manager) return;
+
+    isSurfaceExpanded = true;
+
+    const overlay = SurfaceOverlay.getInstance();
+    const nodes = getNodes().map((node) => ({ id: node.id, type: node.type }));
+    const presentation = glSystem.ipcSystem.hasConnectedOutputWindow() ? 'secondary' : 'main';
+
+    overlay.activate(nodeId, nodes, () => exitSurfaceMode(), {
+      presentation,
+      content: 'custom'
+    });
+
+    glSystem.ipcSystem.sendSurfaceOverlayState({ active: true });
+    p5Manager.setContainer(overlay.customHost);
+
+    void updateSketch();
+  }
+
+  function exitSurfaceMode() {
+    if (!isSurfaceExpanded) return;
+
+    isSurfaceExpanded = false;
+
+    SurfaceOverlay.getInstance().deactivate(nodeId);
+    glSystem.ipcSystem.sendSurfaceOverlayState(null);
+
+    p5Manager?.setContainer(containerElement);
+
+    void updateSketch();
+  }
+
   // Create custom console for routing output to VirtualConsole
   const customConsole = createCustomConsole(nodeId);
 
@@ -193,6 +293,10 @@
 
   onDestroy(() => {
     clearPreservedFrameCanvas();
+    if (isSurfaceExpanded) {
+      SurfaceOverlay.getInstance().deactivate(nodeId);
+      glSystem.ipcSystem.sendSurfaceOverlayState(null);
+    }
     p5Manager?.destroy();
     glSystem.removeNode(nodeId);
     messageContext?.destroy();
@@ -259,6 +363,7 @@
     enablePan = true;
     enableWheel = true;
     let nextVideoOutputEnabled = true;
+    let nextSurfaceModeEnabled = false;
 
     // Clear previous error state at the start of each run
     // If an error occurs during updateCode, it will be set again
@@ -273,6 +378,8 @@
     if (p5Manager && messageContext) {
       try {
         settingsManager.clearCallbacks();
+        p5Manager.shouldSendBitmap = true;
+
         await p5Manager.updateCode({
           code: nextCode,
           messageContext: {
@@ -305,14 +412,36 @@
           },
           settings: settingsAPI,
           pauseOnMount: onMount && !!data.paused,
+          useViewportMouseScale: !isSurfaceExpanded,
           customConsole,
           onRuntimeError: (error) => handleRuntimeError(error, nextCode),
-          onPreserveFrame: preserveFrameCanvas,
+          onPreserveFrame: isSurfaceExpanded ? undefined : preserveFrameCanvas,
           onFrameReady: () => {
             clearPreservedFrameCanvas();
             setVideoOutputEnabled(nextVideoOutputEnabled);
-          }
+          },
+          getSurfaceCanvasSize,
+          onSurfaceModeChange: (enabled) => {
+            nextSurfaceModeEnabled = enabled;
+
+            if (enabled) {
+              nextVideoOutputEnabled = false;
+              setVideoOutputEnabled(false);
+            }
+          },
+          onSurfaceCanvasCreated: styleSurfaceCanvas,
+          onSurfaceFrame: requestSurfaceOverlayMirrorFrame
         });
+
+        p5Manager.shouldSendBitmap = !nextSurfaceModeEnabled;
+
+        if (data.surfaceMode !== nextSurfaceModeEnabled) {
+          updateNodeData(nodeId, { surfaceMode: nextSurfaceModeEnabled });
+        }
+
+        if (!nextSurfaceModeEnabled && isSurfaceExpanded) {
+          exitSurfaceMode();
+        }
 
         measureWidth(100);
 
@@ -363,6 +492,7 @@
   settingsValues={data.settings ?? {}}
   onSettingsValueChange={(key, value) => settingsManager.setValue(key, value)}
   onSettingsRevertAll={() => settingsManager.revertAll()}
+  displayExtraMenuItems={surfaceMenuItems}
 >
   {#snippet topHandle()}
     {#each Array.from({ length: inletCount }) as _, index (index)}

--- a/ui/src/lib/components/nodes/P5CanvasNode.svelte
+++ b/ui/src/lib/components/nodes/P5CanvasNode.svelte
@@ -345,7 +345,9 @@
           onSurfacePointer: surfaceMode.forwardPointer,
           onSurfaceWheel: surfaceMode.forwardWheel,
           hideExitButton: surfaceMode.hideExitButton,
-          setMouseForwarding: surfaceMode.setMouseForwarding
+          setMouseForwarding: surfaceMode.setMouseForwarding,
+          expandSurface: surfaceMode.enter,
+          collapseSurface: surfaceMode.exit
         });
 
         p5Manager.shouldSendBitmap = !nextSurfaceModeEnabled;

--- a/ui/src/lib/components/nodes/P5CanvasNode.svelte
+++ b/ui/src/lib/components/nodes/P5CanvasNode.svelte
@@ -294,6 +294,7 @@
   onDestroy(() => {
     clearPreservedFrameCanvas();
     if (isSurfaceExpanded) {
+      isSurfaceExpanded = false;
       SurfaceOverlay.getInstance().deactivate(nodeId);
       glSystem.ipcSystem.sendSurfaceOverlayState(null);
     }

--- a/ui/src/lib/components/nodes/SurfaceNode.svelte
+++ b/ui/src/lib/components/nodes/SurfaceNode.svelte
@@ -563,9 +563,10 @@
             }
           },
 
-          // Surface activation
-          activate: () => enterFullscreen(),
-          deactivate: () => exitSurface(),
+          // Surface expansion
+          expandSurface: () => enterFullscreen(),
+          collapseSurface: () => exitSurface(),
+
           hideExitButton: () => SurfaceOverlay.getInstance().hideBadge(),
           setMouseForwarding,
 

--- a/ui/src/lib/extensions/preset-packs.test.ts
+++ b/ui/src/lib/extensions/preset-packs.test.ts
@@ -88,6 +88,14 @@ describe('built-in preset packs', () => {
     expect(missingPresetNames).toEqual([]);
   });
 
+  test('enables the p5 surface preset with the p5 demo pack', () => {
+    const p5Demos = BUILT_IN_PRESET_PACKS.find((pack) => pack.id === 'p5-demos');
+
+    expect(p5Demos?.requiredObjects).toEqual(['p5']);
+    expect(p5Demos && getPresetPackPresetNames(p5Demos)).toContain('surface.p5');
+    expect(BUILTIN_PRESETS['surface.p5']?.type).toBe('p5');
+  });
+
   test('groups built-in preset folders by preset pack name', () => {
     const folders = buildBuiltInPresetPackFolders(BUILTIN_PRESETS);
     const textureGenerators = folders['Texture Generators'];

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -189,7 +189,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     description: 'Examples for using P5 for 2D graphics',
     icon: 'Palette',
     requiredObjects: ['p5'],
-    presets: ['bouncing-balls.p5', 'text-banner.p5', 'traffic-light.p5']
+    presets: ['bouncing-balls.p5', 'surface.p5', 'text-banner.p5', 'traffic-light.p5']
   },
   {
     id: 'scope-demos',

--- a/ui/src/lib/p5/P5Manager.ts
+++ b/ui/src/lib/p5/P5Manager.ts
@@ -42,6 +42,11 @@ interface P5SketchConfig {
 
   onPreserveFrame?: (snapshot: P5CanvasSnapshot) => void;
   onFrameReady?: () => void;
+  getSurfaceCanvasSize?: () => { width: number; height: number };
+  onSurfaceModeChange?: (enabled: boolean) => void;
+  onSurfaceCanvasCreated?: (canvas: HTMLCanvasElement) => void;
+  onSurfaceFrame?: (canvas: HTMLCanvasElement) => void;
+  useViewportMouseScale?: boolean;
 }
 
 interface P5CanvasSnapshot {
@@ -60,6 +65,7 @@ export class P5Manager {
 
   private container: HTMLElement | null = null;
   private viewport: { current: Viewport } | null = null;
+  private onSurfaceFrame: ((canvas: HTMLCanvasElement) => void) | null = null;
 
   private static compatLibsLoaded = false;
 
@@ -72,7 +78,13 @@ export class P5Manager {
     window[nodeId] = this;
   }
 
+  setContainer(container: HTMLElement | null) {
+    this.container = container;
+  }
+
   async updateCode(config: P5SketchConfig) {
+    this.onSurfaceFrame = config.onSurfaceFrame ?? null;
+
     if (this.p5) {
       // @ts-expect-error -- p5 exposes the live canvas at runtime.
       const canvas: HTMLCanvasElement | undefined = this.p5.canvas;
@@ -207,29 +219,32 @@ export class P5Manager {
           userCode?.preload?.call(p);
         };
 
-        // Helper to adjust mouse coordinates for zoom
+        // Inline p5 canvases live inside the zoomed XYFlow surface, so p5's
+        // browser coordinates need to be mapped back into node-local space.
+        // Expanded surface canvases are fixed DOM overlays and must not use
+        // XYFlow zoom for mouse coordinates.
         const adjustMouseForZoom = () => {
-          if (this.viewport) {
-            const zoom = this.viewport.current.zoom;
-            // Store original values
-            const originalMouseX = p.mouseX;
-            const originalMouseY = p.mouseY;
-            const originalPmouseX = p.pmouseX;
-            const originalPmouseY = p.pmouseY;
+          if (!this.viewport || config.useViewportMouseScale === false) return;
 
-            // !! Adjust for zoom
-            // @ts-expect-error -- we are hacking the p5 instance here
-            p.mouseX = originalMouseX / zoom;
+          const zoom = this.viewport.current.zoom;
+          // Store original values
+          const originalMouseX = p.mouseX;
+          const originalMouseY = p.mouseY;
+          const originalPmouseX = p.pmouseX;
+          const originalPmouseY = p.pmouseY;
 
-            // @ts-expect-error -- we are hacking the p5 instance here
-            p.mouseY = originalMouseY / zoom;
+          // !! Adjust for zoom
+          // @ts-expect-error -- we are hacking the p5 instance here
+          p.mouseX = originalMouseX / zoom;
 
-            // @ts-expect-error -- we are hacking the p5 instance here
-            p.pmouseX = originalPmouseX / zoom;
+          // @ts-expect-error -- we are hacking the p5 instance here
+          p.mouseY = originalMouseY / zoom;
 
-            // @ts-expect-error -- we are hacking the p5 instance here
-            p.pmouseY = originalPmouseY / zoom;
-          }
+          // @ts-expect-error -- we are hacking the p5 instance here
+          p.pmouseX = originalPmouseX / zoom;
+
+          // @ts-expect-error -- we are hacking the p5 instance here
+          p.pmouseY = originalPmouseY / zoom;
         };
 
         // Guard: only dispatch mouse events that originate within the canvas bounds.
@@ -363,6 +378,29 @@ export class P5Manager {
 
     (sketch as unknown as Record<string, unknown>)['p5'] = P5Constructor;
 
+    const createSurfaceCanvas = (...args: unknown[]) => {
+      config.onSurfaceModeChange?.(true);
+
+      const { width, height } = config.getSurfaceCanvasSize?.() ?? {
+        width: window.innerWidth,
+        height: window.innerHeight
+      };
+
+      const renderer = (
+        sketch as unknown as { createCanvas: (...args: unknown[]) => unknown }
+      ).createCanvas(width, height, ...args) as
+        | { canvas?: HTMLCanvasElement; elt?: HTMLCanvasElement }
+        | undefined;
+
+      const canvas = renderer?.canvas ?? renderer?.elt;
+
+      if (canvas) {
+        config.onSurfaceCanvasCreated?.(canvas);
+      }
+
+      return renderer;
+    };
+
     // P5.js wrapper code that returns the functions
     const codeWithWrapper = `
 			var setup, draw, preload, mousePressed, mouseReleased, mouseClicked, mouseMoved, mouseDragged, mouseWheel, doubleClicked, keyPressed, keyReleased, keyTyped, touchStarted, touchMoved, touchEnded, windowResized, deviceMoved, deviceTurned, deviceShaken;
@@ -387,7 +425,8 @@ export class P5Manager {
         noInteract: config.messageContext?.noInteract,
         noOutput: config.messageContext?.noOutput,
         setHidePorts: config.setHidePorts,
-        settings: config.settings
+        settings: config.settings,
+        createSurfaceCanvas
       }
     });
   }
@@ -442,6 +481,8 @@ export class P5Manager {
     // @ts-expect-error -- do not capture if bitmap is missing
     const canvas: HTMLCanvasElement = this.p5?.canvas;
     if (!canvas) return;
+
+    this.onSurfaceFrame?.(canvas);
 
     if (!this.shouldSendBitmap) return;
     if (!this.glSystem.hasOutgoingVideoConnections(this.nodeId)) return;

--- a/ui/src/lib/p5/P5Manager.ts
+++ b/ui/src/lib/p5/P5Manager.ts
@@ -7,6 +7,7 @@ import type { Viewport } from '@xyflow/svelte';
 import { revokeObjectUrls } from '$lib/vfs';
 import { profiler } from '$lib/profiler';
 import type { SettingsAPI } from '$lib/settings';
+import type { SurfaceMouseForwardingRules } from '$lib/canvas/surfaceMouseForwarding';
 
 interface P5SketchConfig {
   code: string;
@@ -43,9 +44,22 @@ interface P5SketchConfig {
   onPreserveFrame?: (snapshot: P5CanvasSnapshot) => void;
   onFrameReady?: () => void;
   getSurfaceCanvasSize?: () => { width: number; height: number };
+
   onSurfaceModeChange?: (enabled: boolean) => void;
   onSurfaceCanvasCreated?: (canvas: HTMLCanvasElement) => void;
   onSurfaceFrame?: (canvas: HTMLCanvasElement) => void;
+  onSurfacePointer?: (x: number, y: number, buttons: number, type: string) => void;
+
+  onSurfaceWheel?: (event: {
+    x: number;
+    y: number;
+    deltaX: number;
+    deltaY: number;
+    deltaMode: number;
+  }) => void;
+
+  hideExitButton?: () => void;
+  setMouseForwarding?: (rules?: SurfaceMouseForwardingRules) => void;
   useViewportMouseScale?: boolean;
 }
 
@@ -252,11 +266,30 @@ export class P5Manager {
         const isMouseInCanvas = () =>
           p.mouseX >= 0 && p.mouseX <= p.width && p.mouseY >= 0 && p.mouseY <= p.height;
 
+        const dispatchSurfacePointer = (buttons: number, type: string) => {
+          if (!isMouseInCanvas() || p.width <= 0 || p.height <= 0) return;
+
+          config.onSurfacePointer?.(p.mouseX / p.width, p.mouseY / p.height, buttons, type);
+        };
+
+        const dispatchSurfaceWheel = (event: WheelEvent) => {
+          if (!isMouseInCanvas() || p.width <= 0 || p.height <= 0) return;
+
+          config.onSurfaceWheel?.({
+            x: p.mouseX / p.width,
+            y: p.mouseY / p.height,
+            deltaX: event.deltaX,
+            deltaY: event.deltaY,
+            deltaMode: event.deltaMode
+          });
+        };
+
         p.mousePressed = function (event: MouseEvent) {
           adjustMouseForZoom();
 
           if (isMouseInCanvas()) {
             userCode?.mousePressed?.call(p, event);
+            dispatchSurfacePointer(event.buttons || 1, 'down');
           }
         };
 
@@ -265,6 +298,7 @@ export class P5Manager {
 
           if (isMouseInCanvas()) {
             userCode?.mouseReleased?.call(p, event);
+            dispatchSurfacePointer(0, 'up');
           }
         };
 
@@ -281,6 +315,7 @@ export class P5Manager {
 
           if (isMouseInCanvas()) {
             userCode?.mouseMoved?.call(p, event);
+            dispatchSurfacePointer(event.buttons, 'move');
           }
         };
 
@@ -289,6 +324,7 @@ export class P5Manager {
 
           if (isMouseInCanvas()) {
             userCode?.mouseDragged?.call(p, event);
+            dispatchSurfacePointer(event.buttons, 'move');
           }
         };
 
@@ -297,6 +333,7 @@ export class P5Manager {
 
           if (isMouseInCanvas()) {
             userCode?.mouseWheel?.call(p, event);
+            dispatchSurfaceWheel(event);
           }
         };
 
@@ -426,7 +463,9 @@ export class P5Manager {
         noOutput: config.messageContext?.noOutput,
         setHidePorts: config.setHidePorts,
         settings: config.settings,
-        createSurfaceCanvas
+        createSurfaceCanvas,
+        hideExitButton: config.hideExitButton,
+        setMouseForwarding: config.setMouseForwarding
       }
     });
   }

--- a/ui/src/lib/p5/P5Manager.ts
+++ b/ui/src/lib/p5/P5Manager.ts
@@ -60,6 +60,8 @@ interface P5SketchConfig {
 
   hideExitButton?: () => void;
   setMouseForwarding?: (rules?: SurfaceMouseForwardingRules) => void;
+  expandSurface?: () => void;
+  collapseSurface?: () => void;
   useViewportMouseScale?: boolean;
 }
 
@@ -465,7 +467,9 @@ export class P5Manager {
         settings: config.settings,
         createSurfaceCanvas,
         hideExitButton: config.hideExitButton,
-        setMouseForwarding: config.setMouseForwarding
+        setMouseForwarding: config.setMouseForwarding,
+        expandSurface: config.expandSurface,
+        collapseSurface: config.collapseSurface
       }
     });
   }

--- a/ui/src/lib/p5/component-helpers.test.ts
+++ b/ui/src/lib/p5/component-helpers.test.ts
@@ -35,6 +35,14 @@ describe('parseCanvasDimensions', () => {
     ).toBe(false);
   });
 
+  it('keeps preloaded canvas dimensions when code calls createSurfaceCanvas', () => {
+    expect(
+      shouldResetP5CanvasSize(`function setup() {
+			createSurfaceCanvas()
+		}`)
+    ).toBe(false);
+  });
+
   it('clears preloaded canvas dimensions when code no longer calls createCanvas', () => {
     expect(
       shouldResetP5CanvasSize(`function setup() {

--- a/ui/src/lib/p5/component-helpers.ts
+++ b/ui/src/lib/p5/component-helpers.ts
@@ -11,4 +11,4 @@ export function parseCanvasDimensions(code: string): { width: number; height: nu
 }
 
 export const shouldResetP5CanvasSize = (code: string): boolean =>
-  !/\bcreateCanvas\s*\(/.test(stripJavaScriptComments(code));
+  !/\b(?:createCanvas|createSurfaceCanvas)\s*\(/.test(stripJavaScriptComments(code));

--- a/ui/src/lib/p5/use-p5-surface-mode.svelte.ts
+++ b/ui/src/lib/p5/use-p5-surface-mode.svelte.ts
@@ -1,0 +1,141 @@
+import type { Node } from '@xyflow/svelte';
+import { Expand, Shrink } from '@lucide/svelte/icons';
+import { PREVIEW_SCALE_FACTOR } from '$lib/canvas/constants';
+import { SurfaceOverlay } from '$lib/canvas/SurfaceOverlay';
+import type { GLSystem } from '$lib/canvas/GLSystem';
+import type { ExtraMenuItem } from '$lib/components/object-preview-menu-actions';
+import type { P5Manager } from '$lib/p5/P5Manager';
+
+type P5SurfaceModeOptions = {
+  nodeId: string;
+  getNodes: () => Node[];
+  getGlSystem: () => GLSystem;
+  getP5Manager: () => P5Manager | null;
+  getPreviewContainer: () => HTMLElement | null;
+  isSurfaceModeEnabled: () => boolean | undefined;
+  measureWidth: (timeout: number) => void;
+  updateSketch: () => void;
+};
+
+export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
+  let isExpanded = $state(false);
+
+  const menuItems: ExtraMenuItem[] = $derived(
+    options.isSurfaceModeEnabled()
+      ? [
+          {
+            label: isExpanded ? 'Exit surface' : 'Expand',
+            icon: isExpanded ? Shrink : Expand,
+            onclick: () => (isExpanded ? exit() : enter()),
+            variant: isExpanded ? 'danger' : 'default'
+          }
+        ]
+      : []
+  );
+
+  function getCanvasSize() {
+    const [width, height] = options.getGlSystem().outputSize;
+
+    return { width, height };
+  }
+
+  function styleCanvas(canvas: HTMLCanvasElement) {
+    const { width, height } = getCanvasSize();
+
+    if (isExpanded) {
+      const scale = Math.max(window.innerWidth / width, window.innerHeight / height);
+      const displayWidth = width * scale;
+      const displayHeight = height * scale;
+
+      Object.assign(canvas.style, {
+        display: 'block',
+        position: 'absolute',
+        left: `${(window.innerWidth - displayWidth) / 2}px`,
+        top: `${(window.innerHeight - displayHeight) / 2}px`,
+        width: `${displayWidth}px`,
+        height: `${displayHeight}px`,
+        margin: '0',
+        objectFit: 'fill',
+        pointerEvents: 'auto'
+      });
+    } else {
+      Object.assign(canvas.style, {
+        display: 'block',
+        position: 'static',
+        left: '',
+        top: '',
+        width: `${width / PREVIEW_SCALE_FACTOR}px`,
+        height: `${height / PREVIEW_SCALE_FACTOR}px`,
+        margin: '0',
+        objectFit: 'fill',
+        pointerEvents: 'auto'
+      });
+    }
+
+    options.measureWidth(50);
+  }
+
+  function requestMirrorFrame(canvas: HTMLCanvasElement) {
+    if (!isExpanded) return;
+
+    options.getGlSystem().ipcSystem.requestSurfaceOverlayFrame(canvas);
+  }
+
+  function enter() {
+    const p5Manager = options.getP5Manager();
+
+    if (isExpanded || !options.isSurfaceModeEnabled() || !p5Manager) return;
+
+    isExpanded = true;
+
+    const glSystem = options.getGlSystem();
+    const overlay = SurfaceOverlay.getInstance();
+    const nodes = options.getNodes().map((node) => ({ id: node.id, type: node.type }));
+    const presentation = glSystem.ipcSystem.hasConnectedOutputWindow() ? 'secondary' : 'main';
+
+    overlay.activate(options.nodeId, nodes, () => exit(), {
+      presentation,
+      content: 'custom'
+    });
+
+    glSystem.ipcSystem.sendSurfaceOverlayState({ active: true });
+    p5Manager.setContainer(overlay.customHost);
+
+    options.updateSketch();
+  }
+
+  function exit() {
+    if (!isExpanded) return;
+
+    isExpanded = false;
+
+    SurfaceOverlay.getInstance().deactivate(options.nodeId);
+    options.getGlSystem().ipcSystem.sendSurfaceOverlayState(null);
+
+    options.getP5Manager()?.setContainer(options.getPreviewContainer());
+
+    options.updateSketch();
+  }
+
+  function cleanup() {
+    if (!isExpanded) return;
+
+    SurfaceOverlay.getInstance().deactivate(options.nodeId);
+    options.getGlSystem().ipcSystem.sendSurfaceOverlayState(null);
+  }
+
+  return {
+    get isExpanded() {
+      return isExpanded;
+    },
+    get menuItems() {
+      return menuItems;
+    },
+    getCanvasSize,
+    styleCanvas,
+    requestMirrorFrame,
+    enter,
+    exit,
+    cleanup
+  };
+}

--- a/ui/src/lib/p5/use-p5-surface-mode.svelte.ts
+++ b/ui/src/lib/p5/use-p5-surface-mode.svelte.ts
@@ -2,6 +2,8 @@ import type { Node } from '@xyflow/svelte';
 import { Expand, Shrink } from '@lucide/svelte/icons';
 import { PREVIEW_SCALE_FACTOR } from '$lib/canvas/constants';
 import { SurfaceOverlay } from '$lib/canvas/SurfaceOverlay';
+import { SurfaceMouseForwarder } from '$lib/canvas/SurfaceMouseForwarder';
+import type { SurfaceMouseForwardingRules } from '$lib/canvas/surfaceMouseForwarding';
 import type { GLSystem } from '$lib/canvas/GLSystem';
 import type { ExtraMenuItem } from '$lib/components/object-preview-menu-actions';
 import type { P5Manager } from '$lib/p5/P5Manager';
@@ -19,6 +21,7 @@ type P5SurfaceModeOptions = {
 
 export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
   let isExpanded = $state(false);
+  const mouseForwarder = new SurfaceMouseForwarder(options.getNodes);
 
   const menuItems: ExtraMenuItem[] = $derived(
     options.isSurfaceModeEnabled()
@@ -81,6 +84,37 @@ export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
     options.getGlSystem().ipcSystem.requestSurfaceOverlayFrame(canvas);
   }
 
+  function hideExitButton() {
+    SurfaceOverlay.getInstance().hideBadge();
+  }
+
+  function setMouseForwarding(rules?: SurfaceMouseForwardingRules) {
+    mouseForwarder.setForwardingRules(rules);
+
+    if (isExpanded) {
+      mouseForwarder.forceHydraScope('local');
+      mouseForwarder.forceHydraScope('global');
+    }
+  }
+
+  function forwardPointer(x: number, y: number, buttons: number, type: string) {
+    if (!isExpanded) return;
+
+    mouseForwarder.forward(x, y, buttons, type);
+  }
+
+  function forwardWheel(event: {
+    x: number;
+    y: number;
+    deltaX: number;
+    deltaY: number;
+    deltaMode: number;
+  }) {
+    if (!isExpanded) return;
+
+    mouseForwarder.forwardWheel(event);
+  }
+
   function enter() {
     const p5Manager = options.getP5Manager();
 
@@ -101,16 +135,23 @@ export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
     glSystem.ipcSystem.sendSurfaceOverlayState({ active: true });
     p5Manager.setContainer(overlay.customHost);
 
+    mouseForwarder.refreshForwardingTargets();
+    mouseForwarder.forceHydraScope('global');
+
     options.updateSketch();
+  }
+
+  function deactivateMouse() {
+    SurfaceOverlay.getInstance().deactivate(options.nodeId);
+    options.getGlSystem().ipcSystem.sendSurfaceOverlayState(null);
+    mouseForwarder.forceHydraScope('local');
   }
 
   function exit() {
     if (!isExpanded) return;
 
     isExpanded = false;
-
-    SurfaceOverlay.getInstance().deactivate(options.nodeId);
-    options.getGlSystem().ipcSystem.sendSurfaceOverlayState(null);
+    deactivateMouse();
 
     options.getP5Manager()?.setContainer(options.getPreviewContainer());
 
@@ -118,10 +159,14 @@ export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
   }
 
   function cleanup() {
-    if (!isExpanded) return;
+    const wasExpanded = isExpanded;
+    isExpanded = false;
 
-    SurfaceOverlay.getInstance().deactivate(options.nodeId);
-    options.getGlSystem().ipcSystem.sendSurfaceOverlayState(null);
+    if (wasExpanded) {
+      deactivateMouse();
+    }
+
+    mouseForwarder.dispose();
   }
 
   return {
@@ -134,6 +179,10 @@ export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
     getCanvasSize,
     styleCanvas,
     requestMirrorFrame,
+    hideExitButton,
+    setMouseForwarding,
+    forwardPointer,
+    forwardWheel,
     enter,
     exit,
     cleanup

--- a/ui/src/lib/presets/builtin/p5.presets.ts
+++ b/ui/src/lib/presets/builtin/p5.presets.ts
@@ -199,12 +199,57 @@ function draw() {
   text(txt, width/2, height/2)
 }`;
 
-export const P5_PRESETS: Record<string, { type: string; data: { code: string } }> = {
+const SURFACE_P5 = `let hue = 0
+let points = []
+
+function setup() {
+  createSurfaceCanvas()
+
+  noDrag()
+  noStroke()
+}
+
+function draw() {
+  clear()
+
+  if (mouseIsPressed) {
+    points.push({
+      x: mouseX,
+      y: mouseY,
+      hue,
+      size: random(18, 54),
+      life: 1
+    })
+
+    hue = (hue + 4) % 360
+  }
+
+  colorMode(HSL, 360, 100, 100, 1)
+
+  for (const point of points) {
+    fill(point.hue, 90, 62, point.life * 0.8)
+    circle(point.x, point.y, point.size)
+    point.size *= 1.018
+    point.life -= 0.018
+  }
+
+  points = points.filter(point => point.life > 0)
+}`;
+
+export const P5_PRESETS: Record<
+  string,
+  { type: string; description?: string; data: { code: string } }
+> = {
   'traffic-light.p5': { type: 'p5', data: { code: TRAFFIC_LIGHT_P5.trim() } },
   'fft.p5': { type: 'p5', data: { code: AUDIO_FFT_FULL_P5.trim() } },
   'fft-sm.p5': { type: 'p5', data: { code: AUDIO_FFT_SMALL_P5.trim() } },
   'rms.p5': { type: 'p5', data: { code: AUDIO_FFT_RMS_NARROW_P5.trim() } },
   'rms-wide.p5': { type: 'p5', data: { code: AUDIO_FFT_RMS_WIDE_P5.trim() } },
   'bouncing-balls.p5': { type: 'p5', data: { code: BOUNCING_BALLS_P5.trim() } },
+  'surface.p5': {
+    type: 'p5',
+    description: 'Transparent fullscreen p5 drawing surface',
+    data: { code: SURFACE_P5.trim() }
+  },
   'text-banner.p5': { type: 'p5', data: { code: TEXT_BANNER_P5.trim() } }
 };

--- a/ui/static/content/objects/p5.md
+++ b/ui/static/content/objects/p5.md
@@ -33,6 +33,7 @@ P5-specific functions:
 
 - `noOutput()` - hides the video output port (useful for UI widgets that don't need video chaining)
 - `createSurfaceCanvas()` - creates a transparent surface-sized canvas and enables **Expand** so the sketch can run as a fullscreen overlay without chaining p5 pixels through the video pipeline
+- `expandSurface()` / `collapseSurface()` - enters or exits fullscreen surface mode from code
 - `hideExitButton()` - hides the fullscreen surface exit badge when the p5 sketch is expanded
 - `setMouseForwarding({ enabled, only, except })` - in surface mode, forwards p5 mouse and wheel interaction to mouse-aware render nodes such as `hydra`, `glsl`, `shaderpark`, and `three`
 
@@ -60,6 +61,7 @@ By default, expanded p5 surface sketches forward mouse interaction to render nod
 ```javascript
 function setup() {
   createSurfaceCanvas();
+  expandSurface();
   setMouseForwarding({ enabled: false });
 }
 ```

--- a/ui/static/content/objects/p5.md
+++ b/ui/static/content/objects/p5.md
@@ -33,6 +33,8 @@ P5-specific functions:
 
 - `noOutput()` - hides the video output port (useful for UI widgets that don't need video chaining)
 - `createSurfaceCanvas()` - creates a transparent surface-sized canvas and enables **Expand** so the sketch can run as a fullscreen overlay without chaining p5 pixels through the video pipeline
+- `hideExitButton()` - hides the fullscreen surface exit badge when the p5 sketch is expanded
+- `setMouseForwarding({ enabled, only, except })` - in surface mode, forwards p5 mouse and wheel interaction to mouse-aware render nodes such as `hydra`, `glsl`, `shaderpark`, and `three`
 
 ## Surface Overlay Mode
 
@@ -52,6 +54,15 @@ function draw() {
 ```
 
 After running code that calls `createSurfaceCanvas()`, use **Expand** in the node menu to enter the transparent overlay. Use `clear()` when you want the visuals underneath to show through. Use `background()` only when you intentionally want the p5 sketch to cover the output.
+
+By default, expanded p5 surface sketches forward mouse interaction to render nodes in the patch. Use `setMouseForwarding()` to restrict or disable that behavior:
+
+```javascript
+function setup() {
+  createSurfaceCanvas();
+  setMouseForwarding({ enabled: false });
+}
+```
 
 ## Using Libraries
 

--- a/ui/static/content/objects/p5.md
+++ b/ui/static/content/objects/p5.md
@@ -32,6 +32,26 @@ See the [Patchies JavaScript Runner](/docs/javascript-runner) for all available 
 P5-specific functions:
 
 - `noOutput()` - hides the video output port (useful for UI widgets that don't need video chaining)
+- `createSurfaceCanvas()` - creates a transparent surface-sized canvas and enables **Expand** so the sketch can run as a fullscreen overlay without chaining p5 pixels through the video pipeline
+
+## Surface Overlay Mode
+
+Use `createSurfaceCanvas()` when you want p5 interaction drawn directly over the fullscreen output, for example on top of Hydra or GLSL visuals:
+
+```javascript
+function setup() {
+  createSurfaceCanvas();
+}
+
+function draw() {
+  clear();
+  fill(255, 220);
+  noStroke();
+  circle(mouseX, mouseY, 48);
+}
+```
+
+After running code that calls `createSurfaceCanvas()`, use **Expand** in the node menu to enter the transparent overlay. Use `clear()` when you want the visuals underneath to show through. Use `background()` only when you intentionally want the p5 sketch to cover the output.
 
 ## Using Libraries
 

--- a/ui/static/content/objects/surface.md
+++ b/ui/static/content/objects/surface.md
@@ -166,13 +166,13 @@ function draw() {
 }
 ```
 
-## Activation API
+## Expansion API
 
 You can programmatically enter or exit fullscreen surface mode through JavaScript:
 
 ```javascript
-activate();    // Enter fullscreen surface mode
-deactivate();  // Exit fullscreen surface mode
+expandSurface();   // Enter fullscreen surface mode
+collapseSurface(); // Exit fullscreen surface mode
 ```
 
 Or, send messages to the inlet:
@@ -198,7 +198,7 @@ plus:
 - `setDrawMode('always'|'interact'|'manual')` — control render loop
 - `redraw()` — manually trigger a draw (manual mode)
 - `setMouseForwarding({ enabled, only, except })` — enable/disable or filter forwarded mouse events by node ID
-- `activate()` / `deactivate()` — enter/exit fullscreen
+- `expandSurface()` / `collapseSurface()` — enter/exit fullscreen
 - `hideExitButton()` — hide the "Exit surface (Shift+Esc)" badge
 - `noOutput()` — hide video output port
 


### PR DESCRIPTION
Add surface mode similar to the surface object for P5.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `createSurfaceCanvas()` for transparent fullscreen p5 surface overlays (with optional `/output` mirroring).
  * Introduced surface expansion controls (`expandSurface()` / `collapseSurface()`), plus UI helpers like `hideExitButton()` and `setMouseForwarding(...)` with pointer/wheel forwarding.
  * Added the `surface.p5` preset to the p5 demos pack and updated editor completions.
* **Documentation**
  * Updated p5/surface docs and added design guidance for “P5 Surface Mode” and fullscreen interaction.
* **Tests**
  * Added/updated tests for `surface.p5` availability and for preserving preloaded canvas sizing when using `createSurfaceCanvas()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->