### PR TITLE
feat(dsp~, chuck~, tone~, sonic~, elem~): hide audio inputs unless used

### DIFF
--- a/docs/design-docs/specs/162-visible-audio-input-ports.md
+++ b/docs/design-docs/specs/162-visible-audio-input-ports.md
@@ -1,0 +1,20 @@
+# 162. Visible Audio Input Ports
+
+Programmable audio objects should not show blue input handles when the current code does not use incoming audio. The internal audio input stays available for nodes that support it, but the xyflow handle can be hidden to reduce visual noise.
+
+## Scope
+
+- `dsp~`: `setAudioPortCount(0, n)` hides audio input handles while keeping the DSP node implementation unchanged.
+- `tone~`, `sonic~`, and `elem~`: user code can call `noAudioInput()` to hide the fixed audio input handle. This affects only the visible handle; `inputNode` remains available internally.
+- `chuck~`: the audio input handle is visible only when the code references `adc`.
+- Defaults and built-in presets that only synthesize or react to messages should opt out of visible audio input handles.
+
+## Data Flow
+
+`tone~`, `sonic~`, and `elem~` store `showAudioInput` in node data. The shared layout uses that value when present, and otherwise derives an initial value from code that contains `noAudioInput()`. Runtime calls update node data after code runs.
+
+`chuck~` derives visibility directly from the current ChucK expression. Its message inlet keeps its existing handle id, so existing control connections stay compatible even when the audio inlet is hidden.
+
+## Testing
+
+Add pure helper tests for code-derived visibility. Run the focused test first, then run Svelte check after implementation.

--- a/docs/design-docs/specs/162-visible-audio-input-ports.md
+++ b/docs/design-docs/specs/162-visible-audio-input-ports.md
@@ -5,13 +5,15 @@ Programmable audio objects should not show blue input handles when the current c
 ## Scope
 
 - `dsp~`: `setAudioPortCount(0, n)` hides audio input handles while keeping the DSP node implementation unchanged.
-- `tone~`, `sonic~`, and `elem~`: user code can call `noAudioInput()` to hide the fixed audio input handle. This affects only the visible handle; `inputNode` remains available internally.
+- `tone~`, `sonic~`, and `elem~`: hide the fixed audio input handle by default. The handle is shown automatically when code references common audio-input patterns, or explicitly when user code calls `showAudioInput()`. This affects only the visible handle; `inputNode` remains available internally.
 - `chuck~`: the audio input handle is visible only when the code references `adc`.
-- Defaults and built-in presets that only synthesize or react to messages should opt out of visible audio input handles.
+- Defaults and built-in presets that only synthesize or react to messages should not show visible audio input handles.
 
 ## Data Flow
 
-`tone~`, `sonic~`, and `elem~` store `showAudioInput` in node data. Each node wrapper derives an initial value from saved data or code on mount, then derives it again only when the user runs code. The shared layout reads the stored boolean without scanning code during render. Runtime `noAudioInput()` calls can still hide the inlet after code executes.
+`tone~`, `sonic~`, and `elem~` store `showAudioInput` in node data. Each node wrapper derives an initial value from saved data or code on mount, then derives it again only when the user runs code. The shared layout reads the stored boolean without scanning code during render. Runtime `showAudioInput()` calls can still show the inlet after code executes when automatic detection misses indirect input routing.
+
+Automatic detection looks for `inputNode` in `tone~`, `sonic~`, and `elem~` code. `elem~` also treats `el.in(...)` as audio input usage. Detection ignores JavaScript comments and strings.
 
 `chuck~` derives visibility directly from the current ChucK expression. Its message inlet keeps its existing handle id, so existing control connections stay compatible even when the audio inlet is hidden.
 

--- a/docs/design-docs/specs/162-visible-audio-input-ports.md
+++ b/docs/design-docs/specs/162-visible-audio-input-ports.md
@@ -11,7 +11,7 @@ Programmable audio objects should not show blue input handles when the current c
 
 ## Data Flow
 
-`tone~`, `sonic~`, and `elem~` store `showAudioInput` in node data. The shared layout uses that value when present, and otherwise derives an initial value from code that contains `noAudioInput()`. Runtime calls update node data after code runs.
+`tone~`, `sonic~`, and `elem~` store `showAudioInput` in node data. Each node wrapper derives an initial value from saved data or code on mount, then derives it again only when the user runs code. The shared layout reads the stored boolean without scanning code during render. Runtime `noAudioInput()` calls can still hide the inlet after code executes.
 
 `chuck~` derives visibility directly from the current ChucK expression. Its message inlet keeps its existing handle id, so existing control connections stay compatible even when the audio inlet is hidden.
 

--- a/ui/src/lib/ai/debug/handle-specs.ts
+++ b/ui/src/lib/ai/debug/handle-specs.ts
@@ -291,7 +291,7 @@ const MANUAL_HANDLE_SPECS: Record<string, NodeHandleSpec> = {
     inlets: {
       kind: 'dynamic',
       patterns: ['audio-in', 'message-in-{N}'],
-      note: 'audio-in (fixed), then message-in-{N} from setPortCount'
+      note: 'optional audio-in, then message-in-{N} from setPortCount'
     },
     outlets: {
       kind: 'dynamic',
@@ -303,7 +303,7 @@ const MANUAL_HANDLE_SPECS: Record<string, NodeHandleSpec> = {
     inlets: {
       kind: 'dynamic',
       patterns: ['audio-in', 'audio-in-{N}', 'message-in-{N}'],
-      note: 'audio inlets (single=audio-in, multi=audio-in-{N}), then message-in-{N}'
+      note: 'optional audio inlets (single=audio-in, multi=audio-in-{N}), then message-in-{N}'
     },
     outlets: {
       kind: 'dynamic',
@@ -315,7 +315,7 @@ const MANUAL_HANDLE_SPECS: Record<string, NodeHandleSpec> = {
     inlets: {
       kind: 'dynamic',
       patterns: ['audio-in', 'message-in-{N}'],
-      note: 'audio-in (fixed), then message-in-{N} from setPortCount'
+      note: 'optional audio-in, then message-in-{N} from setPortCount'
     },
     outlets: {
       kind: 'dynamic',
@@ -327,7 +327,7 @@ const MANUAL_HANDLE_SPECS: Record<string, NodeHandleSpec> = {
     inlets: {
       kind: 'dynamic',
       patterns: ['audio-in', 'message-in-{N}'],
-      note: 'audio-in (fixed), then message-in-{N}'
+      note: 'optional audio-in, then message-in-{N}'
     },
     outlets: {
       kind: 'dynamic',

--- a/ui/src/lib/ai/object-prompts/dsp~.ts
+++ b/ui/src/lib/ai/object-prompts/dsp~.ts
@@ -11,6 +11,7 @@ Low-level DSP audio processing. MUST implement process(inputs, outputs) function
 - setTitle(name), setPortCount(inlets, outlets), setAudioPortCount(inlets, outlets)
 - recv(callback), send(data, {to: outletIndex}?) - Message I/O
 - setKeepAlive(enabled) - Keep running when unconnected
+- setAudioPortCount(0, 1) hides the visible audio inlet for synth/generator DSPs
 
 **Context Variables (in process):**
 - counter, sampleRate, currentFrame, currentTime

--- a/ui/src/lib/ai/object-prompts/elem~.ts
+++ b/ui/src/lib/ai/object-prompts/elem~.ts
@@ -15,9 +15,11 @@ Elementary Audio declarative DSP synthesis and processing.
 - inputNode: GainNode for audio input
 - outputNode: GainNode for audio output (IMPORTANT: render to this)
 - node: AudioWorkletNode for Web Audio connectivity
+- noAudioInput(): hide the visible audio input handle for generator-only code
 
 **Elem-specific gotchas:**
 - fft() is NOT available (audio node, not video)
+- Call noAudioInput() when code does not use inputNode or el.in()
 
 ${patcherLibraryInstructions}
 
@@ -28,7 +30,8 @@ Example - Sine oscillator:
 {
   "type": "elem~",
   "data": {
-    "code": "setTitle('osc~'); const graph = el.sine(440); core.render(el.mul(graph, 0.1), outputNode);"
+    "code": "noAudioInput(); setTitle('osc~'); const graph = el.sine(440); core.render(el.mul(graph, 0.1), outputNode);",
+    "showAudioInput": false
   }
 }
 \`\`\`
@@ -38,7 +41,8 @@ Example - Frequency control:
 {
   "type": "elem~",
   "data": {
-    "code": "setPortCount(1); let [freq, setFreq] = core.createRef('const', {value: 440}, []); recv(f => { if (typeof f === 'number') setFreq({value: f}); }); const graph = el.sine(freq); core.render(el.mul(graph, 0.1), outputNode);"
+    "code": "setPortCount(1); noAudioInput(); let [freq, setFreq] = core.createRef('const', {value: 440}, []); recv(f => { if (typeof f === 'number') setFreq({value: f}); }); const graph = el.sine(freq); core.render(el.mul(graph, 0.1), outputNode);",
+    "showAudioInput": false
   }
 }
 \`\`\``;

--- a/ui/src/lib/ai/object-prompts/elem~.ts
+++ b/ui/src/lib/ai/object-prompts/elem~.ts
@@ -15,11 +15,11 @@ Elementary Audio declarative DSP synthesis and processing.
 - inputNode: GainNode for audio input
 - outputNode: GainNode for audio output (IMPORTANT: render to this)
 - node: AudioWorkletNode for Web Audio connectivity
-- noAudioInput(): hide the visible audio input handle for generator-only code
+- showAudioInput(): force the visible audio input handle to show when input routing is indirect
 
 **Elem-specific gotchas:**
 - fft() is NOT available (audio node, not video)
-- Call noAudioInput() when code does not use inputNode or el.in()
+- Audio input is hidden by default and auto-shows when code references inputNode or el.in()
 
 ${patcherLibraryInstructions}
 
@@ -30,7 +30,7 @@ Example - Sine oscillator:
 {
   "type": "elem~",
   "data": {
-    "code": "noAudioInput(); setTitle('osc~'); const graph = el.sine(440); core.render(el.mul(graph, 0.1), outputNode);",
+    "code": "setTitle('osc~'); const graph = el.sine(440); core.render(el.mul(graph, 0.1), outputNode);",
     "showAudioInput": false
   }
 }
@@ -41,7 +41,7 @@ Example - Frequency control:
 {
   "type": "elem~",
   "data": {
-    "code": "setPortCount(1); noAudioInput(); let [freq, setFreq] = core.createRef('const', {value: 440}, []); recv(f => { if (typeof f === 'number') setFreq({value: f}); }); const graph = el.sine(freq); core.render(el.mul(graph, 0.1), outputNode);",
+    "code": "setPortCount(1); let [freq, setFreq] = core.createRef('const', {value: 440}, []); recv(f => { if (typeof f === 'number') setFreq({value: f}); }); const graph = el.sine(freq); core.render(el.mul(graph, 0.1), outputNode);",
     "showAudioInput": false
   }
 }

--- a/ui/src/lib/ai/object-prompts/sonic~.ts
+++ b/ui/src/lib/ai/object-prompts/sonic~.ts
@@ -9,11 +9,11 @@ SuperCollider synthesis via SuperSonic AudioWorklet.
 - \`SuperSonic\` — Static utilities (e.g., \`SuperSonic.osc.encodeMessage()\`)
 - \`on(event, callback)\` — Subscribe to SuperSonic events
 - \`outBus\` — Assigned output bus index for this node (number)
-- \`noAudioInput()\` — Hide the visible audio input handle for synth-only code
+- \`showAudioInput()\` — Force the visible audio input handle to show when input routing is indirect
 
 **Sonic-specific gotchas:**
 - fft() is NOT available (audio output node, not video)
-- Call \`noAudioInput()\` when code does not use \`inputNode\`
+- Audio input is hidden by default and auto-shows when code references \`inputNode\`
 - By default, the Prophet synth is loaded
 - **CRITICAL**: Each sonic~ node has its own isolated output bus
   Always pass \`'out_bus', outBus\` when creating synths to route audio to the correct output.
@@ -108,7 +108,6 @@ recv(m => {
 Example — MIDI-controlled synth with note management:
 \`\`\`js
 setPortCount(1);
-noAudioInput();
 await sonic.loadSynthDef('sonic-pi-beep');
 
 const activeNotes = new Map();

--- a/ui/src/lib/ai/object-prompts/sonic~.ts
+++ b/ui/src/lib/ai/object-prompts/sonic~.ts
@@ -9,9 +9,11 @@ SuperCollider synthesis via SuperSonic AudioWorklet.
 - \`SuperSonic\` — Static utilities (e.g., \`SuperSonic.osc.encodeMessage()\`)
 - \`on(event, callback)\` — Subscribe to SuperSonic events
 - \`outBus\` — Assigned output bus index for this node (number)
+- \`noAudioInput()\` — Hide the visible audio input handle for synth-only code
 
 **Sonic-specific gotchas:**
 - fft() is NOT available (audio output node, not video)
+- Call \`noAudioInput()\` when code does not use \`inputNode\`
 - By default, the Prophet synth is loaded
 - **CRITICAL**: Each sonic~ node has its own isolated output bus
   Always pass \`'out_bus', outBus\` when creating synths to route audio to the correct output.
@@ -106,6 +108,7 @@ recv(m => {
 Example — MIDI-controlled synth with note management:
 \`\`\`js
 setPortCount(1);
+noAudioInput();
 await sonic.loadSynthDef('sonic-pi-beep');
 
 const activeNotes = new Map();

--- a/ui/src/lib/ai/object-prompts/tone~.ts
+++ b/ui/src/lib/ai/object-prompts/tone~.ts
@@ -12,17 +12,20 @@ Tone.js synthesis and audio processing.
 - Tone: the Tone.js library
 - inputNode: GainNode for audio input (connect to it)
 - outputNode: GainNode for audio output (connect your nodes to this)
+- noAudioInput(): hide the visible audio input handle for synth-only code
 
 **Tone-specific gotchas:**
 - fft() is NOT available (audio node, not video)
 - Use return { cleanup } instead of onCleanup for Tone.js disposal
+- Call noAudioInput() when code does not use inputNode
 
 Example - Simple synth:
 \`\`\`json
 {
   "type": "tone~",
   "data": {
-    "code": "setPortCount(1); const synth = new Tone.Synth().connect(outputNode); recv(m => { if (m?.type === 'bang') synth.triggerAttackRelease('C4', 0.25); }); return { cleanup: () => synth.dispose() };"
+    "code": "setPortCount(1); noAudioInput(); const synth = new Tone.Synth().connect(outputNode); recv(m => { if (m?.type === 'bang') synth.triggerAttackRelease('C4', 0.25); }); return { cleanup: () => synth.dispose() };",
+    "showAudioInput": false
   }
 }
 \`\`\``;

--- a/ui/src/lib/ai/object-prompts/tone~.ts
+++ b/ui/src/lib/ai/object-prompts/tone~.ts
@@ -12,19 +12,19 @@ Tone.js synthesis and audio processing.
 - Tone: the Tone.js library
 - inputNode: GainNode for audio input (connect to it)
 - outputNode: GainNode for audio output (connect your nodes to this)
-- noAudioInput(): hide the visible audio input handle for synth-only code
+- showAudioInput(): force the visible audio input handle to show when input routing is indirect
 
 **Tone-specific gotchas:**
 - fft() is NOT available (audio node, not video)
 - Use return { cleanup } instead of onCleanup for Tone.js disposal
-- Call noAudioInput() when code does not use inputNode
+- Audio input is hidden by default and auto-shows when code references inputNode
 
 Example - Simple synth:
 \`\`\`json
 {
   "type": "tone~",
   "data": {
-    "code": "setPortCount(1); noAudioInput(); const synth = new Tone.Synth().connect(outputNode); recv(m => { if (m?.type === 'bang') synth.triggerAttackRelease('C4', 0.25); }); return { cleanup: () => synth.dispose() };",
+    "code": "setPortCount(1); const synth = new Tone.Synth().connect(outputNode); recv(m => { if (m?.type === 'bang') synth.triggerAttackRelease('C4', 0.25); }); return { cleanup: () => synth.dispose() };",
     "showAudioInput": false
   }
 }

--- a/ui/src/lib/audio/v2/nodes/DspNode.ts
+++ b/ui/src/lib/audio/v2/nodes/DspNode.ts
@@ -113,10 +113,11 @@ export class DspNode implements AudioNodeV2 {
     // Web Audio API requires at least 1 input or 1 output
     // For analysis-only DSPs with setAudioPortCount(1, 0), we need outputs=1 internally
     // but simply don't connect it to anything audible
+    const effectiveInputs = Math.max(1, this.audioInletCount);
     const effectiveOutputs = Math.max(1, this.audioOutletCount);
 
     this.workletNode = new AudioWorkletNode(this.audioContext, 'dsp-processor', {
-      numberOfInputs: this.audioInletCount,
+      numberOfInputs: effectiveInputs,
       numberOfOutputs: effectiveOutputs,
       processorOptions: { nodeId: this.nodeId }
     });

--- a/ui/src/lib/audio/v2/nodes/ElementaryNode.ts
+++ b/ui/src/lib/audio/v2/nodes/ElementaryNode.ts
@@ -167,7 +167,6 @@ export class ElementaryNode implements AudioNodeV2 {
       this.messageInletCount = 0;
       this.messageOutletCount = 0;
       this.recvCallback = null;
-      this.onSetAudioInputVisible(true);
 
       const settingsManager = AudioService.getInstance().getSettingsManager(this.nodeId);
       settingsManager?.clearCallbacks();

--- a/ui/src/lib/audio/v2/nodes/ElementaryNode.ts
+++ b/ui/src/lib/audio/v2/nodes/ElementaryNode.ts
@@ -206,7 +206,7 @@ export class ElementaryNode implements AudioNodeV2 {
           outputNode: this.audioNode,
           recv,
           send,
-          noAudioInput: () => this.onSetAudioInputVisible(false),
+          showAudioInput: () => this.onSetAudioInputVisible(true),
           ...(settingsManager ? { settings: createSettingsAPI(settingsManager) } : {})
         }
       });

--- a/ui/src/lib/audio/v2/nodes/ElementaryNode.ts
+++ b/ui/src/lib/audio/v2/nodes/ElementaryNode.ts
@@ -14,6 +14,7 @@ import { createSettingsAPI } from '$lib/settings/create-settings-api';
 type RecvCallback = (message: unknown, meta: unknown) => void;
 type OnSetPortCount = (inletCount: number, outletCount: number) => void;
 type OnSetTitle = (title: string) => void;
+type OnSetAudioInputVisible = (visible: boolean) => void;
 
 /**
  * ElementaryNode implements the elem~ audio node.
@@ -61,6 +62,7 @@ export class ElementaryNode implements AudioNodeV2 {
 
   public onSetPortCount: OnSetPortCount = () => {};
   public onSetTitle: OnSetTitle = () => {};
+  public onSetAudioInputVisible: OnSetAudioInputVisible = () => {};
 
   // Custom console for routing output to VirtualConsole
   private customConsole;
@@ -165,6 +167,7 @@ export class ElementaryNode implements AudioNodeV2 {
       this.messageInletCount = 0;
       this.messageOutletCount = 0;
       this.recvCallback = null;
+      this.onSetAudioInputVisible(true);
 
       const settingsManager = AudioService.getInstance().getSettingsManager(this.nodeId);
       settingsManager?.clearCallbacks();
@@ -204,6 +207,7 @@ export class ElementaryNode implements AudioNodeV2 {
           outputNode: this.audioNode,
           recv,
           send,
+          noAudioInput: () => this.onSetAudioInputVisible(false),
           ...(settingsManager ? { settings: createSettingsAPI(settingsManager) } : {})
         }
       });

--- a/ui/src/lib/audio/v2/nodes/SonicNode.ts
+++ b/ui/src/lib/audio/v2/nodes/SonicNode.ts
@@ -145,7 +145,6 @@ export class SonicNode implements AudioNodeV2 {
       this.messageInletCount = 0;
       this.messageOutletCount = 0;
       this.recvCallback = null;
-      this.onSetAudioInputVisible(true);
 
       const settingsManager = AudioService.getInstance().getSettingsManager(this.nodeId);
       settingsManager?.clearCallbacks();

--- a/ui/src/lib/audio/v2/nodes/SonicNode.ts
+++ b/ui/src/lib/audio/v2/nodes/SonicNode.ts
@@ -14,6 +14,7 @@ import { createSettingsAPI } from '$lib/settings/create-settings-api';
 type RecvCallback = (message: unknown, meta: unknown) => void;
 type OnSetPortCount = (inletCount: number, outletCount: number) => void;
 type OnSetTitle = (title: string) => void;
+type OnSetAudioInputVisible = (visible: boolean) => void;
 
 /**
  * SonicNode implements the sonic~ audio node.
@@ -63,6 +64,7 @@ export class SonicNode implements AudioNodeV2 {
 
   public onSetPortCount: OnSetPortCount = () => {};
   public onSetTitle: OnSetTitle = () => {};
+  public onSetAudioInputVisible: OnSetAudioInputVisible = () => {};
 
   // Custom console for routing output to VirtualConsole
   private customConsole;
@@ -143,6 +145,7 @@ export class SonicNode implements AudioNodeV2 {
       this.messageInletCount = 0;
       this.messageOutletCount = 0;
       this.recvCallback = null;
+      this.onSetAudioInputVisible(true);
 
       const settingsManager = AudioService.getInstance().getSettingsManager(this.nodeId);
       settingsManager?.clearCallbacks();
@@ -188,6 +191,7 @@ export class SonicNode implements AudioNodeV2 {
           outBus: this.busAllocation?.busIndex ?? 0,
           recv,
           send,
+          noAudioInput: () => this.onSetAudioInputVisible(false),
           ...(settingsManager ? { settings: createSettingsAPI(settingsManager) } : {})
         }
       });

--- a/ui/src/lib/audio/v2/nodes/SonicNode.ts
+++ b/ui/src/lib/audio/v2/nodes/SonicNode.ts
@@ -190,7 +190,7 @@ export class SonicNode implements AudioNodeV2 {
           outBus: this.busAllocation?.busIndex ?? 0,
           recv,
           send,
-          noAudioInput: () => this.onSetAudioInputVisible(false),
+          showAudioInput: () => this.onSetAudioInputVisible(true),
           ...(settingsManager ? { settings: createSettingsAPI(settingsManager) } : {})
         }
       });

--- a/ui/src/lib/audio/v2/nodes/ToneNode.ts
+++ b/ui/src/lib/audio/v2/nodes/ToneNode.ts
@@ -14,6 +14,7 @@ type RecvCallback = (message: unknown, meta: unknown) => void;
 
 type OnSetPortCount = (inletCount: number, outletCount: number) => void;
 type OnSetTitle = (title: string) => void;
+type OnSetAudioInputVisible = (visible: boolean) => void;
 
 /**
  * ToneNode implements the tone~ audio node.
@@ -60,6 +61,7 @@ export class ToneNode implements AudioNodeV2 {
 
   public onSetPortCount: OnSetPortCount = () => {};
   public onSetTitle: OnSetTitle = () => {};
+  public onSetAudioInputVisible: OnSetAudioInputVisible = () => {};
 
   // Custom console for routing output to VirtualConsole
   private customConsole;
@@ -177,6 +179,7 @@ export class ToneNode implements AudioNodeV2 {
       this.messageInletCount = 0;
       this.messageOutletCount = 0;
       this.recvCallback = null;
+      this.onSetAudioInputVisible(true);
 
       const jsRunner = JSRunner.getInstance();
 
@@ -194,6 +197,7 @@ export class ToneNode implements AudioNodeV2 {
         Tone,
         outputNode: this.audioNode,
         inputNode: this.inputNode,
+        noAudioInput: () => this.onSetAudioInputVisible(false),
         ...(settingsManager ? { settings: createSettingsAPI(settingsManager) } : {})
       };
 

--- a/ui/src/lib/audio/v2/nodes/ToneNode.ts
+++ b/ui/src/lib/audio/v2/nodes/ToneNode.ts
@@ -196,7 +196,7 @@ export class ToneNode implements AudioNodeV2 {
         Tone,
         outputNode: this.audioNode,
         inputNode: this.inputNode,
-        noAudioInput: () => this.onSetAudioInputVisible(false),
+        showAudioInput: () => this.onSetAudioInputVisible(true),
         ...(settingsManager ? { settings: createSettingsAPI(settingsManager) } : {})
       };
 

--- a/ui/src/lib/audio/v2/nodes/ToneNode.ts
+++ b/ui/src/lib/audio/v2/nodes/ToneNode.ts
@@ -179,7 +179,6 @@ export class ToneNode implements AudioNodeV2 {
       this.messageInletCount = 0;
       this.messageOutletCount = 0;
       this.recvCallback = null;
-      this.onSetAudioInputVisible(true);
 
       const jsRunner = JSRunner.getInstance();
 

--- a/ui/src/lib/audio/visible-audio-inputs.test.ts
+++ b/ui/src/lib/audio/visible-audio-inputs.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  getInitialSimpleDspAudioInputVisibility,
+  getRunSimpleDspAudioInputVisibility,
   hasChuckAdcReference,
-  hasNoAudioInputDirective,
-  shouldShowSimpleDspAudioInput
+  hasNoAudioInputDirective
 } from './visible-audio-inputs';
 
 describe('visible audio input helpers', () => {
@@ -27,9 +28,15 @@ describe('visible audio input helpers', () => {
     expect(hasNoAudioInputDirective("const msg = 'noAudioInput()';")).toBe(false);
   });
 
-  it('prefers stored simple DSP audio input state over code-derived state', () => {
-    expect(shouldShowSimpleDspAudioInput(false, '')).toBe(false);
-    expect(shouldShowSimpleDspAudioInput(true, 'noAudioInput()')).toBe(true);
-    expect(shouldShowSimpleDspAudioInput(undefined, '')).toBe(true);
+  it('uses stored simple DSP audio input state during initialization when present', () => {
+    expect(getInitialSimpleDspAudioInputVisibility(false, '')).toBe(false);
+    expect(getInitialSimpleDspAudioInputVisibility(true, 'noAudioInput()')).toBe(true);
+  });
+
+  it('derives simple DSP audio input state from code only for initialization or run', () => {
+    expect(getInitialSimpleDspAudioInputVisibility(undefined, 'noAudioInput()')).toBe(false);
+    expect(getInitialSimpleDspAudioInputVisibility(undefined, '')).toBe(true);
+    expect(getRunSimpleDspAudioInputVisibility('noAudioInput()')).toBe(false);
+    expect(getRunSimpleDspAudioInputVisibility('')).toBe(true);
   });
 });

--- a/ui/src/lib/audio/visible-audio-inputs.test.ts
+++ b/ui/src/lib/audio/visible-audio-inputs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasChuckAdcReference,
+  hasNoAudioInputDirective,
+  shouldShowSimpleDspAudioInput
+} from './visible-audio-inputs';
+
+describe('visible audio input helpers', () => {
+  it('detects ChucK adc references as requiring a visible audio input', () => {
+    expect(hasChuckAdcReference('adc => Gain g => dac;')).toBe(true);
+    expect(hasChuckAdcReference('adc.left => dac.left;')).toBe(true);
+  });
+
+  it('ignores non-adc ChucK code when deciding audio input visibility', () => {
+    expect(hasChuckAdcReference('SinOsc s => dac;')).toBe(false);
+    expect(hasChuckAdcReference('SinOsc modulator => blackhole;')).toBe(false);
+    expect(hasChuckAdcReference('myadc => dac;')).toBe(false);
+    expect(hasChuckAdcReference('// adc => dac;')).toBe(false);
+  });
+
+  it('detects simple DSP audio input opt-out directives', () => {
+    expect(hasNoAudioInputDirective('noAudioInput();')).toBe(true);
+  });
+
+  it('ignores opt-out directive names inside JavaScript comments and strings', () => {
+    expect(hasNoAudioInputDirective('// noAudioInput();')).toBe(false);
+    expect(hasNoAudioInputDirective("const msg = 'noAudioInput()';")).toBe(false);
+  });
+
+  it('prefers stored simple DSP audio input state over code-derived state', () => {
+    expect(shouldShowSimpleDspAudioInput(false, '')).toBe(false);
+    expect(shouldShowSimpleDspAudioInput(true, 'noAudioInput()')).toBe(true);
+    expect(shouldShowSimpleDspAudioInput(undefined, '')).toBe(true);
+  });
+});

--- a/ui/src/lib/audio/visible-audio-inputs.test.ts
+++ b/ui/src/lib/audio/visible-audio-inputs.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   getInitialSimpleDspAudioInputVisibility,
-  getRunSimpleDspAudioInputVisibility,
+  hasAudioInputUsage,
   hasChuckAdcReference,
-  hasNoAudioInputDirective
+  hasShowAudioInputDirective
 } from './visible-audio-inputs';
 
 describe('visible audio input helpers', () => {
@@ -19,24 +19,51 @@ describe('visible audio input helpers', () => {
     expect(hasChuckAdcReference('// adc => dac;')).toBe(false);
   });
 
-  it('detects simple DSP audio input opt-out directives', () => {
-    expect(hasNoAudioInputDirective('noAudioInput();')).toBe(true);
+  it('detects explicit simple DSP audio input opt-in directives', () => {
+    expect(hasShowAudioInputDirective('showAudioInput();')).toBe(true);
   });
 
-  it('ignores opt-out directive names inside JavaScript comments and strings', () => {
-    expect(hasNoAudioInputDirective('// noAudioInput();')).toBe(false);
-    expect(hasNoAudioInputDirective("const msg = 'noAudioInput()';")).toBe(false);
+  it('ignores opt-in directive names inside JavaScript comments and strings', () => {
+    expect(hasShowAudioInputDirective('// showAudioInput();')).toBe(false);
+    expect(hasShowAudioInputDirective("const msg = 'showAudioInput()';")).toBe(false);
   });
 
-  it('uses stored simple DSP audio input state during initialization when present', () => {
-    expect(getInitialSimpleDspAudioInputVisibility(false, '')).toBe(false);
-    expect(getInitialSimpleDspAudioInputVisibility(true, 'noAudioInput()')).toBe(true);
+  it('keeps stored visible audio input state during initialization when present', () => {
+    expect(getInitialSimpleDspAudioInputVisibility('tone~', false, '')).toBe(false);
+    expect(getInitialSimpleDspAudioInputVisibility('tone~', true, '')).toBe(true);
   });
 
-  it('derives simple DSP audio input state from code only for initialization or run', () => {
-    expect(getInitialSimpleDspAudioInputVisibility(undefined, 'noAudioInput()')).toBe(false);
-    expect(getInitialSimpleDspAudioInputVisibility(undefined, '')).toBe(true);
-    expect(getRunSimpleDspAudioInputVisibility('noAudioInput()')).toBe(false);
-    expect(getRunSimpleDspAudioInputVisibility('')).toBe(true);
+  it('auto-shows tone~ audio input when code references inputNode', () => {
+    expect(hasAudioInputUsage('tone~', 'inputNode.connect(filter.input.input)')).toBe(true);
+
+    expect(hasAudioInputUsage('tone~', 'const synth = new Tone.Synth().connect(outputNode)')).toBe(
+      false
+    );
+  });
+
+  it('auto-shows elem~ audio input when code references inputNode or el.in()', () => {
+    expect(hasAudioInputUsage('elem~', 'core.render(el.in({channel: 0}), outputNode)')).toBe(true);
+
+    expect(hasAudioInputUsage('elem~', 'inputNode.connect(node)')).toBe(true);
+
+    expect(hasAudioInputUsage('elem~', 'core.render(el.sine(440), outputNode)')).toBe(false);
+  });
+
+  it('auto-shows sonic~ audio input when code references inputNode', () => {
+    expect(hasAudioInputUsage('sonic~', 'inputNode.connect(sonicNode.input)')).toBe(true);
+
+    expect(hasAudioInputUsage('sonic~', "sonic.send('/s_new', 'default')")).toBe(false);
+  });
+
+  it('showAudioInput() manually shows audio input when heuristics miss usage', () => {
+    expect(hasAudioInputUsage('tone~', 'showAudioInput(); helperUsesInput();')).toBe(true);
+
+    expect(
+      getInitialSimpleDspAudioInputVisibility(
+        'sonic~',
+        false,
+        'showAudioInput(); helperUsesInput();'
+      )
+    ).toBe(true);
   });
 });

--- a/ui/src/lib/audio/visible-audio-inputs.ts
+++ b/ui/src/lib/audio/visible-audio-inputs.ts
@@ -1,0 +1,22 @@
+import { stripJavaScriptComments, stripJavaScriptStrings } from '$lib/utils/javascript-comments';
+
+function stripCodeForIdentifierSearch(code: string) {
+  return stripJavaScriptStrings(stripJavaScriptComments(code));
+}
+
+export function hasChuckAdcReference(code: string): boolean {
+  return /\badc\b/.test(stripCodeForIdentifierSearch(code));
+}
+
+export function hasNoAudioInputDirective(code: string): boolean {
+  return /\bnoAudioInput\s*\(/.test(stripCodeForIdentifierSearch(code));
+}
+
+export function shouldShowSimpleDspAudioInput(
+  showAudioInput: boolean | undefined,
+  code: string
+): boolean {
+  if (showAudioInput !== undefined) return showAudioInput;
+
+  return !hasNoAudioInputDirective(code);
+}

--- a/ui/src/lib/audio/visible-audio-inputs.ts
+++ b/ui/src/lib/audio/visible-audio-inputs.ts
@@ -1,22 +1,39 @@
 import { stripJavaScriptComments, stripJavaScriptStrings } from '$lib/utils/javascript-comments';
 
+export type SimpleDspAudioInputNodeType = 'tone~' | 'sonic~' | 'elem~';
+
 const stripCodeForIdentifierSearch = (code: string) =>
   stripJavaScriptStrings(stripJavaScriptComments(code));
 
 export const hasChuckAdcReference = (code: string): boolean =>
   /\badc\b/.test(stripCodeForIdentifierSearch(code));
 
-export const hasNoAudioInputDirective = (code: string): boolean =>
-  /\bnoAudioInput\s*\(/.test(stripCodeForIdentifierSearch(code));
+export const hasShowAudioInputDirective = (code: string): boolean =>
+  /\bshowAudioInput\s*\(/.test(stripCodeForIdentifierSearch(code));
+
+const hasInputNodeReference = (code: string): boolean =>
+  /\binputNode\b/.test(stripCodeForIdentifierSearch(code));
+
+const hasElementaryInputReference = (code: string): boolean =>
+  /\bel\s*\.\s*in\s*\(/.test(stripCodeForIdentifierSearch(code));
+
+export function hasAudioInputUsage(nodeType: SimpleDspAudioInputNodeType, code: string): boolean {
+  if (hasShowAudioInputDirective(code)) return true;
+
+  if (nodeType === 'elem~') {
+    return hasInputNodeReference(code) || hasElementaryInputReference(code);
+  }
+
+  return hasInputNodeReference(code);
+}
 
 export function getInitialSimpleDspAudioInputVisibility(
+  nodeType: SimpleDspAudioInputNodeType,
   showAudioInput: boolean | undefined,
   code: string
 ): boolean {
+  if (hasAudioInputUsage(nodeType, code)) return true;
   if (showAudioInput !== undefined) return showAudioInput;
 
-  return getRunSimpleDspAudioInputVisibility(code);
+  return false;
 }
-
-export const getRunSimpleDspAudioInputVisibility = (code: string): boolean =>
-  !hasNoAudioInputDirective(code);

--- a/ui/src/lib/audio/visible-audio-inputs.ts
+++ b/ui/src/lib/audio/visible-audio-inputs.ts
@@ -1,22 +1,22 @@
 import { stripJavaScriptComments, stripJavaScriptStrings } from '$lib/utils/javascript-comments';
 
-function stripCodeForIdentifierSearch(code: string) {
-  return stripJavaScriptStrings(stripJavaScriptComments(code));
-}
+const stripCodeForIdentifierSearch = (code: string) =>
+  stripJavaScriptStrings(stripJavaScriptComments(code));
 
-export function hasChuckAdcReference(code: string): boolean {
-  return /\badc\b/.test(stripCodeForIdentifierSearch(code));
-}
+export const hasChuckAdcReference = (code: string): boolean =>
+  /\badc\b/.test(stripCodeForIdentifierSearch(code));
 
-export function hasNoAudioInputDirective(code: string): boolean {
-  return /\bnoAudioInput\s*\(/.test(stripCodeForIdentifierSearch(code));
-}
+export const hasNoAudioInputDirective = (code: string): boolean =>
+  /\bnoAudioInput\s*\(/.test(stripCodeForIdentifierSearch(code));
 
-export function shouldShowSimpleDspAudioInput(
+export function getInitialSimpleDspAudioInputVisibility(
   showAudioInput: boolean | undefined,
   code: string
 ): boolean {
   if (showAudioInput !== undefined) return showAudioInput;
 
-  return !hasNoAudioInputDirective(code);
+  return getRunSimpleDspAudioInputVisibility(code);
 }
+
+export const getRunSimpleDspAudioInputVisibility = (code: string): boolean =>
+  !hasNoAudioInputDirective(code);

--- a/ui/src/lib/canvas/constants.ts
+++ b/ui/src/lib/canvas/constants.ts
@@ -130,7 +130,6 @@ function process(inputs, outputs) {
 }`;
 
 export const DEFAULT_TONE_JS_CODE = `setPortCount(1)
-noAudioInput()
 
 const synth = new Tone.Oscillator(440, 'sine').start()
 synth.connect(outputNode)
@@ -140,7 +139,6 @@ recv(m => {
 })`;
 
 export const DEFAULT_ELEM_CODE = `setPortCount(1)
-noAudioInput()
 
 let [rate, setRate] = core.createRef("const", {
   value: 440
@@ -151,7 +149,6 @@ recv(freq => setRate({ value: freq }))
 core.render(el.cycle(rate), el.cycle(rate))`;
 
 export const DEFAULT_SONIC_CODE = `setPortCount(1);
-noAudioInput();
 
 const name = 'sonic-pi-beep';
 setTitle(name);

--- a/ui/src/lib/canvas/constants.ts
+++ b/ui/src/lib/canvas/constants.ts
@@ -118,7 +118,9 @@ while (true) {
   120::ms => now;
 }`;
 
-export const DEFAULT_DSP_JS_CODE = `function process(inputs, outputs) {
+export const DEFAULT_DSP_JS_CODE = `setAudioPortCount(0, 1)
+
+function process(inputs, outputs) {
   outputs[0].forEach((channel) => {
     for (let i = 0; i < channel.length; i++) {
       let t = (currentFrame + i) / sampleRate
@@ -128,16 +130,17 @@ export const DEFAULT_DSP_JS_CODE = `function process(inputs, outputs) {
 }`;
 
 export const DEFAULT_TONE_JS_CODE = `setPortCount(1)
+noAudioInput()
 
 const synth = new Tone.Oscillator(440, 'sine').start()
 synth.connect(outputNode)
 
 recv(m => {
   synth.frequency.value = m;
-})
-`;
+})`;
 
 export const DEFAULT_ELEM_CODE = `setPortCount(1)
+noAudioInput()
 
 let [rate, setRate] = core.createRef("const", {
   value: 440
@@ -148,6 +151,7 @@ recv(freq => setRate({ value: freq }))
 core.render(el.cycle(rate), el.cycle(rate))`;
 
 export const DEFAULT_SONIC_CODE = `setPortCount(1);
+noAudioInput();
 
 const name = 'sonic-pi-beep';
 setTitle(name);

--- a/ui/src/lib/canvas/sonic-templates.ts
+++ b/ui/src/lib/canvas/sonic-templates.ts
@@ -8,7 +8,6 @@
  */
 export function synthdefTemplate(safeSynthdef: string): string {
   return `setPortCount(1);
-noAudioInput();
 
 const name = '${safeSynthdef}';
 setTitle(name);
@@ -58,7 +57,6 @@ onCleanup(() => {
  */
 export function scSampleTemplate(safeName: string): string {
   return `setPortCount(1);
-noAudioInput();
 setTitle("${safeName}");
 
 await sonic.loadSynthDef('sonic-pi-basic_stereo_player');

--- a/ui/src/lib/canvas/sonic-templates.ts
+++ b/ui/src/lib/canvas/sonic-templates.ts
@@ -8,6 +8,7 @@
  */
 export function synthdefTemplate(safeSynthdef: string): string {
   return `setPortCount(1);
+noAudioInput();
 
 const name = '${safeSynthdef}';
 setTitle(name);
@@ -57,6 +58,7 @@ onCleanup(() => {
  */
 export function scSampleTemplate(safeName: string): string {
   return `setPortCount(1);
+noAudioInput();
 setTitle("${safeName}");
 
 await sonic.loadSynthDef('sonic-pi-basic_stereo_player');

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -151,6 +151,14 @@ describe('patchies completions', () => {
     expect(getCompletionLabels('js', 'setS')).not.toContain('setSize');
   });
 
+  it('shows showAudioInput completions only for simple DSP audio nodes', () => {
+    expect(getCompletionLabels('tone~', 'show')).toContain('showAudioInput');
+    expect(getCompletionLabels('sonic~', 'show')).toContain('showAudioInput');
+    expect(getCompletionLabels('elem~', 'show')).toContain('showAudioInput');
+    expect(getCompletionLabels('js', 'show')).not.toContain('showAudioInput');
+    expect(getCompletionLabels('tone~', 'noA')).not.toContain(`noAudioInput`);
+  });
+
   it('shows Shader Park completions only for shaderpark code', () => {
     expect(getShaderParkCompletionLabels('shaderpark', 'sp')).toContain('sphere');
     expect(getShaderParkCompletionLabels('shaderpark', 'setSpace(getS')).toContain('getSpace');

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -48,11 +48,11 @@ const patchiesAPICompletions: Completion[] = [
     apply: 'setAudioPortCount(0, 1)'
   },
   {
-    label: 'noAudioInput',
+    label: 'showAudioInput',
     type: 'function',
     detail: '() => void',
-    info: 'Hide the visible audio input handle in tone~, sonic~, and elem~ nodes',
-    apply: 'noAudioInput()'
+    info: 'Force the visible audio input handle to show in tone~, sonic~, and elem~ nodes',
+    apply: 'showAudioInput()'
   },
   {
     label: 'setVideoCount',
@@ -465,7 +465,7 @@ const patchiesAPICompletions: Completion[] = [
 // Setup functions that should only appear at top-level (not in function bodies)
 const topLevelOnlyFunctions = new Set([
   'noDrag',
-  'noAudioInput',
+  'showAudioInput',
   'noInteract',
   'noOutput',
   'noPan',
@@ -591,7 +591,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   collapseSurface: ['surface', 'p5'],
   hideExitButton: ['surface', 'p5'],
   setAudioPortCount: ['dsp~'],
-  noAudioInput: ['tone~', 'sonic~', 'elem~'],
+  showAudioInput: ['tone~', 'sonic~', 'elem~'],
   setCanvasSize: ['canvas.dom', 'textmode.dom', 'three.dom'],
   setSize: ['dom', 'vue'],
   setHidePorts: [

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -48,6 +48,13 @@ const patchiesAPICompletions: Completion[] = [
     apply: 'setAudioPortCount(0, 1)'
   },
   {
+    label: 'noAudioInput',
+    type: 'function',
+    detail: '() => void',
+    info: 'Hide the visible audio input handle in tone~, sonic~, and elem~ nodes',
+    apply: 'noAudioInput()'
+  },
+  {
     label: 'setVideoCount',
     type: 'function',
     detail: '(inlets?: number, outlets?: number) => void',
@@ -458,6 +465,7 @@ const patchiesAPICompletions: Completion[] = [
 // Setup functions that should only appear at top-level (not in function bodies)
 const topLevelOnlyFunctions = new Set([
   'noDrag',
+  'noAudioInput',
   'noInteract',
   'noOutput',
   'noPan',
@@ -583,6 +591,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   collapseSurface: ['surface', 'p5'],
   hideExitButton: ['surface', 'p5'],
   setAudioPortCount: ['dsp~'],
+  noAudioInput: ['tone~', 'sonic~', 'elem~'],
   setCanvasSize: ['canvas.dom', 'textmode.dom', 'three.dom'],
   setSize: ['dom', 'vue'],
   setHidePorts: [

--- a/ui/src/lib/components/nodes/ChuckNode.svelte
+++ b/ui/src/lib/components/nodes/ChuckNode.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { CirclePlus, Delete, Expand, Replace, Settings } from '@lucide/svelte/icons';
-  import { useSvelteFlow } from '@xyflow/svelte';
+  import { useSvelteFlow, useUpdateNodeInternals } from '@xyflow/svelte';
   import { onMount, onDestroy } from 'svelte';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import { chuckSchema } from '$lib/objects/schemas/chuck';
@@ -15,6 +15,7 @@
   import { useAudioOutletWarning } from '$lib/composables/useAudioOutletWarning';
   import ChuckSettings from '$lib/components/settings/ChuckSettings.svelte';
   import * as Tooltip from '$lib/components/ui/tooltip';
+  import { hasChuckAdcReference } from '$lib/audio/visible-audio-inputs';
 
   let contentContainer: HTMLDivElement | null = null;
   let contentWidth = $state(100);
@@ -37,6 +38,7 @@
   let audioService = AudioService.getInstance();
 
   const { updateNodeData } = useSvelteFlow();
+  const updateNodeInternals = useUpdateNodeInternals();
   const { warnIfNoOutletConnection } = useAudioOutletWarning(nodeId);
 
   const handleMessage: MessageCallbackFn = (message) => {
@@ -100,7 +102,10 @@
     ])
   ];
 
-  const handleExpressionChange = (newExpr: string) => updateNodeData(nodeId, { expr: newExpr });
+  const handleExpressionChange = (newExpr: string) => {
+    updateNodeData(nodeId, { expr: newExpr });
+    setTimeout(() => updateNodeInternals(nodeId), 5);
+  };
 
   const handleAddShred = () => {
     warnIfNoOutletConnection();
@@ -165,26 +170,29 @@
   });
 
   const isReplaceDisabled = $derived(!data.expr.trim() || shreds.length === 0);
+  const showAudioInput = $derived(hasChuckAdcReference(data.expr ?? ''));
+  const inletCount = $derived((showAudioInput ? 1 : 0) + 1);
 </script>
 
 {#snippet chuckHandles()}
-  <!-- Audio input (accessible via adc in ChucK code) -->
-  <TypedHandle
-    port="inlet"
-    spec={chuckSchema.inlets[0].handle!}
-    title="Audio Input (accessible via adc in ChucK code)"
-    total={2}
-    index={0}
-    {nodeId}
-  />
+  {#if showAudioInput}
+    <TypedHandle
+      port="inlet"
+      spec={chuckSchema.inlets[0].handle!}
+      title="Audio Input (accessible via adc in ChucK code)"
+      total={inletCount}
+      index={0}
+      {nodeId}
+    />
+  {/if}
 
   <!-- Control inlet for messages and code -->
   <TypedHandle
     port="inlet"
     spec={chuckSchema.inlets[1].handle!}
     title="Control Input (code, bang, stop)"
-    total={2}
-    index={1}
+    total={inletCount}
+    index={showAudioInput ? 1 : 0}
     {nodeId}
   />
 {/snippet}

--- a/ui/src/lib/components/nodes/ChuckNode.svelte
+++ b/ui/src/lib/components/nodes/ChuckNode.svelte
@@ -33,6 +33,7 @@
   let isEditing = $state(!data.expr);
   let layoutRef = $state<any>();
   let showSettings = $state(false);
+  let expressionInternalsTimeout: ReturnType<typeof setTimeout> | undefined;
 
   let messageContext: MessageContext;
   let audioService = AudioService.getInstance();
@@ -104,7 +105,15 @@
 
   const handleExpressionChange = (newExpr: string) => {
     updateNodeData(nodeId, { expr: newExpr });
-    setTimeout(() => updateNodeInternals(nodeId), 5);
+
+    if (expressionInternalsTimeout) {
+      clearTimeout(expressionInternalsTimeout);
+    }
+
+    expressionInternalsTimeout = setTimeout(() => {
+      expressionInternalsTimeout = undefined;
+      updateNodeInternals(nodeId);
+    }, 5);
   };
 
   const handleAddShred = () => {
@@ -163,6 +172,10 @@
   });
 
   onDestroy(() => {
+    if (expressionInternalsTimeout) {
+      clearTimeout(expressionInternalsTimeout);
+    }
+
     messageContext.queue.removeCallback(handleMessage);
     messageContext.destroy();
 

--- a/ui/src/lib/components/nodes/DSPNode.svelte
+++ b/ui/src/lib/components/nodes/DSPNode.svelte
@@ -14,6 +14,7 @@
   import { DspNode } from '$lib/audio/v2/nodes/DspNode';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { logger } from '$lib/utils/logger';
+  import { editorFontFamily } from '../../../stores/editor.store';
 
   let contentContainer: HTMLDivElement | null = null;
 
@@ -305,7 +306,7 @@
   });
 </script>
 
-<div class="relative flex gap-x-3">
+<div class="relative flex gap-x-3" style:--patchies-dsp-node-font-family={$editorFontFamily}>
   <div class="group relative">
     <div class="flex flex-col gap-2" bind:this={contentContainer}>
       <div class="absolute -top-7 left-0 flex w-full items-center justify-between">
@@ -389,7 +390,7 @@
           title="Double click to edit code"
         >
           <div class="flex items-center justify-center">
-            <div class="font-mono text-xs text-zinc-300">{data.title ?? 'dsp~'}</div>
+            <div class="dsp-node-label text-xs text-zinc-300">{data.title ?? 'dsp~'}</div>
           </div>
         </button>
 
@@ -485,3 +486,9 @@
     </div>
   {/if}
 </div>
+
+<style>
+  .dsp-node-label {
+    font-family: var(--patchies-dsp-node-font-family, var(--font-mono));
+  }
+</style>

--- a/ui/src/lib/components/nodes/ElementaryAudioNode.svelte
+++ b/ui/src/lib/components/nodes/ElementaryAudioNode.svelte
@@ -13,7 +13,10 @@
   import { SettingsManager } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
-  import { hasNoAudioInputDirective } from '$lib/audio/visible-audio-inputs';
+  import {
+    getInitialSimpleDspAudioInputVisibility,
+    getRunSimpleDspAudioInputVisibility
+  } from '$lib/audio/visible-audio-inputs';
 
   // Get node data from XY Flow - nodes receive their data as props
   let {
@@ -88,10 +91,7 @@
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
 
   function handleCodeChange(newCode: string) {
-    updateNodeData(nodeId, {
-      code: newCode,
-      showAudioInput: !hasNoAudioInputDirective(newCode)
-    });
+    updateNodeData(nodeId, { code: newCode });
 
     setTimeout(() => {
       const elemNode = audioService.getNodeById(nodeId) as ElementaryNode | undefined;
@@ -125,6 +125,11 @@
     consoleRef?.clearConsole();
     lineErrors = undefined;
 
+    updateNodeData(nodeId, {
+      showAudioInput: getRunSimpleDspAudioInputVisibility(data.code)
+    });
+
+    updateNodeInternals(nodeId);
     updateAudioCode(data.code);
   }
 
@@ -134,6 +139,11 @@
 
   onMount(() => {
     audioService.registerSettingsManager(nodeId, settingsManager);
+
+    updateNodeData(nodeId, {
+      showAudioInput: getInitialSimpleDspAudioInputVisibility(data.showAudioInput, data.code)
+    });
+
     audioService.createNode(nodeId, 'elem~', [null, data.code]);
 
     handleCodeChange(data.code);

--- a/ui/src/lib/components/nodes/ElementaryAudioNode.svelte
+++ b/ui/src/lib/components/nodes/ElementaryAudioNode.svelte
@@ -15,7 +15,7 @@
   import type { SettingsSchema } from '$lib/settings';
   import {
     getInitialSimpleDspAudioInputVisibility,
-    getRunSimpleDspAudioInputVisibility
+    hasAudioInputUsage
   } from '$lib/audio/visible-audio-inputs';
 
   // Get node data from XY Flow - nodes receive their data as props
@@ -126,7 +126,7 @@
     lineErrors = undefined;
 
     updateNodeData(nodeId, {
-      showAudioInput: getRunSimpleDspAudioInputVisibility(data.code)
+      showAudioInput: hasAudioInputUsage('elem~', data.code)
     });
 
     updateNodeInternals(nodeId);
@@ -141,7 +141,11 @@
     audioService.registerSettingsManager(nodeId, settingsManager);
 
     updateNodeData(nodeId, {
-      showAudioInput: getInitialSimpleDspAudioInputVisibility(data.showAudioInput, data.code)
+      showAudioInput: getInitialSimpleDspAudioInputVisibility(
+        'elem~',
+        data.showAudioInput,
+        data.code
+      )
     });
 
     audioService.createNode(nodeId, 'elem~', [null, data.code]);

--- a/ui/src/lib/components/nodes/ElementaryAudioNode.svelte
+++ b/ui/src/lib/components/nodes/ElementaryAudioNode.svelte
@@ -13,6 +13,7 @@
   import { SettingsManager } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
+  import { hasNoAudioInputDirective } from '$lib/audio/visible-audio-inputs';
 
   // Get node data from XY Flow - nodes receive their data as props
   let {
@@ -25,6 +26,7 @@
       code: string;
       messageInletCount?: number;
       messageOutletCount?: number;
+      showAudioInput?: boolean;
       title?: string;
       executeCode?: number;
       showConsole?: boolean;
@@ -86,7 +88,10 @@
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
 
   function handleCodeChange(newCode: string) {
-    updateNodeData(nodeId, { code: newCode });
+    updateNodeData(nodeId, {
+      code: newCode,
+      showAudioInput: !hasNoAudioInputDirective(newCode)
+    });
 
     setTimeout(() => {
       const elemNode = audioService.getNodeById(nodeId) as ElementaryNode | undefined;
@@ -105,6 +110,13 @@
       elemNode.onSetTitle = (title: string) => {
         updateNodeData(nodeId, { title });
       };
+
+      elemNode.onSetAudioInputVisible = (showAudioInput: boolean) => {
+        updateNodeData(nodeId, { showAudioInput });
+        updateNodeInternals(nodeId);
+      };
+
+      updateNodeInternals(nodeId);
     }, 10);
   }
 

--- a/ui/src/lib/components/nodes/SimpleDspLayout.svelte
+++ b/ui/src/lib/components/nodes/SimpleDspLayout.svelte
@@ -77,7 +77,7 @@
   const messageInletCount = $derived(data.messageInletCount || 0);
   const messageOutletCount = $derived(data.messageOutletCount || 0);
   const displayTitle = $derived(data.title || nodeName);
-  const showAudioInput = $derived(data.showAudioInput ?? true);
+  const showAudioInput = $derived(data.showAudioInput ?? false);
   const visibleInletCount = $derived((showAudioInput ? 1 : 0) + messageInletCount);
 
   const isCodeEditorDetached = $derived(

--- a/ui/src/lib/components/nodes/SimpleDspLayout.svelte
+++ b/ui/src/lib/components/nodes/SimpleDspLayout.svelte
@@ -20,6 +20,7 @@
   import { defaultEditorLayout } from '../../../stores/editor-layout-settings.store';
   import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
   import { editorFontFamily } from '../../../stores/editor.store';
+  import { shouldShowSimpleDspAudioInput } from '$lib/audio/visible-audio-inputs';
 
   let {
     nodeId,
@@ -47,6 +48,7 @@
       code: string;
       messageInletCount?: number;
       messageOutletCount?: number;
+      showAudioInput?: boolean;
       title?: string;
     };
     selected: boolean;
@@ -76,6 +78,8 @@
   const messageInletCount = $derived(data.messageInletCount || 0);
   const messageOutletCount = $derived(data.messageOutletCount || 0);
   const displayTitle = $derived(data.title || nodeName);
+  const showAudioInput = $derived(shouldShowSimpleDspAudioInput(data.showAudioInput, code));
+  const visibleInletCount = $derived((showAudioInput ? 1 : 0) + messageInletCount);
 
   const isCodeEditorDetached = $derived(
     $activeCodeEditorTarget?.nodeId === nodeId && $activeCodeEditorTarget.dataKey === 'code'
@@ -214,7 +218,7 @@
   let minContainerWidth = $derived.by(() => {
     const baseWidth = 20;
     let inletWidth = 20;
-    return baseWidth + (1 + messageInletCount) * inletWidth;
+    return baseWidth + visibleInletCount * inletWidth;
   });
 </script>
 
@@ -267,18 +271,19 @@
       </div>
 
       <div class="relative">
-        <!-- Total inlets = 1 audio inlet + message inlets -->
+        <!-- Total inlets = optional audio inlet + message inlets -->
         <div>
-          <!-- Audio input (always present) -->
-          <TypedHandle
-            port="inlet"
-            spec={{ handleType: 'audio' }}
-            title="Audio Input"
-            total={1 + messageInletCount}
-            index={0}
-            class="top-0"
-            {nodeId}
-          />
+          {#if showAudioInput}
+            <TypedHandle
+              port="inlet"
+              spec={{ handleType: 'audio' }}
+              title="Audio Input"
+              total={visibleInletCount}
+              index={0}
+              class="top-0"
+              {nodeId}
+            />
+          {/if}
 
           <!-- Message inlets (only show if messageInletCount > 0) -->
           {#if messageInletCount > 0}
@@ -287,8 +292,8 @@
                 port="inlet"
                 spec={{ handleType: 'message', handleId: index }}
                 title={`Message Inlet ${index + 1}`}
-                total={1 + messageInletCount}
-                index={1 + index}
+                total={visibleInletCount}
+                index={(showAudioInput ? 1 : 0) + index}
                 class="top-0"
                 {nodeId}
               />

--- a/ui/src/lib/components/nodes/SimpleDspLayout.svelte
+++ b/ui/src/lib/components/nodes/SimpleDspLayout.svelte
@@ -20,7 +20,6 @@
   import { defaultEditorLayout } from '../../../stores/editor-layout-settings.store';
   import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
   import { editorFontFamily } from '../../../stores/editor.store';
-  import { shouldShowSimpleDspAudioInput } from '$lib/audio/visible-audio-inputs';
 
   let {
     nodeId,
@@ -78,7 +77,7 @@
   const messageInletCount = $derived(data.messageInletCount || 0);
   const messageOutletCount = $derived(data.messageOutletCount || 0);
   const displayTitle = $derived(data.title || nodeName);
-  const showAudioInput = $derived(shouldShowSimpleDspAudioInput(data.showAudioInput, code));
+  const showAudioInput = $derived(data.showAudioInput ?? true);
   const visibleInletCount = $derived((showAudioInput ? 1 : 0) + messageInletCount);
 
   const isCodeEditorDetached = $derived(

--- a/ui/src/lib/components/nodes/SonicNode.svelte
+++ b/ui/src/lib/components/nodes/SonicNode.svelte
@@ -13,7 +13,10 @@
   import { SettingsManager } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
-  import { hasNoAudioInputDirective } from '$lib/audio/visible-audio-inputs';
+  import {
+    getInitialSimpleDspAudioInputVisibility,
+    getRunSimpleDspAudioInputVisibility
+  } from '$lib/audio/visible-audio-inputs';
 
   // Get node data from XY Flow - nodes receive their data as props
   let {
@@ -86,10 +89,7 @@
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
 
   function handleCodeChange(newCode: string) {
-    updateNodeData(nodeId, {
-      code: newCode,
-      showAudioInput: !hasNoAudioInputDirective(newCode)
-    });
+    updateNodeData(nodeId, { code: newCode });
 
     setTimeout(() => {
       const sonicNode = audioService.getNodeById(nodeId) as SonicNode | undefined;
@@ -123,6 +123,11 @@
     consoleRef?.clearConsole();
     lineErrors = undefined;
 
+    updateNodeData(nodeId, {
+      showAudioInput: getRunSimpleDspAudioInputVisibility(data.code)
+    });
+
+    updateNodeInternals(nodeId);
     updateAudioCode(data.code);
   }
 
@@ -132,6 +137,11 @@
 
   onMount(() => {
     audioService.registerSettingsManager(nodeId, settingsManager);
+
+    updateNodeData(nodeId, {
+      showAudioInput: getInitialSimpleDspAudioInputVisibility(data.showAudioInput, data.code)
+    });
+
     audioService.createNode(nodeId, 'sonic~', [null, data.code]);
     handleCodeChange(data.code);
     eventBus.addEventListener('consoleOutput', handleConsoleOutput);

--- a/ui/src/lib/components/nodes/SonicNode.svelte
+++ b/ui/src/lib/components/nodes/SonicNode.svelte
@@ -13,6 +13,7 @@
   import { SettingsManager } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
+  import { hasNoAudioInputDirective } from '$lib/audio/visible-audio-inputs';
 
   // Get node data from XY Flow - nodes receive their data as props
   let {
@@ -25,6 +26,7 @@
       code: string;
       messageInletCount?: number;
       messageOutletCount?: number;
+      showAudioInput?: boolean;
       title?: string;
       executeCode?: number;
       showConsole?: boolean;
@@ -84,7 +86,10 @@
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
 
   function handleCodeChange(newCode: string) {
-    updateNodeData(nodeId, { code: newCode });
+    updateNodeData(nodeId, {
+      code: newCode,
+      showAudioInput: !hasNoAudioInputDirective(newCode)
+    });
 
     setTimeout(() => {
       const sonicNode = audioService.getNodeById(nodeId) as SonicNode | undefined;
@@ -103,6 +108,13 @@
       sonicNode.onSetTitle = (title: string) => {
         updateNodeData(nodeId, { title });
       };
+
+      sonicNode.onSetAudioInputVisible = (showAudioInput: boolean) => {
+        updateNodeData(nodeId, { showAudioInput });
+        updateNodeInternals(nodeId);
+      };
+
+      updateNodeInternals(nodeId);
     }, 10);
   }
 

--- a/ui/src/lib/components/nodes/SonicNode.svelte
+++ b/ui/src/lib/components/nodes/SonicNode.svelte
@@ -15,7 +15,7 @@
   import type { SettingsSchema } from '$lib/settings';
   import {
     getInitialSimpleDspAudioInputVisibility,
-    getRunSimpleDspAudioInputVisibility
+    hasAudioInputUsage
   } from '$lib/audio/visible-audio-inputs';
 
   // Get node data from XY Flow - nodes receive their data as props
@@ -124,7 +124,7 @@
     lineErrors = undefined;
 
     updateNodeData(nodeId, {
-      showAudioInput: getRunSimpleDspAudioInputVisibility(data.code)
+      showAudioInput: hasAudioInputUsage('sonic~', data.code)
     });
 
     updateNodeInternals(nodeId);
@@ -139,7 +139,11 @@
     audioService.registerSettingsManager(nodeId, settingsManager);
 
     updateNodeData(nodeId, {
-      showAudioInput: getInitialSimpleDspAudioInputVisibility(data.showAudioInput, data.code)
+      showAudioInput: getInitialSimpleDspAudioInputVisibility(
+        'sonic~',
+        data.showAudioInput,
+        data.code
+      )
     });
 
     audioService.createNode(nodeId, 'sonic~', [null, data.code]);

--- a/ui/src/lib/components/nodes/ToneNode.svelte
+++ b/ui/src/lib/components/nodes/ToneNode.svelte
@@ -13,7 +13,10 @@
   import { SettingsManager } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
-  import { hasNoAudioInputDirective } from '$lib/audio/visible-audio-inputs';
+  import {
+    getInitialSimpleDspAudioInputVisibility,
+    getRunSimpleDspAudioInputVisibility
+  } from '$lib/audio/visible-audio-inputs';
 
   // Get node data from XY Flow - nodes receive their data as props
   let {
@@ -87,10 +90,7 @@
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
 
   function handleCodeChange(newCode: string) {
-    updateNodeData(nodeId, {
-      code: newCode,
-      showAudioInput: !hasNoAudioInputDirective(newCode)
-    });
+    updateNodeData(nodeId, { code: newCode });
 
     setTimeout(() => {
       const toneNode = audioService.getNodeById(nodeId) as ToneNode | undefined;
@@ -124,6 +124,11 @@
     consoleRef?.clearConsole();
     lineErrors = undefined;
 
+    updateNodeData(nodeId, {
+      showAudioInput: getRunSimpleDspAudioInputVisibility(data.code)
+    });
+
+    updateNodeInternals(nodeId);
     updateAudioCode(data.code);
   }
 
@@ -133,6 +138,11 @@
 
   onMount(() => {
     audioService.registerSettingsManager(nodeId, settingsManager);
+
+    updateNodeData(nodeId, {
+      showAudioInput: getInitialSimpleDspAudioInputVisibility(data.showAudioInput, data.code)
+    });
+
     audioService.createNode(nodeId, 'tone~', [null, data.code]);
     handleCodeChange(data.code);
     eventBus.addEventListener('consoleOutput', handleConsoleOutput);

--- a/ui/src/lib/components/nodes/ToneNode.svelte
+++ b/ui/src/lib/components/nodes/ToneNode.svelte
@@ -13,6 +13,7 @@
   import { SettingsManager } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
+  import { hasNoAudioInputDirective } from '$lib/audio/visible-audio-inputs';
 
   // Get node data from XY Flow - nodes receive their data as props
   let {
@@ -25,6 +26,7 @@
       code: string;
       messageInletCount?: number;
       messageOutletCount?: number;
+      showAudioInput?: boolean;
       title?: string;
       executeCode?: number;
       showConsole?: boolean;
@@ -85,7 +87,10 @@
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
 
   function handleCodeChange(newCode: string) {
-    updateNodeData(nodeId, { code: newCode });
+    updateNodeData(nodeId, {
+      code: newCode,
+      showAudioInput: !hasNoAudioInputDirective(newCode)
+    });
 
     setTimeout(() => {
       const toneNode = audioService.getNodeById(nodeId) as ToneNode | undefined;
@@ -104,6 +109,13 @@
       toneNode.onSetTitle = (title: string) => {
         updateNodeData(nodeId, { title });
       };
+
+      toneNode.onSetAudioInputVisible = (showAudioInput: boolean) => {
+        updateNodeData(nodeId, { showAudioInput });
+        updateNodeInternals(nodeId);
+      };
+
+      updateNodeInternals(nodeId);
     }, 10);
   }
 

--- a/ui/src/lib/components/nodes/ToneNode.svelte
+++ b/ui/src/lib/components/nodes/ToneNode.svelte
@@ -15,7 +15,7 @@
   import type { SettingsSchema } from '$lib/settings';
   import {
     getInitialSimpleDspAudioInputVisibility,
-    getRunSimpleDspAudioInputVisibility
+    hasAudioInputUsage
   } from '$lib/audio/visible-audio-inputs';
 
   // Get node data from XY Flow - nodes receive their data as props
@@ -125,7 +125,7 @@
     lineErrors = undefined;
 
     updateNodeData(nodeId, {
-      showAudioInput: getRunSimpleDspAudioInputVisibility(data.code)
+      showAudioInput: hasAudioInputUsage('tone~', data.code)
     });
 
     updateNodeInternals(nodeId);
@@ -140,7 +140,11 @@
     audioService.registerSettingsManager(nodeId, settingsManager);
 
     updateNodeData(nodeId, {
-      showAudioInput: getInitialSimpleDspAudioInputVisibility(data.showAudioInput, data.code)
+      showAudioInput: getInitialSimpleDspAudioInputVisibility(
+        'tone~',
+        data.showAudioInput,
+        data.code
+      )
     });
 
     audioService.createNode(nodeId, 'tone~', [null, data.code]);

--- a/ui/src/lib/nodes/defaultNodeData.ts
+++ b/ui/src/lib/nodes/defaultNodeData.ts
@@ -166,20 +166,27 @@ export function getDefaultNodeData(nodeType: string): NodeData {
       code: DEFAULT_DSP_JS_CODE,
       messageInletCount: 0,
       messageOutletCount: 0,
-      audioInletCount: 1,
+      audioInletCount: 0,
       audioOutletCount: 1
     }))
     .with('tone~', () => ({
       code: DEFAULT_TONE_JS_CODE,
       messageInletCount: 1,
-      messageOutletCount: 0
+      messageOutletCount: 0,
+      showAudioInput: false
     }))
     .with('sonic~', () => ({
       code: DEFAULT_SONIC_CODE,
       messageInletCount: 1,
-      messageOutletCount: 0
+      messageOutletCount: 0,
+      showAudioInput: false
     }))
-    .with('elem~', () => ({ code: DEFAULT_ELEM_CODE, messageInletCount: 1, messageOutletCount: 0 }))
+    .with('elem~', () => ({
+      code: DEFAULT_ELEM_CODE,
+      messageInletCount: 1,
+      messageOutletCount: 0,
+      showAudioInput: false
+    }))
     .with('csound~', () => ({
       expr: DEFAULT_CSOUND_CODE,
       syncTransport: false

--- a/ui/src/lib/presets/builtin/elementary.preset.ts
+++ b/ui/src/lib/presets/builtin/elementary.preset.ts
@@ -16,7 +16,6 @@ core.render(lpf, lpf)
 recv(freq => setCutoffFreq({value: freq}))`;
 
 const createRatePreset = (name: string) => `setPortCount(1)
-noAudioInput()
 setTitle('${name}~')
 
 let [rate, setRate] = core.createRef("const", {

--- a/ui/src/lib/presets/builtin/elementary.preset.ts
+++ b/ui/src/lib/presets/builtin/elementary.preset.ts
@@ -16,6 +16,7 @@ core.render(lpf, lpf)
 recv(freq => setCutoffFreq({value: freq}))`;
 
 const createRatePreset = (name: string) => `setPortCount(1)
+noAudioInput()
 setTitle('${name}~')
 
 let [rate, setRate] = core.createRef("const", {
@@ -33,10 +34,20 @@ export const ELEMENTARY_PRESETS = {
   },
   'phasor.elem': {
     type: 'elem~',
-    data: { code: createRatePreset('phasor'), messageInletCount: 1, title: 'phasor~' }
+    data: {
+      code: createRatePreset('phasor'),
+      messageInletCount: 1,
+      title: 'phasor~',
+      showAudioInput: false
+    }
   },
   'train.elem': {
     type: 'elem~',
-    data: { code: createRatePreset('train'), messageInletCount: 1, title: 'train~' }
+    data: {
+      code: createRatePreset('train'),
+      messageInletCount: 1,
+      title: 'train~',
+      showAudioInput: false
+    }
   }
 };

--- a/ui/src/lib/presets/builtin/sonic.preset.ts
+++ b/ui/src/lib/presets/builtin/sonic.preset.ts
@@ -5,7 +5,8 @@ const createPreset = (synthdef: string) => ({
   data: {
     code: synthdefTemplate(synthdef),
     title: synthdef,
-    messageInletCount: 1
+    messageInletCount: 1,
+    showAudioInput: false
   }
 });
 
@@ -17,6 +18,7 @@ export const SONIC_PRESETS = {
     type: 'sonic~',
     data: {
       code: `setPortCount(1)
+noAudioInput()
 setTitle('sonic-sample-loop')
 
 // Track loading state
@@ -37,13 +39,15 @@ recv(msg => {
   }
 })`,
       messageInletCount: 1,
-      title: 'sonic-sample-loop'
+      title: 'sonic-sample-loop',
+      showAudioInput: false
     }
   },
   'sonic-multi-synth': {
     type: 'sonic~',
     data: {
       code: `setPortCount(1);
+noAudioInput();
 setTitle('sonic-multi-synth');
 
 const synths = ['sonic-pi-beep', 'sonic-pi-prophet', 'sonic-pi-saw'];
@@ -87,7 +91,8 @@ onCleanup(() => {
   activeNotes.clear();
 });`,
       messageInletCount: 1,
-      title: 'sonic-multi-synth'
+      title: 'sonic-multi-synth',
+      showAudioInput: false
     }
   }
 };

--- a/ui/src/lib/presets/builtin/sonic.preset.ts
+++ b/ui/src/lib/presets/builtin/sonic.preset.ts
@@ -18,7 +18,6 @@ export const SONIC_PRESETS = {
     type: 'sonic~',
     data: {
       code: `setPortCount(1)
-noAudioInput()
 setTitle('sonic-sample-loop')
 
 // Track loading state
@@ -47,7 +46,6 @@ recv(msg => {
     type: 'sonic~',
     data: {
       code: `setPortCount(1);
-noAudioInput();
 setTitle('sonic-multi-synth');
 
 const synths = ['sonic-pi-beep', 'sonic-pi-prophet', 'sonic-pi-saw'];

--- a/ui/src/lib/presets/builtin/tone.preset.ts
+++ b/ui/src/lib/presets/builtin/tone.preset.ts
@@ -1,5 +1,4 @@
 const POLY_SYNTH_MIDI_JS = `setPortCount(1)
-noAudioInput()
 setTitle('synth~')
 
 const reverb = new Tone.Reverb({

--- a/ui/src/lib/presets/builtin/tone.preset.ts
+++ b/ui/src/lib/presets/builtin/tone.preset.ts
@@ -1,4 +1,5 @@
 const POLY_SYNTH_MIDI_JS = `setPortCount(1)
+noAudioInput()
 setTitle('synth~')
 
 const reverb = new Tone.Reverb({
@@ -93,7 +94,12 @@ onCleanup(() => {
 export const TONE_JS_PRESETS = {
   'poly-synth-midi.tone': {
     type: 'tone~',
-    data: { code: POLY_SYNTH_MIDI_JS, messageInletCount: 1, title: 'synth~' }
+    data: {
+      code: POLY_SYNTH_MIDI_JS,
+      messageInletCount: 1,
+      title: 'synth~',
+      showAudioInput: false
+    }
   },
   'tone>': {
     type: 'tone~',

--- a/ui/static/content/objects/chuck~.md
+++ b/ui/static/content/objects/chuck~.md
@@ -50,6 +50,9 @@ ChucK accepts audio input for processing and analysis:
 adc => PitShift p => dac;
 ```
 
+The blue audio inlet appears when your code references `adc`. Synth-only ChucK
+code hides the inlet to keep the node compact.
+
 ## Global Variables
 
 The [demo patch](/?id=2nyuznzjgbp2j0a) shows how global

--- a/ui/static/content/objects/dsp~.md
+++ b/ui/static/content/objects/dsp~.md
@@ -60,6 +60,10 @@ const process = (inputs, outputs) => {
 - `setTitle(title)` - custom object title
 - `setKeepAlive(enabled)` - keep worklet active when disconnected
 
+Use `setAudioPortCount(0, 1)` for synths and generators that do not need incoming
+audio. This hides the blue audio inlet on the node while keeping the worklet's
+internal input available.
+
 ## Multiple Audio Ports
 
 Use `setAudioPortCount(inputs, outputs)` to configure multiple audio ports.

--- a/ui/static/content/objects/elem~.md
+++ b/ui/static/content/objects/elem~.md
@@ -10,16 +10,22 @@ The `elem~` context provides:
 - `node`: the AudioWorkletNode
 - `inputNode`: GainNode for audio input
 - `outputNode`: GainNode for audio output
+- `noAudioInput()`: hide the blue audio input handle when code does not use incoming audio
 
 ## Messaging
 
 Supports [Patchies JavaScript Runner](/docs/javascript-runner) functions
 (`send`, `recv`, `setPortCount`, `onCleanup`, etc.).
 
+Call `noAudioInput()` for generators that only synthesize sound or respond to
+messages. The internal `inputNode` remains available, but the node does not show
+a blue input handle.
+
 ## Example
 
 ```js
 setPortCount(1);
+noAudioInput();
 
 let [rate, setRate] = core.createRef('const', { value: 440 }, []);
 

--- a/ui/static/content/objects/elem~.md
+++ b/ui/static/content/objects/elem~.md
@@ -10,22 +10,22 @@ The `elem~` context provides:
 - `node`: the AudioWorkletNode
 - `inputNode`: GainNode for audio input
 - `outputNode`: GainNode for audio output
-- `noAudioInput()`: hide the blue audio input handle when code does not use incoming audio
+- `showAudioInput()`: show the blue audio input handle when automatic detection misses your input usage
 
 ## Messaging
 
 Supports [Patchies JavaScript Runner](/docs/javascript-runner) functions
 (`send`, `recv`, `setPortCount`, `onCleanup`, etc.).
 
-Call `noAudioInput()` for generators that only synthesize sound or respond to
-messages. The internal `inputNode` remains available, but the node does not show
-a blue input handle.
+`elem~` hides its audio input handle by default. It automatically shows the
+handle when your code references `inputNode` or `el.in(...)`; call
+`showAudioInput()` only when your input routing happens indirectly through
+another helper.
 
 ## Example
 
 ```js
 setPortCount(1);
-noAudioInput();
 
 let [rate, setRate] = core.createRef('const', { value: 440 }, []);
 
@@ -33,6 +33,19 @@ recv((freq) => setRate({ value: freq }));
 
 // Try el.train and el.cycle too
 core.render(el.phasor(rate), el.phasor(rate));
+```
+
+### Manual audio input handle
+
+Use `showAudioInput()` when you want to force the audio input handle to appear.
+This is most useful when incoming audio is routed through shared setup code and
+automatic detection misses it.
+
+```js
+showAudioInput();
+
+const graph = el.in({ channel: 0 });
+core.render(el.mul(graph, 0.5), outputNode);
 ```
 
 Please consider supporting

--- a/ui/static/content/objects/sonic~.md
+++ b/ui/static/content/objects/sonic~.md
@@ -20,7 +20,7 @@ The `sonic~` JavaScript context provides:
 - `inputNode`: Audio input GainNode
 - `outputNode`: Audio output GainNode
 - `outBus`: Assigned output bus index for this node (number)
-- `noAudioInput()`: hide the blue audio input handle when code does not use incoming audio
+- `showAudioInput()`: show the blue audio input handle when automatic detection misses your input usage
 
 ## Audio Routing
 
@@ -49,9 +49,9 @@ Available events: `'ready'`, `'loading:start'`, `'loading:complete'`,
 Supports [Patchies JavaScript Runner](/docs/javascript-runner) functions
 (`send`, `recv`, `setPortCount`, `onCleanup`, etc.).
 
-Call `noAudioInput()` for synths and sample players that only generate sound or
-respond to messages. The internal `inputNode` remains available, but the node
-does not show a blue input handle.
+`sonic~` hides its audio input handle by default. It automatically shows the
+handle when your code references `inputNode`; call `showAudioInput()` only when
+your input routing happens indirectly through another helper.
 
 ## Command Listener
 
@@ -70,7 +70,6 @@ recv(msg => sonic.send(...msg))
 
 ```js
 setPortCount(1);
-noAudioInput();
 
 await sonic.loadSynthDef('sonic-pi-prophet');
 
@@ -78,6 +77,16 @@ recv((note) => {
   sonic.send('/s_new', 'sonic-pi-prophet', -1, 0, 0,
     'note', note, 'release', 2, 'out_bus', outBus);
 });
+```
+
+### Manual audio input handle
+
+Use `showAudioInput()` when you want to force the audio input handle to appear.
+This is most useful when incoming audio is used through SuperSonic routing that
+automatic detection cannot see.
+
+```js
+showAudioInput();
 ```
 
 ## Load and Play Samples

--- a/ui/static/content/objects/sonic~.md
+++ b/ui/static/content/objects/sonic~.md
@@ -20,6 +20,7 @@ The `sonic~` JavaScript context provides:
 - `inputNode`: Audio input GainNode
 - `outputNode`: Audio output GainNode
 - `outBus`: Assigned output bus index for this node (number)
+- `noAudioInput()`: hide the blue audio input handle when code does not use incoming audio
 
 ## Audio Routing
 
@@ -48,6 +49,10 @@ Available events: `'ready'`, `'loading:start'`, `'loading:complete'`,
 Supports [Patchies JavaScript Runner](/docs/javascript-runner) functions
 (`send`, `recv`, `setPortCount`, `onCleanup`, etc.).
 
+Call `noAudioInput()` for synths and sample players that only generate sound or
+respond to messages. The internal `inputNode` remains available, but the node
+does not show a blue input handle.
+
 ## Command Listener
 
 SuperSonic works by sending OSC (OpenSoundControl) messages to the synth engine.
@@ -65,6 +70,7 @@ recv(msg => sonic.send(...msg))
 
 ```js
 setPortCount(1);
+noAudioInput();
 
 await sonic.loadSynthDef('sonic-pi-prophet');
 

--- a/ui/static/content/objects/tone~.md
+++ b/ui/static/content/objects/tone~.md
@@ -9,6 +9,7 @@ The Tone.js context provides:
 - `Tone`: the Tone.js library
 - `inputNode`: GainNode for receiving audio input
 - `outputNode`: GainNode for sending audio output
+- `noAudioInput()`: hide the blue audio input handle when code does not use incoming audio
 
 ## Messaging
 
@@ -46,6 +47,23 @@ filter.connect(outputNode);
 
 recv((m) => {
   filter.frequency.value = m;
+});
+```
+
+### Synth without audio input
+
+Call `noAudioInput()` when a `tone~` node only generates sound or responds to
+messages. The internal `inputNode` still exists, but the node does not show a
+blue input handle.
+
+```js
+setPortCount(1);
+noAudioInput();
+
+const synth = new Tone.Synth().connect(outputNode);
+
+recv((m) => {
+  if (m?.type === 'bang') synth.triggerAttackRelease('C4', 0.25);
 });
 ```
 

--- a/ui/static/content/objects/tone~.md
+++ b/ui/static/content/objects/tone~.md
@@ -9,7 +9,7 @@ The Tone.js context provides:
 - `Tone`: the Tone.js library
 - `inputNode`: GainNode for receiving audio input
 - `outputNode`: GainNode for sending audio output
-- `noAudioInput()`: hide the blue audio input handle when code does not use incoming audio
+- `showAudioInput()`: show the blue audio input handle when automatic detection misses your input usage
 
 ## Messaging
 
@@ -50,21 +50,34 @@ recv((m) => {
 });
 ```
 
-### Synth without audio input
+### Synth
 
-Call `noAudioInput()` when a `tone~` node only generates sound or responds to
-messages. The internal `inputNode` still exists, but the node does not show a
-blue input handle.
+`tone~` hides its audio input handle by default. It automatically shows the
+handle when your code references `inputNode`; call `showAudioInput()` only when
+your input routing happens indirectly through another helper.
 
 ```js
 setPortCount(1);
-noAudioInput();
 
 const synth = new Tone.Synth().connect(outputNode);
 
 recv((m) => {
   if (m?.type === 'bang') synth.triggerAttackRelease('C4', 0.25);
 });
+```
+
+### Manual audio input handle
+
+Use `showAudioInput()` when you want to force the audio input handle to appear.
+This is most useful when an effect uses incoming audio indirectly and automatic
+detection misses it.
+
+```js
+showAudioInput();
+
+const filter = new Tone.Filter(1000, 'lowpass');
+inputNode.connect(filter.input.input);
+filter.connect(outputNode);
 ```
 
 ### Reverb effect


### PR DESCRIPTION
Add functions to hide audio inputs in `dsp~`, `tone~`, `sonic~`, `chuck~` and `elem~`

- `dsp~`: `setAudioPortCount(0, n)` hides audio input handles while keeping the DSP node implementation unchanged.
- `tone~` and `sonic~` and `elem~`: user code can call `noAudioInput()` to hide the fixed audio input handle. This affects only the visible handle; `inputNode` remains available internally.
- `chuck~`: the audio input handle is visible only when the code references `adc`.
- Defaults and built-in presets that only synthesize or react to messages should opt out of visible audio input handles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio input handles can now appear only when needed, keeping nodes cleaner by default.
  * Added a manual `showAudioInput()` option for cases where input routing is indirect.
  * Updated node templates and presets so several audio nodes start with hidden input handles.

* **Bug Fixes**
  * Audio input visibility now updates correctly after code changes and on initial load.
  * Improved handle ordering and layout when the audio input is hidden or shown dynamically.

* **Documentation**
  * Expanded object docs with examples and guidance for the new audio input behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->