### PR TITLE
fix(transport): lookahead scheduler and transport improvements

### DIFF
--- a/docs/design-docs/specs/78-global-transport-control.md
+++ b/docs/design-docs/specs/78-global-transport-control.md
@@ -15,13 +15,13 @@ There is no way to keep visual and audio in perfect sync (beat-match) in Patchie
 
 ### Transport Controls
 
-| Control          | Behavior                                                                                                                                              |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Play/Pause**   | Toggle button. Pause freezes the clock at current position. Spacebar keyboard shortcut.                                                               |
-| **Stop**         | Resets clock to 0 and pauses.                                                                                                                         |
-| **BPM**          | Manual number input. Default: 120.                                                                                                                    |
+| Control          | Behavior                                                                                                                                             |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Play/Pause**   | Toggle button. Pause freezes the clock at current position. Spacebar keyboard shortcut.                                                              |
+| **Stop**         | Resets clock to 0 and pauses.                                                                                                                        |
+| **BPM**          | Manual number input. Default: 120.                                                                                                                   |
 | **Time Display** | Shows current position. Click to toggle formats: time (`02:35:42` = MM:SS:CS), bars (`001:1:01`), seconds (`00004.25`). Double-click to edit & seek. |
-| **DSP On/Off**   | Mute-style button. Red when DSP is off (AudioContext suspended).                                                                                      |
+| **DSP On/Off**   | Mute-style button. Red when DSP is off (AudioContext suspended).                                                                                     |
 
 ### UI
 
@@ -271,6 +271,7 @@ This design ensures:
 1. **Zero Tone.js in initial bundle** - Stub works standalone
 2. **Seamless upgrade** - BPM transfers when upgrading to full transport
 3. **Embed mode** - Skip upgrade entirely for lite embeds (future: add `disableUpgrade()` method)
+4. **Panel-independent settings sync** - persisted, loaded, or settings-panel BPM/time-signature updates in `transportStore` update the active `Transport` context even when `TransportPanel` is not mounted
 
 #### Auto-Sync All Time-Based Nodes
 
@@ -668,20 +669,20 @@ Completed: 2024-02-24
 
 ### Files Modified
 
-| File                                            | Changes                                                                                               |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `src/lib/js-runner/JSRunner.ts`                 | Added `clock` object to execution context with getters for `time`, `ticks`, `beat`, `phase`, `bpm` |
-| `src/lib/canvas/GLSystem.ts`                    | Added `startTransportSync()`, `stopTransportSync()`, `syncTransportTime()`. Transport syncs at 60fps  |
-| `src/workers/rendering/renderWorker.ts`         | Handles `syncTransportTime` message, passes to fboRenderer                                            |
-| `src/workers/rendering/fboRenderer.ts`          | Added `transportTime`, `setTransportTime()`, `defineWorkerGlobals()`, `createWorkerClock()`           |
-| `src/lib/canvas/shadertoy-draw.ts`              | Changed `iTime` uniform to use `props.transportTime` instead of regl's internal clock                 |
-| `src/workers/rendering/hydraRenderer.ts`        | Uses `params.transportTime` for synth.time, passes `createWorkerClock()` to extraContext              |
-| `src/workers/rendering/threeRenderer.ts`        | Passes `createWorkerClock()` to extraContext for Three.js code                                        |
-| `src/workers/rendering/canvasRenderer.ts`       | Passes `createWorkerClock()` to extraContext for Canvas code                                          |
-| `src/workers/rendering/textmodeRenderer.ts`     | Passes `createWorkerClock()` to extraContext for Textmode code                                        |
-| `src/lib/rendering/types.ts`                    | Added `transportTime: number` to `RenderParams` interface                                             |
-| `src/lib/components/BottomToolbar.svelte`       | Replaced VolumeControl with Popover containing TransportPanel. Added tooltips to all toolbar buttons  |
-| `src/lib/components/ObjectPreviewLayout.svelte` | Renamed individual node toggle to Pin/PinOff icons. All buttons now use Tooltip components            |
+| File                                            | Changes                                                                                              |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `src/lib/js-runner/JSRunner.ts`                 | Added `clock` object to execution context with getters for `time`, `ticks`, `beat`, `phase`, `bpm`   |
+| `src/lib/canvas/GLSystem.ts`                    | Added `startTransportSync()`, `stopTransportSync()`, `syncTransportTime()`. Transport syncs at 60fps |
+| `src/workers/rendering/renderWorker.ts`         | Handles `syncTransportTime` message, passes to fboRenderer                                           |
+| `src/workers/rendering/fboRenderer.ts`          | Added `transportTime`, `setTransportTime()`, `defineWorkerGlobals()`, `createWorkerClock()`          |
+| `src/lib/canvas/shadertoy-draw.ts`              | Changed `iTime` uniform to use `props.transportTime` instead of regl's internal clock                |
+| `src/workers/rendering/hydraRenderer.ts`        | Uses `params.transportTime` for synth.time, passes `createWorkerClock()` to extraContext             |
+| `src/workers/rendering/threeRenderer.ts`        | Passes `createWorkerClock()` to extraContext for Three.js code                                       |
+| `src/workers/rendering/canvasRenderer.ts`       | Passes `createWorkerClock()` to extraContext for Canvas code                                         |
+| `src/workers/rendering/textmodeRenderer.ts`     | Passes `createWorkerClock()` to extraContext for Textmode code                                       |
+| `src/lib/rendering/types.ts`                    | Added `transportTime: number` to `RenderParams` interface                                            |
+| `src/lib/components/BottomToolbar.svelte`       | Replaced VolumeControl with Popover containing TransportPanel. Added tooltips to all toolbar buttons |
+| `src/lib/components/ObjectPreviewLayout.svelte` | Renamed individual node toggle to Pin/PinOff icons. All buttons now use Tooltip components           |
 
 ### Key Implementation Details
 
@@ -707,7 +708,7 @@ Solution: All worker-based renderers override `clock` via `extraContext`:
 ```typescript
 // In each worker renderer (Hydra, Three.js, Canvas, Textmode):
 const extraContext = {
-  clock: this.renderer.createWorkerClock()
+  clock: this.renderer.createWorkerClock(),
 };
 ```
 

--- a/docs/design-docs/specs/81-clock-scheduling-api.md
+++ b/docs/design-docs/specs/81-clock-scheduling-api.md
@@ -25,6 +25,8 @@ This is tedious and requires boilerplate in every node.
 
 Add scheduling methods to the `clock` object that work uniformly across all environments. By default, callbacks fire **after** the event (visual-friendly). Pass `{ audio: true }` for lookahead scheduling where callbacks fire early with the precise transport time for Web Audio API scheduling.
 
+For audio lookahead `onBeat` and `every`, callbacks may also receive a second `eventClock` argument. This is a future clock snapshot for the scheduled event time, so `eventClock.time`, `eventClock.beat`, and `eventClock.phase` describe when the event actually lands rather than the scheduler's current polling time.
+
 ## API
 
 ### `clock.onBeat(beat, callback, options?)` - Beat Change Subscription
@@ -60,9 +62,13 @@ clock.schedule("4:0:0", () => breakdown()); // bar 4, beat 0
 clock.schedule("8:2:0", () => buildUp()); // bar 8, beat 2
 
 // Audio-precise — fires early with precise time
-clock.schedule("4:0:0", (time) => {
-  send({ type: 'set', value: 880, time });
-}, { audio: true });
+clock.schedule(
+  "4:0:0",
+  (time) => {
+    send({ type: "set", value: 880, time });
+  },
+  { audio: true },
+);
 
 // Returns ID for cleanup
 const id = clock.schedule("16:0:0", () => finale());
@@ -80,9 +86,13 @@ clock.every("0:1:0", () => pulse()); // every beat
 clock.every("0:0:1", () => tick()); // every sixteenth
 
 // Audio-precise repeating
-clock.every("0:1:0", (time) => {
-  send({ type: 'trigger', ... });
-}, { audio: true });
+clock.every(
+  "0:1:0",
+  (time, eventClock) => {
+    send({ type: "trigger", beat: eventClock.beat, time });
+  },
+  { audio: true },
+);
 
 // Returns ID for cleanup
 const id = clock.every("4:0:0", () => transition());
@@ -119,9 +129,24 @@ interface SchedulerOptions {
 }
 
 interface ClockScheduler {
-  onBeat(beat: number | number[] | "*", callback: (time: number) => void, options?: SchedulerOptions): string;
-  schedule(time: number | string, callback: (time: number) => void, options?: SchedulerOptions): string;
-  every(interval: string, callback: (time: number) => void, options?: SchedulerOptions): string;
+  onBeat(
+    beat: number | number[] | "*",
+    callback: (time: number, clock?: ClockState) => void,
+    options?: SchedulerOptions,
+  ): string;
+  
+  schedule(
+    time: number | string,
+    callback: (time: number, clock?: ClockState) => void,
+    options?: SchedulerOptions,
+  ): string;
+  
+  every(
+    interval: string,
+    callback: (time: number, clock?: ClockState) => void,
+    options?: SchedulerOptions,
+  ): string;
+  
   cancel(id: string): void;
   cancelAll(): void;
 }
@@ -341,14 +366,14 @@ function parseBarBeatSixteenth(notation: string, bpm: number): number {
 
 **Default (visual):** Callbacks fire **after** the event — ~25ms main thread, ~16ms workers. Imperceptible for visual sync.
 
-**`{ audio: true }` (lookahead):** Main thread only. Callbacks fire **before** the event within a ~100ms lookahead window. The `time` argument contains the precise transport time for Web Audio API scheduling.
+**`{ audio: true }` (lookahead):** Main thread only. Callbacks fire **before** the event within a ~100ms lookahead window. The `time` argument contains the precise transport time for Web Audio API scheduling. For `onBeat` and `every`, the optional second `eventClock` argument is derived for that future event time.
 
 Audio lookahead beat callbacks must dedupe by logical beat index, not by the predicted floating-point event time. The scheduler polls repeatedly inside the lookahead window, and tiny clock/phase rounding differences can produce slightly different timestamps for the same upcoming beat.
 
-| Environment | Visual precision    | Audio lookahead   |
-| ----------- | ------------------- | ----------------- |
-| Main Thread | Poll-based (~25ms)  | ~100ms ahead      |
-| Worker      | Frame-based (~16ms) | Not available     |
+| Environment | Visual precision    | Audio lookahead |
+| ----------- | ------------------- | --------------- |
+| Main Thread | Poll-based (~25ms)  | ~100ms ahead    |
+| Worker      | Frame-based (~16ms) | Not available   |
 
 ## Examples
 

--- a/docs/design-docs/specs/81-clock-scheduling-api.md
+++ b/docs/design-docs/specs/81-clock-scheduling-api.md
@@ -343,6 +343,8 @@ function parseBarBeatSixteenth(notation: string, bpm: number): number {
 
 **`{ audio: true }` (lookahead):** Main thread only. Callbacks fire **before** the event within a ~100ms lookahead window. The `time` argument contains the precise transport time for Web Audio API scheduling.
 
+Audio lookahead beat callbacks must dedupe by logical beat index, not by the predicted floating-point event time. The scheduler polls repeatedly inside the lookahead window, and tiny clock/phase rounding differences can produce slightly different timestamps for the same upcoming beat.
+
 | Environment | Visual precision    | Audio lookahead   |
 | ----------- | ------------------- | ----------------- |
 | Main Thread | Poll-based (~25ms)  | ~100ms ahead      |

--- a/docs/design-docs/specs/82-clock-control-api.md
+++ b/docs/design-docs/specs/82-clock-control-api.md
@@ -16,6 +16,8 @@ Extend the clock object with control methods, time signature support, and per-no
 
 Add control methods and play-state listeners to the clock object that work uniformly in main thread and workers. Subdivisions are computed **per-node** via `clock.subdiv(n)` and `clock.subdivPhase(n)` — no global state, so different nodes can use different subdivisions simultaneously.
 
+Audio lookahead `clock.onBeat()` and `clock.every()` callbacks can receive a second `eventClock` argument. It is computed for the scheduled future event time, so callback code can read `eventClock.beat` and `eventClock.phase` without accidentally using the scheduler's current polling clock.
+
 ## API Additions
 
 ### Time Signature

--- a/docs/design-docs/specs/82-clock-control-api.md
+++ b/docs/design-docs/specs/82-clock-control-api.md
@@ -10,40 +10,48 @@ Extend the clock object with control methods, time signature support, and per-no
 2. **No subdivision support**: Can't easily work with triplets, quintuplets, etc.
 3. **Read-only clock**: Can't control transport from within code (play/pause/setBpm)
 4. **Worker limitation**: Workers receive state but can't send commands back
+5. **Play state requires polling**: Code has to manually compare transport state to react to play/pause/stop changes
 
 ## Solution
 
-Add control methods to the clock object that work uniformly in main thread and workers. Subdivisions are computed **per-node** via `clock.subdiv(n)` and `clock.subdivPhase(n)` — no global state, so different nodes can use different subdivisions simultaneously.
+Add control methods and play-state listeners to the clock object that work uniformly in main thread and workers. Subdivisions are computed **per-node** via `clock.subdiv(n)` and `clock.subdivPhase(n)` — no global state, so different nodes can use different subdivisions simultaneously.
 
 ## API Additions
 
 ### Time Signature
 
-| Property          | Type   | Description                |
-| ----------------- | ------ | -------------------------- |
-| `clock.bar`       | number | Current bar (0-indexed)    |
-| `clock.beatsPerBar` | number | Beats per bar (default: 4) |
-| `clock.denominator` | number | Note value that gets one beat (default: 4 = quarter note) |
+| Property            | Type    | Description                                               |
+| ------------------- | ------- | --------------------------------------------------------- |
+| `clock.bar`         | number  | Current bar (0-indexed)                                   |
+| `clock.beatsPerBar` | number  | Beats per bar (default: 4)                                |
+| `clock.denominator` | number  | Note value that gets one beat (default: 4 = quarter note) |
+| `clock.isPlaying`   | boolean | Whether the transport is currently playing                |
 
 ### Per-Node Subdivisions
 
-| Method                  | Return | Description                                        |
-| ----------------------- | ------ | -------------------------------------------------- |
-| `clock.subdiv(n)`       | number | Current subdivision index (0 to n-1) within beat   |
-| `clock.subdivPhase(n)`  | number | Progress within current subdivision (0.0 to 1.0)   |
+| Method                 | Return | Description                                      |
+| ---------------------- | ------ | ------------------------------------------------ |
+| `clock.subdiv(n)`      | number | Current subdivision index (0 to n-1) within beat |
+| `clock.subdivPhase(n)` | number | Progress within current subdivision (0.0 to 1.0) |
 
 These are pure computations from `ticks` and `ppq` — no global state, no syncing needed. Each node picks its own `n`.
 
 ### Control Methods
 
-| Method                                | Description                          |
-| ------------------------------------- | ------------------------------------ |
-| `clock.play()`                        | Start transport                      |
-| `clock.pause()`                       | Pause transport                      |
-| `clock.stop()`                        | Stop and reset to 0                  |
-| `clock.setBpm(bpm)`                   | Set tempo                            |
+| Method                                               | Description                               |
+| ---------------------------------------------------- | ----------------------------------------- |
+| `clock.play()`                                       | Start transport                           |
+| `clock.pause()`                                      | Pause transport                           |
+| `clock.stop()`                                       | Stop and reset to 0                       |
+| `clock.setBpm(bpm)`                                  | Set tempo                                 |
 | `clock.setTimeSignature(numerator, denominator = 4)` | Set time signature (e.g., `6, 8` for 6/8) |
-| `clock.seek(time)`                    | Seek to time in seconds              |
+| `clock.seek(time)`                                   | Seek to time in seconds                   |
+
+### Play State Events
+
+| Method                              | Description                                                                                                |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `clock.onPlayStateChange(callback)` | Fires when transport changes between `playing`, `paused`, and `stopped`; callback receives `(state, time)` |
 
 ## Implementation
 
@@ -97,6 +105,7 @@ export interface TransportState {
   ticks: number;
   bpm: number;
   isPlaying: boolean;
+  playState: "playing" | "paused" | "stopped";
   beat: number;
   phase: number;
   bar: number;
@@ -168,7 +177,7 @@ const angle = (clock.subdiv(5) / 5) * Math.PI * 2;
 
 ```javascript
 // Node A: triplets
-const triColor = ['red', 'green', 'blue'][clock.subdiv(3)];
+const triColor = ["red", "green", "blue"][clock.subdiv(3)];
 
 // Node B: quintuplets (simultaneously, no conflict)
 const quintAngle = (clock.subdiv(5) / 5) * TAU;
@@ -180,7 +189,7 @@ const quintAngle = (clock.subdiv(5) / 5) * TAU;
 // Pulse that breathes once per sixteenth note
 const t = clock.subdivPhase(4);
 const radius = 50 + 20 * Math.sin(t * Math.PI);
-circle(width/2, height/2, radius);
+circle(width / 2, height / 2, radius);
 ```
 
 ### Transport Control from Code
@@ -199,6 +208,23 @@ recv((data) => {
 clock.play();
 ```
 
+### Play State Listener
+
+```javascript
+const id = clock.onPlayStateChange((state, time) => {
+  if (state === "playing") {
+    send({ type: "transport-started", time });
+  }
+
+  if (state === "stopped") {
+    send({ type: "transport-stopped" });
+  }
+});
+
+// Later, remove the listener
+clock.cancel(id);
+```
+
 ### Seek to Bar
 
 ```javascript
@@ -208,21 +234,22 @@ clock.seek(8 * secondsPerBar);
 
 ## Files Modified
 
-| File                                   | Changes                                              |
-| -------------------------------------- | ---------------------------------------------------- |
-| `src/lib/transport/types.ts`           | Remove global subdivision, add `ppq` to state        |
-| `src/lib/transport/constants.ts`       | Remove `DEFAULT_SUBDIVISIONS_PER_BEAT`               |
-| `src/lib/transport/DefaultTransport.ts`| Remove subdivision state, expose `ppq`               |
-| `src/lib/transport/ToneTransport.ts`   | Remove subdivision state, expose `ppq`               |
-| `src/lib/transport/Transport.ts`       | Remove subdivision proxies, add `ppq`                |
-| `src/lib/canvas/GLSystem.ts`           | Remove `setSubdivisions` from clockCommand handler   |
-| `src/workers/rendering/fboRenderer.ts` | Replace subdivision getters with `subdiv`/`subdivPhase` |
-| `src/lib/js-runner/JSRunner.ts`        | Replace subdivision getters with `subdiv`/`subdivPhase` |
-| `src/stores/transport.store.ts`        | Remove `subdivisionsPerBeat` persistence             |
+| File                                    | Changes                                                 |
+| --------------------------------------- | ------------------------------------------------------- |
+| `src/lib/transport/types.ts`            | Remove global subdivision, add `ppq` to state           |
+| `src/lib/transport/constants.ts`        | Remove `DEFAULT_SUBDIVISIONS_PER_BEAT`                  |
+| `src/lib/transport/DefaultTransport.ts` | Remove subdivision state, expose `ppq`                  |
+| `src/lib/transport/ToneTransport.ts`    | Remove subdivision state, expose `ppq`                  |
+| `src/lib/transport/Transport.ts`        | Remove subdivision proxies, add `ppq`                   |
+| `src/lib/canvas/GLSystem.ts`            | Remove `setSubdivisions` from clockCommand handler      |
+| `src/workers/rendering/fboRenderer.ts`  | Replace subdivision getters with `subdiv`/`subdivPhase` |
+| `src/lib/js-runner/JSRunner.ts`         | Replace subdivision getters with `subdiv`/`subdivPhase` |
+| `src/stores/transport.store.ts`         | Remove `subdivisionsPerBeat` persistence                |
 
 ## Tick Math
 
 The denominator determines `ticksPerBeat = ppq * (4 / denominator)`:
+
 - 4/4: `192 * (4/4) = 192` ticks/beat (quarter note beats)
 - 6/8: `192 * (4/8) = 96` ticks/beat (eighth note beats)
 - 3/2: `192 * (4/2) = 384` ticks/beat (half note beats)

--- a/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
+++ b/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
@@ -61,6 +61,7 @@ export const jsRunnerInstructions = `
 - clock.beat - beat in measure (0 to beatsPerBar-1)
 - clock.phase - position within current beat (0.0 to 1.0)
 - clock.bpm - tempo in BPM
+- clock.isPlaying - whether the global transport is currently playing
 - clock.bar - 0-indexed bar
 - clock.beatsPerBar - beats per bar (numerator)
 - clock.timeSignature - [numerator, denominator] tuple (e.g. [4, 4], [6, 8])
@@ -68,6 +69,7 @@ export const jsRunnerInstructions = `
 - clock.subdivPhase(n) - progress within current subdivision (0.0 to 1.0)
 - clock.play(), clock.pause(), clock.stop() - transport control
 - clock.setBpm(bpm), clock.setTimeSignature(num, denom), clock.seek(seconds)
+- clock.onPlayStateChange(cb) - fire when transport changes between 'playing', 'paused', and 'stopped'. cb receives (state, time)
 - clock.onBeat(beat, cb, opts?) - fire on beat (number, array, or '*' for all). cb receives (time). Pass { audio: true } for lookahead scheduling.
 - clock.schedule(time, cb, opts?) - One-shot at seconds or 'bar:beat:sixteenth' notation. Pass { audio: true } for audio-precise timing
 - clock.every(interval, cb, opts?) - Repeating at 'bar:beat:sixteenth' interval

--- a/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
+++ b/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
@@ -70,11 +70,11 @@ export const jsRunnerInstructions = `
 - clock.play(), clock.pause(), clock.stop() - transport control
 - clock.setBpm(bpm), clock.setTimeSignature(num, denom), clock.seek(seconds)
 - clock.onPlayStateChange(cb) - fire when transport changes between 'playing', 'paused', and 'stopped'. cb receives (state, time)
-- clock.onBeat(beat, cb, opts?) - fire on beat (number, array, or '*' for all). cb receives (time). Pass { audio: true } for lookahead scheduling.
+- clock.onBeat(beat, cb, opts?) - fire on beat (number, array, or '*' for all). cb receives (time); with { audio: true }, cb can receive (time, eventClock) where eventClock is the future clock at the scheduled beat.
 - clock.schedule(time, cb, opts?) - One-shot at seconds or 'bar:beat:sixteenth' notation. Pass { audio: true } for audio-precise timing
 - clock.every(interval, cb, opts?) - Repeating at 'bar:beat:sixteenth' interval
   - e.g. '1:0:0' = every bar, '0:1:0' = every beat
-  - Pass { audio: true } for audio-precise timing
+  - Pass { audio: true } for audio-precise timing; cb can receive (time, eventClock) where eventClock is the future clock at the scheduled repeat
 - clock.cancel(id), clock.cancelAll() - Cancel scheduled callbacks
 - clock.setTimelineStyle({ color?, visible? }) - Customize this node's appearance in the timeline (color: CSS color string, visible: false to hide)
 - For full clock docs call get_doc_content({ kind: 'topic', slug: 'clock-api' })

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -785,6 +785,13 @@ const memberCompletions: Record<string, Completion[]> = {
       apply: 'bpm'
     },
     {
+      label: 'isPlaying',
+      type: 'property',
+      detail: 'boolean',
+      info: 'Whether the global transport is currently playing.',
+      apply: 'isPlaying'
+    },
+    {
       label: 'bar',
       type: 'property',
       detail: 'number',
@@ -869,6 +876,13 @@ const memberCompletions: Record<string, Completion[]> = {
       detail: '(time: number | string, callback, options?) => id',
       info: "Schedule a one-shot callback. Accepts seconds or 'bar:beat:sixteenth' notation (zero-indexed).",
       apply: "schedule('4:0:0', () => {\n  \n})"
+    },
+    {
+      label: 'onPlayStateChange',
+      type: 'method',
+      detail: "(callback: (state: 'playing' | 'paused' | 'stopped', time: number) => void) => id",
+      info: 'Subscribe to transport play state changes. Callback receives the new state and current transport time.',
+      apply: 'onPlayStateChange((state, time) => {\n  \n})'
     },
     {
       label: 'cancel',

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -860,15 +860,15 @@ const memberCompletions: Record<string, Completion[]> = {
       label: 'onBeat',
       type: 'method',
       detail: "(beat: number | number[] | '*', callback, options?) => id",
-      info: "Subscribe to beat changes. beat can be index, array of indices, or '*' for every beat.",
-      apply: 'onBeat(0, () => {\n  \n})'
+      info: 'Subscribe to beat changes. With { audio: true }, callback can receive (time, eventClock) for the future beat.',
+      apply: 'onBeat(0, (time) => {\n  \n})'
     },
     {
       label: 'every',
       type: 'method',
       detail: "('bar:beat:sixteenth', callback, options?) => id",
-      info: "Schedule a repeating callback at a musical interval. E.g. '1:0:0' = every bar, '0:1:0' = every beat.",
-      apply: "every('0:1:0', () => {\n  \n})"
+      info: 'Schedule a repeating callback at a musical interval. With { audio: true }, callback can receive (time, eventClock) for the future repeat.',
+      apply: "every('0:1:0', (time) => {\n  \n})"
     },
     {
       label: 'schedule',

--- a/ui/src/lib/js-runner/JSRunner.ts
+++ b/ui/src/lib/js-runner/JSRunner.ts
@@ -8,7 +8,7 @@ import { handleCodeError } from './handleCodeError';
 import { logger } from '$lib/utils/logger';
 import { createKVStore } from '$lib/storage';
 import { Transport } from '$lib/transport';
-import { LookaheadClockScheduler } from '$lib/transport/ClockScheduler';
+import { LookaheadClockScheduler, type ClockState } from '$lib/transport/ClockScheduler';
 import { SchedulerRegistry } from '$lib/transport/SchedulerRegistry';
 import type { FBOFormat } from '$lib/rendering/types';
 
@@ -30,7 +30,7 @@ export interface JSRunnerOptions {
   /** Skip MessageContext setup - use when caller manages their own MessageContext */
   skipMessageContext?: boolean;
 
-  /** Called when clock.onBeat() or clock.every() is registered — used to show active indicator */
+  /** Called when clock scheduler listeners are registered — used to show active indicator */
   onSchedulerCallbackRegistered?: () => void;
 }
 
@@ -41,8 +41,9 @@ export class JSRunner {
 
   public moduleProviderUrl = `https://esm.sh/`;
   public modules: Map<string, string> = new Map();
+
   private messageContextMap: Map<string, MessageContext> = new Map();
-  private schedulerMap: Map<string, LookaheadClockScheduler> = new Map();
+  private lookaheadClockSchedulerMap: Map<string, LookaheadClockScheduler> = new Map();
 
   /** Avoid collision caused by multiple nodes having same library names. */
   private libraryNamesByNode: Map<string, string> = new Map();
@@ -264,31 +265,36 @@ export class JSRunner {
 
   /**
    * Get or create a look-ahead clock scheduler for a node.
+   *
    * Schedulers persist across code executions but are cleaned up when the node is destroyed.
    * Each scheduler self-ticks via setInterval (~25ms) — no external tick loop needed.
    */
-  getScheduler(nodeId: string): LookaheadClockScheduler {
-    if (!this.schedulerMap.has(nodeId)) {
+  getLookaheadClockScheduler(nodeId: string): LookaheadClockScheduler {
+    if (!this.lookaheadClockSchedulerMap.has(nodeId)) {
+      const clockStateProvider = (): ClockState => ({
+        time: Transport.seconds,
+        beat: Transport.beat,
+        bpm: Transport.bpm,
+        isPlaying: Transport.isPlaying,
+        playState: Transport.isPlaying ? 'playing' : Transport.seconds === 0 ? 'stopped' : 'paused',
+        phase: Transport.phase,
+        beatsPerBar: Transport.beatsPerBar
+      });
+
       const scheduler = new LookaheadClockScheduler(
-        () => ({
-          time: Transport.seconds,
-          beat: Transport.beat,
-          bpm: Transport.bpm,
-          phase: Transport.phase,
-          beatsPerBar: Transport.beatsPerBar
-        }),
+        clockStateProvider,
         25,
         0.1,
         logger.ofNode(nodeId)
       );
 
       scheduler.start();
-      this.schedulerMap.set(nodeId, scheduler);
 
+      this.lookaheadClockSchedulerMap.set(nodeId, scheduler);
       SchedulerRegistry.getInstance().register(nodeId, scheduler);
     }
 
-    return this.schedulerMap.get(nodeId)!;
+    return this.lookaheadClockSchedulerMap.get(nodeId)!;
   }
 
   destroy(nodeId: string): void {
@@ -308,11 +314,11 @@ export class JSRunner {
     this.messageContextMap.delete(nodeId);
 
     // Clean up scheduler (stops interval + cancels all callbacks)
-    const scheduler = this.schedulerMap.get(nodeId);
+    const scheduler = this.lookaheadClockSchedulerMap.get(nodeId);
     if (scheduler) {
       SchedulerRegistry.getInstance().unregister(nodeId);
       scheduler.dispose();
-      this.schedulerMap.delete(nodeId);
+      this.lookaheadClockSchedulerMap.delete(nodeId);
     }
 
     revokeObjectUrls(nodeId);
@@ -379,13 +385,14 @@ export class JSRunner {
     // Set up error handler for recv() callbacks
     if (!skipMessageContext) {
       const messageContext = this.getMessageContext(nodeId);
+
       messageContext.onCallbackError = (error) => {
         handleCodeError(error, code, nodeId, customConsole);
       };
     }
 
     // Set up clock scheduler - cancel previous callbacks before executing new code
-    const scheduler = this.getScheduler(nodeId);
+    const scheduler = this.getLookaheadClockScheduler(nodeId);
     scheduler.cancelAll();
 
     const functionParams = [
@@ -429,6 +436,9 @@ export class JSRunner {
       get bpm() {
         return Transport.bpm;
       },
+      get isPlaying() {
+        return Transport.isPlaying;
+      },
       get bar() {
         return Transport.bar;
       },
@@ -464,12 +474,19 @@ export class JSRunner {
       // Scheduling methods
       onBeat: (...args: Parameters<typeof scheduler.onBeat>) => {
         onSchedulerCallbackRegistered?.();
+
         return scheduler.onBeat(...args);
       },
       schedule: scheduler.schedule.bind(scheduler),
       every: (...args: Parameters<typeof scheduler.every>) => {
         onSchedulerCallbackRegistered?.();
+
         return scheduler.every(...args);
+      },
+      onPlayStateChange: (...args: Parameters<typeof scheduler.onPlayStateChange>) => {
+        onSchedulerCallbackRegistered?.();
+
+        return scheduler.onPlayStateChange(...args);
       },
       cancel: scheduler.cancel.bind(scheduler),
       cancelAll: scheduler.cancelAll.bind(scheduler),

--- a/ui/src/lib/transport/ClockScheduler.ts
+++ b/ui/src/lib/transport/ClockScheduler.ts
@@ -98,13 +98,16 @@ type ClockWithScheduler = {
 };
 
 // Shared internal types used by both scheduler implementations
-export type BeatCallback = {
+export interface BeatCallback {
   beats: number[] | '*';
   callback: SchedulerCallback;
   audio: boolean;
+
   lastFiredBeatTime?: number;
-};
-export type ScheduleCallback = {
+  lastFiredBeatIndex?: number;
+}
+
+export interface ScheduleCallback {
   time: number;
   callback: SchedulerCallback;
   fired: boolean;
@@ -112,7 +115,8 @@ export type ScheduleCallback = {
 
   /** BPM at registration time (set when time came from bar:beat:sixteenth notation). */
   bpm?: number;
-};
+}
+
 export type RepeatCallback = {
   interval: number;
   lastFired: number;

--- a/ui/src/lib/transport/ClockScheduler.ts
+++ b/ui/src/lib/transport/ClockScheduler.ts
@@ -12,9 +12,6 @@
  * - Workers (PollingClockScheduler): Frame-based polling (~16ms precision), audio flag accepted but no lookahead
  */
 
-/** Callback that receives the precise transport time of the event. */
-export type SchedulerCallback = (time: number) => void;
-
 /** Transport play state exposed to clock event listeners. */
 export type ClockPlayState = 'playing' | 'paused' | 'stopped';
 
@@ -35,6 +32,8 @@ export interface SchedulerOptions {
 /**
  * Clock scheduler interface for beat-synced callbacks.
  * All callbacks receive a `time` argument — the precise transport time of the event.
+ * Audio lookahead `onBeat` and `every` callbacks may also receive a future
+ * clock snapshot for the scheduled event as their second argument.
  */
 export interface ClockScheduler {
   /**
@@ -98,6 +97,12 @@ export interface ClockState {
   phase?: number;
   beatsPerBar?: number;
 }
+
+/**
+ * Callback that receives the precise transport time of the event.
+ * Audio lookahead callbacks may receive a future clock snapshot as context.
+ */
+export type SchedulerCallback = (time: number, clock?: ClockState) => void;
 
 type ClockWithScheduler = {
   readonly time: number;

--- a/ui/src/lib/transport/ClockScheduler.ts
+++ b/ui/src/lib/transport/ClockScheduler.ts
@@ -15,6 +15,12 @@
 /** Callback that receives the precise transport time of the event. */
 export type SchedulerCallback = (time: number) => void;
 
+/** Transport play state exposed to clock event listeners. */
+export type ClockPlayState = 'playing' | 'paused' | 'stopped';
+
+/** Callback that receives the new transport play state and current transport time. */
+export type PlayStateCallback = (state: ClockPlayState, time: number) => void;
+
 /** Options for scheduling methods. */
 export interface SchedulerOptions {
   /**
@@ -63,6 +69,13 @@ export interface ClockScheduler {
   every(interval: string, callback: SchedulerCallback, options?: SchedulerOptions): string;
 
   /**
+   * Subscribe to transport play state changes.
+   * @param callback - Function to call when play state changes. Receives (state, time).
+   * @returns ID for cancellation
+   */
+  onPlayStateChange(callback: PlayStateCallback): string;
+
+  /**
    * Cancel a scheduled callback by its ID.
    */
   cancel(id: string): void;
@@ -80,6 +93,8 @@ export interface ClockState {
   time: number;
   beat: number;
   bpm: number;
+  isPlaying?: boolean;
+  playState?: ClockPlayState;
   phase?: number;
   beatsPerBar?: number;
 }
@@ -90,9 +105,11 @@ type ClockWithScheduler = {
   readonly beat: number;
   readonly phase: number;
   readonly bpm: number;
+  readonly isPlaying: boolean;
   onBeat: ClockScheduler['onBeat'];
   schedule: ClockScheduler['schedule'];
   every: ClockScheduler['every'];
+  onPlayStateChange: ClockScheduler['onPlayStateChange'];
   cancel: ClockScheduler['cancel'];
   cancelAll: ClockScheduler['cancelAll'];
 };
@@ -125,10 +142,21 @@ export type RepeatCallback = {
   audio: boolean;
 };
 
+export type PlayStateChangeCallback = {
+  callback: PlayStateCallback;
+};
+
 let idCounter = 0;
 
 export function generateId(): string {
   return `sched_${++idCounter}_${Date.now()}`;
+}
+
+export function getClockPlayState(clock: ClockState): ClockPlayState {
+  if (clock.playState) return clock.playState;
+  if (clock.isPlaying) return 'playing';
+
+  return clock.time === 0 ? 'stopped' : 'paused';
 }
 
 /**
@@ -175,7 +203,8 @@ export const createClockWithScheduler = (
   getBeat: () => number,
   getPhase: () => number,
   getBpm: () => number,
-  scheduler: ClockScheduler
+  scheduler: ClockScheduler,
+  getIsPlaying: () => boolean = () => false
 ): ClockWithScheduler => ({
   get time() {
     return getTime();
@@ -192,9 +221,13 @@ export const createClockWithScheduler = (
   get bpm() {
     return getBpm();
   },
+  get isPlaying() {
+    return getIsPlaying();
+  },
   onBeat: scheduler.onBeat.bind(scheduler),
   schedule: scheduler.schedule.bind(scheduler),
   every: scheduler.every.bind(scheduler),
+  onPlayStateChange: scheduler.onPlayStateChange.bind(scheduler),
   cancel: scheduler.cancel.bind(scheduler),
   cancelAll: scheduler.cancelAll.bind(scheduler)
 });

--- a/ui/src/lib/transport/LookaheadClockScheduler.test.ts
+++ b/ui/src/lib/transport/LookaheadClockScheduler.test.ts
@@ -39,7 +39,43 @@ describe('LookaheadClockScheduler', () => {
     scheduler.stop();
 
     expect(callback).toHaveBeenCalledTimes(1);
-    expect(callback).toHaveBeenCalledWith(expect.closeTo(0.5, 6));
+    expect(callback).toHaveBeenCalledWith(expect.closeTo(0.5, 6), expect.any(Object));
+  });
+
+  it('passes the future clock to audio beat callbacks', () => {
+    vi.useFakeTimers();
+
+    const clock: ClockState = {
+      time: 0.41,
+      beat: 0,
+      bpm: 120,
+      phase: 0.82,
+      beatsPerBar: 4,
+      isPlaying: true,
+      playState: 'playing'
+    };
+
+    const callback = vi.fn();
+    const scheduler = new LookaheadClockScheduler(() => clock, 25, 0.1, { error: vi.fn() });
+
+    scheduler.onBeat('*', callback, { audio: true });
+    scheduler.start();
+    vi.advanceTimersByTime(25);
+    scheduler.stop();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(
+      expect.closeTo(0.5, 6),
+      expect.objectContaining({
+        time: expect.closeTo(0.5, 6),
+        beat: 1,
+        bpm: 120,
+        phase: 0,
+        beatsPerBar: 4,
+        isPlaying: true,
+        playState: 'playing'
+      })
+    );
   });
 
   it('fires an audio beat callback again after transport rewinds before that beat', () => {
@@ -82,8 +118,8 @@ describe('LookaheadClockScheduler', () => {
     scheduler.stop();
 
     expect(callback).toHaveBeenCalledTimes(2);
-    expect(callback).toHaveBeenNthCalledWith(1, expect.closeTo(0.5, 6));
-    expect(callback).toHaveBeenNthCalledWith(2, expect.closeTo(0.5, 6));
+    expect(callback).toHaveBeenNthCalledWith(1, expect.closeTo(0.5, 6), expect.any(Object));
+    expect(callback).toHaveBeenNthCalledWith(2, expect.closeTo(0.5, 6), expect.any(Object));
   });
 
   it('fires an audio every callback once while polling before the scheduled time', () => {
@@ -117,7 +153,43 @@ describe('LookaheadClockScheduler', () => {
     scheduler.stop();
 
     expect(callback).toHaveBeenCalledTimes(1);
-    expect(callback).toHaveBeenCalledWith(expect.closeTo(0.5, 6));
+    expect(callback).toHaveBeenCalledWith(expect.closeTo(0.5, 6), expect.any(Object));
+  });
+
+  it('passes the future clock to audio every callbacks', () => {
+    vi.useFakeTimers();
+
+    const clock: ClockState = {
+      time: 0.05,
+      beat: 0,
+      bpm: 120,
+      phase: 0.1,
+      beatsPerBar: 4,
+      isPlaying: true,
+      playState: 'playing'
+    };
+
+    const callback = vi.fn();
+    const scheduler = new LookaheadClockScheduler(() => clock, 25, 0.1, { error: vi.fn() });
+
+    scheduler.every('0:0:1', callback, { audio: true });
+    scheduler.start();
+    vi.advanceTimersByTime(25);
+    scheduler.stop();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(
+      expect.closeTo(0.125, 6),
+      expect.objectContaining({
+        time: expect.closeTo(0.125, 6),
+        beat: 0,
+        bpm: 120,
+        phase: 0.25,
+        beatsPerBar: 4,
+        isPlaying: true,
+        playState: 'playing'
+      })
+    );
   });
 
   it('fires play state change callbacks only when the play state changes', () => {

--- a/ui/src/lib/transport/LookaheadClockScheduler.test.ts
+++ b/ui/src/lib/transport/LookaheadClockScheduler.test.ts
@@ -85,4 +85,38 @@ describe('LookaheadClockScheduler', () => {
     expect(callback).toHaveBeenNthCalledWith(1, expect.closeTo(0.5, 6));
     expect(callback).toHaveBeenNthCalledWith(2, expect.closeTo(0.5, 6));
   });
+
+  it('fires an audio every callback once while polling before the scheduled time', () => {
+    vi.useFakeTimers();
+
+    let clock: ClockState = {
+      time: 0.41,
+      beat: 0,
+      bpm: 120,
+      phase: 0.82,
+      beatsPerBar: 4
+    };
+
+    const callback = vi.fn();
+    const scheduler = new LookaheadClockScheduler(() => clock, 25, 0.1, { error: vi.fn() });
+
+    scheduler.every('0:1:0', callback, { audio: true });
+    scheduler.start();
+
+    const pollsBeforeScheduledTime: ClockState[] = [
+      clock,
+      { time: 0.435, beat: 0, bpm: 120, phase: 0.87, beatsPerBar: 4 },
+      { time: 0.46, beat: 0, bpm: 120, phase: 0.92, beatsPerBar: 4 }
+    ];
+
+    for (const pollState of pollsBeforeScheduledTime) {
+      clock = pollState;
+      vi.advanceTimersByTime(25);
+    }
+
+    scheduler.stop();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(expect.closeTo(0.5, 6));
+  });
 });

--- a/ui/src/lib/transport/LookaheadClockScheduler.test.ts
+++ b/ui/src/lib/transport/LookaheadClockScheduler.test.ts
@@ -41,4 +41,48 @@ describe('LookaheadClockScheduler', () => {
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback).toHaveBeenCalledWith(expect.closeTo(0.5, 6));
   });
+
+  it('fires an audio beat callback again after transport rewinds before that beat', () => {
+    vi.useFakeTimers();
+
+    let clock: ClockState = {
+      time: 0.41,
+      beat: 0,
+      bpm: 120,
+      phase: 0.82,
+      beatsPerBar: 4
+    };
+
+    const callback = vi.fn();
+    const scheduler = new LookaheadClockScheduler(() => clock, 25, 0.1, { error: vi.fn() });
+
+    scheduler.onBeat('*', callback, { audio: true });
+    scheduler.start();
+
+    vi.advanceTimersByTime(25);
+
+    clock = {
+      time: 0.2,
+      beat: 0,
+      bpm: 120,
+      phase: 0.4,
+      beatsPerBar: 4
+    };
+    vi.advanceTimersByTime(25);
+
+    clock = {
+      time: 0.41,
+      beat: 0,
+      bpm: 120,
+      phase: 0.82,
+      beatsPerBar: 4
+    };
+    vi.advanceTimersByTime(25);
+
+    scheduler.stop();
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenNthCalledWith(1, expect.closeTo(0.5, 6));
+    expect(callback).toHaveBeenNthCalledWith(2, expect.closeTo(0.5, 6));
+  });
 });

--- a/ui/src/lib/transport/LookaheadClockScheduler.test.ts
+++ b/ui/src/lib/transport/LookaheadClockScheduler.test.ts
@@ -119,4 +119,71 @@ describe('LookaheadClockScheduler', () => {
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback).toHaveBeenCalledWith(expect.closeTo(0.5, 6));
   });
+
+  it('fires play state change callbacks only when the play state changes', () => {
+    vi.useFakeTimers();
+
+    let clock: ClockState = {
+      time: 0,
+      beat: 0,
+      bpm: 120,
+      isPlaying: false,
+      playState: 'stopped'
+    };
+
+    const callback = vi.fn();
+    const scheduler = new LookaheadClockScheduler(() => clock, 25, 0.1, { error: vi.fn() });
+
+    scheduler.onPlayStateChange(callback);
+    scheduler.start();
+
+    vi.advanceTimersByTime(25);
+
+    clock = { ...clock, time: 0.25, isPlaying: true, playState: 'playing' };
+    vi.advanceTimersByTime(25);
+
+    clock = { ...clock, time: 0.5 };
+    vi.advanceTimersByTime(25);
+
+    clock = { ...clock, time: 0.5, isPlaying: false, playState: 'paused' };
+    vi.advanceTimersByTime(25);
+
+    clock = { ...clock, time: 0, playState: 'stopped' };
+    vi.advanceTimersByTime(25);
+
+    scheduler.stop();
+
+    expect(callback).toHaveBeenCalledTimes(3);
+    expect(callback).toHaveBeenNthCalledWith(1, 'playing', 0.25);
+    expect(callback).toHaveBeenNthCalledWith(2, 'paused', 0.5);
+    expect(callback).toHaveBeenNthCalledWith(3, 'stopped', 0);
+  });
+
+  it('cancels play state change callbacks by id', () => {
+    vi.useFakeTimers();
+
+    let clock: ClockState = {
+      time: 0,
+      beat: 0,
+      bpm: 120,
+      isPlaying: false,
+      playState: 'stopped'
+    };
+
+    const callback = vi.fn();
+    const scheduler = new LookaheadClockScheduler(() => clock, 25, 0.1, { error: vi.fn() });
+    const id = scheduler.onPlayStateChange(callback);
+
+    scheduler.start();
+    vi.advanceTimersByTime(25);
+
+    scheduler.cancel(id);
+
+    clock = { ...clock, time: 0.25, isPlaying: true, playState: 'playing' };
+    vi.advanceTimersByTime(25);
+
+    scheduler.stop();
+
+    expect(callback).not.toHaveBeenCalled();
+  });
 });

--- a/ui/src/lib/transport/LookaheadClockScheduler.test.ts
+++ b/ui/src/lib/transport/LookaheadClockScheduler.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { LookaheadClockScheduler } from './LookaheadClockScheduler';
+import type { ClockState } from './ClockScheduler';
+
+describe('LookaheadClockScheduler', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires an audio beat callback once for the same lookahead beat', () => {
+    vi.useFakeTimers();
+
+    let clock: ClockState = {
+      time: 0.41,
+      beat: 0,
+      bpm: 120,
+      phase: 0.82,
+      beatsPerBar: 4
+    };
+
+    const callback = vi.fn();
+    const scheduler = new LookaheadClockScheduler(() => clock, 25, 0.1, { error: vi.fn() });
+
+    scheduler.onBeat('*', callback, { audio: true });
+    scheduler.start();
+
+    const pollsForSameUpcomingBeat: ClockState[] = [
+      clock,
+      { time: 0.435, beat: 0, bpm: 120, phase: 0.869999, beatsPerBar: 4 },
+      { time: 0.46, beat: 0, bpm: 120, phase: 0.92, beatsPerBar: 4 }
+    ];
+
+    for (const pollState of pollsForSameUpcomingBeat) {
+      clock = pollState;
+      vi.advanceTimersByTime(25);
+    }
+
+    scheduler.stop();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(expect.closeTo(0.5, 6));
+  });
+});

--- a/ui/src/lib/transport/LookaheadClockScheduler.ts
+++ b/ui/src/lib/transport/LookaheadClockScheduler.ts
@@ -197,8 +197,10 @@ export class LookaheadClockScheduler implements ClockScheduler {
             item.beats === '*' || (Array.isArray(item.beats) && item.beats.includes(nextBeat));
 
           if (shouldFire && item.lastFiredBeatIndex !== nextBeatIndex) {
+            const futureClock = this.createFutureClock(clock, nextBeatTime);
+
             try {
-              item.callback(nextBeatTime);
+              item.callback(nextBeatTime, futureClock);
               this.recordFired(id, nextBeatTime);
             } catch (e) {
               this.nodeLog.error('[clock] onBeat audio callback error:', e);
@@ -259,7 +261,7 @@ export class LookaheadClockScheduler implements ClockScheduler {
 
       // Audio precision: lookahead with grid-aligned fire time
       if (item.audio && fireTime <= horizon) {
-        this.fireEveryCallback(item, id, fireTime);
+        this.fireEveryCallback(item, id, fireTime, this.createFutureClock(clock, fireTime));
       }
 
       // Non-audio precision: fire after the event
@@ -301,9 +303,36 @@ export class LookaheadClockScheduler implements ClockScheduler {
     }
   }
 
-  private fireEveryCallback(item: RepeatCallback, id: string, time: number) {
+  private createFutureClock(clock: ClockState, time: number): ClockState {
+    const beatDuration = 60 / clock.bpm;
+    const beatsPerBar = clock.beatsPerBar ?? 4;
+
+    if (!Number.isFinite(beatDuration) || beatDuration <= 0 || beatsPerBar <= 0) {
+      return { ...clock, time };
+    }
+
+    const rawAbsoluteBeat = time / beatDuration;
+    const nearestBeat = Math.round(rawAbsoluteBeat);
+
+    const absoluteBeat =
+      Math.abs(rawAbsoluteBeat - nearestBeat) < 1e-9 ? nearestBeat : rawAbsoluteBeat;
+
+    const beatIndex = Math.floor(absoluteBeat);
+    const phase = absoluteBeat - beatIndex;
+    const beat = ((beatIndex % beatsPerBar) + beatsPerBar) % beatsPerBar;
+
+    return {
+      ...clock,
+      time,
+      beat,
+      phase: Math.abs(phase) < 1e-9 ? 0 : phase,
+      beatsPerBar
+    };
+  }
+
+  private fireEveryCallback(item: RepeatCallback, id: string, time: number, clock?: ClockState) {
     try {
-      item.callback(time);
+      item.callback(time, clock);
       this.recordFired(id, time);
     } catch (e) {
       this.nodeLog.error('[clock] every callback error:', e);

--- a/ui/src/lib/transport/LookaheadClockScheduler.ts
+++ b/ui/src/lib/transport/LookaheadClockScheduler.ts
@@ -7,10 +7,14 @@
  */
 import {
   generateId,
+  getClockPlayState,
   parseBarBeatSixteenth,
   type BeatCallback,
   type ClockScheduler,
+  type ClockPlayState,
   type ClockState,
+  type PlayStateCallback,
+  type PlayStateChangeCallback,
   type RepeatCallback,
   type ScheduleCallback,
   type SchedulerCallback,
@@ -27,11 +31,13 @@ export class LookaheadClockScheduler implements ClockScheduler {
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private lastBeat = -1;
   private lastClockTime = 0;
+  private lastPlayState: ClockPlayState | null = null;
   private currentBpm = 120;
 
   private beatCallbacks = new Map<string, BeatCallback>();
   private scheduleCallbacks = new Map<string, ScheduleCallback>();
   private repeatCallbacks = new Map<string, RepeatCallback>();
+  private playStateCallbacks = new Map<string, PlayStateChangeCallback>();
 
   /** Ring buffer of recently-fired events for timeline visualization. */
   private firedEvents: FiredEventRecord[] = [];
@@ -146,6 +152,8 @@ export class LookaheadClockScheduler implements ClockScheduler {
 
     const horizon = clock.time + this.scheduleAheadS;
     const didRewind = clock.time < this.lastClockTime;
+
+    this.processPlayStateChange(clock);
 
     if (didRewind) {
       this.resetAudioBeatFireTracking();
@@ -263,6 +271,27 @@ export class LookaheadClockScheduler implements ClockScheduler {
     this.lastClockTime = clock.time;
   }
 
+  private processPlayStateChange(clock: ClockState): void {
+    const playState = getClockPlayState(clock);
+
+    if (this.lastPlayState === null) {
+      this.lastPlayState = playState;
+      return;
+    }
+
+    if (playState === this.lastPlayState) return;
+
+    this.lastPlayState = playState;
+
+    for (const { callback } of this.playStateCallbacks.values()) {
+      try {
+        callback(playState, clock.time);
+      } catch (e) {
+        this.nodeLog.error('[clock] onPlayStateChange callback error:', e);
+      }
+    }
+  }
+
   private resetAudioBeatFireTracking(): void {
     for (const item of this.beatCallbacks.values()) {
       if (!item.audio) continue;
@@ -327,18 +356,29 @@ export class LookaheadClockScheduler implements ClockScheduler {
     return id;
   }
 
+  onPlayStateChange(callback: PlayStateCallback): string {
+    const id = generateId();
+
+    this.playStateCallbacks.set(id, { callback });
+
+    return id;
+  }
+
   cancel(id: string): void {
     this.beatCallbacks.delete(id);
     this.scheduleCallbacks.delete(id);
     this.repeatCallbacks.delete(id);
+    this.playStateCallbacks.delete(id);
   }
 
   cancelAll(): void {
     this.beatCallbacks.clear();
     this.scheduleCallbacks.clear();
     this.repeatCallbacks.clear();
+    this.playStateCallbacks.clear();
     this.lastBeat = -1;
     this.lastClockTime = 0;
+    this.lastPlayState = null;
     this._timelineStyle = {};
   }
 }

--- a/ui/src/lib/transport/LookaheadClockScheduler.ts
+++ b/ui/src/lib/transport/LookaheadClockScheduler.ts
@@ -67,6 +67,7 @@ export class LookaheadClockScheduler implements ClockScheduler {
   dispose(): void {
     this.stop();
     this.cancelAll();
+
     this.markers.clear();
     this.firedEvents = [];
     this._timelineStyle = {};
@@ -89,6 +90,7 @@ export class LookaheadClockScheduler implements ClockScheduler {
   addMarker(time: number, color?: string): string {
     const id = generateId();
     this.markers.set(id, { time, color });
+
     return id;
   }
 
@@ -124,12 +126,14 @@ export class LookaheadClockScheduler implements ClockScheduler {
   drainFiredEvents(): FiredEventRecord[] {
     const events = this.firedEvents;
     this.firedEvents = [];
+
     return events;
   }
 
   /** Record that a callback fired (for timeline flash animation). */
   private recordFired(id: string, firedAt: number): void {
     this.firedEvents.push({ id, firedAt, wallTime: performance.now() });
+
     if (this.firedEvents.length > LookaheadClockScheduler.MAX_FIRED_BUFFER) {
       this.firedEvents.shift();
     }
@@ -145,6 +149,7 @@ export class LookaheadClockScheduler implements ClockScheduler {
     if (clock.beat !== this.lastBeat) {
       for (const [id, item] of this.beatCallbacks) {
         if (item.audio) continue;
+
         const shouldFire =
           item.beats === '*' || (Array.isArray(item.beats) && item.beats.includes(clock.beat));
 
@@ -165,23 +170,28 @@ export class LookaheadClockScheduler implements ClockScheduler {
     if (clock.phase != null && clock.beatsPerBar != null) {
       const beatDuration = 60 / clock.bpm;
       const timeUntilNextBeat = (1 - clock.phase) * beatDuration;
+
       const nextBeatTime = clock.time + timeUntilNextBeat;
+      const nextBeatIndex = Math.floor(clock.time / beatDuration) + 1;
       const nextBeat = (clock.beat + 1) % clock.beatsPerBar;
 
       if (nextBeatTime <= horizon) {
         for (const [id, item] of this.beatCallbacks) {
           if (!item.audio) continue;
+
           const shouldFire =
             item.beats === '*' || (Array.isArray(item.beats) && item.beats.includes(nextBeat));
 
-          if (shouldFire && item.lastFiredBeatTime !== nextBeatTime) {
+          if (shouldFire && item.lastFiredBeatIndex !== nextBeatIndex) {
             try {
               item.callback(nextBeatTime);
               this.recordFired(id, nextBeatTime);
             } catch (e) {
               this.nodeLog.error('[clock] onBeat audio callback error:', e);
             }
+
             item.lastFiredBeatTime = nextBeatTime;
+            item.lastFiredBeatIndex = nextBeatIndex;
           }
         }
       }
@@ -194,6 +204,7 @@ export class LookaheadClockScheduler implements ClockScheduler {
       // Recalculate time if BPM changed (only for musical notation times)
       if (item.bpm !== undefined && item.bpm !== clock.bpm) {
         const ratio = item.bpm / clock.bpm;
+
         item.time = item.time * ratio;
         item.bpm = clock.bpm;
       }
@@ -225,36 +236,34 @@ export class LookaheadClockScheduler implements ClockScheduler {
       // Recalculate interval if BPM changed
       if (item.bpm !== clock.bpm) {
         const ratio = item.bpm / clock.bpm;
+
         item.interval = item.interval * ratio;
         item.bpm = clock.bpm;
       }
 
       const fireTime = item.lastFired + item.interval;
 
-      if (item.audio) {
-        // Audio mode: lookahead with grid-aligned fire time
-        if (fireTime <= horizon) {
-          try {
-            item.callback(fireTime);
-            this.recordFired(id, fireTime);
-          } catch (e) {
-            this.nodeLog.error('[clock] every callback error:', e);
-          }
-          item.lastFired = fireTime;
-        }
-      } else {
-        // Visual mode: fire after the event
-        if (clock.time >= fireTime) {
-          try {
-            item.callback(clock.time);
-            this.recordFired(id, clock.time);
-          } catch (e) {
-            this.nodeLog.error('[clock] every callback error:', e);
-          }
-          item.lastFired = clock.time;
-        }
+      // Audio precision: lookahead with grid-aligned fire time
+      if (item.audio && fireTime <= horizon) {
+        this.fireEveryCallback(item, id, fireTime);
+      }
+
+      // Non-audio precision: fire after the event
+      if (!item.audio && clock.time >= fireTime) {
+        this.fireEveryCallback(item, id, clock.time);
       }
     }
+  }
+
+  fireEveryCallback(item: RepeatCallback, id: string, time: number) {
+    try {
+      item.callback(time);
+      this.recordFired(id, time);
+    } catch (e) {
+      this.nodeLog.error('[clock] every callback error:', e);
+    }
+
+    item.lastFired = time;
   }
 
   onBeat(
@@ -264,7 +273,9 @@ export class LookaheadClockScheduler implements ClockScheduler {
   ): string {
     const id = generateId();
     const beats = typeof beat === 'number' ? [beat] : beat;
+
     this.beatCallbacks.set(id, { beats, callback, audio: options?.audio ?? false });
+
     return id;
   }
 

--- a/ui/src/lib/transport/LookaheadClockScheduler.ts
+++ b/ui/src/lib/transport/LookaheadClockScheduler.ts
@@ -145,8 +145,9 @@ export class LookaheadClockScheduler implements ClockScheduler {
     this.currentBpm = clock.bpm;
 
     const horizon = clock.time + this.scheduleAheadS;
+    const didRewind = clock.time < this.lastClockTime;
 
-    if (clock.time < this.lastClockTime) {
+    if (didRewind) {
       this.resetAudioBeatFireTracking();
     }
 
@@ -234,7 +235,7 @@ export class LookaheadClockScheduler implements ClockScheduler {
     // --- every ---
     for (const [id, item] of this.repeatCallbacks) {
       // Detect transport rewind (stop -> play from beginning)
-      if (clock.time < item.lastFired) {
+      if (didRewind) {
         item.lastFired = 0;
       }
 

--- a/ui/src/lib/transport/LookaheadClockScheduler.ts
+++ b/ui/src/lib/transport/LookaheadClockScheduler.ts
@@ -26,6 +26,7 @@ export interface NodeTimelineStyle {
 export class LookaheadClockScheduler implements ClockScheduler {
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private lastBeat = -1;
+  private lastClockTime = 0;
   private currentBpm = 120;
 
   private beatCallbacks = new Map<string, BeatCallback>();
@@ -145,6 +146,10 @@ export class LookaheadClockScheduler implements ClockScheduler {
 
     const horizon = clock.time + this.scheduleAheadS;
 
+    if (clock.time < this.lastClockTime) {
+      this.resetAudioBeatFireTracking();
+    }
+
     // --- onBeat: visual mode (fire after beat change) ---
     if (clock.beat !== this.lastBeat) {
       for (const [id, item] of this.beatCallbacks) {
@@ -253,9 +258,20 @@ export class LookaheadClockScheduler implements ClockScheduler {
         this.fireEveryCallback(item, id, clock.time);
       }
     }
+
+    this.lastClockTime = clock.time;
   }
 
-  fireEveryCallback(item: RepeatCallback, id: string, time: number) {
+  private resetAudioBeatFireTracking(): void {
+    for (const item of this.beatCallbacks.values()) {
+      if (!item.audio) continue;
+
+      item.lastFiredBeatTime = undefined;
+      item.lastFiredBeatIndex = undefined;
+    }
+  }
+
+  private fireEveryCallback(item: RepeatCallback, id: string, time: number) {
     try {
       item.callback(time);
       this.recordFired(id, time);
@@ -321,6 +337,7 @@ export class LookaheadClockScheduler implements ClockScheduler {
     this.scheduleCallbacks.clear();
     this.repeatCallbacks.clear();
     this.lastBeat = -1;
+    this.lastClockTime = 0;
     this._timelineStyle = {};
   }
 }

--- a/ui/src/lib/transport/PollingClockScheduler.test.ts
+++ b/ui/src/lib/transport/PollingClockScheduler.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { PollingClockScheduler } from './PollingClockScheduler';
+import type { ClockState } from './ClockScheduler';
+
+describe('PollingClockScheduler', () => {
+  it('fires play state change callbacks from ticked clock state', () => {
+    const scheduler = new PollingClockScheduler();
+    const callback = vi.fn();
+    const stopped: ClockState = {
+      time: 0,
+      beat: 0,
+      bpm: 120,
+      isPlaying: false,
+      playState: 'stopped'
+    };
+
+    scheduler.onPlayStateChange(callback);
+    scheduler.tick(stopped);
+    scheduler.tick({ ...stopped, time: 0.25, isPlaying: true, playState: 'playing' });
+    scheduler.tick({ ...stopped, time: 0.5, isPlaying: false, playState: 'paused' });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenNthCalledWith(1, 'playing', 0.25);
+    expect(callback).toHaveBeenNthCalledWith(2, 'paused', 0.5);
+  });
+});

--- a/ui/src/lib/transport/PollingClockScheduler.ts
+++ b/ui/src/lib/transport/PollingClockScheduler.ts
@@ -4,10 +4,14 @@
  */
 import {
   generateId,
+  getClockPlayState,
   parseBarBeatSixteenth,
   type BeatCallback,
   type ClockScheduler,
   type ClockState,
+  type ClockPlayState,
+  type PlayStateChangeCallback,
+  type PlayStateCallback,
   type RepeatCallback,
   type ScheduleCallback,
   type SchedulerCallback,
@@ -16,17 +20,20 @@ import {
 
 export class PollingClockScheduler implements ClockScheduler {
   private lastBeat = -1;
+  private lastPlayState: ClockPlayState | null = null;
   private currentBpm = 120;
 
   private beatCallbacks = new Map<string, BeatCallback>();
   private scheduleCallbacks = new Map<string, ScheduleCallback>();
   private repeatCallbacks = new Map<string, RepeatCallback>();
+  private playStateCallbacks = new Map<string, PlayStateChangeCallback>();
 
   /**
    * Called each frame by the render loop to process scheduled callbacks.
    */
   tick(clock: ClockState): void {
     this.currentBpm = clock.bpm;
+    this.processPlayStateChange(clock);
 
     // Check beat changes
     if (clock.beat !== this.lastBeat) {
@@ -95,6 +102,27 @@ export class PollingClockScheduler implements ClockScheduler {
     }
   }
 
+  private processPlayStateChange(clock: ClockState): void {
+    const playState = getClockPlayState(clock);
+
+    if (this.lastPlayState === null) {
+      this.lastPlayState = playState;
+      return;
+    }
+
+    if (playState === this.lastPlayState) return;
+
+    this.lastPlayState = playState;
+
+    for (const { callback } of this.playStateCallbacks.values()) {
+      try {
+        callback(playState, clock.time);
+      } catch (e) {
+        console.error('[clock] onPlayStateChange callback error:', e);
+      }
+    }
+  }
+
   onBeat(
     beat: number | number[] | '*',
     callback: SchedulerCallback,
@@ -139,16 +167,27 @@ export class PollingClockScheduler implements ClockScheduler {
     return id;
   }
 
+  onPlayStateChange(callback: PlayStateCallback): string {
+    const id = generateId();
+
+    this.playStateCallbacks.set(id, { callback });
+
+    return id;
+  }
+
   cancel(id: string): void {
     this.beatCallbacks.delete(id);
     this.scheduleCallbacks.delete(id);
     this.repeatCallbacks.delete(id);
+    this.playStateCallbacks.delete(id);
   }
 
   cancelAll(): void {
     this.beatCallbacks.clear();
     this.scheduleCallbacks.clear();
     this.repeatCallbacks.clear();
+    this.playStateCallbacks.clear();
     this.lastBeat = -1;
+    this.lastPlayState = null;
   }
 }

--- a/ui/src/lib/transport/Transport.test.ts
+++ b/ui/src/lib/transport/Transport.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function stubLocalStorage(initialValues: Record<string, string> = {}) {
+  const items = new Map(Object.entries(initialValues));
+
+  vi.stubGlobal('localStorage', {
+    clear: () => items.clear(),
+    getItem: (key: string) => items.get(key) ?? null,
+    removeItem: (key: string) => items.delete(key),
+    setItem: (key: string, value: string) => items.set(key, value)
+  });
+}
+
+describe('Transport', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    stubLocalStorage();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('initializes bpm and time signature from persisted transport state', async () => {
+    stubLocalStorage({
+      'patchies:transport': JSON.stringify({
+        bpm: 96,
+        timeSignature: [7, 8]
+      })
+    });
+
+    const { Transport } = await import('./Transport');
+
+    expect(Transport.bpm).toBe(96);
+    expect(Transport.beatsPerBar).toBe(7);
+    expect(Transport.denominator).toBe(8);
+  });
+
+  it('keeps the clock source in sync when transport store settings change', async () => {
+    const { Transport } = await import('./Transport');
+    const { transportStore } = await import('../../stores/transport.store');
+
+    transportStore.setBpm(140);
+    transportStore.setTimeSignature(5, 4);
+
+    expect(Transport.bpm).toBe(140);
+    expect(Transport.beatsPerBar).toBe(5);
+    expect(Transport.denominator).toBe(4);
+  });
+});

--- a/ui/src/lib/transport/Transport.test.ts
+++ b/ui/src/lib/transport/Transport.test.ts
@@ -47,4 +47,16 @@ describe('Transport', () => {
     expect(Transport.beatsPerBar).toBe(5);
     expect(Transport.denominator).toBe(4);
   });
+
+  it('stops syncing transport store settings after destroy', async () => {
+    const { Transport } = await import('./Transport');
+    const { transportStore } = await import('../../stores/transport.store');
+
+    Transport.destroy();
+    transportStore.setBpm(150);
+    transportStore.setTimeSignature(3, 4);
+
+    expect(Transport.bpm).not.toBe(150);
+    expect(Transport.beatsPerBar).not.toBe(3);
+  });
 });

--- a/ui/src/lib/transport/Transport.ts
+++ b/ui/src/lib/transport/Transport.ts
@@ -14,6 +14,25 @@ class TransportManager implements ITransport {
   private toneUpgraded = false;
   private toneUpgradeDisabled = false;
 
+  constructor() {
+    this.syncTransportWithStore();
+  }
+
+  /** Syncs BPM and time signature with store */
+  private syncTransportWithStore() {
+    transportStore.subscribe(({ bpm, timeSignature }) => {
+      if (this.context.bpm !== bpm) {
+        this.context.setBpm(bpm);
+      }
+
+      const [beatsPerBar, denominator] = timeSignature;
+
+      if (this.context.beatsPerBar !== beatsPerBar || this.context.denominator !== denominator) {
+        this.context.setTimeSignature(beatsPerBar, denominator);
+      }
+    });
+  }
+
   // Proxy all reads to current implementation
   get seconds(): number {
     return this.context.seconds;

--- a/ui/src/lib/transport/Transport.ts
+++ b/ui/src/lib/transport/Transport.ts
@@ -10,6 +10,7 @@ import { transportStore } from '../../stores/transport.store';
  */
 class TransportManager implements ITransport {
   private context: ITransport = new DefaultTransport();
+  private unsubscribeStore: (() => void) | null = null;
 
   private toneUpgraded = false;
   private toneUpgradeDisabled = false;
@@ -20,7 +21,7 @@ class TransportManager implements ITransport {
 
   /** Syncs BPM and time signature with store */
   private syncTransportWithStore() {
-    transportStore.subscribe(({ bpm, timeSignature }) => {
+    this.unsubscribeStore = transportStore.subscribe(({ bpm, timeSignature }) => {
       if (this.context.bpm !== bpm) {
         this.context.setBpm(bpm);
       }
@@ -31,6 +32,11 @@ class TransportManager implements ITransport {
         this.context.setTimeSignature(beatsPerBar, denominator);
       }
     });
+  }
+
+  destroy(): void {
+    this.unsubscribeStore?.();
+    this.unsubscribeStore = null;
   }
 
   // Proxy all reads to current implementation

--- a/ui/src/lib/transport/Transport.ts
+++ b/ui/src/lib/transport/Transport.ts
@@ -119,6 +119,7 @@ class TransportManager implements ITransport {
       ticks: this.ticks,
       bpm: this.bpm,
       isPlaying: this.isPlaying,
+      playState: this.isPlaying ? 'playing' : this.seconds === 0 ? 'stopped' : 'paused',
       beat: this.beat,
       phase: this.phase,
       bar: this.bar,

--- a/ui/src/lib/transport/types.ts
+++ b/ui/src/lib/transport/types.ts
@@ -37,6 +37,7 @@ export interface TransportState {
   ticks: number;
   bpm: number;
   isPlaying: boolean;
+  playState: 'playing' | 'paused' | 'stopped';
   beat: number;
   phase: number;
   bar: number;

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -10,7 +10,7 @@ import type {
   FBOFormat,
   FBOResolution
 } from '../../lib/rendering/types';
-import type { ClockCommandMessage, ITransport, TransportState } from '$lib/transport/types';
+import type { ClockCommandMessage, TransportState } from '$lib/transport/types';
 import {
   DEFAULT_OUTPUT_SIZE,
   WEBGL_EXTENSIONS,
@@ -57,13 +57,11 @@ import {
   toGLValue
 } from './glUniformUtils';
 import type { WorkerSettingsProxy } from '../shared/workerSettingsProxy';
-import { CookStateManager, type CookPolicy } from './CookStateManager';
+import { CookStateManager } from './CookStateManager';
 import { createGlslCookPolicy } from './cooking/glsl';
 import { createRenderNodeCookPolicy } from './cooking/policies';
 import { isSameMouseData, type MouseData } from './mouseData';
 import { getViewportCookRequiredNodeIds, shouldSkipCookForViewport } from './renderEligibility';
-
-type TransportTimeState = Pick<ITransport, keyof TransportState>;
 
 interface MessageCapableRenderer {
   handleMessage(message: Message): void;
@@ -168,7 +166,7 @@ export class FBORenderer {
   private lastRenderTime: number = 0;
 
   /** Transport time from main thread for synchronized timing */
-  public transportTime: TransportTimeState | null = null;
+  public transportTime: TransportState | null = null;
 
   /** Profiler for frame timing and regl.read() metrics */
   public profiler = new RenderingProfiler();
@@ -1442,7 +1440,7 @@ export class FBORenderer {
    * Set transport time from main thread for synchronized timing.
    * Called at 60fps to keep GLSL/Hydra in sync with global transport.
    */
-  setTransportTime(state: TransportTimeState) {
+  setTransportTime(state: TransportState) {
     this.transportTime = state;
   }
 
@@ -1559,7 +1557,9 @@ export class FBORenderer {
     const clockState: ClockState = {
       time: this.transportTime?.seconds ?? this.lastTime,
       beat: this.transportTime?.beat ?? -1,
-      bpm: this.transportTime?.bpm ?? 120
+      bpm: this.transportTime?.bpm ?? 120,
+      isPlaying: this.transportTime?.isPlaying ?? true,
+      playState: this.transportTime?.playState ?? 'playing'
     };
 
     this.clockScheduler.tick(clockState);
@@ -2469,6 +2469,9 @@ export class FBORenderer {
       get bpm() {
         return renderer.transportTime?.bpm ?? 120;
       },
+      get isPlaying() {
+        return renderer.transportTime?.isPlaying ?? true;
+      },
       get bar() {
         return renderer.transportTime?.bar ?? 0;
       },
@@ -2510,6 +2513,7 @@ export class FBORenderer {
       onBeat: scheduler.onBeat.bind(scheduler),
       schedule: scheduler.schedule.bind(scheduler),
       every: scheduler.every.bind(scheduler),
+      onPlayStateChange: scheduler.onPlayStateChange.bind(scheduler),
       cancel: scheduler.cancel.bind(scheduler),
       cancelAll: scheduler.cancelAll.bind(scheduler)
     };

--- a/ui/static/content/topics/clock-api.md
+++ b/ui/static/content/topics/clock-api.md
@@ -157,7 +157,7 @@ fill(colors[clock.subdiv(5)]);
 
 Instead of manually tracking beat changes, use these scheduling methods for cleaner code. All scheduling callbacks receive a `time` argument — the precise transport time of the event.
 
-By default, callbacks fire **after** the event — ideal for visuals. Pass `{ audio: true }` as the last argument for **lookahead scheduling**, where callbacks fire ~100ms early with the precise time for Web Audio API scheduling.
+By default, callbacks fire **after** the event — ideal for visuals. Pass `{ audio: true }` as the last argument for **lookahead scheduling**, where callbacks fire ~100ms early with the precise time for Web Audio API scheduling. Audio `onBeat` and `every` callbacks can also receive `eventClock` as a second argument, with `time`, `beat`, and `phase` computed for the scheduled event instead of the current poll.
 
 ### onBeat
 
@@ -175,8 +175,11 @@ clock.onBeat([0, 2], () => snare()); // beats 1 and 3
 clock.onBeat('*', () => hihat());
 
 // Audio-precise scheduling — fires early with precise time
-clock.onBeat(0, (time) => {
+clock.onBeat(0, (time, eventClock) => {
   oscillator.start(time);
+
+  // eventClock.beat and eventClock.phase describe the future beat
+  send({ type: 'downbeat', beat: eventClock.beat, time: eventClock.time });
 }, { audio: true });
 ```
 
@@ -211,12 +214,13 @@ clock.every('0:1:0', () => pulse());    // every beat
 clock.every('0:0:1', () => tick());     // every sixteenth
 
 // Audio-precise repeating — fires early with grid-aligned time
-clock.every('0:1:0', (time) => {
+clock.every('0:1:0', (time, eventClock) => {
   send({
     type: 'trigger',
     values: { peak: 1, sustain: 0.7 },
     attack: 0.01,
     decay: 0.1,
+    beat: eventClock.beat,
     time
   });
 }, { audio: true });

--- a/ui/static/content/topics/clock-api.md
+++ b/ui/static/content/topics/clock-api.md
@@ -15,6 +15,7 @@ The `clock` object is available in: [js](/docs/objects/js), [worker](/docs/objec
 | `clock.beat` | number | Current beat in measure (0 to beatsPerBar-1) |
 | `clock.phase` | number | Position within current beat (0.0 to 1.0) |
 | `clock.bpm` | number | Current tempo in BPM |
+| `clock.isPlaying` | boolean | Whether the global transport is currently playing |
 | `clock.bar` | number | Current bar (0-indexed) |
 | `clock.beatsPerBar` | number | Beats per bar (default: 4) |
 | `clock.timeSignature` | [number, number] | Time signature: [6, 8] is 6/8 |
@@ -34,6 +35,11 @@ circle(width/2, height/2, 50 * pulse);
 // Use clock.beat to change on each beat
 const colors = ['red', 'blue', 'green', 'yellow'];
 fill(colors[clock.beat]);
+
+// Gate animation while the transport is stopped
+if (clock.isPlaying) {
+  circle(width / 2, height / 2, 40 + clock.phase * 20);
+}
 ```
 
 ## Control Methods
@@ -48,6 +54,29 @@ Control the transport directly from your code:
 | `clock.setBpm(bpm)` | Set tempo |
 | `clock.setTimeSignature(n, d)` | Set time signature (e.g., `6, 8` for 6/8) |
 | `clock.seek(seconds)` | Seek to time in seconds |
+
+## Play State Events
+
+Use `clock.onPlayStateChange()` when your code needs to react once to play, pause, or stop instead of checking `clock.isPlaying` every frame.
+
+```javascript
+const id = clock.onPlayStateChange((state, time) => {
+  if (state === 'playing') {
+    send({ type: 'started', time });
+  }
+
+  if (state === 'paused') {
+    send({ type: 'paused', time });
+  }
+
+  if (state === 'stopped') {
+    send({ type: 'reset' });
+  }
+});
+
+// Remove the listener later if you no longer need it
+clock.cancel(id);
+```
 
 ### Transport Control Example
 


### PR DESCRIPTION
Fixes broken look-ahead scheduler timing on global transport

### Checklist

- [x] field to see if clock is playing e.g. `clock.isPlaying`
- [x] clock event listeners: add an event listener when the play state changes (play, pause, stop)
- [x] fix lookahead scheduler firing multiple times
- [x] bpm is wrong until transport control mounts -- now it relies on the `$effect` of TransportPanel
- [x] send future clock state in the onBeat and every callback (including the target beat via `clock.beat`)
- [x] fix onBeat misfiring twice on `audio: true`
- [x] fix onBeat misfiring at the end of playback

### References

Sample from @dtinth on how to get it right:

```js
document.querySelector('#app').innerHTML = `
  <div id="beat"></div>
  <button id="play">Play</button>
  <button id="pause">Pause</button>
`;

interface PlaybackState {
  offset: number;
  slope: number;
}

function toBeat(state: PlaybackState, audioTime: number) {
  return state.slope * audioTime + state.offset;
}

function play(
  prevState: PlaybackState,
  bpm: number,
  audioTime: number
): PlaybackState {
  const bps = bpm / 60;

  return {
    slope: bps,
    offset: toBeat(prevState, audioTime) - bps * audioTime,
  };
}

let state: PlaybackState = { offset: 0, slope: 0 };

function doPlay() {
  state = play(state, 180, ctx.currentTime);
}

function doPause() {
  state = play(state, 0, ctx.currentTime);
}

const ctx = new AudioContext();

setInterval(() => {
  document.getElementById('beat').textContent = toBeat(
    state,
    ctx.currentTime
  ).toFixed(2);
});

document.getElementById('play').onclick = () => {
  ctx.resume();
  doPlay();
};

document.getElementById('pause').onclick = () => {
  ctx.resume();
  doPause();
};
```

## Example: Automatic Synchronization

Looks like Bemuse's [[sync mode](https://bemuse.ninja/?mode=sync)](https://bemuse.ninja/?mode=sync) for use in detecting input latency uses a similar mechanism

- https://github.com/bemusic/bemuse/blob/master/bemuse/src/auto-synchro/music/index.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio beat scheduling to dedupe by logical beat index, so the same upcoming audio beat callback fires only once.
  * Correctly handles transport rewinds so audio beat callbacks reset and fire again.
  * Standardized repeat (“every”) callback timing behavior across audio and non-audio paths.

* **New Features**
  * Transport now stays synchronized with stored BPM and time-signature changes at runtime.

* **Documentation**
  * Updated scheduling specs to clarify audio lookahead precision/deduplication; refined transport control spec formatting and sync notes.

* **Tests**
  * Added Vitest coverage for lookahead audio scheduling (polling/rewind) and Transport localStorage synchronization.

* **Refactor**
  * Updated exported scheduling callback typings to use interfaces (same shape).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->