### PR TITLE
feat(settings): add persistent color picker for user settings panel

### DIFF
--- a/docs/design-docs/specs/130-settings-modal.md
+++ b/docs/design-docs/specs/130-settings-modal.md
@@ -88,7 +88,7 @@ Each section header in the sidebar has a small label: `PER-USER` or `PER-PATCH` 
 | Setting | Control | Store | Notes |
 |---------|---------|-------|-------|
 | Render FPS cap | Dropdown (Unlimited/30/60) | `renderFpsCap` (renderer.store) | |
-| Preview background | Color + transparent option | `previewBackgroundColor` (renderer.store) | Per-user; transparent by default; applied as CSS behind preview canvases |
+| Preview background | Color + transparent option | `previewBackgroundColor` (renderer.store) | Per-user; transparent by default; applied as CSS behind preview canvases. Native color picker changes update on `input`, not only `change`, so the live setting continues to respond while the browser/OS picker is open. |
 | Show FPS monitor | Toggle | `isFpsMonitorVisible` (ui.store) | |
 | Show video stats | Toggle | `showVideoStats` (video.store) | |
 | MediaBunny (WebCodecs) | Toggle | `useWebCodecs` (video.store) | Shows browser support note |
@@ -183,6 +183,14 @@ Standard layout for every setting row:
 ```
 
 Renders as a horizontal row: label + description on the left, control on the right. Consistent spacing and alignment across all categories.
+
+### Native Color Picker Lifecycle
+
+Native browser/OS color pickers can outlive the Svelte settings panel that opened them, and there is no reliable standard API to force-close an already-open picker. Settings-modal color controls therefore use the shared persistent native color picker helper instead of owning the `<input type="color">` directly in the panel subtree.
+
+- Color values update from the picker `input` event so changes apply continuously.
+- The picker `change` event is reserved for finalization such as undo tracking.
+- Closing the settings modal blurs the active native color input as a best-effort dismissal, but the active callback remains wired so late picker events can still update the setting when the platform keeps the picker open.
 
 ### Reuse of Existing Controls
 

--- a/docs/design-docs/specs/91-dynamic-object-settings-api.md
+++ b/docs/design-docs/specs/91-dynamic-object-settings-api.md
@@ -325,7 +325,16 @@ If the field has `description` on options, wrap each button in `<Tooltip.Root>` 
 </div>
 ```
 
-If the field has no presets, fall back to a native `<input type="color">` wrapped in a swatch label (SequencerSettings track color pattern).
+If the field has no presets, fall back to the shared native color picker swatch component
+(SequencerSettings track color pattern). The actual `<input type="color">` is owned by a
+persistent helper rather than the settings panel DOM, because browser/OS color pickers can
+stay open after the panel closes.
+
+- Use `input` events for live value updates.
+- Use `change` events only for finalization such as undo tracking.
+- When a panel closes, blur the active picker input as a best-effort dismissal, but keep the
+  active callback alive so late native picker events can still update the setting if the
+  platform keeps the picker open.
 
 **String fields** — text input:
 

--- a/ui/src/lib/components/settings-modal/SettingsModal.svelte
+++ b/ui/src/lib/components/settings-modal/SettingsModal.svelte
@@ -7,6 +7,7 @@
   import VisualSettings from './categories/VisualSettings.svelte';
   import TransportSettings from './categories/TransportSettings.svelte';
   import NetworkSettings from './categories/NetworkSettings.svelte';
+  import { dismissActiveNativeColorPicker } from '$lib/components/settings/native-color-picker';
 
   let {
     open = $bindable(false),
@@ -25,6 +26,7 @@
   });
 
   function handleClose() {
+    dismissActiveNativeColorPicker();
     open = false;
   }
 

--- a/ui/src/lib/components/settings-modal/categories/RenderingSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/RenderingSettings.svelte
@@ -2,6 +2,7 @@
   import SettingRow from '../SettingRow.svelte';
   import SettingToggle from '../SettingToggle.svelte';
   import SettingDropdown from '../SettingDropdown.svelte';
+  import NativeColorPicker from '$lib/components/settings/NativeColorPicker.svelte';
   import { isFpsMonitorVisible } from '../../../../stores/ui.store';
   import {
     previewBackgroundColor,
@@ -61,9 +62,9 @@
       .otherwise(() => previewBackgroundColor.set(customPreviewBackgroundColor));
   }
 
-  function handlePreviewBackgroundColorChange(e: Event) {
-    const target = e.target as HTMLInputElement;
-    const color = target.value as `#${string}`;
+  function handlePreviewBackgroundColorInput(value: string) {
+    const color = value as `#${string}`;
+
     customPreviewBackgroundColor = color;
     previewBackgroundColor.set(color);
   }
@@ -89,12 +90,12 @@
     />
 
     {#if previewBackgroundMode === 'color'}
-      <input
-        type="color"
+      <NativeColorPicker
         value={customPreviewBackgroundColor}
-        onchange={handlePreviewBackgroundColorChange}
         class="h-7 w-9 cursor-pointer rounded border border-white/10 bg-white/5 p-0.5"
-        aria-label="Preview background color"
+        swatchClass="block h-full w-full rounded-sm"
+        ariaLabel="Preview background color"
+        onInput={handlePreviewBackgroundColorInput}
       />
     {/if}
   </div>

--- a/ui/src/lib/components/settings/NativeColorPicker.svelte
+++ b/ui/src/lib/components/settings/NativeColorPicker.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import {
+    dismissActiveNativeColorPicker,
+    openNativeColorPicker,
+    type NativeColorPickerSession
+  } from './native-color-picker';
+
+  let {
+    value,
+    ariaLabel,
+    class: className = 'inline-flex cursor-pointer items-center gap-2',
+    swatchClass = 'h-6 w-6 rounded border border-zinc-600',
+    valueClass = 'text-xs text-zinc-400',
+    showValue = false,
+    onOpen = undefined,
+    onInput,
+    onChange = undefined
+  }: {
+    value: string;
+    ariaLabel: string;
+    class?: string;
+    swatchClass?: string;
+    valueClass?: string;
+    showValue?: boolean;
+    onOpen?: () => void;
+    onInput: (value: string) => void;
+    onChange?: (value: string) => void;
+  } = $props();
+
+  let activeSession: NativeColorPickerSession | null = null;
+
+  function handleOpen() {
+    onOpen?.();
+
+    activeSession = openNativeColorPicker({
+      value,
+      onInput,
+      onChange
+    });
+  }
+
+  onDestroy(() => {
+    dismissActiveNativeColorPicker(activeSession);
+  });
+</script>
+
+<button type="button" class={className} onclick={handleOpen} aria-label={ariaLabel}>
+  <span class={swatchClass} style:background-color={value}></span>
+
+  {#if showValue}
+    <span class={valueClass}>{value}</span>
+  {/if}
+</button>

--- a/ui/src/lib/components/settings/ObjectSettings.svelte
+++ b/ui/src/lib/components/settings/ObjectSettings.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { RotateCcw, X } from '@lucide/svelte/icons';
   import SettingsSlider from '$lib/components/SettingsSlider.svelte';
+  import NativeColorPicker from '$lib/components/settings/NativeColorPicker.svelte';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { useNodeDataTracker } from '$lib/history';
   import type { SettingsField, SettingsSchema } from '$lib/settings/types';
+  import { dismissActiveNativeColorPicker } from './native-color-picker';
 
   let {
     nodeId,
@@ -71,6 +73,11 @@
     if (persistence === 'node') {
       tracker.commit(trackingKey(field.key), oldValue, newValue);
     }
+  }
+
+  function handleClose() {
+    dismissActiveNativeColorPicker();
+    onClose();
   }
 
   // For slider/string/number: track focus→blur for undo (node-persistence only)
@@ -153,7 +160,7 @@
     {/if}
     {#if showCloseButton}
       <button
-        onclick={onClose}
+        onclick={handleClose}
         class="h-6 w-6 cursor-pointer rounded bg-zinc-950 p-1 text-zinc-300 hover:bg-zinc-700"
       >
         <X class="h-4 w-4" />
@@ -390,23 +397,16 @@
             <!-- Native color picker fallback -->
             {@const colorTracker = makeTracker(field)}
 
-            <label class="flex cursor-pointer items-center gap-2">
-              <span
-                class="h-6 w-6 rounded border border-zinc-600"
-                style="background-color: {(getCurrentValue(field) as string) ?? '#ffffff'};"
-              ></span>
+            {@const currentColor = (getCurrentValue(field) as string) ?? '#ffffff'}
 
-              <input
-                type="color"
-                value={(getCurrentValue(field) as string) ?? '#ffffff'}
-                class="sr-only"
-                onfocus={colorTracker.onFocus}
-                oninput={(e) => onValueChange(field.key, (e.target as HTMLInputElement).value)}
-                onchange={colorTracker.onBlur}
-              />
-
-              <span class="text-xs text-zinc-400">{(getCurrentValue(field) as string) ?? ''}</span>
-            </label>
+            <NativeColorPicker
+              value={currentColor}
+              ariaLabel={field.label}
+              showValue
+              onOpen={colorTracker.onFocus}
+              onInput={(value) => onValueChange(field.key, value)}
+              onChange={() => colorTracker.onBlur()}
+            />
           {/if}
         </div>
       {:else if field.type === 'vec2'}

--- a/ui/src/lib/components/settings/SequencerSettings.svelte
+++ b/ui/src/lib/components/settings/SequencerSettings.svelte
@@ -2,6 +2,7 @@
   import type { ContinuousTracker } from '$lib/history';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import SettingsSlider from '$lib/components/SettingsSlider.svelte';
+  import NativeColorPicker from '$lib/components/settings/NativeColorPicker.svelte';
   import { Plus, Trash2 } from '@lucide/svelte/icons';
   import type { TrackData } from '$lib/nodes/sequencer-constants';
 
@@ -262,18 +263,13 @@
         {#each tracks as track, trackIdx (trackIdx)}
           <div class="flex items-center gap-1.5">
             <!-- Color swatch / native color picker -->
-            <label class="relative cursor-pointer">
-              <div
-                class="h-5 w-5 rounded border border-zinc-600"
-                style:background-color={track.color}
-              ></div>
-              <input
-                type="color"
-                value={track.color}
-                onchange={(e) => onUpdateTrackColor(trackIdx, (e.target as HTMLInputElement).value)}
-                class="absolute inset-0 h-0 w-0 opacity-0"
-              />
-            </label>
+            <NativeColorPicker
+              value={track.color}
+              ariaLabel="Track color"
+              class="h-5 w-5 cursor-pointer rounded border border-zinc-600 p-0"
+              swatchClass="block h-full w-full rounded"
+              onInput={(value) => onUpdateTrackColor(trackIdx, value)}
+            />
 
             <!-- Name -->
             <input

--- a/ui/src/lib/components/settings/native-color-picker.test.ts
+++ b/ui/src/lib/components/settings/native-color-picker.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetNativeColorPickerForTests,
+  dismissActiveNativeColorPicker,
+  openNativeColorPicker
+} from './native-color-picker';
+
+type Listener = () => void;
+
+class FakeColorInput {
+  type = '';
+  value = '';
+  className = '';
+  tabIndex = 0;
+  ariaHidden = '';
+  style = {};
+  blurred = false;
+  clicked = false;
+  shown = false;
+
+  private listeners = new Map<string, Listener[]>();
+
+  addEventListener(type: string, listener: Listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener();
+    }
+  }
+
+  blur() {
+    this.blurred = true;
+  }
+
+  click() {
+    this.clicked = true;
+  }
+
+  showPicker() {
+    this.shown = true;
+  }
+}
+
+class FakeDocument {
+  input: FakeColorInput | null = null;
+  createCount = 0;
+  body = {
+    appendChild: vi.fn()
+  };
+
+  createElement(tag: string) {
+    expect(tag).toBe('input');
+    this.createCount += 1;
+    this.input = new FakeColorInput();
+    return this.input;
+  }
+}
+
+describe('native color picker helper', () => {
+  beforeEach(() => {
+    __resetNativeColorPickerForTests();
+  });
+
+  it('keeps applying input events after a best-effort dismiss', () => {
+    const doc = new FakeDocument();
+    const values: string[] = [];
+
+    const session = openNativeColorPicker({
+      value: '#111111',
+      onInput: (value) => values.push(value),
+      getDocument: () => doc as unknown as Document
+    });
+
+    expect(doc.input).not.toBeNull();
+    expect(doc.input?.shown).toBe(true);
+
+    doc.input!.value = '#222222';
+    doc.input!.dispatch('input');
+
+    dismissActiveNativeColorPicker(session);
+    expect(doc.input?.blurred).toBe(true);
+
+    doc.input!.value = '#333333';
+    doc.input!.dispatch('input');
+
+    expect(values).toEqual(['#222222', '#333333']);
+  });
+
+  it('reuses the persistent input and routes events to the latest opener', () => {
+    const doc = new FakeDocument();
+    const firstValues: string[] = [];
+    const secondValues: string[] = [];
+
+    openNativeColorPicker({
+      value: '#111111',
+      onInput: (value) => firstValues.push(value),
+      getDocument: () => doc as unknown as Document
+    });
+
+    const input = doc.input;
+
+    openNativeColorPicker({
+      value: '#222222',
+      onInput: (value) => secondValues.push(value),
+      getDocument: () => doc as unknown as Document
+    });
+
+    expect(doc.createCount).toBe(1);
+    expect(doc.input).toBe(input);
+
+    doc.input!.value = '#444444';
+    doc.input!.dispatch('input');
+
+    expect(firstValues).toEqual([]);
+    expect(secondValues).toEqual(['#444444']);
+  });
+});

--- a/ui/src/lib/components/settings/native-color-picker.ts
+++ b/ui/src/lib/components/settings/native-color-picker.ts
@@ -1,0 +1,102 @@
+export interface NativeColorPickerSession {
+  id: number;
+}
+
+export interface OpenNativeColorPickerOptions {
+  value: string;
+  onInput: (value: string) => void;
+  onChange?: (value: string) => void;
+  getDocument?: () => Document | undefined;
+}
+
+interface ActiveCallbacks {
+  id: number;
+  onInput: (value: string) => void;
+  onChange?: (value: string) => void;
+}
+
+let activeInput: HTMLInputElement | null = null;
+let activeCallbacks: ActiveCallbacks | null = null;
+let nextSessionId = 1;
+
+const currentDocument = (): Document | undefined =>
+  typeof document === 'undefined' ? undefined : document;
+
+function ensureColorInput(doc: Document): HTMLInputElement {
+  if (activeInput) return activeInput;
+
+  const input = doc.createElement('input');
+  input.type = 'color';
+  input.className = 'patchies-native-color-picker';
+  input.tabIndex = -1;
+  input.ariaHidden = 'true';
+
+  Object.assign(input.style, {
+    position: 'fixed',
+    left: '0',
+    top: '0',
+    width: '1px',
+    height: '1px',
+    opacity: '0',
+    pointerEvents: 'none'
+  });
+
+  input.addEventListener('input', () => {
+    activeCallbacks?.onInput(input.value);
+  });
+
+  input.addEventListener('change', () => {
+    activeCallbacks?.onChange?.(input.value);
+  });
+
+  doc.body.appendChild(input);
+  activeInput = input;
+
+  return input;
+}
+
+export function openNativeColorPicker({
+  value,
+  onInput,
+  onChange,
+  getDocument = currentDocument
+}: OpenNativeColorPickerOptions): NativeColorPickerSession | null {
+  const doc = getDocument();
+  if (!doc) return null;
+
+  const input = ensureColorInput(doc);
+  const session = { id: nextSessionId++ };
+
+  activeCallbacks = { id: session.id, onInput, onChange };
+  input.value = value;
+
+  try {
+    if (typeof input.showPicker === 'function') {
+      input.showPicker();
+    } else {
+      input.click();
+    }
+  } catch {
+    try {
+      input.click();
+    } catch {
+      // Some browsers reject programmatic picker opening in edge cases.
+      // The callbacks remain active in case the input still produces events.
+    }
+  }
+
+  return session;
+}
+
+export function dismissActiveNativeColorPicker(session?: NativeColorPickerSession | null): void {
+  if (!activeInput) return;
+  if (session && activeCallbacks?.id !== session.id) return;
+
+  activeInput.blur();
+}
+
+export function __resetNativeColorPickerForTests(): void {
+  activeInput = null;
+  activeCallbacks = null;
+  nextSessionId = 1;
+}


### PR DESCRIPTION
Make color pickers persistent in user settings panel. When the settings panel is closed, color pickers should remain functional.