### PR TITLE
feat(shaderpark): cook frames conditionally and on mouse events

### DIFF
--- a/docs/design-docs/specs/122-render-pipeline-optimizations.md
+++ b/docs/design-docs/specs/122-render-pipeline-optimizations.md
@@ -249,7 +249,7 @@ for (const nodeId of sortedNodes) {
 }
 ```
 
-Uniform, message, mouse, FFT, bitmap, and float texture updates should mark the affected node dirty immediately when the worker receives the update message. Graph rebuilds and FBO reallocations should mark affected nodes dirty with `config`, `output-size`, or `first-frame`.
+Uniform, message, mouse, FFT, bitmap, and float texture updates should mark the affected node dirty immediately when the worker receives the update message. `mouseDependent` means the node is eligible to cook from `mouse` dirty events; it should not force a cook every frame by itself. Graph rebuilds and FBO reallocations should mark affected nodes dirty with `config`, `output-size`, or `first-frame`.
 
 Preview readback should follow the same freshness signal. A node preview may harvest an already-started async read, but it should only initiate a new GPU readback for nodes that are dirty since their last preview read. Newly enabled previews should also start dirty so previews do not stay blank if the node cooked before the preview canvas was ready. After a preview read starts, cached nodes keep displaying the previous preview bitmap until their FBO changes again.
 

--- a/docs/design-docs/specs/122-render-pipeline-optimizations.md
+++ b/docs/design-docs/specs/122-render-pipeline-optimizations.md
@@ -198,7 +198,7 @@ The first implementation should be conservative:
 | Type                             | Initial cook mode                                     | Notes                                                                              |
 | -------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | `glsl`                           | `on-demand` when no dynamic dependencies are detected | First supported node type                                                          |
-| `shaderpark`                     | `always` initially                                    | Can opt in after uniform/time/mouse handling is audited                            |
+| `shaderpark`                     | `on-demand` when no dynamic dependencies are detected | Time, mouse, 3D orbit, input, uniform, and feedback dependencies cook as needed     |
 | `hydra`                          | `on-demand` for static/input-only code                | Animated generators, custom functions, callbacks, mouse, and datamosh stay dynamic |
 | `three`                          | `always` initially                                    | JS code can access time and mutate scenes implicitly                               |
 | `regl`                           | `always` initially                                    | JS code can hide dependencies                                                      |

--- a/ui/src/lib/components/CanvasPreviewLayout.svelte
+++ b/ui/src/lib/components/CanvasPreviewLayout.svelte
@@ -8,7 +8,7 @@
   import type { SupportedLanguage } from '$lib/codemirror/types';
   import { useCookStatus } from '$lib/canvas/use-cook-status.svelte';
 
-  const COOK_DEBUG_OBJECT_TYPES = new Set(['glsl', 'hydra']);
+  const COOK_DEBUG_OBJECT_TYPES = new Set(['glsl', 'hydra', 'shaderpark']);
 
   let {
     title,

--- a/ui/src/workers/rendering/CookStateManager.test.ts
+++ b/ui/src/workers/rendering/CookStateManager.test.ts
@@ -89,13 +89,17 @@ describe('CookStateManager', () => {
     });
   });
 
-  it('keeps mouse-dependent nodes cooking while active', () => {
+  it('cooks mouse-dependent nodes only after mouse input marks them dirty', () => {
     const manager = new CookStateManager();
 
     manager.registerNode('interactive-shader', { mode: 'on-demand', mouseDependent: true });
     manager.beginFrame({ transportTime: 0, prevTransportTime: 0, isTransportPlaying: false });
     manager.markCooked('interactive-shader', ['first-frame', 'mouse'], 0.3);
     manager.beginFrame({ transportTime: 0, prevTransportTime: 0, isTransportPlaying: false });
+
+    expect(manager.shouldCook('interactive-shader')).toEqual({ shouldCook: false, reasons: [] });
+
+    manager.markDirty('interactive-shader', 'mouse');
 
     expect(manager.shouldCook('interactive-shader')).toEqual({
       shouldCook: true,

--- a/ui/src/workers/rendering/CookStateManager.ts
+++ b/ui/src/workers/rendering/CookStateManager.ts
@@ -159,10 +159,6 @@ export class CookStateManager {
       reasons.add('time');
     }
 
-    if (state.policy.mouseDependent) {
-      reasons.add('mouse');
-    }
-
     if (state.policy.feedbackDependent) {
       reasons.add('feedback');
     }

--- a/ui/src/workers/rendering/cooking/policies.test.ts
+++ b/ui/src/workers/rendering/cooking/policies.test.ts
@@ -48,6 +48,22 @@ describe('createRenderNodeCookPolicy', () => {
     );
   });
 
+  it('uses Shader Park dependency policies', () => {
+    expect(
+      createRenderNodeCookPolicy(renderNode('shaderpark', { code: 'sphere(0.7);' }), baseGraph)
+    ).toEqual(ON_DEMAND);
+
+    expect(
+      createRenderNodeCookPolicy(
+        renderNode('shaderpark', { code: 'sphere(0.5 + sin(time));' }),
+        baseGraph
+      )
+    ).toEqual({
+      mode: 'on-demand',
+      timeDependent: true
+    });
+  });
+
   it('preserves feedback dependency for on-demand passthrough nodes', () => {
     const node = renderNode('send.vdo', { channel: 'main' });
 

--- a/ui/src/workers/rendering/cooking/policies.ts
+++ b/ui/src/workers/rendering/cooking/policies.ts
@@ -3,6 +3,7 @@ import type { RenderGraph, RenderNode } from '$lib/rendering/types';
 import type { CookPolicy } from '../CookStateManager';
 import { createGlslCookPolicy } from './glsl';
 import { createHydraCookPolicy } from './hydra';
+import { createShaderParkCookPolicy } from './shaderpark';
 
 export function createRenderNodeCookPolicy(node: RenderNode, renderGraph: RenderGraph): CookPolicy {
   const feedbackDependent =
@@ -15,6 +16,10 @@ export function createRenderNodeCookPolicy(node: RenderNode, renderGraph: Render
     }))
     .with({ type: 'hydra' }, (node) => ({
       ...createHydraCookPolicy(node.data.code),
+      ...(feedbackDependent ? { feedbackDependent: true } : {})
+    }))
+    .with({ type: 'shaderpark' }, (node) => ({
+      ...createShaderParkCookPolicy(node.data.code, { renderMode: node.data.renderMode }),
       ...(feedbackDependent ? { feedbackDependent: true } : {})
     }))
     .with(

--- a/ui/src/workers/rendering/cooking/shaderpark.test.ts
+++ b/ui/src/workers/rendering/cooking/shaderpark.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { createShaderParkCookPolicy } from './shaderpark';
+import { COOK_TEST_UTILS } from './test-utils';
+
+const { ON_DEMAND, TIME_DEPENDENT, MOUSE_DEPENDENT } = COOK_TEST_UTILS;
+
+describe('createShaderParkCookPolicy', () => {
+  it('allows static Shader Park code to cook on demand', () => {
+    expect(createShaderParkCookPolicy('sphere(0.7);')).toEqual(ON_DEMAND);
+  });
+
+  it('treats code that reads time as transport-time dependent', () => {
+    expect(createShaderParkCookPolicy('sphere(0.5 + 0.1 * sin(time));')).toEqual(TIME_DEPENDENT);
+  });
+
+  it('treats mouse-reactive code as mouse dependent', () => {
+    expect(createShaderParkCookPolicy('sphere(length(mouseIntersection()) * 0.1);')).toEqual(
+      MOUSE_DEPENDENT
+    );
+    expect(createShaderParkCookPolicy('color(vec3(mouse.x, mouse.y, 0.0));')).toEqual(
+      MOUSE_DEPENDENT
+    );
+  });
+
+  it('treats 3D Shader Park nodes as mouse dependent for orbit controls', () => {
+    expect(createShaderParkCookPolicy('sphere(0.7);', { renderMode: '3d' })).toEqual(
+      MOUSE_DEPENDENT
+    );
+  });
+
+  it('ignores dependencies in comments', () => {
+    expect(
+      createShaderParkCookPolicy(`
+        // time mouse mouseIntersection
+        /*
+          time should not count here either
+        */
+        sphere(0.7);
+      `)
+    ).toEqual(ON_DEMAND);
+  });
+});

--- a/ui/src/workers/rendering/cooking/shaderpark.test.ts
+++ b/ui/src/workers/rendering/cooking/shaderpark.test.ts
@@ -17,6 +17,7 @@ describe('createShaderParkCookPolicy', () => {
     expect(createShaderParkCookPolicy('sphere(length(mouseIntersection()) * 0.1);')).toEqual(
       MOUSE_DEPENDENT
     );
+
     expect(createShaderParkCookPolicy('color(vec3(mouse.x, mouse.y, 0.0));')).toEqual(
       MOUSE_DEPENDENT
     );

--- a/ui/src/workers/rendering/cooking/shaderpark.ts
+++ b/ui/src/workers/rendering/cooking/shaderpark.ts
@@ -1,0 +1,20 @@
+import { stripJavaScriptComments } from '$lib/utils/javascript-comments';
+import type { ShaderParkRenderMode } from '$lib/rendering/types';
+import type { CookPolicy } from '../CookStateManager';
+
+const TIME_PATTERN = /\btime\b/;
+const MOUSE_PATTERN = /\bmouse\b|\bmouseIntersection\b/;
+
+export function createShaderParkCookPolicy(
+  code: string,
+  options: { renderMode?: ShaderParkRenderMode } = {}
+): CookPolicy {
+  const source = stripJavaScriptComments(code);
+  const isMouseDependent = options.renderMode === '3d' || MOUSE_PATTERN.test(source);
+
+  return {
+    mode: 'on-demand',
+    ...(TIME_PATTERN.test(source) ? { timeDependent: true } : {}),
+    ...(isMouseDependent ? { mouseDependent: true } : {})
+  };
+}

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -60,6 +60,7 @@ import type { WorkerSettingsProxy } from '../shared/workerSettingsProxy';
 import { CookStateManager, type CookPolicy } from './CookStateManager';
 import { createGlslCookPolicy } from './cooking/glsl';
 import { createRenderNodeCookPolicy } from './cooking/policies';
+import { isSameMouseData, type MouseData } from './mouseData';
 
 type TransportTimeState = Pick<ITransport, keyof TransportState>;
 
@@ -114,7 +115,7 @@ export class FBORenderer {
   public nodePausedMap: Map<string, boolean> = new Map();
 
   /** Mapping of nodeID to mouse state (iMouse vec4: xy = current, zw = click) */
-  public mouseDataByNode: Map<string, [number, number, number, number, number?]> = new Map();
+  public mouseDataByNode: Map<string, MouseData> = new Map();
 
   /** Enable the WebGL workaround for iOS Safari */
   public usesMobileSafariWebGLWorkaround = false;
@@ -1454,7 +1455,13 @@ export class FBORenderer {
 
   /** Set mouse data for a node (Shadertoy iMouse format) */
   setMouseData(nodeId: string, x: number, y: number, z: number, w: number, buttons?: number) {
-    this.mouseDataByNode.set(nodeId, [x, y, z, w, buttons]);
+    const nextMouseData: MouseData = [x, y, z, w, buttons];
+    const previousMouseData = this.mouseDataByNode.get(nodeId);
+
+    if (isSameMouseData(previousMouseData, nextMouseData)) return;
+
+    this.mouseDataByNode.set(nodeId, nextMouseData);
+    this.cookState.markDirty(nodeId, 'mouse');
   }
 
   sendThreeWheelData(
@@ -1470,6 +1477,7 @@ export class FBORenderer {
 
   zoomShaderParkOrbit(nodeId: string, deltaY: number) {
     this.shaderParkThreeByNode.get(nodeId)?.zoom(deltaY);
+    this.cookState.markDirty(nodeId, 'mouse');
   }
 
   /** Get list of nodes with preview enabled */

--- a/ui/src/workers/rendering/mouseData.test.ts
+++ b/ui/src/workers/rendering/mouseData.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { isSameMouseData, type MouseData } from './mouseData';
+
+describe('isSameMouseData', () => {
+  it('matches identical mouse payloads', () => {
+    expect(isSameMouseData([0, 0, -1, -1], [0, 0, -1, -1])).toBe(true);
+  });
+
+  it('detects changed mouse coordinates and buttons', () => {
+    const previous: MouseData = [0, 0, -1, -1, 0];
+
+    expect(isSameMouseData(previous, [1, 0, -1, -1, 0])).toBe(false);
+    expect(isSameMouseData(previous, [0, 0, -1, -1, 1])).toBe(false);
+  });
+});

--- a/ui/src/workers/rendering/mouseData.ts
+++ b/ui/src/workers/rendering/mouseData.ts
@@ -1,0 +1,9 @@
+export type MouseData = [number, number, number, number, number?];
+
+export const isSameMouseData = (a: MouseData | undefined, b: MouseData): boolean =>
+  a !== undefined &&
+  a[0] === b[0] &&
+  a[1] === b[1] &&
+  a[2] === b[2] &&
+  a[3] === b[3] &&
+  a[4] === b[4];


### PR DESCRIPTION
Cook shaderpark frames conditionally, and only cook them when there are mouse movements