### PR TITLE
feat(swgl): conditionally cook frames

### DIFF
--- a/docs/design-docs/specs/122-render-pipeline-optimizations.md
+++ b/docs/design-docs/specs/122-render-pipeline-optimizations.md
@@ -202,7 +202,7 @@ The first implementation should be conservative:
 | `hydra`                          | `on-demand` for static/input-only code                | Animated generators, custom functions, callbacks, mouse, and datamosh stay dynamic |
 | `three`                          | `always` initially                                    | JS code can access time and mutate scenes implicitly                               |
 | `regl`                           | `always` initially                                    | JS code can hide dependencies                                                      |
-| `swgl`                           | `on-demand` when no dynamic dependencies are detected | `t`, input, message, and feedback dependencies cook as needed                      |
+| `swgl`                           | `on-demand` when no dynamic dependencies are detected | `t`, `fft()`, input, message, and feedback dependencies cook as needed             |
 | `canvas`                         | `always` initially                                    | User code may draw from timers, messages, or internal state                        |
 | `textmode`                       | `always` initially                                    | Stateful runtime                                                                   |
 | `img`, `float.tex`               | `on-demand`, externally dirty                        | Cook only when uploaded bitmap/texture data changes                                |

--- a/docs/design-docs/specs/122-render-pipeline-optimizations.md
+++ b/docs/design-docs/specs/122-render-pipeline-optimizations.md
@@ -202,7 +202,7 @@ The first implementation should be conservative:
 | `hydra`                          | `on-demand` for static/input-only code                | Animated generators, custom functions, callbacks, mouse, and datamosh stay dynamic |
 | `three`                          | `always` initially                                    | JS code can access time and mutate scenes implicitly                               |
 | `regl`                           | `always` initially                                    | JS code can hide dependencies                                                      |
-| `swgl`                           | `always` initially                                    | JS code can hide dependencies                                                      |
+| `swgl`                           | `on-demand` when no dynamic dependencies are detected | `t`, input, message, and feedback dependencies cook as needed                      |
 | `canvas`                         | `always` initially                                    | User code may draw from timers, messages, or internal state                        |
 | `textmode`                       | `always` initially                                    | Stateful runtime                                                                   |
 | `img`, `float.tex`               | `on-demand`, externally dirty                        | Cook only when uploaded bitmap/texture data changes                                |

--- a/ui/src/lib/components/CanvasPreviewLayout.svelte
+++ b/ui/src/lib/components/CanvasPreviewLayout.svelte
@@ -8,7 +8,7 @@
   import type { SupportedLanguage } from '$lib/codemirror/types';
   import { useCookStatus } from '$lib/canvas/use-cook-status.svelte';
 
-  const COOK_DEBUG_OBJECT_TYPES = new Set(['glsl', 'hydra', 'shaderpark']);
+  const COOK_DEBUG_OBJECT_TYPES = new Set(['glsl', 'hydra', 'shaderpark', 'swgl']);
 
   let {
     title,

--- a/ui/src/lib/utils/javascript-comments.ts
+++ b/ui/src/lib/utils/javascript-comments.ts
@@ -52,3 +52,38 @@ export function stripJavaScriptComments(code: string): string {
 
   return output;
 }
+
+export function stripJavaScriptStrings(code: string): string {
+  let output = '';
+  let quote: '"' | "'" | '`' | null = null;
+  let escaped = false;
+
+  for (let index = 0; index < code.length; index += 1) {
+    const char = code[index];
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+
+      output += char === '\n' ? '\n' : ' ';
+
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      output += ' ';
+
+      continue;
+    }
+
+    output += char;
+  }
+
+  return output;
+}

--- a/ui/src/workers/rendering/cooking/hydra.ts
+++ b/ui/src/workers/rendering/cooking/hydra.ts
@@ -1,4 +1,4 @@
-import { stripJavaScriptComments } from '$lib/utils/javascript-comments';
+import { stripJavaScriptComments, stripJavaScriptStrings } from '$lib/utils/javascript-comments';
 import type { CookPolicy } from '../CookStateManager';
 
 const TIME_DEPENDENT_GENERATOR_PATTERN = /\b(?:osc|noise|voronoi|gradient)\s*\(/;
@@ -10,7 +10,7 @@ const CONSERVATIVE_ALWAYS_PATTERN =
   /\b(?:datamosh|setFunction|setInterval|setTimeout|requestAnimationFrame)\b|\b(?:Math\.random|Date\.|performance\.now)\b/;
 
 export function createHydraCookPolicy(code: string): CookPolicy {
-  const source = stripStrings(stripJavaScriptComments(code));
+  const source = stripJavaScriptStrings(stripJavaScriptComments(code));
 
   if (CONSERVATIVE_ALWAYS_PATTERN.test(source)) {
     return { mode: 'always' };
@@ -26,39 +26,4 @@ export function createHydraCookPolicy(code: string): CookPolicy {
     ...(MOUSE_PATTERN.test(source) ? { mouseDependent: true } : {}),
     ...(FFT_PATTERN.test(source) ? { fftDependent: true } : {})
   };
-}
-
-function stripStrings(code: string): string {
-  let output = '';
-  let quote: '"' | "'" | '`' | null = null;
-  let escaped = false;
-
-  for (let index = 0; index < code.length; index += 1) {
-    const char = code[index];
-
-    if (quote) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === '\\') {
-        escaped = true;
-      } else if (char === quote) {
-        quote = null;
-      }
-
-      output += char === '\n' ? '\n' : ' ';
-
-      continue;
-    }
-
-    if (char === '"' || char === "'" || char === '`') {
-      quote = char;
-      output += ' ';
-
-      continue;
-    }
-
-    output += char;
-  }
-
-  return output;
 }

--- a/ui/src/workers/rendering/cooking/policies.test.ts
+++ b/ui/src/workers/rendering/cooking/policies.test.ts
@@ -3,7 +3,7 @@ import type { RenderGraph, RenderNode } from '$lib/rendering/types';
 import { createRenderNodeCookPolicy } from './policies';
 import { COOK_TEST_UTILS } from './test-utils';
 
-const { ON_DEMAND, TIME_DEPENDENT, FEEDBACK_DEPENDENT } = COOK_TEST_UTILS;
+const { ON_DEMAND, TIME_DEPENDENT, FFT_DEPENDENT, FEEDBACK_DEPENDENT } = COOK_TEST_UTILS;
 
 const baseGraph: RenderGraph = {
   nodes: [],
@@ -71,6 +71,13 @@ describe('createRenderNodeCookPolicy', () => {
         baseGraph
       )
     ).toEqual(TIME_DEPENDENT);
+
+    expect(
+      createRenderNodeCookPolicy(
+        renderNode('swgl', { code: 'function render() { shader({ amp: fft().a[0] }); }' }),
+        baseGraph
+      )
+    ).toEqual(FFT_DEPENDENT);
   });
 
   it('preserves feedback dependency for on-demand passthrough nodes', () => {

--- a/ui/src/workers/rendering/cooking/policies.test.ts
+++ b/ui/src/workers/rendering/cooking/policies.test.ts
@@ -3,7 +3,7 @@ import type { RenderGraph, RenderNode } from '$lib/rendering/types';
 import { createRenderNodeCookPolicy } from './policies';
 import { COOK_TEST_UTILS } from './test-utils';
 
-const { ON_DEMAND } = COOK_TEST_UTILS;
+const { ON_DEMAND, TIME_DEPENDENT, FEEDBACK_DEPENDENT } = COOK_TEST_UTILS;
 
 const baseGraph: RenderGraph = {
   nodes: [],
@@ -15,8 +15,8 @@ const baseGraph: RenderGraph = {
   feedbackNodes: new Set()
 };
 
-function renderNode(type: RenderNode['type'], data: RenderNode['data'] = {}): RenderNode {
-  return {
+const renderNode = (type: RenderNode['type'], data: RenderNode['data'] = {}): RenderNode =>
+  ({
     id: `${type}-1`,
     type,
     data,
@@ -24,8 +24,7 @@ function renderNode(type: RenderNode['type'], data: RenderNode['data'] = {}): Re
     outputs: [],
     inletMap: new Map(),
     backEdgeInlets: new Set()
-  } as RenderNode;
-}
+  }) as RenderNode;
 
 describe('createRenderNodeCookPolicy', () => {
   it('lets video channel passthrough nodes cook on demand', () => {
@@ -58,10 +57,20 @@ describe('createRenderNodeCookPolicy', () => {
         renderNode('shaderpark', { code: 'sphere(0.5 + sin(time));' }),
         baseGraph
       )
-    ).toEqual({
-      mode: 'on-demand',
-      timeDependent: true
-    });
+    ).toEqual(TIME_DEPENDENT);
+  });
+
+  it('uses SwissGL dependency policies', () => {
+    expect(
+      createRenderNodeCookPolicy(renderNode('swgl', { code: 'function render() {}' }), baseGraph)
+    ).toEqual(ON_DEMAND);
+
+    expect(
+      createRenderNodeCookPolicy(
+        renderNode('swgl', { code: 'function render({ t }) { shader({ t }); }' }),
+        baseGraph
+      )
+    ).toEqual(TIME_DEPENDENT);
   });
 
   it('preserves feedback dependency for on-demand passthrough nodes', () => {
@@ -72,9 +81,6 @@ describe('createRenderNodeCookPolicy', () => {
         ...baseGraph,
         feedbackNodes: new Set([node.id])
       })
-    ).toEqual({
-      mode: 'on-demand',
-      feedbackDependent: true
-    });
+    ).toEqual(FEEDBACK_DEPENDENT);
   });
 });

--- a/ui/src/workers/rendering/cooking/policies.ts
+++ b/ui/src/workers/rendering/cooking/policies.ts
@@ -4,6 +4,7 @@ import type { CookPolicy } from '../CookStateManager';
 import { createGlslCookPolicy } from './glsl';
 import { createHydraCookPolicy } from './hydra';
 import { createShaderParkCookPolicy } from './shaderpark';
+import { createSwglCookPolicy } from './swgl';
 
 export function createRenderNodeCookPolicy(node: RenderNode, renderGraph: RenderGraph): CookPolicy {
   const feedbackDependent =
@@ -20,6 +21,10 @@ export function createRenderNodeCookPolicy(node: RenderNode, renderGraph: Render
     }))
     .with({ type: 'shaderpark' }, (node) => ({
       ...createShaderParkCookPolicy(node.data.code, { renderMode: node.data.renderMode }),
+      ...(feedbackDependent ? { feedbackDependent: true } : {})
+    }))
+    .with({ type: 'swgl' }, (node) => ({
+      ...createSwglCookPolicy(node.data.code),
       ...(feedbackDependent ? { feedbackDependent: true } : {})
     }))
     .with(

--- a/ui/src/workers/rendering/cooking/swgl.test.ts
+++ b/ui/src/workers/rendering/cooking/swgl.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { createSwglCookPolicy } from './swgl';
+import { COOK_TEST_UTILS } from './test-utils';
+
+const { ON_DEMAND, TIME_DEPENDENT } = COOK_TEST_UTILS;
+
+describe('createSwglCookPolicy', () => {
+  it('allows static SwissGL code to cook on demand', () => {
+    expect(
+      createSwglCookPolicy(`
+        const shader = await glsl({ FP: 'color = vec4(1, 0, 0, 1);' });
+
+        function render() {
+          shader();
+        }
+      `)
+    ).toEqual(ON_DEMAND);
+  });
+
+  it('treats code that passes transport time as time dependent', () => {
+    expect(
+      createSwglCookPolicy(`
+        const shader = await glsl({ FP: 'color = vec4(sin(t), 0, 0, 1);' });
+
+        function render({ t }) {
+          shader({ t });
+        }
+      `)
+    ).toEqual(TIME_DEPENDENT);
+  });
+
+  it('ignores time references in comments', () => {
+    expect(
+      createSwglCookPolicy(`
+        // t should not count here
+        /*
+          t should not count here either
+        */
+        const shader = await glsl({ FP: 'color = vec4(1);' });
+
+        function render() {
+          shader();
+        }
+      `)
+    ).toEqual(ON_DEMAND);
+  });
+});

--- a/ui/src/workers/rendering/cooking/swgl.test.ts
+++ b/ui/src/workers/rendering/cooking/swgl.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
+
 import { createSwglCookPolicy } from './swgl';
 import { COOK_TEST_UTILS } from './test-utils';
 
-const { ON_DEMAND, TIME_DEPENDENT } = COOK_TEST_UTILS;
+const { ON_DEMAND, TIME_DEPENDENT, FFT_DEPENDENT } = COOK_TEST_UTILS;
 
 describe('createSwglCookPolicy', () => {
   it('allows static SwissGL code to cook on demand', () => {
@@ -29,13 +30,42 @@ describe('createSwglCookPolicy', () => {
     ).toEqual(TIME_DEPENDENT);
   });
 
-  it('ignores time references in comments', () => {
+  it('treats code that reads fft analysis as fft dependent', () => {
     expect(
       createSwglCookPolicy(`
-        // t should not count here
+        const shader = await glsl({ FP: 'color = vec4(amp, 0, 0, 1);' });
+
+        function render() {
+          shader({ amp: fft().getEnergy('bass') });
+        }
+      `)
+    ).toEqual(FFT_DEPENDENT);
+  });
+
+  it('detects combined time and fft dependencies', () => {
+    expect(
+      createSwglCookPolicy(`
+        const shader = await glsl({ FP: 'color = vec4(sin(t) * amp, 0, 0, 1);' });
+
+        function render({ t }) {
+          shader({ t, amp: fft().a[0] });
+        }
+      `)
+    ).toEqual({
+      mode: 'on-demand',
+      timeDependent: true,
+      fftDependent: true
+    });
+  });
+
+  it('ignores dependencies in comments and strings when appropriate', () => {
+    expect(
+      createSwglCookPolicy(`
+        // t and fft() should not count here
         /*
-          t should not count here either
+          t and fft() should not count here either
         */
+        const label = "fft() should not count here";
         const shader = await glsl({ FP: 'color = vec4(1);' });
 
         function render() {

--- a/ui/src/workers/rendering/cooking/swgl.ts
+++ b/ui/src/workers/rendering/cooking/swgl.ts
@@ -1,0 +1,13 @@
+import { stripJavaScriptComments } from '$lib/utils/javascript-comments';
+import type { CookPolicy } from '../CookStateManager';
+
+const TIME_PATTERN = /\bt\b/;
+
+export function createSwglCookPolicy(code: string): CookPolicy {
+  const source = stripJavaScriptComments(code);
+
+  return {
+    mode: 'on-demand',
+    ...(TIME_PATTERN.test(source) ? { timeDependent: true } : {})
+  };
+}

--- a/ui/src/workers/rendering/cooking/swgl.ts
+++ b/ui/src/workers/rendering/cooking/swgl.ts
@@ -1,13 +1,17 @@
-import { stripJavaScriptComments } from '$lib/utils/javascript-comments';
+import { stripJavaScriptComments, stripJavaScriptStrings } from '$lib/utils/javascript-comments';
+
 import type { CookPolicy } from '../CookStateManager';
 
 const TIME_PATTERN = /\bt\b/;
+const FFT_PATTERN = /\bfft\s*\(/;
 
 export function createSwglCookPolicy(code: string): CookPolicy {
   const source = stripJavaScriptComments(code);
+  const dependencySource = stripJavaScriptStrings(source);
 
   return {
     mode: 'on-demand',
-    ...(TIME_PATTERN.test(source) ? { timeDependent: true } : {})
+    ...(TIME_PATTERN.test(source) ? { timeDependent: true } : {}),
+    ...(FFT_PATTERN.test(dependencySource) ? { fftDependent: true } : {})
   };
 }

--- a/ui/src/workers/rendering/cooking/test-utils.ts
+++ b/ui/src/workers/rendering/cooking/test-utils.ts
@@ -5,5 +5,6 @@ export const COOK_TEST_UTILS = {
   MOUSE_DEPENDENT: { mode: 'on-demand', mouseDependent: true },
   FFT_DEPENDENT: { mode: 'on-demand', fftDependent: true },
   FRAME_DEPENDENT: { mode: 'on-demand', frameDependent: true },
-  DATE_DEPENDENT: { mode: 'on-demand', dateDependent: true }
+  DATE_DEPENDENT: { mode: 'on-demand', dateDependent: true },
+  FEEDBACK_DEPENDENT: { mode: 'on-demand', feedbackDependent: true }
 };


### PR DESCRIPTION
Conditionally cook SWGL frames. Possible reasons are time and fft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional render type, improving cooking behavior for more preview content.
  * Better detection of time- and FFT-based dependencies in shader code, even with comments or strings present.

* **Bug Fixes**
  * Preview rendering now avoids unnecessary always-on cooking in more cases, helping reduce extra work and improve responsiveness.

* **Documentation**
  * Updated renderer guidance to reflect the new cooking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->