### PR TITLE
perf(canvas): pause uncooked rAF frames

### DIFF
--- a/ui/src/lib/components/CookDebugOverlay.svelte
+++ b/ui/src/lib/components/CookDebugOverlay.svelte
@@ -19,13 +19,25 @@
     showCookDebug = visible;
   });
 
+  const HIDDEN_COOK_REASONS = new Set(['first-frame', 'renderer-policy']);
+
   const cookStatusLabel = $derived(cookStatus?.status ?? 'cached');
-  const cookReasons = $derived.by(() => {
+  let lastVisibleCookReasons = $state<string[]>([]);
+
+  $effect(() => {
     const visibleReasons = (cookStatus?.lastCookReasons ?? []).filter(
-      (reason) => reason !== 'first-frame'
+      (reason) => !HIDDEN_COOK_REASONS.has(reason)
     );
 
-    return visibleReasons.join(', ') || 'none';
+    if (visibleReasons.length > 0) {
+      lastVisibleCookReasons = visibleReasons;
+    } else if (cookStatus?.status !== 'cooked') {
+      lastVisibleCookReasons = [];
+    }
+  });
+
+  const cookReasons = $derived.by(() => {
+    return lastVisibleCookReasons.join(', ') || 'none';
   });
   const cookTime = $derived(
     cookStatus?.lastCookTimeMs == null ? '--' : `${cookStatus.lastCookTimeMs.toFixed(2)}ms`

--- a/ui/src/lib/components/sidebar/ProfilerView.svelte
+++ b/ui/src/lib/components/sidebar/ProfilerView.svelte
@@ -201,8 +201,7 @@
     </div>
   {:else if !$profilerSnapshot || $profilerSnapshot.entries.length === 0}
     <div class="flex flex-1 flex-col items-center justify-center gap-2 px-4 text-center">
-      <p class="text-xs text-zinc-500">Waiting for messages…</p>
-      <p class="text-xs text-zinc-600">Send a message to a text object (metro, kv, etc.)</p>
+      <p class="text-xs text-zinc-500">Waiting for events…</p>
     </div>
   {:else}
     <div class="min-h-0 flex-1 overflow-y-auto">

--- a/ui/src/workers/rendering/canvasRenderer.test.ts
+++ b/ui/src/workers/rendering/canvasRenderer.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CanvasRenderer } from './canvasRenderer';
+
+interface PausedRenderer {
+  pausedCallback: FrameRequestCallback | null;
+  scheduleAnimationFrame(callback: FrameRequestCallback): number;
+}
+
+interface ScheduleRenderer {
+  scheduleAnimationFrame(callback: FrameRequestCallback): number;
+}
+
+describe('CanvasRenderer animation scheduling', () => {
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+  let pendingFrames: FrameRequestCallback[];
+
+  beforeEach(() => {
+    pendingFrames = [];
+
+    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      pendingFrames.push(callback);
+
+      return pendingFrames.length;
+    });
+
+    globalThis.cancelAnimationFrame = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  it('does not replay an already completed one-shot RAF callback on resume', () => {
+    const renderer = new (CanvasRenderer as unknown as new (
+      config: { code: string; nodeId: string },
+      framebuffer: unknown,
+      renderer: unknown
+    ) => CanvasRenderer)(
+      { code: '', nodeId: 'canvas-1' },
+      {},
+      {
+        isNodePaused: () => false,
+        isNodeCookRequired: () => true,
+        drawProfiler: { measure: (_nodeId: string, _category: string, fn: () => void) => fn() }
+      }
+    );
+
+    const callback = vi.fn();
+
+    (renderer as unknown as PausedRenderer).pausedCallback = callback;
+    (renderer as unknown as ScheduleRenderer).scheduleAnimationFrame(callback);
+
+    pendingFrames.shift()?.(16);
+    renderer.resumeAnimation();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(pendingFrames).toHaveLength(0);
+  });
+});

--- a/ui/src/workers/rendering/canvasRenderer.ts
+++ b/ui/src/workers/rendering/canvasRenderer.ts
@@ -97,6 +97,35 @@ export class CanvasRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
   // Canvas uses RAF internally, not the pipeline's renderFrame
   renderFrame() {}
 
+  private scheduleAnimationFrame(callback: FrameRequestCallback): number {
+    if (this.shouldSkipFrame()) {
+      this.animationId = null;
+      return -1;
+    }
+
+    this.animationId = requestAnimationFrame((ts) => {
+      this.animationId = null;
+
+      if (this.shouldSkipFrame()) return;
+
+      this.renderer.drawProfiler.measure(this.config.nodeId, 'draw', () => callback(ts));
+      this.drawCanvasToTexture();
+
+      if (this.animationId === null && this.pausedCallback === callback) {
+        this.pausedCallback = null;
+      }
+    });
+
+    return this.animationId;
+  }
+
+  private shouldSkipFrame() {
+    return (
+      this.renderer.isNodePaused(this.config.nodeId) ||
+      !this.renderer.isNodeCookRequired(this.config.nodeId)
+    );
+  }
+
   public async updateCode() {
     if (!this.ctx || !this.offscreenCanvas) return;
 
@@ -123,19 +152,7 @@ export class CanvasRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
         requestAnimationFrame: (callback: FrameRequestCallback) => {
           // Store callback for resume
           this.pausedCallback = callback;
-
-          // Don't schedule if paused
-          if (this.renderer.isNodePaused(this.config.nodeId)) {
-            return -1;
-          }
-
-          this.animationId = requestAnimationFrame((ts) => {
-            this.renderer.drawProfiler.measure(this.config.nodeId, 'draw', () => callback(ts));
-
-            this.drawCanvasToTexture();
-          });
-
-          return this.animationId;
+          return this.scheduleAnimationFrame(callback);
         },
 
         cancelAnimationFrame: (id: number) => {
@@ -167,15 +184,9 @@ export class CanvasRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
 
   /** Resume animation loop after unpausing */
   resumeAnimation() {
-    if (this.pausedCallback && !this.renderer.isNodePaused(this.config.nodeId)) {
-      const callback = this.pausedCallback;
+    if (!this.pausedCallback || this.animationId !== null) return;
 
-      this.animationId = requestAnimationFrame(() => {
-        callback(performance.now());
-
-        this.drawCanvasToTexture();
-      });
-    }
+    this.scheduleAnimationFrame(this.pausedCallback);
   }
 
   setHidePorts(hidePorts: boolean) {

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -721,6 +721,8 @@ export class FBORenderer {
         })
       );
     }
+
+    this.resumeViewportManagedRenderers();
   }
 
   // Some nodes are externally managed, e.g. the texture will be uploaded on it.
@@ -1470,6 +1472,18 @@ export class FBORenderer {
     return this.nodePausedMap.get(nodeId) ?? false;
   }
 
+  isNodeCookRequired(nodeId: string): boolean {
+    const effectiveOutputNodeId = this.getEffectiveOutputNodeId();
+    const requiredNodeIds = this.getViewportCookRequiredNodeIds(effectiveOutputNodeId);
+
+    return !shouldSkipCookForViewport({ node: { id: nodeId }, requiredNodeIds });
+  }
+
+  setOverrideOutputNode(nodeId: string | null) {
+    this.overrideOutputNodeId = nodeId;
+    this.resumeViewportManagedRenderers();
+  }
+
   /** Set mouse data for a node (Shadertoy iMouse format) */
   setMouseData(nodeId: string, x: number, y: number, z: number, w: number, buttons?: number) {
     const nextMouseData: MouseData = [x, y, z, w, buttons];
@@ -1815,6 +1829,7 @@ export class FBORenderer {
   setVisibleNodes(nodeIds: Set<string>) {
     this.visibleNodeIds = new Set(nodeIds);
     this.previewRenderer.setVisibleNodes(nodeIds);
+    this.resumeViewportManagedRenderers();
   }
 
   private getViewportCookRequiredNodeIds(effectiveOutputNodeId: string | null): Set<string> | null {
@@ -1848,6 +1863,12 @@ export class FBORenderer {
     };
 
     return requiredNodeIds;
+  }
+
+  private resumeViewportManagedRenderers() {
+    for (const renderer of this.canvasByNode.values()) {
+      renderer?.resumeAnimation();
+    }
   }
 
   /** Globally enable/disable all previews */

--- a/ui/src/workers/rendering/renderWorker.ts
+++ b/ui/src/workers/rendering/renderWorker.ts
@@ -163,7 +163,7 @@ self.onmessage = (event) => {
       fboRenderer.setTransportTime(data);
     })
     .with('setOverrideOutputNode', () => {
-      fboRenderer.overrideOutputNodeId = data.nodeId ?? null;
+      fboRenderer.setOverrideOutputNode(data.nodeId ?? null);
     })
     .with('channelMessage', () => {
       fboRenderer.sendChannelMessageToNode(data.nodeId, data.channel, data.data, data.sourceNodeId);


### PR DESCRIPTION
Pause `requestAnimationFrame` frames that are considered uncooked (e.g. outside of XYFlow viewport)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animation resumption so viewport updates continue playing smoothly after render changes or when an override output is set.
  * Fixed animation-frame handling to use a more reliable scheduling flow, reducing missed or out-of-sync redraws.
  * Updated render updates to better trigger canvas refreshes when visible content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->