### PR TITLE
fix(renderer): final output alpha is broken

### DIFF
--- a/docs/design-docs/specs/137-final-output-alpha.md
+++ b/docs/design-docs/specs/137-final-output-alpha.md
@@ -13,21 +13,26 @@ Create the worker WebGL context with explicit alpha settings:
 - `alpha: true` so the drawing buffer has an alpha channel.
 - `premultipliedAlpha: false` because Patchies FBO content is straight alpha.
 
-The final blit still uses the existing GPU path:
+The final presentation pass converts internal straight-alpha node output into
+premultiplied-alpha pixels for the browser-visible `ImageBitmap`:
 
 ```typescript
-gl.bindFramebuffer(gl.READ_FRAMEBUFFER, sourceFbo);
-gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
-gl.blitFramebuffer(...);
+vec4 color = texture(sourceTexture, sourceUv);
+fragColor = vec4(color.rgb * color.a, color.a);
 ```
 
-This keeps output transfer zero-copy while making the background path match preview semantics.
+This keeps alpha transparent while preventing hidden RGB in fully transparent
+pixels from leaking through `bitmaprenderer` presentation. Internal FBOs and
+node-to-node video textures remain straight-alpha.
 
 ## Files affected
 
-| File                                   | Change                                      |
-| -------------------------------------- | ------------------------------------------- |
-| `src/workers/rendering/fboRenderer.ts` | Use explicit straight-alpha WebGL settings. |
+| File                                                        | Change                                      |
+| ----------------------------------------------------------- | ------------------------------------------- |
+| `ui/src/workers/rendering/fboRenderer.ts`                   | Use explicit straight-alpha WebGL settings. |
+| `ui/src/workers/rendering/finalOutputPresentation.ts`       | Premultiply final output pixels for presentation. |
+| `ui/src/lib/components/BackgroundOutputCanvas.svelte`       | Request an alpha-capable background bitmap renderer. |
+| `ui/src/routes/output/+page.svelte`                         | Request alpha-capable output-window bitmap renderers. |
 
 ## What does NOT change
 

--- a/ui/src/lib/components/BackgroundOutputCanvas.svelte
+++ b/ui/src/lib/components/BackgroundOutputCanvas.svelte
@@ -23,7 +23,7 @@
   }
 
   onMount(() => {
-    bitmapContext = outputCanvasElement.getContext('bitmaprenderer')!;
+    bitmapContext = outputCanvasElement.getContext('bitmaprenderer', { alpha: true })!;
 
     glSystem.backgroundOutputCanvasContext = bitmapContext;
     // Call directly (no debounce) on mount so initial size is set immediately.

--- a/ui/src/routes/output/+page.svelte
+++ b/ui/src/routes/output/+page.svelte
@@ -91,8 +91,8 @@
 
     resizeCanvases();
 
-    outputBitmapContext = outputCanvas.getContext('bitmaprenderer')!;
-    surfaceBitmapContext = surfaceCanvas.getContext('bitmaprenderer')!;
+    outputBitmapContext = outputCanvas.getContext('bitmaprenderer', { alpha: true })!;
+    surfaceBitmapContext = surfaceCanvas.getContext('bitmaprenderer', { alpha: true })!;
 
     const handleMessage = (event: MessageEvent<unknown>) => {
       if (event.origin !== expectedOrigin) return;

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -62,6 +62,7 @@ import { createGlslCookPolicy } from './cooking/glsl';
 import { createRenderNodeCookPolicy } from './cooking/policies';
 import { isSameMouseData, type MouseData } from './mouseData';
 import { getViewportCookRequiredNodeIds, shouldSkipCookForViewport } from './renderEligibility';
+import { createFinalOutputPresentationCommand } from './finalOutputPresentation';
 
 interface MessageCapableRenderer {
   handleMessage(message: Message): void;
@@ -104,6 +105,9 @@ export class FBORenderer {
   public offscreenCanvas: OffscreenCanvas;
   public gl: WebGL2RenderingContext;
   public regl: regl.Regl;
+
+  // Draw command for outputting the final image
+  private drawFinalOutput: regl.DrawCommand;
 
   // Mapping of nodeId -> uniform key -> uniform value
   // example: {'glsl-0': {'sliderValue': 0.5}}
@@ -221,6 +225,10 @@ export class FBORenderer {
       extensions: WEBGL_EXTENSIONS,
       optionalExtensions: WEBGL_OPTIONAL_EXTENSIONS
     });
+
+    // Draw final output by pre-multiplying alpha channel
+    // Fixes alpha not being rendered in final output
+    this.drawFinalOutput = createFinalOutputPresentationCommand(this.regl);
 
     // Detect float FBO support
     this.colorBufferFloatSupported = !!this.gl.getExtension('EXT_color_buffer_float');
@@ -1951,6 +1959,7 @@ export class FBORenderer {
     const gl = this.regl._gl as WebGL2RenderingContext;
 
     let framebuffer: regl.Framebuffer2D | null = null;
+    let texture = node.colorAttachments[this.outputOutletIndex] ?? node.texture;
 
     // Source size comes from the node's FBO (not the background)
     let sourceWidth = node.texture.width;
@@ -1961,6 +1970,7 @@ export class FBORenderer {
 
       // Use cached FBO instead of creating new one every frame (fixes massive leak)
       framebuffer = this.videoTextures.getDestinationFBO(node.id) || null;
+      texture = tex;
       sourceWidth = tex.width;
       sourceHeight = tex.height;
     } else {
@@ -1970,11 +1980,6 @@ export class FBORenderer {
     if (!framebuffer) {
       return;
     }
-
-    gl.viewport(0, 0, outputWidth, outputHeight);
-    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, getFramebuffer(framebuffer));
-    gl.readBuffer(gl.COLOR_ATTACHMENT0 + this.outputOutletIndex);
-    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
 
     // Cover-mode blit: crop the source to match the background's aspect ratio,
     // so the output fills the screen without stretching (spec 128).
@@ -2002,19 +2007,16 @@ export class FBORenderer {
       sourceY1 = Math.floor(offset + cropHeight);
     }
 
-    gl.blitFramebuffer(
-      sourceX0,
-      sourceY0,
-      sourceX1,
-      sourceY1,
-      0,
-      0,
-      outputWidth,
-      outputHeight,
-      gl.COLOR_BUFFER_BIT,
-      gl.LINEAR
-    );
+    gl.viewport(0, 0, outputWidth, outputHeight);
 
+    const sourceUvRect = [
+      sourceX0 / sourceWidth,
+      sourceY0 / sourceHeight,
+      sourceX1 / sourceWidth,
+      sourceY1 / sourceHeight
+    ];
+
+    this.drawFinalOutput({ texture, sourceUvRect });
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
   }
 

--- a/ui/src/workers/rendering/finalOutputPresentation.ts
+++ b/ui/src/workers/rendering/finalOutputPresentation.ts
@@ -1,0 +1,64 @@
+import type regl from 'regl';
+
+type FinalOutputPresentationProps = {
+  texture: regl.Texture2D;
+  sourceUvRect: [number, number, number, number];
+};
+
+const RECT_VERTEX = [
+  [-1, -1],
+  [1, -1],
+  [-1, 1],
+  [1, 1]
+];
+
+const VERTEX_SHADER = `#version 300 es
+  precision highp float;
+
+  in vec2 position;
+  out vec2 uv;
+
+  void main() {
+    uv = 0.5 * (position + 1.0);
+
+    gl_Position = vec4(position, 0.0, 1.0);
+  }
+`;
+
+const FRAGMENT_SHADER = `#version 300 es
+  precision highp float;
+
+  uniform sampler2D sourceTexture;
+  uniform vec4 sourceUvRect;
+
+  in vec2 uv;
+  out vec4 fragColor;
+
+  void main() {
+    vec2 sourceUv = mix(sourceUvRect.xy, sourceUvRect.zw, uv);
+    vec4 color = texture(sourceTexture, sourceUv);
+
+    fragColor = vec4(color.rgb * color.a, color.a);
+  }
+`;
+
+export const createFinalOutputPresentationCommand = (regl: regl.Regl): regl.DrawCommand =>
+  regl({
+    frag: FRAGMENT_SHADER,
+    vert: VERTEX_SHADER,
+
+    attributes: {
+      position: regl.buffer(RECT_VERTEX)
+    },
+
+    uniforms: {
+      sourceTexture: regl.prop<FinalOutputPresentationProps, 'texture'>('texture'),
+      sourceUvRect: regl.prop<FinalOutputPresentationProps, 'sourceUvRect'>('sourceUvRect')
+    },
+
+    primitive: 'triangle strip',
+    count: 4,
+    depth: { enable: false },
+    blend: { enable: false },
+    framebuffer: null
+  });


### PR DESCRIPTION
Lets the final output properly display the alpha transparency channel.

<img width="2026" height="1656" alt="CleanShot 2569-06-25 at 15 10 13@2x" src="https://github.com/user-attachments/assets/a6273ae6-f969-435a-9268-a8bcbdafba4c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved final output rendering for browser display with better alpha handling.
  * Added support for alpha-capable bitmap presentation so transparent pixels render cleanly without color artifacts.

* **Bug Fixes**
  * Fixed issues where fully transparent areas could show unwanted RGB remnants in the final image.
  * Updated the output path to preserve the intended appearance when presenting rendered frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->