### PR TITLE
perf(hydra): conditionally cook hydra frames

### DIFF
--- a/docs/design-docs/specs/122-render-pipeline-optimizations.md
+++ b/docs/design-docs/specs/122-render-pipeline-optimizations.md
@@ -128,6 +128,7 @@ type CookReason =
   | "force"
   | "config"
   | "uniform"
+  | "message"
   | "input"
   | "time"
   | "mouse"
@@ -194,18 +195,18 @@ This keeps cooking policy separate from renderer execution. Individual renderers
 
 The first implementation should be conservative:
 
-| Type                             | Initial cook mode                                     | Notes                                                        |
-| -------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------ |
-| `glsl`                           | `on-demand` when no dynamic dependencies are detected | First supported node type                                    |
-| `shaderpark`                     | `always` initially                                    | Can opt in after uniform/time/mouse handling is audited      |
-| `hydra`                          | `always` initially                                    | Hydra code is stateful and time-oriented                     |
-| `three`                          | `always` initially                                    | JS code can access time and mutate scenes implicitly         |
-| `regl`                           | `always` initially                                    | JS code can hide dependencies                                |
-| `swgl`                           | `always` initially                                    | JS code can hide dependencies                                |
-| `canvas`                         | `always` initially                                    | User code may draw from timers, messages, or internal state  |
-| `textmode`                       | `always` initially                                    | Stateful runtime                                             |
-| `img`, `float.tex`               | externally dirty                                      | Cook only when uploaded bitmap/texture data changes          |
-| `send.vdo`, `recv.vdo`, `bg.out` | passthrough/empty                                     | No expensive cook, but downstream invalidation still matters |
+| Type                             | Initial cook mode                                     | Notes                                                                              |
+| -------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `glsl`                           | `on-demand` when no dynamic dependencies are detected | First supported node type                                                          |
+| `shaderpark`                     | `always` initially                                    | Can opt in after uniform/time/mouse handling is audited                            |
+| `hydra`                          | `on-demand` for static/input-only code                | Animated generators, custom functions, callbacks, mouse, and datamosh stay dynamic |
+| `three`                          | `always` initially                                    | JS code can access time and mutate scenes implicitly                               |
+| `regl`                           | `always` initially                                    | JS code can hide dependencies                                                      |
+| `swgl`                           | `always` initially                                    | JS code can hide dependencies                                                      |
+| `canvas`                         | `always` initially                                    | User code may draw from timers, messages, or internal state                        |
+| `textmode`                       | `always` initially                                    | Stateful runtime                                                                   |
+| `img`, `float.tex`               | externally dirty                                      | Cook only when uploaded bitmap/texture data changes                                |
+| `send.vdo`, `recv.vdo`, `bg.out` | passthrough/empty                                     | No expensive cook, but downstream invalidation still matters                       |
 
 Later, JS-based renderers can opt into `on-demand` through explicit APIs or directives such as `setCookMode('on-demand')`, `setStatic(true)`, or `// @static`. Until a renderer declares that it is safe to cache, keep it in `always` mode.
 
@@ -247,7 +248,7 @@ for (const nodeId of sortedNodes) {
 }
 ```
 
-Uniform, mouse, FFT, bitmap, and float texture updates should mark the affected node dirty immediately when the worker receives the update message. Graph rebuilds and FBO reallocations should mark affected nodes dirty with `config`, `output-size`, or `first-frame`.
+Uniform, message, mouse, FFT, bitmap, and float texture updates should mark the affected node dirty immediately when the worker receives the update message. Graph rebuilds and FBO reallocations should mark affected nodes dirty with `config`, `output-size`, or `first-frame`.
 
 Preview readback should follow the same freshness signal. A node preview may harvest an already-started async read, but it should only initiate a new GPU readback for nodes that are dirty since their last preview read. Newly enabled previews should also start dirty so previews do not stay blank if the node cooked before the preview canvas was ready. After a preview read starts, cached nodes keep displaying the previous preview bitmap until their FBO changes again.
 

--- a/ui/src/lib/canvas/use-cook-status.svelte.ts
+++ b/ui/src/lib/canvas/use-cook-status.svelte.ts
@@ -6,14 +6,29 @@ import type { RenderCookStatus } from '$lib/rendering/types';
  * Tracks worker-reported cook status for a render node.
  * Returns a reactive `status` getter.
  */
-export function useCookStatus(nodeId: string) {
+export function useCookStatus(
+  nodeId: string | undefined | (() => string | undefined),
+  enabled: boolean | (() => boolean) = true
+) {
   let status = $state<RenderCookStatus | undefined>(undefined);
 
   $effect(() => {
+    if (!getValue(enabled)) {
+      status = undefined;
+      return;
+    }
+
+    const currentNodeId = getValue(nodeId);
+
+    if (!currentNodeId) {
+      status = undefined;
+      return;
+    }
+
     const eventBus = PatchiesEventBus.getInstance();
 
     const handle = (event: CookStatusUpdateEvent) => {
-      if (event.nodeId !== nodeId) return;
+      if (event.nodeId !== currentNodeId) return;
 
       status = {
         status: event.status,
@@ -35,3 +50,6 @@ export function useCookStatus(nodeId: string) {
     }
   };
 }
+
+const getValue = <T>(value: T | (() => T)): T =>
+  typeof value === 'function' ? (value as () => T)() : value;

--- a/ui/src/lib/components/CanvasPreviewLayout.svelte
+++ b/ui/src/lib/components/CanvasPreviewLayout.svelte
@@ -4,9 +4,11 @@
   import ObjectPreviewLayout from './ObjectPreviewLayout.svelte';
   import type { SettingsSchema } from '$lib/settings';
   import type { ExtraMenuItem } from './object-preview-menu-actions';
-  import { previewBackgroundColor } from '../../stores/renderer.store';
+  import { previewBackgroundColor, showCookStats } from '../../stores/renderer.store';
   import type { SupportedLanguage } from '$lib/codemirror/types';
-  import type { RenderCookStatus } from '$lib/rendering/types';
+  import { useCookStatus } from '$lib/canvas/use-cook-status.svelte';
+
+  const COOK_DEBUG_OBJECT_TYPES = new Set(['glsl', 'hydra']);
 
   let {
     title,
@@ -50,9 +52,7 @@
     displayExtraMenuItems = undefined,
     showBgOutputOption = true,
     showExpandOption = true,
-    showCookDebugOption = false,
-    cookDebugVisible = false,
-    cookStatus = undefined,
+    showCookDebugOption = undefined,
     class: className = ''
   }: {
     title: string;
@@ -97,10 +97,17 @@
     showBgOutputOption?: boolean;
     showExpandOption?: boolean;
     showCookDebugOption?: boolean;
-    cookDebugVisible?: boolean;
-    cookStatus?: RenderCookStatus;
     class?: string;
   } = $props();
+
+  const cookDebugSupported = $derived(
+    showCookDebugOption ?? Boolean(objectType && COOK_DEBUG_OBJECT_TYPES.has(objectType))
+  );
+
+  const cookStatus = useCookStatus(
+    () => nodeId,
+    () => cookDebugSupported && $showCookStats
+  );
 
   // Build the interaction class string based on individual flags
   const interactionClass = $derived.by(() => {
@@ -166,7 +173,11 @@
           : `background-color:${$previewBackgroundColor};${pixelated ? 'image-rendering:pixelated;' : ''}${style}`}
       ></canvas>
 
-      <CookDebugOverlay enabled={showCookDebugOption} visible={cookDebugVisible} {cookStatus} />
+      <CookDebugOverlay
+        enabled={cookDebugSupported && $showCookStats}
+        visible={$showCookStats}
+        cookStatus={cookStatus.status}
+      />
     </div>
   {/snippet}
 </ObjectPreviewLayout>

--- a/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
+++ b/ui/src/lib/components/nodes/GLSLCanvasNode.svelte
@@ -9,7 +9,6 @@
   import { messages } from '$lib/objects/schemas/common';
   import { GLSystem, type UserUniformValue } from '$lib/canvas/GLSystem';
   import { outputSize, previewWidth, previewHeight } from '../../../stores/renderer.store';
-  import { showCookStats } from '../../../stores/renderer.store';
   import { toGLValue } from '$workers/rendering/glUniformUtils';
   import { CanvasMouseHandler } from '$lib/canvas/CanvasMouseHandler';
   import {
@@ -28,7 +27,6 @@
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { ConsoleOutputEvent, PrimaryButton } from '$lib/eventbus/events';
   import type { FBOFormat, FBOResolution } from '$lib/rendering/types';
-  import { useCookStatus } from '$lib/canvas/use-cook-status.svelte';
 
   let {
     id: nodeId,
@@ -68,8 +66,6 @@
   let consoleRef = $state<{ clearConsole: () => void } | null>(null);
   let shaderName = $state<string | undefined>(parseShaderName(data.code || ''));
   let lineErrors: Record<number, string[]> | undefined = $state(undefined);
-  const cookStatus = useCookStatus(nodeId);
-
   const code = $derived(data.code || '');
   const uniformsSchema = $derived(uniformDefsToSettingsSchema(data.glUniformDefs ?? []));
   const visibleUniformInlets = $derived(visibleUniformInletDefs(data.glUniformDefs ?? []));
@@ -377,9 +373,6 @@
   settingsValues={uniformValues}
   onSettingsValueChange={handleUniformValueChange}
   onSettingsRevertAll={handleUniformRevertAll}
-  showCookDebugOption={$showCookStats}
-  cookDebugVisible={$showCookStats}
-  cookStatus={cookStatus.status}
 >
   {#snippet topHandle()}
     {#each visibleUniformInlets as { def, uniformIndex }, visibleIndex (uniformIndex)}

--- a/ui/src/lib/components/nodes/HydraNode.svelte
+++ b/ui/src/lib/components/nodes/HydraNode.svelte
@@ -3,7 +3,7 @@
   import { onMount, onDestroy } from 'svelte';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
   import { MessageContext } from '$lib/messages/MessageContext';
-  import { outputSize, previewSize } from '../../../stores/renderer.store';
+  import { outputSize, previewSize, showCookStats } from '../../../stores/renderer.store';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { match } from 'ts-pattern';
@@ -23,6 +23,7 @@
   import { SettingsManager, createWorkerSettingsCallbacks } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
+  import { useCookStatus } from '$lib/canvas/use-cook-status.svelte';
 
   let {
     id: nodeId,
@@ -66,6 +67,7 @@
   let consoleRef: VirtualConsole | null = $state(null);
   let lineErrors: Record<number, string[]> | undefined = $state(undefined);
   let previousExecuteCode = $state<number | undefined>(undefined);
+  const cookStatus = useCookStatus(nodeId);
 
   // Reactively update preview canvas dimensions when output size changes
   $effect(() => {
@@ -328,6 +330,9 @@
       glSystem.sendSettingsValueChanged(nodeId, key, value);
     }
   }}
+  showCookDebugOption={$showCookStats}
+  cookDebugVisible={$showCookStats}
+  cookStatus={cookStatus.status}
 >
   {#snippet topHandle()}
     {#each Array.from({ length: videoInletCount }) as _, index (index)}

--- a/ui/src/lib/components/nodes/HydraNode.svelte
+++ b/ui/src/lib/components/nodes/HydraNode.svelte
@@ -3,7 +3,7 @@
   import { onMount, onDestroy } from 'svelte';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
   import { MessageContext } from '$lib/messages/MessageContext';
-  import { outputSize, previewSize, showCookStats } from '../../../stores/renderer.store';
+  import { outputSize, previewSize } from '../../../stores/renderer.store';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { match } from 'ts-pattern';
@@ -23,7 +23,6 @@
   import { SettingsManager, createWorkerSettingsCallbacks } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
-  import { useCookStatus } from '$lib/canvas/use-cook-status.svelte';
 
   let {
     id: nodeId,
@@ -67,8 +66,6 @@
   let consoleRef: VirtualConsole | null = $state(null);
   let lineErrors: Record<number, string[]> | undefined = $state(undefined);
   let previousExecuteCode = $state<number | undefined>(undefined);
-  const cookStatus = useCookStatus(nodeId);
-
   // Reactively update preview canvas dimensions when output size changes
   $effect(() => {
     if (!previewCanvas) return;
@@ -330,9 +327,6 @@
       glSystem.sendSettingsValueChanged(nodeId, key, value);
     }
   }}
-  showCookDebugOption={$showCookStats}
-  cookDebugVisible={$showCookStats}
-  cookStatus={cookStatus.status}
 >
   {#snippet topHandle()}
     {#each Array.from({ length: videoInletCount }) as _, index (index)}

--- a/ui/src/workers/rendering/CookStateManager.test.ts
+++ b/ui/src/workers/rendering/CookStateManager.test.ts
@@ -59,6 +59,22 @@ describe('CookStateManager', () => {
     expect(manager.shouldCook('time-shader')).toEqual({ shouldCook: false, reasons: [] });
   });
 
+  it('cooks a paused time-dependent node after a message marks it dirty', () => {
+    const manager = new CookStateManager();
+
+    manager.registerNode('hydra-1', { mode: 'on-demand', timeDependent: true });
+    manager.beginFrame({ transportTime: 1, prevTransportTime: 0, isTransportPlaying: true });
+    manager.markCooked('hydra-1', ['first-frame', 'time'], 0.8);
+
+    manager.beginFrame({ transportTime: 1, prevTransportTime: 1, isTransportPlaying: false });
+    manager.markDirty('hydra-1', 'message');
+
+    expect(manager.shouldCook('hydra-1')).toEqual({
+      shouldCook: true,
+      reasons: ['message']
+    });
+  });
+
   it('keeps always-mode nodes cooking every frame', () => {
     const manager = new CookStateManager();
 

--- a/ui/src/workers/rendering/CookStateManager.ts
+++ b/ui/src/workers/rendering/CookStateManager.ts
@@ -3,6 +3,7 @@ export type CookReason =
   | 'force'
   | 'config'
   | 'uniform'
+  | 'message'
   | 'input'
   | 'time'
   | 'mouse'

--- a/ui/src/workers/rendering/cooking/glsl.test.ts
+++ b/ui/src/workers/rendering/cooking/glsl.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { createGlslCookPolicy } from './glsl';
+import { COOK_TEST_UTILS } from './test-utils';
+
+const { ON_DEMAND, TIME_DEPENDENT, FRAME_DEPENDENT, DATE_DEPENDENT } = COOK_TEST_UTILS;
 
 describe('createGlslCookPolicy', () => {
   it('allows static shaders to cook on demand', () => {
@@ -10,7 +13,7 @@ describe('createGlslCookPolicy', () => {
       }
     `);
 
-    expect(policy).toEqual({ mode: 'on-demand' });
+    expect(policy).toEqual(ON_DEMAND);
   });
 
   it('detects transport-time dependent shaders', () => {
@@ -20,7 +23,7 @@ describe('createGlslCookPolicy', () => {
       }
     `);
 
-    expect(policy).toMatchObject({ mode: 'on-demand', timeDependent: true });
+    expect(policy).toMatchObject(TIME_DEPENDENT);
   });
 
   it('ignores time builtins in comments', () => {
@@ -34,19 +37,16 @@ describe('createGlslCookPolicy', () => {
       }
     `);
 
-    expect(policy).toEqual({ mode: 'on-demand' });
+    expect(policy).toEqual(ON_DEMAND);
   });
 
   it('treats iFrame and iDate as frame-time dependencies', () => {
     expect(
       createGlslCookPolicy('void mainImage(out vec4 c, in vec2 p) { c = vec4(iFrame); }')
-    ).toMatchObject({
-      frameDependent: true
-    });
+    ).toMatchObject(FRAME_DEPENDENT);
+
     expect(
       createGlslCookPolicy('void mainImage(out vec4 c, in vec2 p) { c = iDate; }')
-    ).toMatchObject({
-      dateDependent: true
-    });
+    ).toMatchObject(DATE_DEPENDENT);
   });
 });

--- a/ui/src/workers/rendering/cooking/glsl.test.ts
+++ b/ui/src/workers/rendering/cooking/glsl.test.ts
@@ -23,7 +23,7 @@ describe('createGlslCookPolicy', () => {
       }
     `);
 
-    expect(policy).toMatchObject(TIME_DEPENDENT);
+    expect(policy).toEqual(TIME_DEPENDENT);
   });
 
   it('ignores time builtins in comments', () => {
@@ -43,10 +43,10 @@ describe('createGlslCookPolicy', () => {
   it('treats iFrame and iDate as frame-time dependencies', () => {
     expect(
       createGlslCookPolicy('void mainImage(out vec4 c, in vec2 p) { c = vec4(iFrame); }')
-    ).toMatchObject(FRAME_DEPENDENT);
+    ).toEqual(FRAME_DEPENDENT);
 
-    expect(
-      createGlslCookPolicy('void mainImage(out vec4 c, in vec2 p) { c = iDate; }')
-    ).toMatchObject(DATE_DEPENDENT);
+    expect(createGlslCookPolicy('void mainImage(out vec4 c, in vec2 p) { c = iDate; }')).toEqual(
+      DATE_DEPENDENT
+    );
   });
 });

--- a/ui/src/workers/rendering/cooking/glsl.test.ts
+++ b/ui/src/workers/rendering/cooking/glsl.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createGlslCookPolicy } from './glslCookPolicy';
+import { createGlslCookPolicy } from './glsl';
 
 describe('createGlslCookPolicy', () => {
   it('allows static shaders to cook on demand', () => {

--- a/ui/src/workers/rendering/cooking/glsl.ts
+++ b/ui/src/workers/rendering/cooking/glsl.ts
@@ -1,4 +1,4 @@
-import type { CookPolicy } from './CookStateManager';
+import type { CookPolicy } from '../CookStateManager';
 
 const TIME_PATTERN = /\biTime\b|\biTimeDelta\b/;
 const FRAME_PATTERN = /\biFrame\b/;
@@ -17,6 +17,5 @@ export function createGlslCookPolicy(code: string): CookPolicy {
   };
 }
 
-function stripGlslComments(code: string): string {
-  return code.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
-}
+const stripGlslComments = (code: string): string =>
+  code.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');

--- a/ui/src/workers/rendering/cooking/hydra.test.ts
+++ b/ui/src/workers/rendering/cooking/hydra.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { createHydraCookPolicy } from './hydra';
+
+describe('createHydraCookPolicy', () => {
+  it('allows static solid hydra code to cook on demand', () => {
+    expect(createHydraCookPolicy('solid(1, 0, 0).out()')).toEqual({ mode: 'on-demand' });
+  });
+
+  it('allows input-only hydra code to cook on demand', () => {
+    expect(createHydraCookPolicy('src(s0).blend(s1).out()')).toEqual({ mode: 'on-demand' });
+  });
+
+  it('treats common animated generators as transport-time dependent', () => {
+    expect(createHydraCookPolicy('osc(10, 0.1, 1.5).out()')).toMatchObject({
+      mode: 'on-demand',
+      timeDependent: true
+    });
+  });
+
+  it('detects mouse and fft dependencies', () => {
+    expect(createHydraCookPolicy('osc(10).rotate(mouse.x).out()')).toMatchObject({
+      mouseDependent: true
+    });
+    expect(createHydraCookPolicy("osc(() => fft().getEnergy('bass')).out()")).toMatchObject({
+      fftDependent: true
+    });
+  });
+
+  it('keeps arbitrary callbacks and custom functions conservative', () => {
+    expect(createHydraCookPolicy('osc(() => Math.random()).out()')).toEqual({ mode: 'always' });
+    expect(
+      createHydraCookPolicy(`
+        await setFunction({
+          name: 'custom',
+          type: 'src',
+          glsl: 'return vec4(1.0);'
+        })
+      `)
+    ).toEqual({ mode: 'always' });
+  });
+
+  it('ignores dependencies in comments and strings', () => {
+    expect(
+      createHydraCookPolicy(`
+        // osc(10).out()
+        const label = "mouse fft osc"
+        solid(1, 0, 0).out()
+      `)
+    ).toEqual({ mode: 'on-demand' });
+  });
+});

--- a/ui/src/workers/rendering/cooking/hydra.test.ts
+++ b/ui/src/workers/rendering/cooking/hydra.test.ts
@@ -1,33 +1,43 @@
 import { describe, expect, it } from 'vitest';
 import { createHydraCookPolicy } from './hydra';
+import { COOK_TEST_UTILS } from './test-utils';
+
+const { ALWAYS, ON_DEMAND, TIME_DEPENDENT, MOUSE_DEPENDENT, FFT_DEPENDENT } = COOK_TEST_UTILS;
 
 describe('createHydraCookPolicy', () => {
   it('allows static solid hydra code to cook on demand', () => {
-    expect(createHydraCookPolicy('solid(1, 0, 0).out()')).toEqual({ mode: 'on-demand' });
+    expect(createHydraCookPolicy('solid(1, 0, 0).out()')).toEqual(ON_DEMAND);
   });
 
   it('allows input-only hydra code to cook on demand', () => {
-    expect(createHydraCookPolicy('src(s0).blend(s1).out()')).toEqual({ mode: 'on-demand' });
+    expect(createHydraCookPolicy('src(s0).blend(s1).out()')).toEqual(ON_DEMAND);
   });
 
   it('treats common animated generators as transport-time dependent', () => {
-    expect(createHydraCookPolicy('osc(10, 0.1, 1.5).out()')).toMatchObject({
-      mode: 'on-demand',
-      timeDependent: true
-    });
+    expect(createHydraCookPolicy('osc(10, 0.1, 1.5).out()')).toMatchObject(TIME_DEPENDENT);
+  });
+
+  it('treats Hydra callbacks that read transport time as time dependent', () => {
+    expect(createHydraCookPolicy('solid(() => time % 1, 0, 0).out()')).toMatchObject(
+      TIME_DEPENDENT
+    );
+
+    expect(createHydraCookPolicy('solid(() => clock.time % 1, 0, 0).out()')).toMatchObject(
+      TIME_DEPENDENT
+    );
   });
 
   it('detects mouse and fft dependencies', () => {
-    expect(createHydraCookPolicy('osc(10).rotate(mouse.x).out()')).toMatchObject({
-      mouseDependent: true
-    });
-    expect(createHydraCookPolicy("osc(() => fft().getEnergy('bass')).out()")).toMatchObject({
-      fftDependent: true
-    });
+    expect(createHydraCookPolicy('osc(10).rotate(mouse.x).out()')).toMatchObject(MOUSE_DEPENDENT);
+
+    expect(createHydraCookPolicy("osc(() => fft().getEnergy('bass')).out()")).toMatchObject(
+      FFT_DEPENDENT
+    );
   });
 
   it('keeps arbitrary callbacks and custom functions conservative', () => {
     expect(createHydraCookPolicy('osc(() => Math.random()).out()')).toEqual({ mode: 'always' });
+
     expect(
       createHydraCookPolicy(`
         await setFunction({
@@ -36,7 +46,7 @@ describe('createHydraCookPolicy', () => {
           glsl: 'return vec4(1.0);'
         })
       `)
-    ).toEqual({ mode: 'always' });
+    ).toEqual(ALWAYS);
   });
 
   it('ignores dependencies in comments and strings', () => {
@@ -46,6 +56,6 @@ describe('createHydraCookPolicy', () => {
         const label = "mouse fft osc"
         solid(1, 0, 0).out()
       `)
-    ).toEqual({ mode: 'on-demand' });
+    ).toEqual(ON_DEMAND);
   });
 });

--- a/ui/src/workers/rendering/cooking/hydra.ts
+++ b/ui/src/workers/rendering/cooking/hydra.ts
@@ -2,6 +2,7 @@ import { stripJavaScriptComments } from '$lib/utils/javascript-comments';
 import type { CookPolicy } from '../CookStateManager';
 
 const TIME_DEPENDENT_GENERATOR_PATTERN = /\b(?:osc|noise|voronoi|gradient)\s*\(/;
+const TRANSPORT_TIME_PATTERN = /\b(?:clock\s*\.\s*)?time\b/;
 const MOUSE_PATTERN = /\bmouse\b/;
 const FFT_PATTERN = /\bfft\s*\(/;
 
@@ -15,9 +16,13 @@ export function createHydraCookPolicy(code: string): CookPolicy {
     return { mode: 'always' };
   }
 
+  const isTimeDependent =
+    TIME_DEPENDENT_GENERATOR_PATTERN.test(source) || TRANSPORT_TIME_PATTERN.test(source);
+
   return {
     mode: 'on-demand',
-    ...(TIME_DEPENDENT_GENERATOR_PATTERN.test(source) ? { timeDependent: true } : {}),
+
+    ...(isTimeDependent ? { timeDependent: true } : {}),
     ...(MOUSE_PATTERN.test(source) ? { mouseDependent: true } : {}),
     ...(FFT_PATTERN.test(source) ? { fftDependent: true } : {})
   };

--- a/ui/src/workers/rendering/cooking/hydra.ts
+++ b/ui/src/workers/rendering/cooking/hydra.ts
@@ -1,0 +1,59 @@
+import { stripJavaScriptComments } from '$lib/utils/javascript-comments';
+import type { CookPolicy } from '../CookStateManager';
+
+const TIME_DEPENDENT_GENERATOR_PATTERN = /\b(?:osc|noise|voronoi|gradient)\s*\(/;
+const MOUSE_PATTERN = /\bmouse\b/;
+const FFT_PATTERN = /\bfft\s*\(/;
+
+const CONSERVATIVE_ALWAYS_PATTERN =
+  /\b(?:datamosh|setFunction|setInterval|setTimeout|requestAnimationFrame)\b|\b(?:Math\.random|Date\.|performance\.now)\b/;
+
+export function createHydraCookPolicy(code: string): CookPolicy {
+  const source = stripStrings(stripJavaScriptComments(code));
+
+  if (CONSERVATIVE_ALWAYS_PATTERN.test(source)) {
+    return { mode: 'always' };
+  }
+
+  return {
+    mode: 'on-demand',
+    ...(TIME_DEPENDENT_GENERATOR_PATTERN.test(source) ? { timeDependent: true } : {}),
+    ...(MOUSE_PATTERN.test(source) ? { mouseDependent: true } : {}),
+    ...(FFT_PATTERN.test(source) ? { fftDependent: true } : {})
+  };
+}
+
+function stripStrings(code: string): string {
+  let output = '';
+  let quote: '"' | "'" | '`' | null = null;
+  let escaped = false;
+
+  for (let index = 0; index < code.length; index += 1) {
+    const char = code[index];
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+
+      output += char === '\n' ? '\n' : ' ';
+
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      output += ' ';
+
+      continue;
+    }
+
+    output += char;
+  }
+
+  return output;
+}

--- a/ui/src/workers/rendering/cooking/test-utils.ts
+++ b/ui/src/workers/rendering/cooking/test-utils.ts
@@ -1,0 +1,9 @@
+export const COOK_TEST_UTILS = {
+  ALWAYS: { mode: 'always' },
+  ON_DEMAND: { mode: 'on-demand' },
+  TIME_DEPENDENT: { mode: 'on-demand', timeDependent: true },
+  MOUSE_DEPENDENT: { mode: 'on-demand', mouseDependent: true },
+  FFT_DEPENDENT: { mode: 'on-demand', fftDependent: true },
+  FRAME_DEPENDENT: { mode: 'on-demand', frameDependent: true },
+  DATE_DEPENDENT: { mode: 'on-demand', dateDependent: true }
+};

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -58,9 +58,15 @@ import {
 } from './glUniformUtils';
 import type { WorkerSettingsProxy } from '../shared/workerSettingsProxy';
 import { CookStateManager, type CookPolicy } from './CookStateManager';
-import { createGlslCookPolicy } from './glslCookPolicy';
+import { createGlslCookPolicy } from './cooking/glsl';
+import { createHydraCookPolicy } from './cooking/hydra';
 
 type TransportTimeState = Pick<ITransport, keyof TransportState>;
+
+type MessageCapableRenderer = {
+  handleMessage(message: Message): void;
+  handleChannelMessage(channel: string, data: unknown, sourceNodeId: string): void;
+};
 
 export const FBO_RENDERER_CONTEXT_ATTRIBUTES: WebGLContextAttributes = {
   alpha: true,
@@ -711,6 +717,10 @@ export class FBORenderer {
     return match(node)
       .with({ type: 'glsl' }, (node) => ({
         ...createGlslCookPolicy(node.data.code),
+        ...(feedbackDependent ? { feedbackDependent: true } : {})
+      }))
+      .with({ type: 'hydra' }, (node) => ({
+        ...createHydraCookPolicy(node.data.code),
         ...(feedbackDependent ? { feedbackDependent: true } : {})
       }))
       .with({ type: P.union('img', 'float.tex') }, () => ({ mode: 'on-demand' as const }))
@@ -2159,86 +2169,33 @@ export class FBORenderer {
 
   /** Send message to nodes */
   sendMessageToNode(nodeId: string, message: Message) {
-    const node = this.renderGraph?.nodes.find((n) => n.id === nodeId);
-    if (!node) return;
+    const renderer = this.getMessageCapableRenderer(nodeId);
+    if (!renderer) return;
 
-    match(node.type)
-      .with('hydra', () => {
-        const hydraRenderer = this.hydraByNode.get(nodeId);
-        if (!hydraRenderer) return;
-
-        hydraRenderer.handleMessage(message);
-      })
-      .with('canvas', () => {
-        const canvasRenderer = this.canvasByNode.get(nodeId);
-        if (!canvasRenderer) return;
-
-        canvasRenderer.handleMessage(message);
-      })
-      .with('swgl', () => {
-        const swglRenderer = this.swglByNode.get(nodeId);
-        if (!swglRenderer) return;
-
-        swglRenderer.handleMessage(message);
-      })
-      .with('textmode', () => {
-        const textmodeRenderer = this.textmodeByNode.get(nodeId);
-        if (!textmodeRenderer) return;
-
-        textmodeRenderer.handleMessage(message);
-      })
-      .with('three', () => {
-        const threeRenderer = this.threeByNode.get(nodeId);
-        if (!threeRenderer) return;
-
-        threeRenderer.handleMessage(message);
-      })
-      .with('regl', () => {
-        const reglRenderer = this.reglByNode.get(nodeId);
-        if (!reglRenderer) return;
-
-        reglRenderer.handleMessage(message);
-      })
-      .with(
-        P.union(
-          'glsl',
-          'shaderpark',
-          'img',
-          'float.tex',
-          'bg.out',
-          'send.vdo',
-          'recv.vdo',
-          'projmap'
-        ),
-        () => {}
-      )
-      .exhaustive();
+    this.cookState.markDirty(nodeId, 'message');
+    renderer.handleMessage(message);
   }
 
   /** Route a channel message to the renderer for a given node. */
   sendChannelMessageToNode(nodeId: string, channel: string, data: unknown, sourceNodeId: string) {
-    const node = this.renderGraph?.nodes.find((n) => n.id === nodeId);
-    if (!node) return;
+    const renderer = this.getMessageCapableRenderer(nodeId);
+    if (!renderer) return;
 
-    match(node.type)
-      .with('hydra', () => {
-        this.hydraByNode.get(nodeId)?.handleChannelMessage(channel, data, sourceNodeId);
-      })
-      .with('canvas', () => {
-        this.canvasByNode.get(nodeId)?.handleChannelMessage(channel, data, sourceNodeId);
-      })
-      .with('textmode', () => {
-        this.textmodeByNode.get(nodeId)?.handleChannelMessage(channel, data, sourceNodeId);
-      })
-      .with('three', () => {
-        this.threeByNode.get(nodeId)?.handleChannelMessage(channel, data, sourceNodeId);
-      })
-      .with('regl', () => {
-        this.reglByNode.get(nodeId)?.handleChannelMessage(channel, data, sourceNodeId);
-      })
-      .with('swgl', () => {
-        this.swglByNode.get(nodeId)?.handleChannelMessage(channel, data, sourceNodeId);
-      })
+    this.cookState.markDirty(nodeId, 'message');
+    renderer.handleChannelMessage(channel, data, sourceNodeId);
+  }
+
+  private getMessageCapableRenderer(nodeId: string): MessageCapableRenderer | null {
+    const node = this.renderGraph?.nodes.find((n) => n.id === nodeId);
+    if (!node) return null;
+
+    return match(node.type)
+      .with('hydra', () => this.hydraByNode.get(nodeId) ?? null)
+      .with('canvas', () => this.canvasByNode.get(nodeId) ?? null)
+      .with('swgl', () => this.swglByNode.get(nodeId) ?? null)
+      .with('textmode', () => this.textmodeByNode.get(nodeId) ?? null)
+      .with('three', () => this.threeByNode.get(nodeId) ?? null)
+      .with('regl', () => this.reglByNode.get(nodeId) ?? null)
       .with(
         P.union(
           'glsl',
@@ -2250,7 +2207,7 @@ export class FBORenderer {
           'recv.vdo',
           'projmap'
         ),
-        () => {}
+        () => null
       )
       .exhaustive();
   }

--- a/ui/static/content/objects/hydra.md
+++ b/ui/static/content/objects/hydra.md
@@ -78,18 +78,6 @@ feed different Hydra chains into different parts of your patch simultaneously.
 > **Note**: The maximum is 8 inlets and 8 outlets, matching WebGL2's
 > hardware limit for simultaneous render targets.
 
-## Cook Behavior
-
-Hydra previews use the same render cook system as other video objects. Static
-patches such as `solid(1, 0, 0).out()` or input-only chains such as
-`src(s0).out()` cook when their inputs or configuration change, then reuse the
-cached frame.
-
-Common animated generators such as `osc()`, `noise()`, `voronoi()`, and
-`gradient()` cook while transport time advances. Mouse, FFT, datamosh, and
-custom function code paths are treated conservatively so interactive or stateful
-patches keep updating.
-
 ## Available Objects
 
 - Full Hydra synth is available as `h`
@@ -229,6 +217,18 @@ Instead, use `fft()` inside arrow functions to get the FFT data. Hydra **must** 
 ```javascript
 osc(() => fft().getEnergy('bass')).out()
 ```
+
+## Cook Behavior
+
+Hydra previews use the same render cook system as other video objects. Static
+patches such as `solid(1, 0, 0).out()` or input-only chains such as
+`src(s0).out()` cook when their inputs or configuration change, then reuse the
+cached frame.
+
+Common animated generators such as `osc()`, `noise()`, `voronoi()`, and
+`gradient()` cook while transport time advances. Mouse, FFT, datamosh, and
+custom function code paths are treated conservatively so interactive or stateful
+patches keep updating.
 
 ## Resources
 

--- a/ui/static/content/objects/hydra.md
+++ b/ui/static/content/objects/hydra.md
@@ -78,6 +78,18 @@ feed different Hydra chains into different parts of your patch simultaneously.
 > **Note**: The maximum is 8 inlets and 8 outlets, matching WebGL2's
 > hardware limit for simultaneous render targets.
 
+## Cook Behavior
+
+Hydra previews use the same render cook system as other video objects. Static
+patches such as `solid(1, 0, 0).out()` or input-only chains such as
+`src(s0).out()` cook when their inputs or configuration change, then reuse the
+cached frame.
+
+Common animated generators such as `osc()`, `noise()`, `voronoi()`, and
+`gradient()` cook while transport time advances. Mouse, FFT, datamosh, and
+custom function code paths are treated conservatively so interactive or stateful
+patches keep updating.
+
 ## Available Objects
 
 - Full Hydra synth is available as `h`


### PR DESCRIPTION
Conditionally re-render hydra frames only when needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hydra previews now use smarter update behavior, reusing cached frames when content is static while continuing to update for animated, interactive, or stateful patches.
  * Added cook status/debug visibility in node previews to better understand rendering update decisions.

* **Bug Fixes**
  * Message-driven updates now correctly mark affected nodes as needing refresh, improving responsiveness when new data arrives.

* **Documentation**
  * Added guidance describing Hydra “cook” behavior and when previews update versus reuse cached results.

* **Tests**
  * Added/expanded coverage for Hydra and cook-state transitions, including message-triggered recooking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->