### PR TITLE
perf(renderer): do not cook frames if outside viewport

### DIFF
--- a/docs/design-docs/specs/122-render-pipeline-optimizations.md
+++ b/docs/design-docs/specs/122-render-pipeline-optimizations.md
@@ -253,6 +253,8 @@ Uniform, message, mouse, FFT, bitmap, and float texture updates should mark the 
 
 Preview readback should follow the same freshness signal. A node preview may harvest an already-started async read, but it should only initiate a new GPU readback for nodes that are dirty since their last preview read. Newly enabled previews should also start dirty so previews do not stay blank if the node cooked before the preview canvas was ready. After a preview read starts, cached nodes keep displaying the previous preview bitmap until their FBO changes again.
 
+Viewport visibility should also gate cooking for nodes that are not part of the active video graph. If a node is outside the xyflow viewport, has no connected video output, and is not the effective background output (`bg.out` source or background override), `FBORenderer.renderFrame()` should skip it before evaluating its cook policy. The node keeps its dirty state while skipped so it cooks when it becomes visible or connected again. Nodes with downstream video consumers, wireless video outputs, or background output responsibilities keep cooking even when offscreen.
+
 ### Feedback Loops
 
 Feedback nodes need special handling. A feedback loop can evolve even when the shader does not use `iTime`, because the previous-frame texture is itself state. If a node reads a back-edge input, mark it dirty when the source feedback texture advanced on the previous frame.

--- a/ui/src/lib/canvas/GLSystem.test.ts
+++ b/ui/src/lib/canvas/GLSystem.test.ts
@@ -23,6 +23,29 @@ import { GLSystem } from './GLSystem';
 import { VideoChannelRegistry } from './VideoChannelRegistry';
 
 describe('GLSystem', () => {
+  it('sends connected video output node ids with render graph updates', () => {
+    const glSystem = new GLSystem();
+    const worker = glSystem.renderWorker as unknown as { postMessage: ReturnType<typeof vi.fn> };
+
+    glSystem.upsertNode('glsl-1', 'glsl', { code: '', glUniformDefs: [] });
+    worker.postMessage.mockClear();
+
+    glSystem.registerPatchbayVideoEdge('edge-1', {
+      id: 'edge-1',
+      source: 'glsl-1',
+      target: 'worker-1',
+      sourceHandle: 'video-out',
+      targetHandle: 'video-in-0'
+    });
+
+    expect(worker.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'buildRenderGraph',
+        connectedVideoOutputNodeIds: ['glsl-1']
+      })
+    );
+  });
+
   it('does not resubscribe unchanged video channel nodes', () => {
     const glSystem = new GLSystem();
     const registry = VideoChannelRegistry.getInstance();

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -9,6 +9,7 @@ import type { ElementImageLike } from '$lib/html-in-canvas/html-canvas-video-out
 import RenderWorker from '$workers/rendering/renderWorker?worker';
 
 import * as ohash from 'ohash';
+
 import {
   previewVisibleMap,
   isGlslPlaying,
@@ -53,6 +54,11 @@ import { Transport, type TransportState } from '$lib/transport';
 import { FloatTextureUploadBufferPool } from '$lib/float-texture/upload-buffer-pool';
 
 export type UserUniformValue = number | boolean | number[] | boolean[] | number[][];
+
+const isVideoRenderEdge = (edge: REdge): boolean =>
+  edge.sourceHandle?.startsWith('video-out') === true ||
+  edge.targetHandle?.startsWith('video-in') === true ||
+  /(video-out|video-in|sampler2D)/.test(edge.id);
 
 export class GLSystem {
   /** Web worker for offscreen rendering. */
@@ -915,9 +921,12 @@ export class GLSystem {
     if (!force && !this.hasFlowGraphChanged(this.nodes, edges)) return false;
 
     const graph = buildRenderGraph(this.nodes, edges);
-    if (!force && !this.hasHashChanged('graph', graph)) return false;
+    const connectedVideoOutputNodeIds = Array.from(this.getConnectedVideoOutputNodeIds(edges));
 
-    this.send('buildRenderGraph', { graph });
+    const graphPayload = { graph, connectedVideoOutputNodeIds };
+    if (!force && !this.hasHashChanged('graph', graphPayload)) return false;
+
+    this.send('buildRenderGraph', graphPayload);
     this.renderGraph = graph;
 
     // Expose feedback back-edges to UI for dashed edge styling
@@ -944,6 +953,16 @@ export class GLSystem {
 
   private getAllRenderEdges(): REdge[] {
     return [...this.edges, ...this.patchbay.getEdges()];
+  }
+
+  private getConnectedVideoOutputNodeIds(edges: REdge[]): Set<string> {
+    const nodeIds = new Set<string>();
+
+    for (const edge of edges) {
+      if (isVideoRenderEdge(edge)) nodeIds.add(edge.source);
+    }
+
+    return nodeIds;
   }
 
   private registerVideoChannelNode(
@@ -982,6 +1001,7 @@ export class GLSystem {
 
     this.outputSize = [outputWidth, outputHeight];
     this.hasExplicitOutputSize = true;
+
     outputSizeStore.set([outputWidth, outputHeight]);
 
     previewSizeStore.set(
@@ -1127,18 +1147,17 @@ export class GLSystem {
       return this.outgoingConnectionsCache.get(nodeId)!;
     }
 
+    const edges = this.getAllRenderEdges();
+
     // Check all edges (not just FBO-filtered ones) for video connections
     // This allows external texture nodes (webcam, img) to upload when connected
     // to non-FBO nodes like vdo.ninja.push
-    const hasOutgoingVideoEdges = this.getAllRenderEdges().some(
-      (edge) => edge.source === nodeId && /(video-out|video-in|sampler2D)/.test(edge.id)
-    );
+    const hasOutgoingVideoEdges = this.getConnectedVideoOutputNodeIds(edges).has(nodeId);
 
     const isOutputNode =
       this.renderGraph?.outputNodeId === nodeId || this.overrideOutputNodeId === nodeId;
 
     const hasConnections = hasOutgoingVideoEdges || isOutputNode;
-
     this.outgoingConnectionsCache.set(nodeId, hasConnections);
 
     return hasConnections;

--- a/ui/src/lib/rendering/types.ts
+++ b/ui/src/lib/rendering/types.ts
@@ -181,7 +181,11 @@ export interface FBONode {
 
 // Message types for worker communication (main -> worker)
 export type WorkerMessage =
-  | { type: 'buildRenderGraph'; nodes: RenderNode[]; edges: RenderEdge[] }
+  | {
+      type: 'buildRenderGraph';
+      graph: RenderGraph;
+      connectedVideoOutputNodeIds?: string[];
+    }
   | { type: 'startAnimation' }
   | { type: 'stopAnimation' }
   | { type: 'setPreviewEnabled'; nodeId: string; enabled: boolean }

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -61,6 +61,7 @@ import { CookStateManager, type CookPolicy } from './CookStateManager';
 import { createGlslCookPolicy } from './cooking/glsl';
 import { createRenderNodeCookPolicy } from './cooking/policies';
 import { isSameMouseData, type MouseData } from './mouseData';
+import { shouldSkipCookForViewport } from './renderEligibility';
 
 type TransportTimeState = Pick<ITransport, keyof TransportState>;
 
@@ -145,9 +146,11 @@ export class FBORenderer {
   private frameCount: number = 0;
   private contextLossReported = false;
   private renderErrorKeysByNode = new Map<string, Set<string>>();
-  private glErrorKeysByNode = new Map<string, Set<string>>();
+
   private lastCookStatusSignatures = new Map<string, string>();
   private cookStatsEnabled = false;
+  private visibleNodeIds: Set<string> | null = null;
+  private connectedVideoOutputNodeIds: Set<string> = new Set();
 
   /** Minimum interval between rendered frames (ms). 0 = unlimited. */
   private renderIntervalMs: number = 0;
@@ -355,7 +358,11 @@ export class FBORenderer {
   }
 
   /** Build FBOs for all nodes in the render graph */
-  async buildFBOs(renderGraph: RenderGraph) {
+  async buildFBOs(renderGraph: RenderGraph, connectedVideoOutputNodeIds?: Set<string>) {
+    if (connectedVideoOutputNodeIds) {
+      this.connectedVideoOutputNodeIds = new Set(connectedVideoOutputNodeIds);
+    }
+
     // Get the set of node IDs that will exist in the new graph
     const newNodeIds = new Set(renderGraph.nodes.map((n) => n.id));
 
@@ -1519,6 +1526,9 @@ export class FBORenderer {
       isTransportPlaying: this.transportTime?.isPlaying ?? true
     });
 
+    const isOverride = this.hasValidOutputOverride();
+    const effectiveOutputNodeId = this.getEffectiveOutputNodeId(isOverride);
+
     // Render each node in topological order
     for (const nodeId of this.renderGraph.sortedNodes) {
       if (!this.renderGraph) continue;
@@ -1526,6 +1536,15 @@ export class FBORenderer {
       const node = this.renderGraph.nodes.find((n) => n.id === nodeId);
       const fboNode = this.fboNodes.get(nodeId);
       if (!node || !fboNode) continue;
+
+      const shouldSkipCooking = shouldSkipCookForViewport({
+        node,
+        visibleNodeIds: this.visibleNodeIds,
+        connectedVideoOutputNodeIds: this.connectedVideoOutputNodeIds,
+        effectiveOutputNodeId
+      });
+
+      if (shouldSkipCooking) continue;
 
       const cookDecision = this.cookState.shouldCook(node.id);
 
@@ -1554,10 +1573,6 @@ export class FBORenderer {
 
     // Render the final result to the main canvas.
     // Use override if set and the node exists; otherwise fall back to bg.out.
-    const isOverride = this.overrideOutputNodeId && this.fboNodes.has(this.overrideOutputNodeId);
-
-    const effectiveOutputNodeId = isOverride ? this.overrideOutputNodeId : this.outputNodeId;
-
     // Override always uses attachment 0; bg.out respects the connected outlet index.
     const savedOutletIndex = this.outputOutletIndex;
     if (isOverride) this.outputOutletIndex = 0;
@@ -1783,6 +1798,14 @@ export class FBORenderer {
     reglInstance._refresh?.();
   }
 
+  private hasValidOutputOverride(): boolean {
+    return Boolean(this.overrideOutputNodeId && this.fboNodes.has(this.overrideOutputNodeId));
+  }
+
+  private getEffectiveOutputNodeId(isOverride = this.hasValidOutputOverride()): string | null {
+    return isOverride ? this.overrideOutputNodeId : this.outputNodeId;
+  }
+
   /**
    * Render previews for enabled nodes and return ImageBitmaps directly.
    * Uses async PBO reads - returns bitmaps from *previous* frame's reads
@@ -1800,6 +1823,7 @@ export class FBORenderer {
 
   /** Set which nodes are visible in the viewport for preview culling */
   setVisibleNodes(nodeIds: Set<string>) {
+    this.visibleNodeIds = new Set(nodeIds);
     this.previewRenderer.setVisibleNodes(nodeIds);
   }
 

--- a/ui/src/workers/rendering/renderEligibility.test.ts
+++ b/ui/src/workers/rendering/renderEligibility.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { shouldSkipCookForViewport } from './renderEligibility';
+
+const hiddenNode = { id: 'glsl-1', outputs: [] };
+
+describe('shouldSkipCookForViewport', () => {
+  it('skips nodes that are hidden, disconnected, and not the effective output', () => {
+    expect(
+      shouldSkipCookForViewport({
+        node: hiddenNode,
+        visibleNodeIds: new Set(['hydra-1']),
+        connectedVideoOutputNodeIds: new Set(),
+        effectiveOutputNodeId: null
+      })
+    ).toBe(true);
+  });
+
+  it('does not skip when viewport visibility has not been initialized', () => {
+    expect(
+      shouldSkipCookForViewport({
+        node: hiddenNode,
+        visibleNodeIds: null,
+        connectedVideoOutputNodeIds: new Set(),
+        effectiveOutputNodeId: null
+      })
+    ).toBe(false);
+  });
+
+  it('does not skip visible nodes', () => {
+    expect(
+      shouldSkipCookForViewport({
+        node: hiddenNode,
+        visibleNodeIds: new Set(['glsl-1']),
+        connectedVideoOutputNodeIds: new Set(),
+        effectiveOutputNodeId: null
+      })
+    ).toBe(false);
+  });
+
+  it('does not skip graph-connected video sources', () => {
+    expect(
+      shouldSkipCookForViewport({
+        node: { id: 'glsl-1', outputs: ['hydra-1'] },
+        visibleNodeIds: new Set(),
+        connectedVideoOutputNodeIds: new Set(),
+        effectiveOutputNodeId: null
+      })
+    ).toBe(false);
+  });
+
+  it('does not skip sources connected to non-FBO video consumers', () => {
+    expect(
+      shouldSkipCookForViewport({
+        node: hiddenNode,
+        visibleNodeIds: new Set(),
+        connectedVideoOutputNodeIds: new Set(['glsl-1']),
+        effectiveOutputNodeId: null
+      })
+    ).toBe(false);
+  });
+
+  it('does not skip the effective background output node', () => {
+    expect(
+      shouldSkipCookForViewport({
+        node: hiddenNode,
+        visibleNodeIds: new Set(),
+        connectedVideoOutputNodeIds: new Set(),
+        effectiveOutputNodeId: 'glsl-1'
+      })
+    ).toBe(false);
+  });
+});

--- a/ui/src/workers/rendering/renderEligibility.ts
+++ b/ui/src/workers/rendering/renderEligibility.ts
@@ -1,0 +1,25 @@
+import type { RenderNode } from '$lib/rendering/types';
+
+type ViewportCookSkipInput = {
+  node: Pick<RenderNode, 'id' | 'outputs'>;
+  visibleNodeIds: Set<string> | null;
+  connectedVideoOutputNodeIds: Set<string>;
+  effectiveOutputNodeId: string | null;
+};
+
+export function shouldSkipCookForViewport({
+  node,
+  visibleNodeIds,
+  connectedVideoOutputNodeIds,
+  effectiveOutputNodeId
+}: ViewportCookSkipInput): boolean {
+  if (visibleNodeIds === null) return false;
+  if (visibleNodeIds.has(node.id)) return false;
+
+  if (node.id === effectiveOutputNodeId) return false;
+  if (node.outputs.length > 0) return false;
+
+  if (connectedVideoOutputNodeIds.has(node.id)) return false;
+
+  return true;
+}

--- a/ui/src/workers/rendering/renderWorker.ts
+++ b/ui/src/workers/rendering/renderWorker.ts
@@ -32,7 +32,9 @@ self.onmessage = (event) => {
     .with('setPatchId', () => {
       PatchStorageService.getInstance().setPatchId(data.patchId);
     })
-    .with('buildRenderGraph', () => handleBuildRenderGraph(data.graph))
+    .with('buildRenderGraph', () =>
+      handleBuildRenderGraph(data.graph, new Set(data.connectedVideoOutputNodeIds ?? []))
+    )
     .with('startAnimation', () => handleStartAnimation())
     .with('stopAnimation', () => handleStopAnimation())
     .with('setPreviewEnabled', () => handleSetPreviewEnabled(data.nodeId, data.enabled))
@@ -179,19 +181,26 @@ self.onmessage = (event) => {
 // the current build finishes. This prevents race conditions when setPortCount
 // messages trigger rebuilds during the initial build's async Phase 2.
 let buildInProgress = false;
-let pendingGraph: RenderGraph | null = null;
 
-async function handleBuildRenderGraph(graph: RenderGraph) {
+let pendingBuild: {
+  graph: RenderGraph;
+  connectedVideoOutputNodeIds: Set<string>;
+} | null = null;
+
+async function handleBuildRenderGraph(
+  graph: RenderGraph,
+  connectedVideoOutputNodeIds: Set<string> = new Set()
+) {
   if (buildInProgress) {
     // A build is running — queue the latest graph (drop any previously queued one)
-    pendingGraph = graph;
+    pendingBuild = { graph, connectedVideoOutputNodeIds };
     return;
   }
 
   buildInProgress = true;
 
   try {
-    await fboRenderer.buildFBOs(graph);
+    await fboRenderer.buildFBOs(graph, connectedVideoOutputNodeIds);
   } catch (error) {
     if (error instanceof Error) {
       self.postMessage({
@@ -203,11 +212,11 @@ async function handleBuildRenderGraph(graph: RenderGraph) {
     buildInProgress = false;
 
     // If a new graph was queued while we were building, build it now
-    if (pendingGraph) {
-      const next = pendingGraph;
+    if (pendingBuild) {
+      const next = pendingBuild;
 
-      pendingGraph = null;
-      handleBuildRenderGraph(next);
+      pendingBuild = null;
+      handleBuildRenderGraph(next.graph, next.connectedVideoOutputNodeIds);
     }
   }
 }


### PR DESCRIPTION
Do not cook frames if the node is outside of the viewport.

Stop frames from cooking entirely if the node is all of the above:

- Node is outside of xyflow viewport
- Node doesn't have connected video output
- Node is not outputting to background (via background override / bg.out)

Currently when nodes are outside of viewport, we stop it from capturing / sending previews, but we did not stop it from actually rendering.