### PR TITLE
Add simple charts preset

### DIFF
--- a/docs/design-docs/specs/59-preset-packs.md
+++ b/docs/design-docs/specs/59-preset-packs.md
@@ -94,6 +94,7 @@ export const enabledPresets = derived(
 | **Animation**           | Frame-based animation helpers           | js, p5               | bang-every-frame.js, frame-counter.js, interval.js                 |
 | **Livecoding Examples** | Example patches for livecoding          | strudel, hydra, orca | (various strudel/orca presets)                                     |
 | **Canvas Widgets**      | Interactive canvas components           | canvas.dom           | XY Pad, hsla-picker.canvas, rgba-picker.canvas, plotter.canvas     |
+| **Simple Charts**       | Live data visualization widgets         | dom                  | Line Chart, Bar Chart, Pie Chart                                   |
 
 ### Preset Assignment (Draft)
 

--- a/ui/src/lib/extensions/pack-icons.ts
+++ b/ui/src/lib/extensions/pack-icons.ts
@@ -2,6 +2,7 @@ import {
   Box,
   ArrowRightLeft,
   Camera,
+  ChartLine,
   Clock,
   Palette,
   Shapes,
@@ -38,6 +39,7 @@ export function getPackIcon(iconName: string) {
     .with('Box', () => Box)
     .with('ArrowRightLeft', () => ArrowRightLeft)
     .with('Camera', () => Camera)
+    .with('ChartLine', () => ChartLine)
     .with('Clock', () => Clock)
     .with('Palette', () => Palette)
     .with('Shapes', () => Shapes)

--- a/ui/src/lib/extensions/preset-packs.ts
+++ b/ui/src/lib/extensions/preset-packs.ts
@@ -38,6 +38,14 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     ]
   },
   {
+    id: 'charts',
+    name: 'Simple Charts',
+    description: 'Data visualization widgets for live values',
+    icon: 'ChartLine',
+    requiredObjects: ['dom'],
+    presets: ['Line Chart', 'Bar Chart', 'Pie Chart']
+  },
+  {
     id: 'hydra-operators',
     name: 'Hydra Operators',
     description: 'Video operators built with Hydra',

--- a/ui/src/lib/presets/builtin/charts.presets.ts
+++ b/ui/src/lib/presets/builtin/charts.presets.ts
@@ -1,0 +1,9 @@
+import { barChartPreset } from './charts.presets/bar-chart';
+import { lineChartPreset } from './charts.presets/line-chart';
+import { pieChartPreset } from './charts.presets/pie-chart';
+
+export const CHARTS_PRESETS = {
+  'Line Chart': lineChartPreset,
+  'Bar Chart': barChartPreset,
+  'Pie Chart': pieChartPreset
+};

--- a/ui/src/lib/presets/builtin/charts.presets/bar-chart.ts
+++ b/ui/src/lib/presets/builtin/charts.presets/bar-chart.ts
@@ -1,0 +1,145 @@
+export const BAR_CHART_JS = `setTitle('Bar Chart')
+
+const d3 = await esm("d3");
+
+// Configuration & State
+let data = [10, 40, 20, 70, 45, 90, 30];
+
+const margin = { top: 20, right: 20, bottom: 30, left: 40 };
+const width = 450;
+const height = 280;
+
+noPan();
+setSize(width, height);
+
+root.className = "p-4 rounded-lg overflow-hidden font-mono text-[10px]";
+root.style.background = 'transparent';
+
+await settings.define([
+  { key: 'barColor', label: 'Bar Color', type: 'color', default: '#22d3ee' },
+  { key: 'bufferSize', label: 'Buffer Size', type: 'slider', min: 2, max: 512, default: 20 },
+  { key: 'showValues', label: 'Show Values', type: 'boolean', default: false }
+]);
+
+const render = () => {
+  root.innerHTML = '';
+
+  const svg = d3.select(root)
+    .append("svg")
+    .attr("viewBox", \`0 0 \${width} \${height}\`)
+    .attr("class", "w-full h-auto");
+
+  const x = d3.scaleBand()
+    .domain(data.map((_, i) => i))
+    .range([margin.left, width - margin.right])
+    .padding(0.18);
+
+  const yMax = data.length > 0 ? d3.max(data) : 100;
+  const yPad = yMax * 0.1 || 5;
+
+  const y = d3.scaleLinear()
+    .domain([0, yMax + yPad])
+    .range([height - margin.bottom, margin.top])
+    .nice();
+
+  const color = settings.get('barColor');
+
+  // Grid Lines
+  svg.append("g")
+    .attr("stroke", "#27272a")
+    .selectAll("line")
+    .data(y.ticks(5))
+    .join("line")
+    .attr("x1", margin.left)
+    .attr("x2", width - margin.right)
+    .attr("y1", d => y(d))
+    .attr("y2", d => y(d));
+
+  // Baseline
+  svg.append("line")
+    .attr("x1", margin.left)
+    .attr("x2", width - margin.right)
+    .attr("y1", y(0))
+    .attr("y2", y(0))
+    .attr("stroke", "#3f3f46")
+    .attr("stroke-width", 1);
+
+  // Bars
+  const barGroup = svg.selectAll(".bar")
+    .data(data)
+    .enter()
+    .append("g");
+
+  barGroup.append("rect")
+    .attr("class", "cursor-pointer")
+    .attr("x", (d, i) => x(i))
+    .attr("y", d => y(d))
+    .attr("width", x.bandwidth())
+    .attr("height", d => y(0) - y(d))
+    .attr("fill", color)
+    .attr("rx", 2)
+    .attr("opacity", 0.85)
+    .on("mouseover", function() {
+      d3.select(this).attr("opacity", 1).attr("fill", "white");
+    })
+    .on("mouseout", function() {
+      d3.select(this).attr("opacity", 0.85).attr("fill", color);
+    })
+    .on("click", (event, d) => {
+      send({ type: 'bar_selected', value: d });
+    });
+
+  // Value Labels
+  if (settings.get('showValues')) {
+    barGroup.append("text")
+      .attr("x", (d, i) => x(i) + x.bandwidth() / 2)
+      .attr("y", d => y(d) - 4)
+      .attr("text-anchor", "middle")
+      .attr("fill", color)
+      .attr("font-size", "9px")
+      .attr("font-family", "monospace")
+      .text(d => Number.isInteger(d) ? d : d.toFixed(1));
+  }
+
+  // Y Axis
+  const yAxis = d3.axisLeft(y).ticks(5).tickSize(0).tickPadding(8);
+  svg.append("g")
+    .attr("transform", \`translate(\${margin.left},0)\`)
+    .call(yAxis)
+    .call(g => g.select(".domain").remove())
+    .attr("color", "#52525b");
+};
+
+recv(msg => {
+  if (typeof msg === 'number') {
+    data.push(msg);
+    const bufferSize = settings.get('bufferSize');
+    while (data.length > bufferSize) data.shift();
+    render();
+  } else if (Array.isArray(msg)) {
+    data = msg.slice(0, settings.get('bufferSize'));
+    render();
+  } else if (msg && typeof msg === 'object' && msg.type === 'clear') {
+    data = [];
+    render();
+  }
+});
+
+settings.onChange((key) => {
+  if (key === 'bufferSize') {
+    const bufferSize = settings.get('bufferSize');
+    while (data.length > bufferSize) data.shift();
+  }
+  render();
+});
+
+render();`;
+
+export const barChartPreset = {
+  type: 'dom' as const,
+  data: {
+    code: BAR_CHART_JS,
+    inletCount: 1,
+    outletCount: 1
+  }
+};

--- a/ui/src/lib/presets/builtin/charts.presets/line-chart.ts
+++ b/ui/src/lib/presets/builtin/charts.presets/line-chart.ts
@@ -1,0 +1,132 @@
+export const LINE_CHART_JS = `setTitle('Line Chart')
+
+const d3 = await esm("d3");
+
+// Configuration & State
+let data = [10, 40, 20, 70, 45, 90, 30];
+
+const margin = { top: 20, right: 20, bottom: 10, left: 40 };
+const width = 450;
+const height = 280;
+
+// Aesthetic Setup
+noPan();
+setSize(width, height);
+
+root.className = "p-4 rounded-lg overflow-hidden font-mono text-[10px]";
+root.style.background = 'transparent';
+
+// Define Settings
+await settings.define([
+  { key: 'lineColor', label: 'Line Color', type: 'color', default: '#22d3ee' },
+  { key: 'pointSize', label: 'Point Size', type: 'slider', min: 2, max: 10, default: 4 },
+  { key: 'bufferSize', label: 'Buffer Size', type: 'slider', min: 2, max: 512, default: 20 }
+]);
+
+const render = () => {
+  root.innerHTML = '';
+
+  const svg = d3.select(root)
+    .append("svg")
+    .attr("viewBox", \`0 0 \${width} \${height}\`)
+    .attr("class", "w-full h-auto");
+
+  const x = d3.scaleLinear()
+    .domain([0, data.length - 1])
+    .range([margin.left, width - margin.right]);
+
+  const yMin = data.length > 0 ? d3.min(data) : 0;
+  const yMax = data.length > 0 ? d3.max(data) : 100;
+  const yPad = (yMax - yMin) * 0.1 || 5;
+
+  const y = d3.scaleLinear()
+    .domain([yMin - yPad, yMax + yPad])
+    .range([height - margin.bottom, margin.top])
+    .nice();
+
+  // Grid Lines
+  svg.append("g")
+    .attr("stroke", "#27272a")
+    .selectAll("line")
+    .data(y.ticks(5))
+    .join("line")
+    .attr("x1", margin.left)
+    .attr("x2", width - margin.right)
+    .attr("y1", d => y(d))
+    .attr("y2", d => y(d));
+
+  // Line Generator
+  const line = d3.line()
+    .x((d, i) => x(i))
+    .y(d => y(d))
+    .curve(d3.curveMonotoneX);
+
+  // Draw Line
+  svg.append("path")
+    .datum(data)
+    .attr("fill", "none")
+    .attr("stroke", settings.get('lineColor'))
+    .attr("stroke-width", 2.5)
+    .attr("d", line);
+
+  // Interactive Points
+  svg.selectAll(".dot")
+    .data(data)
+    .enter()
+    .append("circle")
+    .attr("cx", (d, i) => x(i))
+    .attr("cy", d => y(d))
+    .attr("r", settings.get('pointSize'))
+    .attr("class", "cursor-pointer hover:fill-white transition-all")
+    .attr("fill", settings.get('lineColor'))
+    .on("click", (event, d) => {
+       send({ type: 'point_selected', value: d });
+       d3.select(event.currentTarget)
+         .attr("r", settings.get('pointSize') * 2)
+         .transition()
+         .duration(300)
+         .attr("r", settings.get('pointSize'));
+    });
+
+  // Y Axis only
+  const yAxis = d3.axisLeft(y).ticks(5).tickSize(0).tickPadding(10);
+
+  svg.append("g")
+    .attr("transform", \`translate(\${margin.left},0)\`)
+    .call(yAxis)
+    .call(g => g.select(".domain").remove())
+    .attr("color", "#52525b");
+};
+
+// Handle incoming data to update chart dynamically
+recv(msg => {
+  if (typeof msg === 'number') {
+    data.push(msg);
+    const bufferSize = settings.get('bufferSize');
+    while (data.length > bufferSize) data.shift();
+    render();
+  } else if (msg && typeof msg === 'object' && msg.type === 'clear') {
+    data = [];
+    render();
+  }
+});
+
+settings.onChange((key) => {
+  if (key === 'bufferSize') {
+    const bufferSize = settings.get('bufferSize');
+    while (data.length > bufferSize) data.shift();
+  }
+
+  render();
+});
+
+render();`;
+
+export const lineChartPreset = {
+  type: 'dom' as const,
+  data: {
+    code: LINE_CHART_JS,
+    inletCount: 1,
+    outletCount: 1
+  }
+};

--- a/ui/src/lib/presets/builtin/charts.presets/pie-chart.ts
+++ b/ui/src/lib/presets/builtin/charts.presets/pie-chart.ts
@@ -1,0 +1,229 @@
+export const PIE_CHART_JS = `setTitle('Pie Chart')
+
+const d3 = await esm('d3');
+
+// Configuration & State
+let data = [
+  { label: 'A', value: 30 },
+  { label: 'B', value: 20 },
+  { label: 'C', value: 25 },
+  { label: 'D', value: 15 },
+  { label: 'E', value: 10 }
+];
+
+const width = 420;
+const height = 320;
+
+noPan();
+setSize(width, height);
+
+root.className = 'rounded-lg overflow-hidden';
+root.style.background = 'transparent';
+root.style.fontFamily = '"DM Mono", monospace';
+
+await settings.define([
+  { key: 'donut', label: 'Donut Mode', type: 'boolean', default: true },
+  { key: 'innerRadius', label: 'Inner Radius %', type: 'slider', min: 10, max: 80, default: 45 },
+  { key: 'showLabels', label: 'Show Labels', type: 'boolean', default: true },
+  { key: 'spacing', label: 'Slice Spacing', type: 'slider', min: 0, max: 10, default: 0 }
+]);
+
+const palette = [
+  '#22d3ee', '#f472b6', '#a3e635', '#fb923c', '#818cf8',
+  '#34d399', '#fbbf24', '#e879f9', '#38bdf8', '#4ade80'
+];
+
+const fmtVal = v => {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return String(v);
+
+  return Number.isInteger(n) ? String(n) : parseFloat(n.toFixed(2)).toString();
+};
+
+/**
+ * Normalizes incoming data formats to {label, value}[]
+ */
+const normalizeData = (input) => {
+  if (!Array.isArray(input)) return [];
+
+  // Check if first element is an array [label, value]
+  if (input.length > 0 && Array.isArray(input[0])) {
+    return input.map(item => ({ label: String(item[0]), value: Number(item[1]) }));
+  }
+
+  return input;
+};
+
+const render = () => {
+  root.innerHTML = '';
+
+  const legendWidth = 80;
+  const padding = 20;
+  const chartAreaWidth = width - legendWidth - (padding * 2);
+  const cx = padding + chartAreaWidth / 2;
+  const cy = height / 2;
+  const outerR = Math.min(chartAreaWidth / 2, cy - padding);
+
+  const isDonut = settings.get('donut');
+  const innerR = isDonut ? outerR * (settings.get('innerRadius') / 100) : 0;
+  const showLabels = settings.get('showLabels');
+  const padAngle = settings.get('spacing') / 100;
+
+  const svg = d3.select(root)
+    .append('svg')
+    .attr('viewBox', \`0 0 \${width} \${height}\`)
+    .attr('width', width)
+    .attr('height', height)
+    .style('shape-rendering', 'geometricPrecision');
+
+  const pie = d3.pie()
+    .value(d => d.value)
+    .sort(null)
+    .padAngle(padAngle);
+
+  const arc = d3.arc()
+    .innerRadius(innerR)
+    .outerRadius(outerR)
+    .cornerRadius(0);
+
+  const arcHover = d3.arc()
+    .innerRadius(innerR)
+    .outerRadius(outerR + 4)
+    .cornerRadius(0);
+
+  const arcs = pie(data);
+
+  const g = svg.append('g')
+    .attr('transform', \`translate(\${cx}, \${cy})\`);
+
+  // Tooltip
+  const tooltip = d3.select(root)
+    .append('div')
+    .attr('class', 'pointer-events-none absolute opacity-0 transition-opacity duration-150 z-10')
+    .style('background', '#18181bE6')
+    .style('backdrop-filter', 'blur(4px)')
+    .style('border', '1px solid #3f3f46')
+    .style('padding', '4px 8px')
+    .style('border-radius', '4px')
+    .style('font-size', '10px')
+    .style('color', '#fff');
+
+  // Slices
+  g.selectAll('path')
+    .data(arcs)
+    .enter()
+    .append('path')
+    .attr('d', arc)
+    .attr('fill', (d, i) => palette[i % palette.length])
+    .attr('stroke', 'transparent')
+    .attr('stroke-width', padAngle > 0 ? 0 : 0.5)
+    .attr('class', 'cursor-pointer transition-all duration-200')
+    .on('mouseover', function(event, d) {
+      d3.select(this).attr('d', arcHover).style('filter', 'brightness(1.1)');
+      tooltip.style('opacity', '1').html(\`<span style="color:\${palette[arcs.indexOf(d) % palette.length]}">\${d.data.label}</span>: \${fmtVal(d.data.value)}\`);
+    })
+    .on('mousemove', function(event) {
+      const [mx, my] = d3.pointer(event, root);
+      tooltip.style('left', \`\${mx + 15}px\`).style('top', \`\${my - 15}px\`);
+    })
+    .on('mouseout', function() {
+      d3.select(this).attr('d', arc).style('filter', null);
+      tooltip.style('opacity', '0');
+    })
+    .on('click', (event, d) => {
+      send({ type: 'slice_selected', label: d.data.label, value: d.data.value });
+    });
+
+  // Center Text
+  if (isDonut) {
+    const total = d3.sum(data, d => d.value);
+    const centerText = g.append('g').attr('class', 'pointer-events-none');
+
+    centerText.append('text')
+      .attr('text-anchor', 'middle')
+      .attr('dominant-baseline', 'middle')
+      .attr('fill', '#fff')
+      .attr('font-size', '24px')
+      .attr('font-weight', '600')
+      .text(fmtVal(total));
+
+    centerText.append('text')
+      .attr('text-anchor', 'middle')
+      .attr('y', 18)
+      .attr('fill', '#71717a')
+      .attr('font-size', '10px')
+      .attr('text-transform', 'uppercase')
+      .attr('letter-spacing', '0.05em')
+      .text('total');
+  }
+
+  // Legend
+  const legendX = cx + outerR + 25;
+  const legendG = svg.append('g')
+    .attr('transform', \`translate(\${legendX}, \${cy - (data.length * 20) / 2})\`);
+
+  data.forEach((d, i) => {
+    const row = legendG.append('g')
+      .attr('transform', \`translate(0, \${i * 20})\`)
+      .attr('class', 'cursor-default group');
+
+    row.append('rect')
+      .attr('width', 10)
+      .attr('height', 10)
+      .attr('rx', 2)
+      .attr('fill', palette[i % palette.length]);
+
+    row.append('text')
+      .attr('x', 16)
+      .attr('y', 9)
+      .attr('fill', '#a1a1aa')
+      .attr('font-size', '11px')
+      .text(d.label);
+
+    row.append('text')
+      .attr('x', 16)
+      .attr('y', 9)
+      .attr('text-anchor', 'start')
+      .attr('fill', '#52525b')
+      .attr('font-size', '10px')
+      .attr('transform', \`translate(28, 0)\`)
+      .text(fmtVal(d.value));
+  });
+};
+
+recv(msg => {
+  // Handle direct array input (supporting both {label, value} and [label, value])
+  if (Array.isArray(msg)) {
+    data = normalizeData(msg);
+    render();
+
+    return;
+  }
+
+  // Handle object-based messages
+  if (msg && typeof msg === 'object') {
+    if (msg.type === 'set' && Array.isArray(msg.data)) {
+      data = normalizeData(msg.data);
+    } else if (msg.type === 'update') {
+      const entry = data.find(d => d.label === msg.label);
+      if (entry) entry.value = msg.value;
+      else data.push({ label: msg.label, value: msg.value });
+    } else if (msg.type === 'clear') {
+      data = [];
+    }
+
+    render();
+  }
+});
+
+settings.onChange(() => render());
+render();`;
+
+export const pieChartPreset = {
+  type: 'dom' as const,
+  data: {
+    code: PIE_CHART_JS,
+    inletCount: 1,
+    outletCount: 1
+  }
+};

--- a/ui/src/lib/presets/builtin/charts.presets/pie-chart.ts
+++ b/ui/src/lib/presets/builtin/charts.presets/pie-chart.ts
@@ -40,6 +40,11 @@ const fmtVal = v => {
   return Number.isInteger(n) ? String(n) : parseFloat(n.toFixed(2)).toString();
 };
 
+const toChartValue = (value) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+};
+
 /**
  * Normalizes incoming data formats to {label, value}[]
  */
@@ -48,10 +53,13 @@ const normalizeData = (input) => {
 
   // Check if first element is an array [label, value]
   if (input.length > 0 && Array.isArray(input[0])) {
-    return input.map(item => ({ label: String(item[0]), value: Number(item[1]) }));
+    return input.map(item => ({ label: String(item[0]), value: toChartValue(item[1]) }));
   }
 
-  return input;
+  return input.map(item => ({
+    label: String(item.label),
+    value: toChartValue(item.value)
+  }));
 };
 
 const render = () => {
@@ -206,8 +214,9 @@ recv(msg => {
       data = normalizeData(msg.data);
     } else if (msg.type === 'update') {
       const entry = data.find(d => d.label === msg.label);
-      if (entry) entry.value = msg.value;
-      else data.push({ label: msg.label, value: msg.value });
+      const value = toChartValue(msg.value);
+      if (entry) entry.value = value;
+      else data.push({ label: String(msg.label), value });
     } else if (msg.type === 'clear') {
       data = [];
     }

--- a/ui/src/lib/presets/builtin/index.ts
+++ b/ui/src/lib/presets/builtin/index.ts
@@ -29,6 +29,7 @@ import { SWGL_PRESETS } from './swgl.presets';
 import { SHADERPARK_PRESETS } from './shaderpark.presets';
 import { FLOAT_TEXTURE_PRESETS } from './float-texture.presets';
 import { SURFACE_PRESETS } from './surface.presets';
+import { CHARTS_PRESETS } from './charts.presets';
 
 // Re-export individual preset collections
 export {
@@ -59,7 +60,8 @@ export {
   SWGL_PRESETS,
   SHADERPARK_PRESETS,
   FLOAT_TEXTURE_PRESETS,
-  SURFACE_PRESETS
+  SURFACE_PRESETS,
+  CHARTS_PRESETS
 };
 
 /**
@@ -97,5 +99,6 @@ export const BUILTIN_PRESETS: Record<
   ...SWGL_PRESETS,
   ...SHADERPARK_PRESETS,
   ...FLOAT_TEXTURE_PRESETS,
-  ...SURFACE_PRESETS
+  ...SURFACE_PRESETS,
+  ...CHARTS_PRESETS
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new built-in **Simple Charts** preset pack with line, bar, and pie chart presets.
  * Chart presets are now available in the built-in preset library and can be used like other presets.
  * Added icon support for the new chart pack.

* **Documentation**
  * Updated the preset pack reference to include the new chart pack and its available presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->