### PR TITLE
perf(canvas): conditionally cook frames and do not cook if connected node is outside

### DIFF
--- a/docs/design-docs/specs/122-render-pipeline-optimizations.md
+++ b/docs/design-docs/specs/122-render-pipeline-optimizations.md
@@ -203,7 +203,7 @@ The first implementation should be conservative:
 | `three`                          | `always` initially                                    | JS code can access time and mutate scenes implicitly                               |
 | `regl`                           | `always` initially                                    | JS code can hide dependencies                                                      |
 | `swgl`                           | `on-demand` when no dynamic dependencies are detected | `t`, `fft()`, input, message, and feedback dependencies cook as needed             |
-| `canvas`                         | `always` initially                                    | User code may draw from timers, messages, or internal state                        |
+| `canvas`                         | `on-demand` when no dynamic dependencies are detected | Time, mouse, FFT, input, message, and feedback dependencies cook as needed; timers and RAF stay dynamic |
 | `textmode`                       | `always` initially                                    | Stateful runtime                                                                   |
 | `img`, `float.tex`               | `on-demand`, externally dirty                        | Cook only when uploaded bitmap/texture data changes                                |
 | `send.vdo`, `recv.vdo`, `bg.out` | `on-demand`, passthrough/empty                       | No expensive cook, but downstream invalidation still matters                       |

--- a/ui/src/lib/canvas/GLSystem.test.ts
+++ b/ui/src/lib/canvas/GLSystem.test.ts
@@ -46,6 +46,32 @@ describe('GLSystem', () => {
     );
   });
 
+  it('does not send internal FBO video edges as external output node ids', () => {
+    const glSystem = new GLSystem();
+    const worker = glSystem.renderWorker as unknown as { postMessage: ReturnType<typeof vi.fn> };
+
+    glSystem.upsertNode('hydra-1', 'hydra', { code: '' });
+    glSystem.upsertNode('glsl-1', 'glsl', { code: '', glUniformDefs: [] });
+    worker.postMessage.mockClear();
+
+    glSystem.updateEdges([
+      {
+        id: 'edge-1',
+        source: 'hydra-1',
+        target: 'glsl-1',
+        sourceHandle: 'video-out',
+        targetHandle: 'video-in-0'
+      }
+    ]);
+
+    expect(worker.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'buildRenderGraph',
+        connectedVideoOutputNodeIds: []
+      })
+    );
+  });
+
   it('does not resubscribe unchanged video channel nodes', () => {
     const glSystem = new GLSystem();
     const registry = VideoChannelRegistry.getInstance();

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -4,7 +4,13 @@ import {
   type REdge,
   type RNode
 } from '$lib/rendering/graphUtils';
-import type { FBOFormat, RenderGraph, RenderNode, RenderWorkerMessage } from '$lib/rendering/types';
+import {
+  isFBOCompatible,
+  type FBOFormat,
+  type RenderGraph,
+  type RenderNode,
+  type RenderWorkerMessage
+} from '$lib/rendering/types';
 import type { ElementImageLike } from '$lib/html-in-canvas/html-canvas-video-output';
 import RenderWorker from '$workers/rendering/renderWorker?worker';
 
@@ -921,7 +927,10 @@ export class GLSystem {
     if (!force && !this.hasFlowGraphChanged(this.nodes, edges)) return false;
 
     const graph = buildRenderGraph(this.nodes, edges);
-    const connectedVideoOutputNodeIds = Array.from(this.getConnectedVideoOutputNodeIds(edges));
+
+    const connectedVideoOutputNodeIds = Array.from(
+      this.getExternalConnectedVideoOutputNodeIds(edges)
+    );
 
     const graphPayload = { graph, connectedVideoOutputNodeIds };
     if (!force && !this.hasHashChanged('graph', graphPayload)) return false;
@@ -960,6 +969,22 @@ export class GLSystem {
 
     for (const edge of edges) {
       if (isVideoRenderEdge(edge)) nodeIds.add(edge.source);
+    }
+
+    return nodeIds;
+  }
+
+  private getExternalConnectedVideoOutputNodeIds(edges: REdge[]): Set<string> {
+    const nodeById = new Map(this.nodes.map((node) => [node.id, node]));
+    const nodeIds = new Set<string>();
+
+    for (const edge of edges) {
+      if (!isVideoRenderEdge(edge)) continue;
+
+      const targetType = nodeById.get(edge.target)?.type;
+      if (targetType && isFBOCompatible(targetType)) continue;
+
+      nodeIds.add(edge.source);
     }
 
     return nodeIds;

--- a/ui/src/workers/rendering/cooking/canvas.test.ts
+++ b/ui/src/workers/rendering/cooking/canvas.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { createCanvasCookPolicy } from './canvas';
+import { COOK_TEST_UTILS } from './test-utils';
+
+const { ALWAYS, ON_DEMAND, TIME_DEPENDENT, MOUSE_DEPENDENT, FFT_DEPENDENT } = COOK_TEST_UTILS;
+
+describe('createCanvasCookPolicy', () => {
+  it('allows static canvas code to cook on demand', () => {
+    expect(createCanvasCookPolicy('ctx.fillRect(0, 0, width, height);')).toEqual(ON_DEMAND);
+  });
+
+  it('detects transport time dependencies', () => {
+    expect(createCanvasCookPolicy('ctx.fillText(clock.time.toFixed(2), 0, 20);')).toEqual(
+      TIME_DEPENDENT
+    );
+  });
+
+  it('detects mouse and fft dependencies', () => {
+    expect(createCanvasCookPolicy('ctx.fillRect(mouse.x, mouse.y, 10, 10);')).toEqual(
+      MOUSE_DEPENDENT
+    );
+
+    expect(createCanvasCookPolicy("const bass = fft().getEnergy('bass');")).toEqual(FFT_DEPENDENT);
+  });
+
+  it('keeps explicit animation loops conservative', () => {
+    expect(
+      createCanvasCookPolicy(`
+        function draw() {
+          ctx.clearRect(0, 0, width, height);
+          requestAnimationFrame(draw);
+        }
+
+        draw();
+      `)
+    ).toEqual(ALWAYS);
+  });
+
+  it('ignores dependencies in comments and strings', () => {
+    expect(
+      createCanvasCookPolicy(`
+        // clock.time mouse fft() requestAnimationFrame(draw)
+        const label = "clock.time mouse fft() requestAnimationFrame";
+        ctx.fillRect(0, 0, width, height);
+      `)
+    ).toEqual(ON_DEMAND);
+  });
+});

--- a/ui/src/workers/rendering/cooking/canvas.ts
+++ b/ui/src/workers/rendering/cooking/canvas.ts
@@ -1,0 +1,17 @@
+import type { CookPolicy } from '../CookStateManager';
+import { detectJavaScriptCookDependencies } from './javascript';
+
+export function createCanvasCookPolicy(code: string): CookPolicy {
+  const dependencies = detectJavaScriptCookDependencies(code);
+
+  if (dependencies.always) {
+    return { mode: 'always' };
+  }
+
+  return {
+    mode: 'on-demand',
+    ...(dependencies.timeDependent ? { timeDependent: true } : {}),
+    ...(dependencies.mouseDependent ? { mouseDependent: true } : {}),
+    ...(dependencies.fftDependent ? { fftDependent: true } : {})
+  };
+}

--- a/ui/src/workers/rendering/cooking/hydra.ts
+++ b/ui/src/workers/rendering/cooking/hydra.ts
@@ -1,29 +1,29 @@
-import { stripJavaScriptComments, stripJavaScriptStrings } from '$lib/utils/javascript-comments';
 import type { CookPolicy } from '../CookStateManager';
+import { detectJavaScriptCookDependencies } from './javascript';
 
 const TIME_DEPENDENT_GENERATOR_PATTERN = /\b(?:osc|noise|voronoi|gradient)\s*\(/;
 const TRANSPORT_TIME_PATTERN = /\b(?:clock\s*\.\s*)?time\b/;
-const MOUSE_PATTERN = /\bmouse\b/;
-const FFT_PATTERN = /\bfft\s*\(/;
+const HYDRA_TIME_PATTERN = new RegExp(
+  `${TIME_DEPENDENT_GENERATOR_PATTERN.source}|${TRANSPORT_TIME_PATTERN.source}`
+);
 
 const CONSERVATIVE_ALWAYS_PATTERN =
   /\b(?:datamosh|setFunction|setInterval|setTimeout|requestAnimationFrame)\b|\b(?:Math\.random|Date\.|performance\.now)\b/;
 
 export function createHydraCookPolicy(code: string): CookPolicy {
-  const source = stripJavaScriptStrings(stripJavaScriptComments(code));
+  const dependencies = detectJavaScriptCookDependencies(code, {
+    alwaysPattern: CONSERVATIVE_ALWAYS_PATTERN,
+    timePattern: HYDRA_TIME_PATTERN
+  });
 
-  if (CONSERVATIVE_ALWAYS_PATTERN.test(source)) {
+  if (dependencies.always) {
     return { mode: 'always' };
   }
 
-  const isTimeDependent =
-    TIME_DEPENDENT_GENERATOR_PATTERN.test(source) || TRANSPORT_TIME_PATTERN.test(source);
-
   return {
     mode: 'on-demand',
-
-    ...(isTimeDependent ? { timeDependent: true } : {}),
-    ...(MOUSE_PATTERN.test(source) ? { mouseDependent: true } : {}),
-    ...(FFT_PATTERN.test(source) ? { fftDependent: true } : {})
+    ...(dependencies.timeDependent ? { timeDependent: true } : {}),
+    ...(dependencies.mouseDependent ? { mouseDependent: true } : {}),
+    ...(dependencies.fftDependent ? { fftDependent: true } : {})
   };
 }

--- a/ui/src/workers/rendering/cooking/javascript.test.ts
+++ b/ui/src/workers/rendering/cooking/javascript.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectJavaScriptCookDependencies } from './javascript';
+
+describe('detectJavaScriptCookDependencies', () => {
+  it('detects no dependencies for static JavaScript code', () => {
+    expect(detectJavaScriptCookDependencies('ctx.fillRect(0, 0, width, height);')).toEqual({});
+  });
+
+  it('detects transport time dependencies', () => {
+    expect(detectJavaScriptCookDependencies('const phase = time % 1;')).toEqual({
+      timeDependent: true
+    });
+
+    expect(detectJavaScriptCookDependencies('const phase = clock.time % 1;')).toEqual({
+      timeDependent: true
+    });
+  });
+
+  it('detects mouse and fft dependencies', () => {
+    expect(detectJavaScriptCookDependencies('ctx.fillRect(mouse.x, mouse.y, 10, 10);')).toEqual({
+      mouseDependent: true
+    });
+
+    expect(detectJavaScriptCookDependencies("const bass = fft().getEnergy('bass');")).toEqual({
+      fftDependent: true
+    });
+  });
+
+  it('keeps timers, animation frames, and wall-clock reads conservative', () => {
+    expect(detectJavaScriptCookDependencies('requestAnimationFrame(draw);')).toEqual({
+      always: true
+    });
+
+    expect(detectJavaScriptCookDependencies('setInterval(draw, 1000);')).toEqual({
+      always: true
+    });
+
+    expect(detectJavaScriptCookDependencies('const value = Math.random();')).toEqual({
+      always: true
+    });
+
+    expect(detectJavaScriptCookDependencies('const value = Date.now();')).toEqual({
+      always: true
+    });
+
+    expect(detectJavaScriptCookDependencies('const value = performance.now();')).toEqual({
+      always: true
+    });
+  });
+
+  it('ignores dependencies in comments and strings', () => {
+    expect(
+      detectJavaScriptCookDependencies(`
+        // time clock.time mouse fft() requestAnimationFrame(draw)
+        const label = "time mouse fft() requestAnimationFrame";
+        ctx.fillRect(0, 0, width, height);
+      `)
+    ).toEqual({});
+  });
+});

--- a/ui/src/workers/rendering/cooking/javascript.ts
+++ b/ui/src/workers/rendering/cooking/javascript.ts
@@ -16,6 +16,7 @@ interface DetectJavaScriptCookDependenciesOptions {
 
 const ALWAYS_PATTERN =
   /\b(?:setInterval|setTimeout|requestAnimationFrame)\b|\b(?:Math\.random|Date\.|performance\.now)\b/;
+
 const TIME_PATTERN = /\b(?:clock\s*\.\s*)?time\b/;
 const MOUSE_PATTERN = /\bmouse\b/;
 const FFT_PATTERN = /\bfft\s*\(/;

--- a/ui/src/workers/rendering/cooking/javascript.ts
+++ b/ui/src/workers/rendering/cooking/javascript.ts
@@ -1,0 +1,43 @@
+import { stripJavaScriptComments, stripJavaScriptStrings } from '$lib/utils/javascript-comments';
+
+export interface JavaScriptCookDependencies {
+  always?: boolean;
+  timeDependent?: boolean;
+  mouseDependent?: boolean;
+  fftDependent?: boolean;
+}
+
+interface DetectJavaScriptCookDependenciesOptions {
+  alwaysPattern?: RegExp;
+  timePattern?: RegExp;
+  mousePattern?: RegExp;
+  fftPattern?: RegExp;
+}
+
+const ALWAYS_PATTERN =
+  /\b(?:setInterval|setTimeout|requestAnimationFrame)\b|\b(?:Math\.random|Date\.|performance\.now)\b/;
+const TIME_PATTERN = /\b(?:clock\s*\.\s*)?time\b/;
+const MOUSE_PATTERN = /\bmouse\b/;
+const FFT_PATTERN = /\bfft\s*\(/;
+
+export function detectJavaScriptCookDependencies(
+  code: string,
+  options: DetectJavaScriptCookDependenciesOptions = {}
+): JavaScriptCookDependencies {
+  const source = stripJavaScriptStrings(stripJavaScriptComments(code));
+  const alwaysPattern = options.alwaysPattern ?? ALWAYS_PATTERN;
+
+  if (alwaysPattern.test(source)) {
+    return { always: true };
+  }
+
+  const timePattern = options.timePattern ?? TIME_PATTERN;
+  const mousePattern = options.mousePattern ?? MOUSE_PATTERN;
+  const fftPattern = options.fftPattern ?? FFT_PATTERN;
+
+  return {
+    ...(timePattern.test(source) ? { timeDependent: true } : {}),
+    ...(mousePattern.test(source) ? { mouseDependent: true } : {}),
+    ...(fftPattern.test(source) ? { fftDependent: true } : {})
+  };
+}

--- a/ui/src/workers/rendering/cooking/policies.test.ts
+++ b/ui/src/workers/rendering/cooking/policies.test.ts
@@ -80,6 +80,22 @@ describe('createRenderNodeCookPolicy', () => {
     ).toEqual(FFT_DEPENDENT);
   });
 
+  it('uses Canvas dependency policies', () => {
+    expect(
+      createRenderNodeCookPolicy(
+        renderNode('canvas', { code: 'ctx.fillRect(0, 0, width, height);' }),
+        baseGraph
+      )
+    ).toEqual(ON_DEMAND);
+
+    expect(
+      createRenderNodeCookPolicy(
+        renderNode('canvas', { code: 'ctx.fillText(clock.time, 0, 20);' }),
+        baseGraph
+      )
+    ).toEqual(TIME_DEPENDENT);
+  });
+
   it('preserves feedback dependency for on-demand passthrough nodes', () => {
     const node = renderNode('send.vdo', { channel: 'main' });
 

--- a/ui/src/workers/rendering/cooking/policies.ts
+++ b/ui/src/workers/rendering/cooking/policies.ts
@@ -1,6 +1,7 @@
 import { match, P } from 'ts-pattern';
 import type { RenderGraph, RenderNode } from '$lib/rendering/types';
 import type { CookPolicy } from '../CookStateManager';
+import { createCanvasCookPolicy } from './canvas';
 import { createGlslCookPolicy } from './glsl';
 import { createHydraCookPolicy } from './hydra';
 import { createShaderParkCookPolicy } from './shaderpark';
@@ -25,6 +26,10 @@ export function createRenderNodeCookPolicy(node: RenderNode, renderGraph: Render
     }))
     .with({ type: 'swgl' }, (node) => ({
       ...createSwglCookPolicy(node.data.code),
+      ...(feedbackDependent ? { feedbackDependent: true } : {})
+    }))
+    .with({ type: 'canvas' }, (node) => ({
+      ...createCanvasCookPolicy(node.data.code),
       ...(feedbackDependent ? { feedbackDependent: true } : {})
     }))
     .with(

--- a/ui/src/workers/rendering/cooking/swgl.ts
+++ b/ui/src/workers/rendering/cooking/swgl.ts
@@ -1,17 +1,23 @@
-import { stripJavaScriptComments, stripJavaScriptStrings } from '$lib/utils/javascript-comments';
+import { stripJavaScriptComments } from '$lib/utils/javascript-comments';
 
 import type { CookPolicy } from '../CookStateManager';
+import { detectJavaScriptCookDependencies } from './javascript';
 
 const TIME_PATTERN = /\bt\b/;
-const FFT_PATTERN = /\bfft\s*\(/;
+const NEVER_PATTERN = /$^/;
 
 export function createSwglCookPolicy(code: string): CookPolicy {
   const source = stripJavaScriptComments(code);
-  const dependencySource = stripJavaScriptStrings(source);
+  const dependencies = detectJavaScriptCookDependencies(code, { timePattern: NEVER_PATTERN });
+
+  if (dependencies.always) {
+    return { mode: 'always' };
+  }
 
   return {
     mode: 'on-demand',
     ...(TIME_PATTERN.test(source) ? { timeDependent: true } : {}),
-    ...(FFT_PATTERN.test(dependencySource) ? { fftDependent: true } : {})
+    ...(dependencies.mouseDependent ? { mouseDependent: true } : {}),
+    ...(dependencies.fftDependent ? { fftDependent: true } : {})
   };
 }

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -61,14 +61,22 @@ import { CookStateManager, type CookPolicy } from './CookStateManager';
 import { createGlslCookPolicy } from './cooking/glsl';
 import { createRenderNodeCookPolicy } from './cooking/policies';
 import { isSameMouseData, type MouseData } from './mouseData';
-import { shouldSkipCookForViewport } from './renderEligibility';
+import { getViewportCookRequiredNodeIds, shouldSkipCookForViewport } from './renderEligibility';
 
 type TransportTimeState = Pick<ITransport, keyof TransportState>;
 
-type MessageCapableRenderer = {
+interface MessageCapableRenderer {
   handleMessage(message: Message): void;
   handleChannelMessage(channel: string, data: unknown, sourceNodeId: string): void;
-};
+}
+
+interface ViewportCookCache {
+  renderGraph: RenderGraph;
+  visibleNodeIds: Set<string> | null;
+  connectedVideoOutputNodeIds: Set<string>;
+  effectiveOutputNodeId: string | null;
+  requiredNodeIds: Set<string> | null;
+}
 
 export const FBO_RENDERER_CONTEXT_ATTRIBUTES: WebGLContextAttributes = {
   alpha: true,
@@ -147,10 +155,12 @@ export class FBORenderer {
   private contextLossReported = false;
   private renderErrorKeysByNode = new Map<string, Set<string>>();
 
-  private lastCookStatusSignatures = new Map<string, string>();
-  private cookStatsEnabled = false;
   private visibleNodeIds: Set<string> | null = null;
   private connectedVideoOutputNodeIds: Set<string> = new Set();
+
+  private cookStatsEnabled = false;
+  private lastCookStatusSignatures = new Map<string, string>();
+  private viewportCookRequiredCache: ViewportCookCache | null = null;
 
   /** Minimum interval between rendered frames (ms). 0 = unlimited. */
   private renderIntervalMs: number = 0;
@@ -1528,6 +1538,7 @@ export class FBORenderer {
 
     const isOverride = this.hasValidOutputOverride();
     const effectiveOutputNodeId = this.getEffectiveOutputNodeId(isOverride);
+    const requiredNodeIds = this.getViewportCookRequiredNodeIds(effectiveOutputNodeId);
 
     // Render each node in topological order
     for (const nodeId of this.renderGraph.sortedNodes) {
@@ -1537,13 +1548,7 @@ export class FBORenderer {
       const fboNode = this.fboNodes.get(nodeId);
       if (!node || !fboNode) continue;
 
-      const shouldSkipCooking = shouldSkipCookForViewport({
-        node,
-        visibleNodeIds: this.visibleNodeIds,
-        connectedVideoOutputNodeIds: this.connectedVideoOutputNodeIds,
-        effectiveOutputNodeId
-      });
-
+      const shouldSkipCooking = shouldSkipCookForViewport({ node, requiredNodeIds });
       if (shouldSkipCooking) continue;
 
       const cookDecision = this.cookState.shouldCook(node.id);
@@ -1724,21 +1729,6 @@ export class FBORenderer {
     });
   }
 
-  private getWebGLErrorName(errorCode: number): string {
-    const gl = this.gl;
-
-    const errorNames = new Map<number, string>([
-      [gl.INVALID_ENUM, 'INVALID_ENUM'],
-      [gl.INVALID_VALUE, 'INVALID_VALUE'],
-      [gl.INVALID_OPERATION, 'INVALID_OPERATION'],
-      [gl.INVALID_FRAMEBUFFER_OPERATION, 'INVALID_FRAMEBUFFER_OPERATION'],
-      [gl.OUT_OF_MEMORY, 'OUT_OF_MEMORY'],
-      [gl.CONTEXT_LOST_WEBGL, 'CONTEXT_LOST_WEBGL']
-    ]);
-
-    return errorNames.get(errorCode) ?? `UNKNOWN_${errorCode}`;
-  }
-
   private reportNodeRenderError(node: RenderNode, error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     const errorKey = `${node.type}:${message}`;
@@ -1825,6 +1815,39 @@ export class FBORenderer {
   setVisibleNodes(nodeIds: Set<string>) {
     this.visibleNodeIds = new Set(nodeIds);
     this.previewRenderer.setVisibleNodes(nodeIds);
+  }
+
+  private getViewportCookRequiredNodeIds(effectiveOutputNodeId: string | null): Set<string> | null {
+    const cached = this.viewportCookRequiredCache;
+
+    if (
+      cached &&
+      cached.renderGraph === this.renderGraph &&
+      cached.visibleNodeIds === this.visibleNodeIds &&
+      cached.connectedVideoOutputNodeIds === this.connectedVideoOutputNodeIds &&
+      cached.effectiveOutputNodeId === effectiveOutputNodeId
+    ) {
+      return cached.requiredNodeIds;
+    }
+
+    if (!this.renderGraph) return null;
+
+    const requiredNodeIds = getViewportCookRequiredNodeIds({
+      nodes: this.renderGraph.nodes,
+      visibleNodeIds: this.visibleNodeIds,
+      connectedVideoOutputNodeIds: this.connectedVideoOutputNodeIds,
+      effectiveOutputNodeId
+    });
+
+    this.viewportCookRequiredCache = {
+      renderGraph: this.renderGraph,
+      visibleNodeIds: this.visibleNodeIds,
+      connectedVideoOutputNodeIds: this.connectedVideoOutputNodeIds,
+      effectiveOutputNodeId,
+      requiredNodeIds
+    };
+
+    return requiredNodeIds;
   }
 
   /** Globally enable/disable all previews */

--- a/ui/src/workers/rendering/renderEligibility.test.ts
+++ b/ui/src/workers/rendering/renderEligibility.test.ts
@@ -1,72 +1,150 @@
 import { describe, expect, it } from 'vitest';
-import { shouldSkipCookForViewport } from './renderEligibility';
+import { getViewportCookRequiredNodeIds, shouldSkipCookForViewport } from './renderEligibility';
+import type { RenderNode } from '$lib/rendering/types';
 
-const hiddenNode = { id: 'glsl-1', outputs: [] };
+const renderNode = (id: string, inputs: string[] = [], outputs: string[] = []): RenderNode =>
+  ({
+    id,
+    type: 'glsl',
+    inputs,
+    outputs,
+    data: { code: '', glUniformDefs: [] },
+    inletMap: new Map(),
+    backEdgeInlets: new Set()
+  }) as RenderNode;
+
+const hiddenNode = renderNode('glsl-1');
 
 describe('shouldSkipCookForViewport', () => {
   it('skips nodes that are hidden, disconnected, and not the effective output', () => {
+    const requiredNodeIds = getViewportCookRequiredNodeIds({
+      nodes: [hiddenNode],
+      visibleNodeIds: new Set(['hydra-1']),
+      connectedVideoOutputNodeIds: new Set(),
+      effectiveOutputNodeId: null
+    });
+
     expect(
       shouldSkipCookForViewport({
         node: hiddenNode,
-        visibleNodeIds: new Set(['hydra-1']),
-        connectedVideoOutputNodeIds: new Set(),
-        effectiveOutputNodeId: null
+        requiredNodeIds
       })
     ).toBe(true);
   });
 
   it('does not skip when viewport visibility has not been initialized', () => {
+    const requiredNodeIds = getViewportCookRequiredNodeIds({
+      nodes: [hiddenNode],
+      visibleNodeIds: null,
+      connectedVideoOutputNodeIds: new Set(),
+      effectiveOutputNodeId: null
+    });
+
     expect(
       shouldSkipCookForViewport({
         node: hiddenNode,
-        visibleNodeIds: null,
-        connectedVideoOutputNodeIds: new Set(),
-        effectiveOutputNodeId: null
+        requiredNodeIds
       })
     ).toBe(false);
   });
 
   it('does not skip visible nodes', () => {
+    const requiredNodeIds = getViewportCookRequiredNodeIds({
+      nodes: [hiddenNode],
+      visibleNodeIds: new Set(['glsl-1']),
+      connectedVideoOutputNodeIds: new Set(),
+      effectiveOutputNodeId: null
+    });
+
     expect(
       shouldSkipCookForViewport({
         node: hiddenNode,
-        visibleNodeIds: new Set(['glsl-1']),
-        connectedVideoOutputNodeIds: new Set(),
-        effectiveOutputNodeId: null
+        requiredNodeIds
       })
     ).toBe(false);
   });
 
-  it('does not skip graph-connected video sources', () => {
+  it('skips hidden upstream nodes when their only downstream FBO consumer is hidden', () => {
+    const hydra = renderNode('hydra-1', [], ['glsl-1']);
+    const glsl = renderNode('glsl-1', ['hydra-1']);
+
+    const requiredNodeIds = getViewportCookRequiredNodeIds({
+      nodes: [hydra, glsl],
+      visibleNodeIds: new Set(),
+      connectedVideoOutputNodeIds: new Set(),
+      effectiveOutputNodeId: null
+    });
+
     expect(
       shouldSkipCookForViewport({
-        node: { id: 'glsl-1', outputs: ['hydra-1'] },
-        visibleNodeIds: new Set(),
-        connectedVideoOutputNodeIds: new Set(),
-        effectiveOutputNodeId: null
+        node: hydra,
+        requiredNodeIds
+      })
+    ).toBe(true);
+  });
+
+  it('does not skip hidden upstream nodes when a downstream FBO consumer is visible', () => {
+    const hydra = renderNode('hydra-1', [], ['glsl-1']);
+    const glsl = renderNode('glsl-1', ['hydra-1']);
+
+    const requiredNodeIds = getViewportCookRequiredNodeIds({
+      nodes: [hydra, glsl],
+      visibleNodeIds: new Set(['glsl-1']),
+      connectedVideoOutputNodeIds: new Set(),
+      effectiveOutputNodeId: null
+    });
+
+    expect(
+      shouldSkipCookForViewport({
+        node: hydra,
+        requiredNodeIds
       })
     ).toBe(false);
   });
 
-  it('does not skip sources connected to non-FBO video consumers', () => {
+  it('does not skip transitive hidden upstream nodes needed by a visible FBO consumer', () => {
+    const hydra = renderNode('hydra-1', [], ['glsl-1']);
+    const glsl = renderNode('glsl-1', ['hydra-1'], ['shaderpark-1']);
+    const shaderpark = renderNode('shaderpark-1', ['glsl-1']);
+
+    const requiredNodeIds = getViewportCookRequiredNodeIds({
+      nodes: [hydra, glsl, shaderpark],
+      visibleNodeIds: new Set(['shaderpark-1']),
+      connectedVideoOutputNodeIds: new Set(),
+      effectiveOutputNodeId: null
+    });
+
     expect(
       shouldSkipCookForViewport({
-        node: hiddenNode,
-        visibleNodeIds: new Set(),
-        connectedVideoOutputNodeIds: new Set(['glsl-1']),
-        effectiveOutputNodeId: null
+        node: hydra,
+        requiredNodeIds
       })
     ).toBe(false);
   });
 
-  it('does not skip the effective background output node', () => {
-    expect(
-      shouldSkipCookForViewport({
-        node: hiddenNode,
-        visibleNodeIds: new Set(),
-        connectedVideoOutputNodeIds: new Set(),
-        effectiveOutputNodeId: 'glsl-1'
-      })
-    ).toBe(false);
+  it('does not skip sources connected to external video consumers', () => {
+    const requiredNodeIds = getViewportCookRequiredNodeIds({
+      nodes: [hiddenNode],
+      visibleNodeIds: new Set(),
+      connectedVideoOutputNodeIds: new Set(['glsl-1']),
+      effectiveOutputNodeId: null
+    });
+
+    expect(shouldSkipCookForViewport({ node: hiddenNode, requiredNodeIds })).toBe(false);
+  });
+
+  it('does not skip the effective background output node or its inputs', () => {
+    const hydra = renderNode('hydra-1', [], ['glsl-1']);
+    const glsl = renderNode('glsl-1', ['hydra-1']);
+
+    const requiredNodeIds = getViewportCookRequiredNodeIds({
+      nodes: [hydra, glsl],
+      visibleNodeIds: new Set(),
+      connectedVideoOutputNodeIds: new Set(),
+      effectiveOutputNodeId: 'glsl-1'
+    });
+
+    expect(shouldSkipCookForViewport({ node: glsl, requiredNodeIds })).toBe(false);
+    expect(shouldSkipCookForViewport({ node: hydra, requiredNodeIds })).toBe(false);
   });
 });

--- a/ui/src/workers/rendering/renderEligibility.ts
+++ b/ui/src/workers/rendering/renderEligibility.ts
@@ -1,25 +1,62 @@
 import type { RenderNode } from '$lib/rendering/types';
 
-type ViewportCookSkipInput = {
-  node: Pick<RenderNode, 'id' | 'outputs'>;
+interface ViewportCookSkipInput {
+  node: Pick<RenderNode, 'id'>;
+  requiredNodeIds: Set<string> | null;
+}
+
+interface ViewportCookRequiredInput {
+  nodes: RenderNode[];
   visibleNodeIds: Set<string> | null;
   connectedVideoOutputNodeIds: Set<string>;
   effectiveOutputNodeId: string | null;
-};
+}
 
-export function shouldSkipCookForViewport({
-  node,
+export function getViewportCookRequiredNodeIds({
+  nodes,
   visibleNodeIds,
   connectedVideoOutputNodeIds,
   effectiveOutputNodeId
+}: ViewportCookRequiredInput): Set<string> | null {
+  if (visibleNodeIds === null) return null;
+
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const requiredNodeIds = new Set<string>();
+
+  const addWithInputs = (nodeId: string) => {
+    if (requiredNodeIds.has(nodeId)) return;
+
+    const node = nodeById.get(nodeId);
+    if (!node) return;
+
+    requiredNodeIds.add(nodeId);
+
+    for (const inputId of node.inputs) {
+      addWithInputs(inputId);
+    }
+  };
+
+  for (const nodeId of visibleNodeIds) {
+    addWithInputs(nodeId);
+  }
+
+  if (effectiveOutputNodeId) {
+    addWithInputs(effectiveOutputNodeId);
+  }
+
+  for (const nodeId of connectedVideoOutputNodeIds) {
+    addWithInputs(nodeId);
+  }
+
+  return requiredNodeIds;
+}
+
+export function shouldSkipCookForViewport({
+  node,
+  requiredNodeIds
 }: ViewportCookSkipInput): boolean {
-  if (visibleNodeIds === null) return false;
-  if (visibleNodeIds.has(node.id)) return false;
-
-  if (node.id === effectiveOutputNodeId) return false;
-  if (node.outputs.length > 0) return false;
-
-  if (connectedVideoOutputNodeIds.has(node.id)) return false;
+  if (requiredNodeIds === null) return false;
+  if (requiredNodeIds.has(node.id)) return false;
 
   return true;
 }


### PR DESCRIPTION
- Conditionally cook canvas node frames
- Do not cook frames if output connected node is outside of viewport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canvas rendering support to the cooking policy system, with automatic handling for on-demand, time-dependent, mouse-dependent, FFT-dependent, and always-updating cases.
  * Improved JavaScript source analysis so rendering behavior is inferred more accurately from code patterns.

* **Bug Fixes**
  * Ignored dependency-like words inside comments and strings, reducing false detections.
  * Aligned canvas, Hydra, and SWGL behavior with the same dependency-detection rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->