### PR TITLE
feat(profiler): show inactive worker profiler stats with dimmed text

### DIFF
--- a/ui/src/lib/components/sidebar/ProfilerView.svelte
+++ b/ui/src/lib/components/sidebar/ProfilerView.svelte
@@ -152,7 +152,7 @@
     return ORDERED_CATEGORIES.filter((c) => seen.has(c));
   }
 
-  /** Max avg across all categories for a node in the history */
+  /** Max active avg across all categories for a node in the history */
   function historyMax(nodeId: string, history: ProfilerSnapshot[]): number {
     let max = 0.01;
 
@@ -161,7 +161,7 @@
       if (!entry) continue;
 
       for (const t of Object.values(entry.timings)) {
-        if (t && t.avg > max) {
+        if (t && isTimingActive(t) && t.avg > max) {
           max = t.avg;
         }
       }
@@ -175,8 +175,8 @@
     return CH - CP - (v / maxVal) * (CH - CP * 2);
   }
 
-  /** SVG path string for a category's avg over the history window */
-  function buildPath(
+  /** SVG path string for active samples in a category's avg history. */
+  function buildActivePath(
     nodeId: string,
     category: ProfilerCategory,
     history: ProfilerSnapshot[],
@@ -189,14 +189,45 @@
     let penDown = false;
 
     for (let i = 0; i < n; i++) {
-      const v = history[i].entries.find((e) => e.nodeId === nodeId)?.timings[category]?.avg ?? null;
-      if (v === null) {
+      const t = history[i].entries.find((e) => e.nodeId === nodeId)?.timings[category];
+      if (!t || !isTimingActive(t)) {
+        penDown = false;
+        continue;
+      }
+
+      const v = t.avg;
+      const x = n > 1 ? (i / (n - 1)) * (CW - CP * 2) + CP : CW / 2;
+      const y = valY(v, maxVal);
+
+      path += penDown ? `L${x.toFixed(1)} ${y.toFixed(1)}` : `M${x.toFixed(1)} ${y.toFixed(1)}`;
+      penDown = true;
+    }
+
+    return path;
+  }
+
+  /** SVG path string for inactive spans, rendered as a dim zero baseline. */
+  function buildInactivePath(
+    nodeId: string,
+    category: ProfilerCategory,
+    history: ProfilerSnapshot[],
+    maxVal: number
+  ): string {
+    const n = history.length;
+    if (n === 0) return '';
+
+    let path = '';
+    let penDown = false;
+
+    for (let i = 0; i < n; i++) {
+      const t = history[i].entries.find((e) => e.nodeId === nodeId)?.timings[category];
+      if (!t || isTimingActive(t)) {
         penDown = false;
         continue;
       }
 
       const x = n > 1 ? (i / (n - 1)) * (CW - CP * 2) + CP : CW / 2;
-      const y = valY(v, maxVal);
+      const y = valY(0, maxVal);
 
       path += penDown ? `L${x.toFixed(1)} ${y.toFixed(1)}` : `M${x.toFixed(1)} ${y.toFixed(1)}`;
       penDown = true;
@@ -438,7 +469,21 @@
 
                 <!-- Category paths -->
                 {#each cats as cat (cat)}
-                  {@const d = buildPath(entry.nodeId, cat, history, maxMs)}
+                  {@const inactiveD = buildInactivePath(entry.nodeId, cat, history, maxMs)}
+
+                  {#if inactiveD}
+                    <path
+                      d={inactiveD}
+                      stroke="#3f3f46"
+                      stroke-width="1.25"
+                      stroke-opacity="0.7"
+                      fill="none"
+                      stroke-linejoin="round"
+                      stroke-linecap="round"
+                    />
+                  {/if}
+
+                  {@const d = buildActivePath(entry.nodeId, cat, history, maxMs)}
 
                   {#if d}
                     <path
@@ -458,9 +503,11 @@
                     .at(-1)
                     ?.entries.find((e) => e.nodeId === entry.nodeId)}
 
-                  {@const v = lastEntry?.timings[cat]?.avg}
+                  {@const latestTiming = lastEntry?.timings[cat]}
+                  {@const v = latestTiming?.avg}
+                  {@const isLatestActive = latestTiming ? isTimingActive(latestTiming) : false}
 
-                  {#if v != null}
+                  {#if v != null && isLatestActive}
                     <circle cx={CW - CP} cy={valY(v, maxMs)} r="2.5" fill={CATEGORY_COLOR[cat]} />
                   {/if}
                 {/each}

--- a/ui/src/lib/components/sidebar/ProfilerView.svelte
+++ b/ui/src/lib/components/sidebar/ProfilerView.svelte
@@ -23,8 +23,22 @@
     FLUSH_INTERVAL_OPTIONS,
     HOT_THRESHOLD_OPTIONS
   } from '../../../stores/profiler-settings.store';
+
   import type { ProfilerCategory, ProfilerSnapshot, TimingStats } from '$lib/profiler/types';
-  import { SvelteSet } from 'svelte/reactivity';
+
+  import {
+    PROFILER_CHART_HEIGHT as CH,
+    PROFILER_CHART_PADDING as CP,
+    PROFILER_CHART_WIDTH as CW,
+    buildActivePath,
+    buildInactivePath,
+    buildRenderPath,
+    getChartY,
+    getNodeActiveHistoryMax,
+    getNodeCategories,
+    getRenderHistoryMax,
+    isTimingActive
+  } from '$lib/profiler/profiler-chart-utils';
 
   // ─── Display stat helpers ──────────────────────────────────────────────────
 
@@ -59,10 +73,6 @@
     return fps.toFixed(1) + ' fps';
   }
 
-  function isTimingActive(t: TimingStats): boolean {
-    return t.callsPerSecond > 0;
-  }
-
   function timingTextClass(t: TimingStats, isSevere: boolean, isHot: boolean): string {
     if (!isTimingActive(t)) return 'text-zinc-700';
 
@@ -74,7 +84,6 @@
 
   // ─── Category metadata ───────────────────────────────────────────────────────
 
-  const ORDERED_CATEGORIES: ProfilerCategory[] = ['init', 'message', 'draw', 'interval', 'raf'];
   const MAIN_VIEW_CATEGORIES: ProfilerCategory[] = ['message', 'draw', 'interval', 'raf'];
 
   const CATEGORY_LABEL: Record<ProfilerCategory, string> = {
@@ -130,111 +139,7 @@
 
   // ─── Chart helpers ───────────────────────────────────────────────────────────
 
-  const CW = 240; // viewBox width
-  const CH = 52; // viewBox height
-  const CP = 3; // padding
-
   const COL_W = '2.8rem';
-
-  /** Categories that appear for a node across the entire history */
-  function nodeCats(nodeId: string, history: ProfilerSnapshot[]): ProfilerCategory[] {
-    const seen = new SvelteSet<ProfilerCategory>();
-
-    for (const snap of history) {
-      const entry = snap.entries.find((e) => e.nodeId === nodeId);
-      if (!entry) continue;
-
-      for (const cat of ORDERED_CATEGORIES) {
-        if (entry.timings[cat]) seen.add(cat);
-      }
-    }
-
-    return ORDERED_CATEGORIES.filter((c) => seen.has(c));
-  }
-
-  /** Max active avg across all categories for a node in the history */
-  function historyMax(nodeId: string, history: ProfilerSnapshot[]): number {
-    let max = 0.01;
-
-    for (const snap of history) {
-      const entry = snap.entries.find((e) => e.nodeId === nodeId);
-      if (!entry) continue;
-
-      for (const t of Object.values(entry.timings)) {
-        if (t && isTimingActive(t) && t.avg > max) {
-          max = t.avg;
-        }
-      }
-    }
-
-    return max;
-  }
-
-  /** Y coordinate for a value given a shared max */
-  function valY(v: number, maxVal: number): number {
-    return CH - CP - (v / maxVal) * (CH - CP * 2);
-  }
-
-  /** SVG path string for active samples in a category's avg history. */
-  function buildActivePath(
-    nodeId: string,
-    category: ProfilerCategory,
-    history: ProfilerSnapshot[],
-    maxVal: number
-  ): string {
-    const n = history.length;
-    if (n === 0) return '';
-
-    let path = '';
-    let penDown = false;
-
-    for (let i = 0; i < n; i++) {
-      const t = history[i].entries.find((e) => e.nodeId === nodeId)?.timings[category];
-      if (!t || !isTimingActive(t)) {
-        penDown = false;
-        continue;
-      }
-
-      const v = t.avg;
-      const x = n > 1 ? (i / (n - 1)) * (CW - CP * 2) + CP : CW / 2;
-      const y = valY(v, maxVal);
-
-      path += penDown ? `L${x.toFixed(1)} ${y.toFixed(1)}` : `M${x.toFixed(1)} ${y.toFixed(1)}`;
-      penDown = true;
-    }
-
-    return path;
-  }
-
-  /** SVG path string for inactive spans, rendered as a dim zero baseline. */
-  function buildInactivePath(
-    nodeId: string,
-    category: ProfilerCategory,
-    history: ProfilerSnapshot[],
-    maxVal: number
-  ): string {
-    const n = history.length;
-    if (n === 0) return '';
-
-    let path = '';
-    let penDown = false;
-
-    for (let i = 0; i < n; i++) {
-      const t = history[i].entries.find((e) => e.nodeId === nodeId)?.timings[category];
-      if (!t || isTimingActive(t)) {
-        penDown = false;
-        continue;
-      }
-
-      const x = n > 1 ? (i / (n - 1)) * (CW - CP * 2) + CP : CW / 2;
-      const y = valY(0, maxVal);
-
-      path += penDown ? `L${x.toFixed(1)} ${y.toFixed(1)}` : `M${x.toFixed(1)} ${y.toFixed(1)}`;
-      penDown = true;
-    }
-
-    return path;
-  }
 
   // ─── Renderer chart helpers ─────────────────────────────────────────────────
 
@@ -252,42 +157,6 @@
     { key: 'p95', label: 'p95', color: '#fb923c', get: (rf) => rf.p95Ms },
     { key: 'p99', label: 'p99', color: '#f87171', get: (rf) => rf.p99Ms }
   ];
-
-  function buildRenderPath(
-    metric: RenderMetric,
-    history: ProfilerSnapshot[],
-    maxVal: number
-  ): string {
-    const n = history.length;
-    if (n === 0) return '';
-    let path = '';
-    let penDown = false;
-    for (let i = 0; i < n; i++) {
-      const rf = history[i].renderFrame;
-      if (!rf) {
-        penDown = false;
-        continue;
-      }
-      const v = metric.get(rf);
-      const x = n > 1 ? (i / (n - 1)) * (CW - CP * 2) + CP : CW / 2;
-      const y = valY(v, maxVal);
-      path += penDown ? `L${x.toFixed(1)} ${y.toFixed(1)}` : `M${x.toFixed(1)} ${y.toFixed(1)}`;
-      penDown = true;
-    }
-    return path;
-  }
-
-  function renderHistoryMax(history: ProfilerSnapshot[], metrics: RenderMetric[]): number {
-    let max = 0.01;
-    for (const snap of history) {
-      if (!snap.renderFrame) continue;
-      for (const m of metrics) {
-        const v = m.get(snap.renderFrame);
-        if (v > max) max = v;
-      }
-    }
-    return max;
-  }
 
   // ─── Toggles ────────────────────────────────────────────────────────────────
   let showDevStats = $state(false);
@@ -439,9 +308,9 @@
         <!-- Expanded sparkline chart -->
         {#if isSelected}
           {@const history = $profilerHistory}
-          {@const cats = nodeCats(entry.nodeId, history)}
-          {@const maxMs = historyMax(entry.nodeId, history)}
-          {@const hotY = maxMs > hotThreshold ? valY(hotThreshold, maxMs) : null}
+          {@const cats = getNodeCategories(entry.nodeId, history)}
+          {@const maxMs = getNodeActiveHistoryMax(entry.nodeId, history)}
+          {@const hotY = maxMs > hotThreshold ? getChartY(hotThreshold, maxMs) : null}
           {@const histSpanSecs = ((history.length - 1) * 0.5).toFixed(0)}
 
           <div class="border-b border-zinc-800/50 bg-zinc-900/40 px-3 pt-1.5 pb-2">
@@ -508,7 +377,12 @@
                   {@const isLatestActive = latestTiming ? isTimingActive(latestTiming) : false}
 
                   {#if v != null && isLatestActive}
-                    <circle cx={CW - CP} cy={valY(v, maxMs)} r="2.5" fill={CATEGORY_COLOR[cat]} />
+                    <circle
+                      cx={CW - CP}
+                      cy={getChartY(v, maxMs)}
+                      r="2.5"
+                      fill={CATEGORY_COLOR[cat]}
+                    />
                   {/if}
                 {/each}
               </svg>
@@ -707,7 +581,7 @@
       {#if showDevStats}
         {@const rf = $profilerSnapshot?.renderFrame}
         {@const history = $profilerHistory}
-        {@const rMaxMs = renderHistoryMax(history, RENDER_METRICS)}
+        {@const rMaxMs = getRenderHistoryMax(history, RENDER_METRICS)}
         {@const rHistSpan = ((history.length - 1) * 0.5).toFixed(0)}
         <div class="mt-1.5 border-t border-zinc-800/60 pt-1.5">
           <div class="mb-1 font-mono font-light tracking-wide text-zinc-500">renderer</div>
@@ -741,7 +615,7 @@
                   {@const lastRf = history.at(-1)?.renderFrame}
                   {#if lastRf}
                     {@const v = metric.get(lastRf)}
-                    <circle cx={CW - CP} cy={valY(v, rMaxMs)} r="2.5" fill={metric.color} />
+                    <circle cx={CW - CP} cy={getChartY(v, rMaxMs)} r="2.5" fill={metric.color} />
                   {/if}
                 {/each}
               </svg>

--- a/ui/src/lib/components/sidebar/ProfilerView.svelte
+++ b/ui/src/lib/components/sidebar/ProfilerView.svelte
@@ -59,6 +59,19 @@
     return fps.toFixed(1) + ' fps';
   }
 
+  function isTimingActive(t: TimingStats): boolean {
+    return t.callsPerSecond > 0;
+  }
+
+  function timingTextClass(t: TimingStats, isSevere: boolean, isHot: boolean): string {
+    if (!isTimingActive(t)) return 'text-zinc-700';
+
+    if (isSevere) return 'text-red-300';
+    if (isHot) return 'text-amber-300';
+
+    return 'text-zinc-400';
+  }
+
   // ─── Category metadata ───────────────────────────────────────────────────────
 
   const ORDERED_CATEGORIES: ProfilerCategory[] = ['init', 'message', 'draw', 'interval', 'raf'];
@@ -309,8 +322,9 @@
         {@const primaryTiming = entry.timings.message ?? entry.timings.draw}
         {@const primaryVal = primaryTiming ? getStatValue(primaryTiming) : 0}
         {@const isTimeStat = displayStat !== 'calls/s'}
+        {@const isActive = primaryTiming ? isTimingActive(primaryTiming) : false}
 
-        {@const isSevere = isTimeStat && primaryVal > hotThreshold * 5}
+        {@const isSevere = isActive && isTimeStat && primaryVal > hotThreshold * 5}
         {@const isHot = isTimeStat && entry.isHot}
         {@const barPct = Math.min(100, (primaryVal / maxStat) * 100)}
 
@@ -365,7 +379,9 @@
                   ? 'bg-red-500'
                   : isHot
                     ? 'bg-amber-500'
-                    : 'bg-zinc-500'}"
+                    : isActive
+                      ? 'bg-zinc-500'
+                      : 'bg-zinc-700'}"
                 style:width="{barPct}%"
               ></div>
             </div>
@@ -376,14 +392,12 @@
             {@const t = entry.timings[cat]}
             {#if t}
               {@const val = getStatValue(t)}
-              {@const catSevere = isTimeStat && val > hotThreshold * 5}
-              {@const catHot = isTimeStat && val > hotThreshold}
+              {@const catActive = isTimingActive(t)}
+              {@const catSevere = catActive && isTimeStat && val > hotThreshold * 5}
+              {@const catHot = catActive && isTimeStat && val > hotThreshold}
               <span
-                class="font-mono text-[10px] tabular-nums {catSevere
-                  ? 'text-red-300'
-                  : catHot
-                    ? 'text-amber-300'
-                    : 'text-zinc-400'}">{fmtStat(t)}</span
+                class="font-mono text-[10px] tabular-nums {timingTextClass(t, catSevere, catHot)}"
+                >{fmtStat(t)}</span
               >
             {:else}
               <span class="text-zinc-800 tabular-nums">—</span>
@@ -494,18 +508,19 @@
                   </span>
 
                   {#if t}
-                    {@const catSevere = t.avg > hotThreshold * 5}
-                    {@const catHot = t.avg > hotThreshold}
-                    {@const color = catSevere
-                      ? 'text-red-300'
-                      : catHot
-                        ? 'text-amber-300'
-                        : 'text-zinc-400'}
+                    {@const catActive = isTimingActive(t)}
+                    {@const catSevere = catActive && t.avg > hotThreshold * 5}
+                    {@const catHot = catActive && t.avg > hotThreshold}
+                    {@const color = timingTextClass(t, catSevere, catHot)}
                     <span class="text-right {color}">{fmt(t.avg)}</span>
                     <span class="text-right {color}">{fmt(t.max)}</span>
                     <span class="text-right {color}">{fmt(t.p95)}</span>
-                    <span class="text-right text-zinc-500">{fmt(t.last)}</span>
-                    <span class="text-right text-zinc-500">{t.callsPerSecond.toFixed(1)}</span>
+                    <span class="text-right {catActive ? 'text-zinc-500' : 'text-zinc-700'}"
+                      >{fmt(t.last)}</span
+                    >
+                    <span class="text-right {catActive ? 'text-zinc-500' : 'text-zinc-700'}"
+                      >{t.callsPerSecond.toFixed(1)}</span
+                    >
                   {:else}
                     <span class="text-right text-zinc-800">—</span>
                     <span class="text-right text-zinc-800">—</span>

--- a/ui/src/lib/profiler/ProfilerCollector.test.ts
+++ b/ui/src/lib/profiler/ProfilerCollector.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { ProfilerCollector } from './ProfilerCollector';
+
+describe('ProfilerCollector', () => {
+  it('preserves last timing values when no calls occur in a flush window', () => {
+    const collector = new ProfilerCollector();
+
+    collector.record(2);
+    collector.record(4);
+
+    const active = collector.flush(performance.now() + 500);
+    expect(active.avg).toBe(3);
+    expect(active.max).toBe(4);
+    expect(active.last).toBe(4);
+    expect(active.callsPerSecond).toBeGreaterThan(0);
+
+    const inactive = collector.flush(performance.now() + 1000);
+    expect(inactive.avg).toBe(3);
+    expect(inactive.max).toBe(4);
+    expect(inactive.last).toBe(4);
+    expect(inactive.callsPerSecond).toBe(0);
+  });
+
+  it('still returns zero stats before the first sample', () => {
+    const collector = new ProfilerCollector();
+
+    expect(collector.flush(performance.now() + 500)).toEqual({
+      avg: 0,
+      max: 0,
+      p95: 0,
+      last: 0,
+      callsPerSecond: 0
+    });
+  });
+});

--- a/ui/src/lib/profiler/ProfilerCollector.ts
+++ b/ui/src/lib/profiler/ProfilerCollector.ts
@@ -18,6 +18,7 @@ export class ProfilerCollector {
   private count = 0;
   private messagesSinceFlush = 0;
   private lastFlushTime = performance.now();
+  private lastAvg = 0;
 
   constructor(capacity: number = DEFAULT_CAPACITY) {
     this.capacity = capacity;
@@ -75,6 +76,10 @@ export class ProfilerCollector {
       }
 
       avg = recentSum / recentCount;
+
+      this.lastAvg = avg;
+    } else {
+      avg = this.lastAvg;
     }
 
     return { avg, max, p95, last, callsPerSecond };
@@ -84,6 +89,8 @@ export class ProfilerCollector {
     this.head = 0;
     this.count = 0;
     this.messagesSinceFlush = 0;
+
     this.lastFlushTime = performance.now();
+    this.lastAvg = 0;
   }
 }

--- a/ui/src/lib/profiler/ProfilerCoordinator.ts
+++ b/ui/src/lib/profiler/ProfilerCoordinator.ts
@@ -9,20 +9,19 @@ import type {
 
 const HISTORY_CAPACITY = 120; // ring buffer entries (adjusts with flush interval)
 
+type Collectors = [ProfilerCategory, ProfilerCollector][];
+type Timings = [ProfilerCategory, TimingStats][];
+
 export interface ProfilerConfig {
   /** Ring buffer capacity per collector (samples). Larger = spikes stay in max longer. */
   sampleCapacity: number;
+
   /** How often stats are flushed and the UI is updated (ms). */
   flushIntervalMs: number;
+
   /** Average ms above which a node is flagged as hot. */
   hotThresholdMs: number;
 }
-
-export const DEFAULT_CONFIG: ProfilerConfig = {
-  sampleCapacity: DEFAULT_CAPACITY,
-  flushIntervalMs: 500,
-  hotThresholdMs: 2
-};
 
 interface NodeCollectors {
   type: string;
@@ -36,6 +35,12 @@ interface NodeCollectors {
   /** Smoothed sort key (EMA) — prevents sort order from jumping between flushes */
   sortKey: number;
 }
+
+export const DEFAULT_CONFIG: ProfilerConfig = {
+  sampleCapacity: DEFAULT_CAPACITY,
+  flushIntervalMs: 500,
+  hotThresholdMs: 2
+};
 
 /**
  * Coordinates per-node timing data on the main thread.
@@ -97,7 +102,10 @@ export class ProfilerCoordinator {
     if (partial.flushIntervalMs && partial.flushIntervalMs !== prev.flushIntervalMs) {
       if (this.intervalId !== null) {
         clearInterval(this.intervalId);
-        this.intervalId = setInterval(() => this.flush(), this.config.flushIntervalMs);
+
+        this.intervalId = setInterval(() => {
+          this.flush();
+        }, this.config.flushIntervalMs);
       }
     }
   }
@@ -124,6 +132,7 @@ export class ProfilerCoordinator {
 
     if (!entry) {
       entry = { collectors: {}, type, workerStats: {}, sortKey: 0 };
+
       this.nodes.set(nodeId, entry);
     }
 
@@ -223,19 +232,20 @@ export class ProfilerCoordinator {
     for (const [nodeId, entry] of this.nodes) {
       const { collectors, type, workerStats } = entry;
       const timings: Partial<Record<ProfilerCategory, TimingStats>> = {};
+
       let hasActivity = false;
 
-      for (const [cat, collector] of Object.entries(collectors) as [
-        ProfilerCategory,
-        ProfilerCollector
-      ][]) {
+      for (const [cat, collector] of Object.entries(collectors) as Collectors) {
         if (!collector) continue;
 
         const stats = collector.flush(now);
 
-        if (stats.avg > 0 || stats.callsPerSecond > 0) {
+        if (stats.avg > 0 || stats.max > 0 || stats.p95 > 0 || stats.last > 0) {
           timings[cat] = stats;
-          hasActivity = true;
+
+          if (stats.callsPerSecond > 0) {
+            hasActivity = true;
+          }
         }
       }
 
@@ -243,9 +253,12 @@ export class ProfilerCoordinator {
       for (const [cat, stats] of Object.entries(workerStats) as [ProfilerCategory, TimingStats][]) {
         if (!stats) continue;
 
-        if (stats.avg > 0 || stats.callsPerSecond > 0) {
+        if (stats.avg > 0 || stats.max > 0 || stats.p95 > 0 || stats.last > 0) {
           timings[cat] = stats;
-          hasActivity = true;
+
+          if (stats.callsPerSecond > 0) {
+            hasActivity = true;
+          }
         }
       }
 
@@ -254,7 +267,7 @@ export class ProfilerCoordinator {
 
       // isHot if any non-init category exceeds threshold
       const isHot = hasActivity
-        ? (Object.entries(timings) as [ProfilerCategory, TimingStats][]).some(
+        ? (Object.entries(timings) as Timings).some(
             ([cat, t]) => cat !== 'init' && t.avg > hotThreshold
           )
         : false;
@@ -264,6 +277,7 @@ export class ProfilerCoordinator {
         timings.message?.avg ??
         timings.draw?.avg ??
         Math.max(...Object.values(timings).map((t) => t?.avg ?? 0), 0);
+
       entry.sortKey = entry.sortKey === 0 ? instantKey : entry.sortKey * 0.7 + instantKey * 0.3;
 
       // Always emit registered nodes for stable UI (empty timings = idle)
@@ -280,6 +294,7 @@ export class ProfilerCoordinator {
     const snapshot: ProfilerSnapshot = {
       timestamp: now,
       entries,
+
       ...(this.latestRenderFrame && {
         renderFrame: this.latestRenderFrame
       })
@@ -288,7 +303,10 @@ export class ProfilerCoordinator {
     // Push to history ring buffer
     this.history[this.historyHead] = snapshot;
     this.historyHead = (this.historyHead + 1) % HISTORY_CAPACITY;
-    if (this.historyCount < HISTORY_CAPACITY) this.historyCount++;
+
+    if (this.historyCount < HISTORY_CAPACITY) {
+      this.historyCount++;
+    }
 
     this.onSnapshot?.(snapshot);
   }

--- a/ui/src/lib/profiler/profiler-chart-utils.test.ts
+++ b/ui/src/lib/profiler/profiler-chart-utils.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import type { ProfilerSnapshot, TimingStats } from './types';
+import {
+  buildActivePath,
+  buildInactivePath,
+  buildRenderPath,
+  getNodeActiveHistoryMax,
+  getNodeCategories,
+  getRenderHistoryMax,
+  isTimingActive
+} from './profiler-chart-utils';
+
+const active = (avg: number): TimingStats => ({
+  avg,
+  max: avg,
+  p95: avg,
+  last: avg,
+  callsPerSecond: 2
+});
+
+const inactive = (avg: number): TimingStats => ({
+  avg,
+  max: avg,
+  p95: avg,
+  last: avg,
+  callsPerSecond: 0
+});
+
+const snapshot = (timing?: TimingStats): ProfilerSnapshot => ({
+  timestamp: 0,
+  entries: [
+    { nodeId: 'glsl-1', nodeType: 'glsl', timings: timing ? { draw: timing } : {}, isHot: false }
+  ]
+});
+
+describe('profiler chart utils', () => {
+  it('detects active timings from calls per second', () => {
+    expect(isTimingActive(active(1))).toBe(true);
+    expect(isTimingActive(inactive(1))).toBe(false);
+  });
+
+  it('collects node categories in profiler order', () => {
+    const history: ProfilerSnapshot[] = [
+      {
+        timestamp: 0,
+        entries: [
+          {
+            nodeId: 'glsl-1',
+            nodeType: 'glsl',
+            timings: { raf: active(1), draw: active(2) },
+            isHot: false
+          }
+        ]
+      }
+    ];
+
+    expect(getNodeCategories('glsl-1', history)).toEqual(['draw', 'raf']);
+  });
+
+  it('scales history by active timings only', () => {
+    const history = [snapshot(active(3)), snapshot(inactive(10))];
+
+    expect(getNodeActiveHistoryMax('glsl-1', history)).toBe(3);
+  });
+
+  it('splits active and inactive paths', () => {
+    const history = [snapshot(active(2)), snapshot(inactive(2)), snapshot(active(4))];
+
+    expect(buildActivePath('glsl-1', 'draw', history, 4)).toBe('M3.0 26.0M237.0 3.0');
+    expect(buildInactivePath('glsl-1', 'draw', history, 4)).toBe('M120.0 49.0');
+  });
+
+  it('builds render frame paths and breaks on missing frame stats', () => {
+    const history: ProfilerSnapshot[] = [
+      {
+        ...snapshot(),
+        renderFrame: {
+          fps: 60,
+          avgMs: 2,
+          p50Ms: 1,
+          p95Ms: 3,
+          p99Ms: 4,
+          drops60: 0,
+          gpuReadAvgMs: null,
+          blitAvgMs: null,
+          transferAvgMs: null,
+          previewAvgMs: null,
+          videoAvgMs: null
+        }
+      },
+      snapshot(),
+      {
+        ...snapshot(),
+        renderFrame: {
+          fps: 30,
+          avgMs: 4,
+          p50Ms: 2,
+          p95Ms: 5,
+          p99Ms: 6,
+          drops60: 1,
+          gpuReadAvgMs: null,
+          blitAvgMs: null,
+          transferAvgMs: null,
+          previewAvgMs: null,
+          videoAvgMs: null
+        }
+      }
+    ];
+
+    const avgMetric = {
+      get: (renderFrame: NonNullable<ProfilerSnapshot['renderFrame']>) => renderFrame.avgMs
+    };
+
+    expect(getRenderHistoryMax(history, [avgMetric])).toBe(4);
+    expect(buildRenderPath(avgMetric, history, 4)).toBe('M3.0 26.0M237.0 3.0');
+  });
+});

--- a/ui/src/lib/profiler/profiler-chart-utils.ts
+++ b/ui/src/lib/profiler/profiler-chart-utils.ts
@@ -1,0 +1,143 @@
+import type { ProfilerCategory, ProfilerSnapshot, RenderFrameStats, TimingStats } from './types';
+
+export const PROFILER_CHART_WIDTH = 240;
+export const PROFILER_CHART_HEIGHT = 52;
+export const PROFILER_CHART_PADDING = 3;
+
+const ORDERED_CATEGORIES: ProfilerCategory[] = ['init', 'message', 'draw', 'interval', 'raf'];
+
+export const isTimingActive = (t: TimingStats): boolean => t.callsPerSecond > 0;
+
+export function getNodeCategories(nodeId: string, history: ProfilerSnapshot[]): ProfilerCategory[] {
+  const seen = new Set<ProfilerCategory>();
+
+  for (const snapshot of history) {
+    const entry = snapshot.entries.find((e) => e.nodeId === nodeId);
+    if (!entry) continue;
+
+    for (const cat of ORDERED_CATEGORIES) {
+      if (entry.timings[cat]) seen.add(cat);
+    }
+  }
+
+  return ORDERED_CATEGORIES.filter((cat) => seen.has(cat));
+}
+
+export function getNodeActiveHistoryMax(nodeId: string, history: ProfilerSnapshot[]): number {
+  let max = 0.01;
+
+  for (const snap of history) {
+    const entry = snap.entries.find((e) => e.nodeId === nodeId);
+    if (!entry) continue;
+
+    for (const t of Object.values(entry.timings)) {
+      if (t && isTimingActive(t) && t.avg > max) {
+        max = t.avg;
+      }
+    }
+  }
+
+  return max;
+}
+
+export const getChartY = (value: number, maxValue: number): number =>
+  PROFILER_CHART_HEIGHT -
+  PROFILER_CHART_PADDING -
+  (value / maxValue) * (PROFILER_CHART_HEIGHT - PROFILER_CHART_PADDING * 2);
+
+export const buildActivePath = (
+  nodeId: string,
+  category: ProfilerCategory,
+  history: ProfilerSnapshot[],
+  maxValue: number
+): string =>
+  buildTimelinePath(history, maxValue, (snapshot) =>
+    getNodeTiming(snapshot, nodeId, category, (timing) =>
+      timing && isTimingActive(timing) ? timing.avg : null
+    )
+  );
+
+export const buildInactivePath = (
+  nodeId: string,
+  category: ProfilerCategory,
+  history: ProfilerSnapshot[],
+  maxValue: number
+): string =>
+  buildTimelinePath(history, maxValue, (snapshot) =>
+    getNodeTiming(snapshot, nodeId, category, (timing) =>
+      timing && !isTimingActive(timing) ? 0 : null
+    )
+  );
+
+export type RenderMetricGetter = {
+  get: (renderFrame: RenderFrameStats) => number;
+};
+
+export const buildRenderPath = (
+  metric: RenderMetricGetter,
+  history: ProfilerSnapshot[],
+  maxValue: number
+): string =>
+  buildTimelinePath(history, maxValue, (snapshot) =>
+    snapshot.renderFrame ? metric.get(snapshot.renderFrame) : null
+  );
+
+export function getRenderHistoryMax(
+  history: ProfilerSnapshot[],
+  metrics: RenderMetricGetter[]
+): number {
+  let max = 0.01;
+
+  for (const snap of history) {
+    if (!snap.renderFrame) continue;
+
+    for (const metric of metrics) {
+      const value = metric.get(snap.renderFrame);
+      if (value > max) max = value;
+    }
+  }
+
+  return max;
+}
+
+const getNodeTiming = (
+  snap: ProfilerSnapshot,
+  nodeId: string,
+  category: ProfilerCategory,
+  getValue: (timing: TimingStats | undefined) => number | null
+): number | null =>
+  getValue(snap.entries.find((entry) => entry.nodeId === nodeId)?.timings[category]);
+
+function buildTimelinePath(
+  history: ProfilerSnapshot[],
+  maxValue: number,
+  getValue: (snap: ProfilerSnapshot) => number | null
+): string {
+  const len = history.length;
+  if (len === 0) return '';
+
+  let path = '';
+  let penDown = false;
+
+  for (let i = 0; i < len; i++) {
+    const value = getValue(history[i]);
+
+    if (value === null) {
+      penDown = false;
+      continue;
+    }
+
+    const x =
+      len > 1
+        ? (i / (len - 1)) * (PROFILER_CHART_WIDTH - PROFILER_CHART_PADDING * 2) +
+          PROFILER_CHART_PADDING
+        : PROFILER_CHART_WIDTH / 2;
+
+    const y = getChartY(value, maxValue);
+
+    path += penDown ? `L${x.toFixed(1)} ${y.toFixed(1)}` : `M${x.toFixed(1)} ${y.toFixed(1)}`;
+    penDown = true;
+  }
+
+  return path;
+}

--- a/ui/src/workers/shared/WorkerProfiler.test.ts
+++ b/ui/src/workers/shared/WorkerProfiler.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ProfilerCategory, TimingStats } from '$lib/profiler/types';
+import { WorkerProfiler } from './WorkerProfiler';
+
+interface Flush {
+  nodeId: string;
+  category: ProfilerCategory;
+  stats: TimingStats;
+}
+
+describe('WorkerProfiler', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('flushes an inactive zero-rate sample with preserved timings', () => {
+    vi.useFakeTimers();
+
+    const flushes: Flush[] = [];
+
+    const profiler = new WorkerProfiler((nodeId, category, stats) => {
+      flushes.push({ nodeId, category, stats });
+    });
+
+    profiler.setEnabled(true);
+
+    profiler.measure('glsl-1', 'draw', () => {
+      vi.advanceTimersByTime(2);
+    });
+
+    vi.advanceTimersByTime(498);
+    expect(flushes).toHaveLength(1);
+
+    expect(flushes[0]).toMatchObject({
+      nodeId: 'glsl-1',
+      category: 'draw',
+      stats: { avg: 2, max: 2, last: 2 }
+    });
+
+    expect(flushes[0].stats.callsPerSecond).toBeGreaterThan(0);
+
+    vi.advanceTimersByTime(500);
+    expect(flushes).toHaveLength(2);
+
+    expect(flushes[1]).toMatchObject({
+      nodeId: 'glsl-1',
+      category: 'draw',
+      stats: { avg: 2, max: 2, last: 2, callsPerSecond: 0 }
+    });
+
+    profiler.setEnabled(false);
+  });
+});

--- a/ui/src/workers/shared/WorkerProfiler.ts
+++ b/ui/src/workers/shared/WorkerProfiler.ts
@@ -90,11 +90,11 @@ export class WorkerProfiler {
 
     for (const [key, collector] of this.collectors) {
       const stats = collector.flush(now);
-      if (stats.avg === 0 && stats.callsPerSecond === 0) continue;
 
-      const sep = key.lastIndexOf('|');
-      const nodeId = key.slice(0, sep);
-      const category = key.slice(sep + 1) as ProfilerCategory;
+      const separator = key.lastIndexOf('|');
+      const nodeId = key.slice(0, separator);
+      const category = key.slice(separator + 1) as ProfilerCategory;
+
       this.onFlush(nodeId, category, stats);
     }
   }


### PR DESCRIPTION
When a render node becomes inactive, we still show the stats but in dimmed text, and we reset the count.

<img width="684" height="400" alt="CleanShot 2569-06-25 at 00 43 33@2x" src="https://github.com/user-attachments/assets/3a612cee-7597-4f1c-8d34-82ce3ac3b364" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profiler charts now distinguish active and inactive timings more clearly, with consistent coloring and updated chart paths.
  * Timeline views now render more reliable dots and summaries for recent activity.

* **Bug Fixes**
  * Timing stats now stay visible after periods of no new samples instead of dropping to zero unexpectedly.
  * Profiler flushes now include zero-value updates, improving consistency in idle states.
  * Added coverage for idle flush behavior and chart path rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->