### PR TITLE
feat(tap~): add ability to disable zero crossing

### DIFF
--- a/docs/design-docs/specs/127-tap-tilde-headless-scope.md
+++ b/docs/design-docs/specs/127-tap-tilde-headless-scope.md
@@ -6,9 +6,8 @@
 for responsiveness, but it has no outlet. This makes it impossible to route waveform
 data into video nodes (GLSL, Hydra, Three.js, etc.) or do any downstream processing.
 
-`tap~` solves this by separating the DSP from the display. It reuses the same
-`scope.processor` worklet with the same trigger logic (rising zero-crossing, maxWait
-fallback), but instead of rendering, it forwards each captured buffer as a message on
+`tap~` solves this by separating the DSP from the display. It captures audio
+frames in a native DSP worklet and forwards each captured buffer as a message on
 its outlet. Users pair it with canvas presets or any other downstream node.
 
 The existing `scope~` visual node is **unchanged**.
@@ -44,25 +43,27 @@ Float32Array  (length = bufferSize)
 { x: Float32Array, y: Float32Array }  (each length = bufferSize)
 ```
 
-The buffer is trigger-synced (rising zero-crossing on the X channel) — the same
-guarantee as `scope~`.
+When zero-crossing detection is enabled, the buffer is trigger-synced (rising
+zero-crossing on the X channel) with the same stability as `scope~`. When it is
+disabled, `tap~` continuously captures frames as soon as the FPS limit allows.
 
-### Settings (same as scope~)
+### Settings
 
-Exposed via the same `ScopeSettings.svelte` panel:
+Exposed via the `TapSettings.svelte` panel:
 
-| Setting              | Range         | Default  | Notes                                 |
-| -------------------- | ------------- | -------- | ------------------------------------- |
-| Samples (bufferSize) | 64–2048       | 512      | Controls buffer length sent per frame |
-| Mode                 | waveform / xy | waveform | Switches inlet count and output shape |
-| Refresh (fps)        | 0–120         | 0 (max)  | Throttles how often the worklet sends |
+| Setting              | Range     | Default | Notes                                            |
+| -------------------- | --------- | ------- | ------------------------------------------------ |
+| Samples (bufferSize) | 64–2048   | 512     | Controls buffer length sent per frame            |
+| Mode                 | wave / xy | wave    | Switches inlet count and output shape            |
+| FPS Limit (fps)      | 0–120     | 0 (max) | Throttles how often the worklet captures         |
+| Zero Crossing        | on / off  | on      | Starts captures on rising zero-crossings when on |
 
 X Scale, Y Scale, Plot Type, Decay, and Unipolar are **not** settings of `tap~` —
 they are rendering concerns owned by whichever canvas preset receives the data.
 
-The settings panel reuses `ScopeSettings.svelte` with only the relevant controls shown
-(Samples, Mode, Refresh + the Advanced accordion for Mode). X/Y scale, plot type,
-decay, and unipolar are hidden.
+The node UI itself stays compact and displays only the object name and sample
+count, for example `tap~ 512`. Mode and FPS are configured from settings, not
+shown on the node face.
 
 ---
 
@@ -107,14 +108,14 @@ from `tap~` in XY mode.
 
 **Settings:**
 
-| Setting         | Type                            | Description                            |
-| --------------- | ------------------------------- | -------------------------------------- |
-| xScale          | number                          | Horizontal zoom (default 1)            |
-| yScale          | number                          | Vertical zoom (default 1)              |
-| plotType        | `'line'`\|`'point'`\|`'bezier'` | Drawing style (default `'line'`)       |
-| decay           | number 0.01–1                   | Phosphor persistence (default 1)       |
-| foregroundColor | CSS color                       | Plot color (default `#22c55e`)         |
-| backgroundColor | CSS color                       | Clear/fade color (default `#080809`)   |
+| Setting         | Type                            | Description                          |
+| --------------- | ------------------------------- | ------------------------------------ |
+| xScale          | number                          | Horizontal zoom (default 1)          |
+| yScale          | number                          | Vertical zoom (default 1)            |
+| plotType        | `'line'`\|`'point'`\|`'bezier'` | Drawing style (default `'line'`)     |
+| decay           | number 0.01–1                   | Phosphor persistence (default 1)     |
+| foregroundColor | CSS color                       | Plot color (default `#22c55e`)       |
+| backgroundColor | CSS color                       | Clear/fade color (default `#080809`) |
 
 Drawing code is lifted directly from `ScopeNode.svelte:219–287` (`drawLissajous`).
 
@@ -128,39 +129,22 @@ Drawing code is lifted directly from `ScopeNode.svelte:219–287` (`drawLissajou
 component. `tap~` needs the opposite: push each buffer through the **message system**
 as soon as the worklet sends it.
 
-`tap~` is implemented as a **text object** (`TextObjectV2`) that owns its own
-`AudioWorkletNode` internally — it does not go through `AudioService.createNode()`.
-Instead, on `create()`:
-
-1. Ensures the `scope~` worklet module is loaded (reuse `ScopeAudioNode`'s module
-   registration to avoid double-loading the same worklet).
-2. Creates an `AudioWorkletNode` directly on the `AudioContext`.
-3. Sets `port.onmessage` to call `this.context.send(msg)` for each buffer received.
-
-This mirrors how `ScopeAudioNode` works but routes output to the message system
-instead of storing it.
+`tap~` is implemented as a dedicated Svelte node component backed by the native
+DSP audio node registered with `AudioService`. The component owns the compact UI
+and settings panel, while the native DSP worklet captures buffers and forwards
+them through `MessageSystem`.
 
 ### Audio connections
 
-Because `tap~` is a text object, `AudioService` won't wire up its audio connections
-automatically. It needs to implement `connectFrom()` (same logic as `ScopeAudioNode`)
-and register itself so the audio routing system can find its `AudioWorkletNode`.
-
-Pattern to follow: examine how hybrid audio/message nodes are handled in the codebase
-(e.g. `snapshot~`). If no clean pattern exists yet, `tap~` may need to expose its
-`audioNode` reference and hook into `AudioService` manually.
-
-> **Open question for implementation:** confirm the exact mechanism by which a text
-> object can participate in audio graph routing. This may require a small addition to
-> AudioService or a new interface.
+Because `tap~` is a dedicated node type, `AudioService` wires its audio inlets the
+same way it wires other native DSP nodes. The processor has two audio inputs and
+one message outlet.
 
 ---
 
 ## Files to Create
 
 ```
-ui/src/lib/audio/v2/nodes/TapAudioNode.ts          # AudioNodeV2 with message forwarding
-ui/src/lib/objects/v2/nodes/TapTildeObject.ts       # TextObjectV2 wrapper (owns audio node)
 ui/src/lib/presets/builtin/canvas.presets/scope.ts  # scope.canvas preset
 ui/src/lib/presets/builtin/canvas.presets/lissajous.ts  # scope-xy.canvas preset
 ui/static/content/objects/tap~.md                   # Object documentation
@@ -169,12 +153,14 @@ ui/static/content/objects/tap~.md                   # Object documentation
 ## Files to Modify
 
 ```
-ui/src/lib/audio/v2/nodes/index.ts                  # Register TapAudioNode
-ui/src/lib/objects/v2/nodes/index.ts                # Register TapTildeObject
+ui/src/lib/components/nodes/TapTildeNode.svelte     # Compact UI node
+ui/src/lib/components/settings/TapSettings.svelte   # tap~ settings panel
+ui/src/lib/audio/native-dsp/nodes/tap.node.ts       # Native DSP node metadata
+ui/src/lib/audio/native-dsp/processors/tap.processor.ts # Capture processor
 ui/src/lib/extensions/object-packs.ts               # Add tap~ to Audio pack
 ui/src/lib/presets/builtin/canvas.presets/index.ts  # Export scope.canvas + scope-xy.canvas
 ui/src/lib/extensions/preset-packs.ts               # Add presets to pack
-ui/src/lib/components/settings/ScopeSettings.svelte # Add props to hide irrelevant controls
+ui/src/lib/migration/migrations                     # Migrate old text-object tap~
 ```
 
 ---
@@ -195,7 +181,7 @@ ui/src/lib/components/settings/ScopeSettings.svelte # Add props to hide irreleva
 
 ## Out of Scope
 
-- `tap~` does not render anything itself — no canvas, no display.
+- `tap~` does not render waveforms itself — no canvas, no display.
 - The canvas presets do not emit data — they are sinks.
 - `scope~` (visual) is unchanged.
 - No changes to `scope.processor.ts` — it is shared as-is.

--- a/ui/src/lib/ai/object-descriptions-types.ts
+++ b/ui/src/lib/ai/object-descriptions-types.ts
@@ -15,6 +15,7 @@ export const OBJECT_TYPE_LIST = `## Basic Control & UI
 - out~: Audio output to speakers/headphones
 - meter~: Visual audio level meter
 - scope~: Oscilloscope display for audio signals
+- tap~: Headless audio frame capture for routing waveform data as messages
 - soundfile~: Load and play audio files
 - sampler~: Sample playback with triggering
 - pads~: 16-pad drum sampler triggered by MIDI noteOn/noteOff (GM drum map, note 36 = pad 1)
@@ -34,7 +35,7 @@ export const OBJECT_TYPE_LIST = `## Basic Control & UI
   * Timing: beat~ (fire on beat subdivisions), bang~ (convert signal bang to message bang)
   * Routing: send (send messages to a named channel), recv (receive messages from a named channel), send~, recv~ (wireless audio routing)
   * Utility: bang, float, metro, loadbang, samplerate~, mtof (message-rate)
-  * Analysis: fft~ (FFT spectrum analyzer), tap~ (capture trigger-synced audio frames as messages)
+  * Analysis: fft~ (FFT spectrum analyzer)
   * IMPORTANT: Use type "object" with data containing THREE fields: expr (full string), name (first word only), params (array of values matching arguments)
   * data format: { "expr": "name arg1 arg2", "name": "name", "params": [arg1, arg2] }
   * Examples:
@@ -190,6 +191,7 @@ export const SPARKS_OBJECT_LIST = `## Visuals
 ## Audio Analysis
 - fft~: FFT spectrum analyzer — frequency bands drive visuals or routing
 - scope~: Oscilloscope — visualise waveforms in real time
+- tap~: Headless audio frame capture — route waveform buffers to canvas or GLSL
 - meter~: Audio level meter
 
 ## Audio I/O

--- a/ui/src/lib/ai/object-prompts/tap~.ts
+++ b/ui/src/lib/ai/object-prompts/tap~.ts
@@ -1,45 +1,64 @@
 export const tapTildePrompt = `## tap~ Object Instructions
 
-Headless oscilloscope — captures trigger-synced audio frames and forwards them as messages. Use when you want waveform data to flow into canvas, GLSL, Hydra, or any downstream node.
+Headless oscilloscope — captures audio frames and forwards them as messages. Use when you want waveform data to flow into canvas, GLSL, Hydra, or any downstream node.
 
 Unlike scope~ (which renders a built-in display), tap~ has no display. Pair it with scope.canvas (waveform) or scope-xy.canvas (XY) presets, or process the raw buffers yourself.
+
+Node format:
+- Create tap~ as a dedicated node: "type": "tap~"
+- Do NOT create tap~ as a generic "object" node
+- Do NOT use text-object fields like expr, name, or params
+- Store settings directly in data: bufferSize, mode, fps, zeroCrossing
 
 Inlets:
 - inlet 0: audio signal (X axis in XY mode)
 - inlet 1: Y axis signal (XY mode only)
-- inlet 2: bufferSize (int, 64–2048, default 512)
-- inlet 3: mode ("wave" or "xy", default "wave")
-- inlet 4: fps (float, 0 = unlimited, default 0)
 
 Output (outlet 0):
-- wave mode: Float32Array of audio samples, trigger-synced on rising zero-crossing
+- wave mode: Float32Array of audio samples
 - xy mode: { type: "xy", x: Float32Array, y: Float32Array }
+
+Settings:
+- bufferSize: 64–2048, default 512
+- mode: "wave" or "xy", default "wave"
+- fps: 0–120, default 0 (unlimited)
+- zeroCrossing: boolean, default true. Set false for continuous monitoring without scope-style trigger locking.
+
+Default data:
+\`\`\`json
+{
+  "bufferSize": 512,
+  "mode": "wave",
+  "fps": 0,
+  "zeroCrossing": true
+}
+\`\`\`
 
 Example - Basic waveform tap into scope.canvas:
 \`\`\`json
 {
-  "type": "object",
-  "data": { "expr": "tap~", "name": "tap~", "params": [] }
+  "type": "tap~",
+  "data": { "bufferSize": 512, "mode": "wave", "fps": 0, "zeroCrossing": true }
 }
 \`\`\`
 
 Example - XY mode for Lissajous figures:
 \`\`\`json
 {
-  "type": "object",
-  "data": { "expr": "tap~ 512 xy", "name": "tap~", "params": [512, "xy"] }
+  "type": "tap~",
+  "data": { "bufferSize": 512, "mode": "xy", "fps": 0, "zeroCrossing": true }
 }
 \`\`\`
 
-Example - Throttled capture at 30fps:
+Example - Continuous monitoring at 30fps:
 \`\`\`json
 {
-  "type": "object",
-  "data": { "expr": "tap~ 512 wave 30", "name": "tap~", "params": [512, "wave", 30] }
+  "type": "tap~",
+  "data": { "bufferSize": 512, "mode": "wave", "fps": 30, "zeroCrossing": false }
 }
 \`\`\`
 
 Typical patch pattern:
 - [osc~ 440] → [tap~] → [scope.canvas]
 - [osc~ 440] → [tap~] → [glsl~] (pass buffer as uniform)
-- [osc~ 440] + [osc~ 220] → [tap~ 512 xy] → [scope-xy.canvas]`;
+- [osc~ 440] + [osc~ 220] → [tap~] with mode "xy" → [scope-xy.canvas]`;

--- a/ui/src/lib/audio/native-dsp/nodes/tap.node.ts
+++ b/ui/src/lib/audio/native-dsp/nodes/tap.node.ts
@@ -45,6 +45,12 @@ export const TapNode = createWorkletDspNode({
       defaultValue: 0,
       minNumber: 0,
       maxNumber: 120
+    },
+    {
+      name: 'zeroCrossing',
+      type: 'bool',
+      description: 'Trigger captures on rising zero-crossings for stable scope-style frames',
+      defaultValue: true
     }
   ],
 
@@ -52,7 +58,7 @@ export const TapNode = createWorkletDspNode({
     {
       name: 'out',
       type: 'message',
-      description: 'Captured buffer, trigger-synced on rising zero-crossing.',
+      description: 'Captured buffer.',
       messages: [
         {
           schema: Type.Unsafe<Float32Array>({ type: 'Float32Array' }),

--- a/ui/src/lib/audio/native-dsp/processors/tap-trigger.test.ts
+++ b/ui/src/lib/audio/native-dsp/processors/tap-trigger.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest';
+
+import { shouldStartCapture } from './tap-trigger';
+
+describe('tap~ capture trigger', () => {
+  test('waits for a rising zero-crossing when zero-crossing is enabled', () => {
+    expect(
+      shouldStartCapture({
+        zeroCrossing: true,
+        prevSample: 0.2,
+        sample: 0.3,
+        samplesSinceLastSend: 128,
+        maxWait: 4096
+      })
+    ).toBe(false);
+
+    expect(
+      shouldStartCapture({
+        zeroCrossing: true,
+        prevSample: -0.1,
+        sample: 0.1,
+        samplesSinceLastSend: 128,
+        maxWait: 4096
+      })
+    ).toBe(true);
+  });
+
+  test('starts continuously after cooldown when zero-crossing is disabled', () => {
+    expect(
+      shouldStartCapture({
+        zeroCrossing: false,
+        prevSample: 0.2,
+        sample: 0.3,
+        samplesSinceLastSend: 128,
+        maxWait: 4096
+      })
+    ).toBe(true);
+  });
+
+  test('still forces capture after max wait when zero-crossing is enabled', () => {
+    expect(
+      shouldStartCapture({
+        zeroCrossing: true,
+        prevSample: 0.2,
+        sample: 0.3,
+        samplesSinceLastSend: 4096,
+        maxWait: 4096
+      })
+    ).toBe(true);
+  });
+});

--- a/ui/src/lib/audio/native-dsp/processors/tap-trigger.ts
+++ b/ui/src/lib/audio/native-dsp/processors/tap-trigger.ts
@@ -1,0 +1,20 @@
+export type TapCaptureTriggerInput = {
+  zeroCrossing: boolean;
+  prevSample: number;
+  sample: number;
+  samplesSinceLastSend: number;
+  maxWait: number;
+};
+
+export function shouldStartCapture({
+  zeroCrossing,
+  prevSample,
+  sample,
+  samplesSinceLastSend,
+  maxWait
+}: TapCaptureTriggerInput): boolean {
+  if (samplesSinceLastSend >= maxWait) return true;
+  if (!zeroCrossing) return true;
+
+  return prevSample <= 0 && sample > 0;
+}

--- a/ui/src/lib/audio/native-dsp/processors/tap.processor.ts
+++ b/ui/src/lib/audio/native-dsp/processors/tap.processor.ts
@@ -1,4 +1,5 @@
 import { defineDSP } from '../define-dsp';
+import { shouldStartCapture } from './tap-trigger';
 
 defineDSP({
   name: 'tap~',
@@ -16,7 +17,8 @@ defineDSP({
     bufferSize: 512,
     maxWait: 4096,
     cooldownSamples: 0,
-    mode: 'wave' as 'wave' | 'xy'
+    mode: 'wave' as 'wave' | 'xy',
+    zeroCrossing: true
   }),
 
   recv(state, data, inlet) {
@@ -50,6 +52,14 @@ defineDSP({
           : 0;
       return;
     }
+
+    // inlet 5 = zeroCrossing (boolean)
+    if (inlet === 5 && typeof data === 'boolean') {
+      state.zeroCrossing = data;
+      state.phase = 'waiting';
+      state.writeIndex = 0;
+      return;
+    }
   },
 
   process(state, inputs, _outputs, send) {
@@ -71,7 +81,15 @@ defineDSP({
           continue;
         }
 
-        if ((state.prevSample <= 0 && sample > 0) || state.samplesSinceLastSend >= state.maxWait) {
+        if (
+          shouldStartCapture({
+            zeroCrossing: state.zeroCrossing,
+            prevSample: state.prevSample,
+            sample,
+            samplesSinceLastSend: state.samplesSinceLastSend,
+            maxWait: state.maxWait
+          })
+        ) {
           state.phase = 'filling';
           state.writeIndex = 0;
 

--- a/ui/src/lib/components/nodes/TapTildeNode.svelte
+++ b/ui/src/lib/components/nodes/TapTildeNode.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
+  import { Settings, X, RotateCcw } from '@lucide/svelte/icons';
+  import { useEdges, useSvelteFlow, useUpdateNodeInternals } from '@xyflow/svelte';
+  import { AudioService } from '$lib/audio/v2/AudioService';
+  import type { AudioNodeV2 } from '$lib/audio/v2/interfaces/audio-nodes';
+  import TypedHandle from '$lib/components/TypedHandle.svelte';
+  import TapSettings from '$lib/components/settings/TapSettings.svelte';
+  import * as Tooltip from '$lib/components/ui/tooltip';
+  import { checkAudioConnections } from '$lib/composables/checkHandleConnections';
+  import { useNodeDataTracker } from '$lib/history';
+  import { shouldShowHandles } from '../../../stores/ui.store';
+  import { editorFontFamily } from '../../../stores/editor.store';
+
+  type TapMode = 'wave' | 'xy';
+  type TapNodeData = {
+    mode?: TapMode;
+    bufferSize?: number;
+    fps?: number;
+    zeroCrossing?: boolean;
+  };
+
+  const DEFAULTS = {
+    mode: 'wave' as TapMode,
+    bufferSize: 512,
+    fps: 0,
+    zeroCrossing: true
+  };
+
+  let node: {
+    id: string;
+    data: TapNodeData;
+    selected: boolean;
+  } = $props();
+
+  const { updateNodeData, getEdges, deleteElements } = useSvelteFlow();
+  const updateNodeInternals = useUpdateNodeInternals();
+  const edges = useEdges();
+  const tracker = useNodeDataTracker(node.id);
+  const audioService = AudioService.getInstance();
+
+  let showSettings = $state(false);
+  let tapNode: AudioNodeV2 | null = $state(null);
+  let nodeButton: HTMLButtonElement | null = $state(null);
+  let resizeObserver: ResizeObserver | null = null;
+  let settingsOffset = $state(112);
+  let mode = $state<TapMode>(node.data.mode ?? DEFAULTS.mode);
+  let bufferSize = $state(node.data.bufferSize ?? DEFAULTS.bufferSize);
+  let fps = $state(node.data.fps ?? DEFAULTS.fps);
+  let zeroCrossing = $state(node.data.zeroCrossing ?? DEFAULTS.zeroCrossing);
+
+  const connections = $derived(checkAudioConnections(edges.current, node.id));
+  const inletCount = $derived(mode === 'xy' ? 2 : 1);
+  const containerClass = $derived(node.selected ? 'object-container-selected' : 'object-container');
+  const HIDDEN_HANDLE_CLASS = 'opacity-30 group-hover:opacity-100 sm:opacity-0';
+  const handleInletClass = $derived(
+    node.selected || $shouldShowHandles || connections.hasInlet ? '' : HIDDEN_HANDLE_CLASS
+  );
+
+  function sendSetting(key: string, value: unknown) {
+    tapNode?.send?.(key, value);
+  }
+
+  function updateSettingsOffset() {
+    if (!nodeButton) return;
+
+    settingsOffset = nodeButton.offsetWidth + 10;
+  }
+
+  function applyAllSettings() {
+    sendSetting('bufferSize', bufferSize);
+    sendSetting('mode', mode);
+    sendSetting('fps', fps);
+    sendSetting('zeroCrossing', zeroCrossing);
+  }
+
+  function updateSettings(updates: Partial<TapNodeData>) {
+    updateNodeData(node.id, updates);
+  }
+
+  function handleModeChange(value: TapMode) {
+    const oldValue = mode;
+    mode = value;
+    updateSettings({ mode: value });
+    sendSetting('mode', value);
+    tracker.commit('mode', oldValue, value);
+  }
+
+  const bufferSizeTracker = tracker.track('bufferSize', () => node.data.bufferSize ?? 512);
+
+  function handleBufferSizeChange(value: number) {
+    bufferSize = value;
+    updateSettings({ bufferSize: value });
+    sendSetting('bufferSize', value);
+  }
+
+  const fpsTracker = tracker.track('fps', () => node.data.fps ?? 0);
+
+  function handleFpsChange(value: number) {
+    fps = value;
+    updateSettings({ fps: value });
+    sendSetting('fps', value);
+  }
+
+  function handleZeroCrossingChange(value: boolean) {
+    const oldValue = zeroCrossing;
+    zeroCrossing = value;
+    updateSettings({ zeroCrossing: value });
+    sendSetting('zeroCrossing', value);
+    tracker.commit('zeroCrossing', oldValue, value);
+  }
+
+  function resetSettings() {
+    const oldMode = mode;
+    const oldZeroCrossing = zeroCrossing;
+
+    mode = DEFAULTS.mode;
+    bufferSize = DEFAULTS.bufferSize;
+    fps = DEFAULTS.fps;
+    zeroCrossing = DEFAULTS.zeroCrossing;
+
+    updateSettings({ ...DEFAULTS });
+    sendSetting('bufferSize', DEFAULTS.bufferSize);
+    sendSetting('mode', DEFAULTS.mode);
+    sendSetting('fps', DEFAULTS.fps);
+    sendSetting('zeroCrossing', DEFAULTS.zeroCrossing);
+    tracker.commit('mode', oldMode, mode);
+    tracker.commit('zeroCrossing', oldZeroCrossing, zeroCrossing);
+  }
+
+  let prevInletCount: number | null = null;
+  $effect(() => {
+    const count = inletCount;
+    updateNodeInternals(node.id);
+
+    if (prevInletCount === null) {
+      prevInletCount = count;
+      return;
+    }
+
+    if (count < prevInletCount) {
+      const staleEdges = getEdges().filter(
+        (edge) => edge.target === node.id && edge.targetHandle === 'audio-in-1'
+      );
+      if (staleEdges.length > 0) {
+        deleteElements({ edges: staleEdges });
+      }
+    }
+
+    prevInletCount = count;
+  });
+
+  onMount(async () => {
+    tapNode = await audioService.createNode(node.id, 'tap~', []);
+    applyAllSettings();
+
+    updateSettingsOffset();
+    if (nodeButton && typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(updateSettingsOffset);
+      resizeObserver.observe(nodeButton);
+    }
+  });
+
+  onDestroy(() => {
+    resizeObserver?.disconnect();
+    audioService.removeNodeById(node.id);
+  });
+</script>
+
+<div class="relative flex gap-x-3" style:--patchies-tap-node-font-family={$editorFontFamily}>
+  <div class="group relative">
+    <div class="absolute -top-7 right-0 z-10 flex gap-x-1">
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          <button
+            class={[
+              'cursor-pointer rounded p-1 transition-opacity hover:bg-zinc-700',
+              node.selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+            ]}
+            onclick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              showSettings = !showSettings;
+            }}
+            aria-label="Configure tap"
+          >
+            <Settings class="h-4 w-4 text-zinc-300" />
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Content>Settings</Tooltip.Content>
+      </Tooltip.Root>
+    </div>
+
+    <div class="relative">
+      <TypedHandle
+        port="inlet"
+        spec={{ handleType: 'audio', handleId: '0' }}
+        total={inletCount}
+        index={0}
+        title={mode === 'xy' ? 'X axis' : 'Audio input'}
+        class={handleInletClass}
+        nodeId={node.id}
+      />
+
+      {#if mode === 'xy'}
+        <TypedHandle
+          port="inlet"
+          spec={{ handleType: 'audio', handleId: '1' }}
+          total={inletCount}
+          index={1}
+          title="Y axis"
+          class={handleInletClass}
+          nodeId={node.id}
+        />
+      {/if}
+
+      <button
+        bind:this={nodeButton}
+        class={['cursor-pointer rounded-lg border px-3 py-2', containerClass]}
+      >
+        <div class="tap-node-label text-xs text-zinc-300">tap~ {bufferSize}</div>
+      </button>
+
+      <TypedHandle
+        port="outlet"
+        spec={{ handleType: 'message', handleId: '0' }}
+        total={1}
+        index={0}
+        title="Captured buffer output"
+        nodeId={node.id}
+      />
+    </div>
+  </div>
+
+  {#if showSettings}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="absolute z-20"
+      style:left={`${settingsOffset}px`}
+      onclick={(e) => e.stopPropagation()}
+    >
+      <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button
+              onclick={resetSettings}
+              class="h-6 w-6 cursor-pointer rounded bg-zinc-950 p-1 text-zinc-300 hover:bg-zinc-700"
+              aria-label="Reset tap settings"
+            >
+              <RotateCcw class="h-4 w-4" />
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>Reset</Tooltip.Content>
+        </Tooltip.Root>
+
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button
+              onclick={() => (showSettings = false)}
+              class="h-6 w-6 cursor-pointer rounded bg-zinc-950 p-1 text-zinc-300 hover:bg-zinc-700"
+              aria-label="Close tap settings"
+            >
+              <X class="h-4 w-4" />
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>Close</Tooltip.Content>
+        </Tooltip.Root>
+      </div>
+
+      <div class="nodrag ml-2 w-48 rounded-md border border-zinc-600 bg-zinc-900 p-4 shadow-xl">
+        <TapSettings
+          {mode}
+          {bufferSize}
+          {fps}
+          {zeroCrossing}
+          {bufferSizeTracker}
+          {fpsTracker}
+          onModeChange={handleModeChange}
+          onBufferSizeChange={handleBufferSizeChange}
+          onFpsChange={handleFpsChange}
+          onZeroCrossingChange={handleZeroCrossingChange}
+        />
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .tap-node-label {
+    font-family: var(--patchies-tap-node-font-family, var(--font-mono));
+  }
+</style>

--- a/ui/src/lib/components/settings/TapSettings.svelte
+++ b/ui/src/lib/components/settings/TapSettings.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import SettingsSlider from '$lib/components/SettingsSlider.svelte';
+
+  type TapMode = 'wave' | 'xy';
+
+  let {
+    mode,
+    bufferSize,
+    fps,
+    zeroCrossing,
+    bufferSizeTracker,
+    fpsTracker,
+    onModeChange,
+    onBufferSizeChange,
+    onFpsChange,
+    onZeroCrossingChange
+  }: {
+    mode: TapMode;
+    bufferSize: number;
+    fps: number;
+    zeroCrossing: boolean;
+    bufferSizeTracker: { onFocus: () => void; onBlur: () => void };
+    fpsTracker: { onFocus: () => void; onBlur: () => void };
+    onModeChange: (value: TapMode) => void;
+    onBufferSizeChange: (value: number) => void;
+    onFpsChange: (value: number) => void;
+    onZeroCrossingChange: (value: boolean) => void;
+  } = $props();
+</script>
+
+<div class="space-y-4">
+  <div>
+    <div class="mb-1 flex items-center justify-between">
+      <span class="text-xs font-medium text-zinc-300">Samples</span>
+      <span class="text-xs text-zinc-500">{bufferSize}</span>
+    </div>
+
+    <SettingsSlider
+      min={64}
+      max={2048}
+      value={bufferSize}
+      onchange={onBufferSizeChange}
+      onpointerdown={bufferSizeTracker.onFocus}
+      onpointerup={bufferSizeTracker.onBlur}
+    />
+  </div>
+
+  <div class="flex items-center justify-between">
+    <span class="text-xs font-medium text-zinc-300">Zero Crossing</span>
+    <button
+      class={[
+        'h-5 w-9 cursor-pointer rounded-full transition-colors',
+        zeroCrossing ? 'bg-green-600' : 'bg-zinc-700'
+      ]}
+      onclick={() => onZeroCrossingChange(!zeroCrossing)}
+      aria-label="Toggle zero-crossing detection"
+      aria-pressed={zeroCrossing}
+    >
+      <div
+        class={[
+          'h-4 w-4 rounded-full bg-white transition-transform',
+          zeroCrossing ? 'translate-x-4.5' : 'translate-x-0.5'
+        ]}
+      ></div>
+    </button>
+  </div>
+
+  <div>
+    <span class="mb-1 block text-xs font-medium text-zinc-300">Mode</span>
+    <div class="flex gap-1">
+      {#each ['wave', 'xy'] as modeOption (modeOption)}
+        <button
+          class={[
+            'flex-1 cursor-pointer rounded px-2 py-1 text-xs transition-colors',
+            mode === modeOption
+              ? 'bg-green-600 text-white'
+              : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700'
+          ]}
+          onclick={() => onModeChange(modeOption as TapMode)}
+        >
+          {modeOption}
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <div>
+    <div class="mb-1 flex items-center justify-between">
+      <span class="text-xs font-medium text-zinc-300">FPS Limit</span>
+      <span class="text-xs text-zinc-500">{fps === 0 ? 'max' : `${fps} fps`}</span>
+    </div>
+    <SettingsSlider
+      min={0}
+      max={120}
+      value={fps}
+      onchange={onFpsChange}
+      onpointerdown={fpsTracker.onFocus}
+      onpointerup={fpsTracker.onBlur}
+    />
+  </div>
+</div>

--- a/ui/src/lib/generated/object-schemas.generated.ts
+++ b/ui/src/lib/generated/object-schemas.generated.ts
@@ -3751,13 +3751,25 @@ export const generatedObjectSchemas: ObjectSchemaRegistry = {
           }
         ],
         handle: { handleType: 'message', handleId: 4 }
+      },
+      {
+        id: 'zeroCrossing',
+        type: 'bool',
+        description: 'Trigger captures on rising zero-crossings for stable scope-style frames',
+        messages: [
+          {
+            schema: Type.Boolean(),
+            description: 'Trigger captures on rising zero-crossings for stable scope-style frames'
+          }
+        ],
+        handle: { handleType: 'message', handleId: 5 }
       }
     ],
     outlets: [
       {
         id: 'out',
         type: 'message',
-        description: 'Captured buffer, trigger-synced on rising zero-crossing.',
+        description: 'Captured buffer.',
         messages: [
           { schema: Type.Unsafe({ type: 'Float32Array' }), description: 'Wave Mode' },
           {

--- a/ui/src/lib/migration/migrate-patch.ts
+++ b/ui/src/lib/migration/migrate-patch.ts
@@ -12,6 +12,7 @@ import { migration010 } from './migrations/010-table-to-visual-node';
 import { migration011 } from './migrations/011-fix-redundant-handle-ids';
 import { migration012 } from './migrations/012-default-output-size-for-old-patches';
 import { migration013 } from './migrations/013-expr-multi-outlet-handles';
+import { migration014 } from './migrations/014-tap-to-ui-node';
 
 /**
  * All migrations in order. Each migration upgrades from version N-1 to N.
@@ -30,7 +31,8 @@ const migrations: Migration[] = [
   migration010,
   migration011,
   migration012,
-  migration013
+  migration013,
+  migration014
 ];
 
 /**

--- a/ui/src/lib/migration/migrations/014-tap-to-ui-node.test.ts
+++ b/ui/src/lib/migration/migrations/014-tap-to-ui-node.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'vitest';
+
+import { migration014 } from './014-tap-to-ui-node';
+import type { RawPatchData } from '../types';
+
+describe('migration014', () => {
+  test('converts tap~ text objects to dedicated UI nodes with settings data', () => {
+    const patch: RawPatchData = {
+      version: '13',
+      nodes: [
+        {
+          id: 'tap-1',
+          type: 'object',
+          position: { x: 0, y: 0 },
+          data: {
+            expr: 'tap~ 1024 xy 30',
+            name: 'tap~',
+            params: [1024, 'xy', 30]
+          }
+        },
+        {
+          id: 'tap-2',
+          type: 'object',
+          position: { x: 0, y: 100 },
+          data: {
+            expr: 'tap~',
+            name: 'tap~',
+            params: []
+          }
+        }
+      ],
+      edges: [
+        {
+          id: 'audio-in',
+          source: 'osc-1',
+          target: 'tap-1',
+          sourceHandle: 'audio-out',
+          targetHandle: 'audio-in'
+        },
+        {
+          id: 'message-out',
+          source: 'tap-1',
+          target: 'canvas-1',
+          sourceHandle: 'message-out',
+          targetHandle: 'message-in'
+        }
+      ]
+    };
+
+    const migrated = migration014.migrate(patch);
+
+    expect(migrated.nodes?.[0]).toMatchObject({
+      id: 'tap-1',
+      type: 'tap~',
+      data: {
+        bufferSize: 1024,
+        mode: 'xy',
+        fps: 30,
+        zeroCrossing: true
+      }
+    });
+
+    expect(migrated.nodes?.[1]).toMatchObject({
+      id: 'tap-2',
+      type: 'tap~',
+      data: {
+        bufferSize: 512,
+        mode: 'wave',
+        fps: 0,
+        zeroCrossing: true
+      }
+    });
+
+    expect(migrated.edges).toEqual([
+      expect.objectContaining({ id: 'audio-in', targetHandle: 'audio-in-0' }),
+      expect.objectContaining({ id: 'message-out', sourceHandle: 'message-out-0' })
+    ]);
+  });
+});

--- a/ui/src/lib/migration/migrations/014-tap-to-ui-node.ts
+++ b/ui/src/lib/migration/migrations/014-tap-to-ui-node.ts
@@ -1,0 +1,117 @@
+import type { Migration } from '../types';
+
+type TapMode = 'wave' | 'xy';
+
+/**
+ * Migration 014: Convert tap~ text objects to dedicated UI nodes.
+ *
+ * Before: tap~ was a generic `object` node with expression params.
+ * After: tap~ has a compact Svelte UI and stores its settings in node data.
+ */
+export const migration014: Migration = {
+  version: 14,
+  name: 'tap-to-ui-node',
+
+  migrate(patch) {
+    if (!patch.nodes) return patch;
+
+    const migratedNodeIds = new Set<string>();
+
+    const migratedNodes = patch.nodes.map((node) => {
+      if (node.type !== 'object') return node;
+
+      const data = node.data as { expr?: string; name?: string; params?: unknown[] } | undefined;
+      const exprName = typeof data?.expr === 'string' ? data.expr.trim().split(/\s+/)[0] : '';
+      if (data?.name !== 'tap~' && exprName !== 'tap~') return node;
+
+      migratedNodeIds.add(node.id);
+
+      return {
+        ...node,
+        type: 'tap~',
+        data: getTapSettings(data)
+      };
+    });
+
+    const migratedEdges = patch.edges?.map((edge) => {
+      let nextEdge = edge;
+
+      if (migratedNodeIds.has(edge.target)) {
+        nextEdge = {
+          ...nextEdge,
+          targetHandle: rewriteTapInletHandle(edge.targetHandle)
+        };
+      }
+
+      if (migratedNodeIds.has(edge.source)) {
+        nextEdge = {
+          ...nextEdge,
+          sourceHandle: rewriteTapOutletHandle(edge.sourceHandle)
+        };
+      }
+
+      return nextEdge;
+    });
+
+    return { ...patch, nodes: migratedNodes, edges: migratedEdges };
+  }
+};
+
+function getTapSettings(data: { expr?: string; params?: unknown[] } | undefined) {
+  const params = Array.isArray(data?.params) ? data.params : [];
+  const exprParts = typeof data?.expr === 'string' ? data.expr.trim().split(/\s+/).slice(1) : [];
+  const hasSignalParamPlaceholders = params[0] === null && params[1] === null;
+
+  const compactParams = hasSignalParamPlaceholders ? params.slice(2) : params;
+  const compactExprParts = exprParts;
+
+  return {
+    bufferSize: parseBufferSize(compactParams[0] ?? compactExprParts[0]),
+    mode: parseMode(compactParams[1] ?? compactExprParts[1]),
+    fps: parseFps(compactParams[2] ?? compactExprParts[2]),
+    zeroCrossing: parseZeroCrossing(compactParams[3] ?? compactExprParts[3])
+  };
+}
+
+function parseBufferSize(value: unknown): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed < 64 || parsed > 2048) return 512;
+
+  return Math.round(parsed);
+}
+
+function parseMode(value: unknown): TapMode {
+  return value === 'xy' ? 'xy' : 'wave';
+}
+
+function parseFps(value: unknown): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 120) return 0;
+
+  return parsed;
+}
+
+function parseZeroCrossing(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (value === 'false' || value === 'off' || value === 'none') return false;
+
+  return true;
+}
+
+function rewriteTapInletHandle(handle: string | null | undefined): string | null | undefined {
+  if (handle === 'audio-in' || handle === 'signal-in' || handle === 'signal-in-0') {
+    return 'audio-in-0';
+  }
+
+  if (handle === 'signal-in-1') {
+    return 'audio-in-1';
+  }
+
+  return handle;
+}
+
+function rewriteTapOutletHandle(handle: string | null | undefined): string | null | undefined {
+  if (handle === 'message-out') return 'message-out-0';
+
+  return handle;
+}

--- a/ui/src/lib/nodes/defaultNodeData.ts
+++ b/ui/src/lib/nodes/defaultNodeData.ts
@@ -219,6 +219,12 @@ export function getDefaultNodeData(nodeType: string): NodeData {
       plotType: 'line',
       decay: 1
     }))
+    .with('tap~', () => ({
+      mode: 'wave',
+      bufferSize: 512,
+      fps: 0,
+      zeroCrossing: true
+    }))
     .with('keyboard', () => ({ keybind: '', mode: 'all', trigger: 'keydown', repeat: false }))
     .with('sampler~', () => ({
       hasRecording: false,

--- a/ui/src/lib/nodes/node-types.ts
+++ b/ui/src/lib/nodes/node-types.ts
@@ -89,6 +89,7 @@ import PostItNode from '$lib/components/nodes/PostItNode.svelte';
 import PatchbayNode from '$lib/components/nodes/PatchbayNode.svelte';
 import TitleNode from '$lib/components/nodes/TitleNode.svelte';
 import ScopeNode from '$lib/components/nodes/ScopeNode.svelte';
+import TapTildeNode from '$lib/components/nodes/TapTildeNode.svelte';
 import UiuaNode from '$lib/components/nodes/UiuaNode.svelte';
 import BytebeatNode from '$lib/components/nodes/BytebeatNode.svelte';
 import SequencerNode from '$lib/components/nodes/SequencerNode.svelte';
@@ -203,6 +204,7 @@ export const nodeTypes: Record<string, any> = {
   note: PostItNode,
   title: TitleNode,
   'scope~': ScopeNode,
+  'tap~': TapTildeNode,
   uiua: UiuaNode,
   'bytebeat~': BytebeatNode,
   sequencer: SequencerNode,

--- a/ui/src/lib/objects/builtin-shorthands.ts
+++ b/ui/src/lib/objects/builtin-shorthands.ts
@@ -4,6 +4,8 @@ import { normalizeMessageType } from '$lib/messages/message-types';
 import type { ObjectShorthand } from './v2/interfaces/shorthands';
 import { tableShorthandTransform } from '$objects/table/shorthand';
 
+type TapMode = 'wave' | 'xy';
+
 const createExprTransform = (nodeType: string, field: string) => (expr: string, name: string) => ({
   nodeType,
   data: {
@@ -116,6 +118,27 @@ export const BUILTIN_OBJECT_SHORTHANDS: ObjectShorthand[] = [
     nodeType: 'tap',
     description: 'Execute side effects and pass through',
     transform: createExprTransform('tap', 'expr')
+  },
+  {
+    names: ['tap~'],
+    nodeType: 'tap~',
+    description: 'Capture audio frames and forward as messages',
+    transform: (expr, name) => {
+      const [bufferSizeArg, modeArg, fpsArg] = expr.replace(name, '').trim().split(/\s+/);
+      const bufferSize = parseTapBufferSize(bufferSizeArg);
+      const mode = parseTapMode(modeArg);
+      const fps = parseTapFps(fpsArg);
+
+      return {
+        nodeType: 'tap~',
+        data: {
+          ...getDefaultNodeData('tap~'),
+          bufferSize,
+          mode,
+          fps
+        }
+      };
+    }
   },
   {
     names: ['scan'],
@@ -319,6 +342,28 @@ export const BUILTIN_OBJECT_SHORTHANDS: ObjectShorthand[] = [
     }
   }
 ];
+
+function parseTapBufferSize(value: string | undefined): number {
+  if (!value) return 512;
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 64 || parsed > 2048) return 512;
+
+  return Math.round(parsed);
+}
+
+function parseTapMode(value: string | undefined): TapMode {
+  return value === 'xy' ? 'xy' : 'wave';
+}
+
+function parseTapFps(value: string | undefined): number {
+  if (!value) return 0;
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 120) return 0;
+
+  return parsed;
+}
 
 /**
  * Parse slider expression: "slider min max [default] [step]"

--- a/ui/static/content/objects/tap~.md
+++ b/ui/static/content/objects/tap~.md
@@ -1,13 +1,12 @@
-Capture triggered audio frames and forward them as messages,
-enabling waveform data to flow into canvas, GLSL, or any
-downstream node.
+Capture audio frames and forward them as messages, enabling
+waveform data to flow into canvas, GLSL, or any downstream node.
 
 ## Overview
 
-`tap~` uses the same zero-crossing trigger as [scope~](/docs/objects/scope~)
-but outputs each captured buffer as a message rather than
-rendering it. Connect the outlet to a canvas preset or any
-node that can process sample data.
+`tap~` can use the same zero-crossing trigger as
+[scope~](/docs/objects/scope~), but it outputs each captured
+buffer as a message rather than rendering it. Connect the outlet
+to a canvas preset or any node that can process sample data.
 
 **Waveform mode** sends a `Float32Array` of audio samples.
 **XY mode** sends `{ type: 'xy', x: Float32Array, y: Float32Array }`.
@@ -45,15 +44,21 @@ configurable via the settings panel on each preset.
   capture more of the waveform per trigger.
 - **Mode** (waveform / xy): Waveform sends a single array; XY
   sends `{ x, y }` and uses both inlets.
-- **Refresh** (0–120 fps): Throttle how often the processor
-  triggers. 0 (default) means no limit.
+- **FPS Limit** (0–120 fps): Throttle how often the processor
+  captures. 0 (default) means no limit.
+- **Zero Crossing**: When enabled, captures start on rising
+  zero-crossings for stable scope-style frames. Disable it for
+  continuous monitoring when you do not need waveform locking.
 
 ## Trigger Stability
 
-Frames are trigger-synced on rising zero-crossings of the X
-(first) inlet signal, giving the same stable display as
-`scope~`. If no zero-crossing is found within 2048 samples,
-a capture is forced after 4096 samples to prevent stalling.
+When zero-crossing detection is enabled, frames are trigger-synced
+on rising zero-crossings of the X (first) inlet signal, giving the
+same stable display behavior as `scope~`. If no zero-crossing is
+found within 4096 samples, a capture is forced to prevent stalling.
+
+When zero-crossing detection is disabled, `tap~` continuously
+captures frames as soon as the FPS limit allows.
 
 ## See Also
 


### PR DESCRIPTION
Add the ability to disable zero-crossing in `tap~`. It also makes it a UI object instead of a text object.

<img width="1068" height="886" alt="CleanShot 2569-06-23 at 21 09 48@2x" src="https://github.com/user-attachments/assets/e6bc7d51-74ea-4a2c-ba53-3482eda6f570" />
