### PR TITLE
perf(video): speed up video seeking

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -63,7 +63,7 @@
         "marked-highlight": "^2.2.3",
         "marked-katex-extension": "^5.1.7",
         "matter-js": "^0.20.0",
-        "mediabunny": "^1.31.0",
+        "mediabunny": "^1.49.0",
         "memfs": "^4.39.0",
         "meyda": "^5.6.3",
         "midi-file": "^1.2.4",
@@ -2097,7 +2097,7 @@
 
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
-    "mediabunny": ["mediabunny@1.31.0", "", { "dependencies": { "@types/dom-mediacapture-transform": "^0.1.11", "@types/dom-webcodecs": "0.1.13" } }, "sha512-nqM+6cOpNC/aDxCAZKnZe7oXnGaCn4rlgprzAmiH6C8GRdOHFnB6bZC0+WXGTT6mtAxXQd+BXuZ2q2zkma7dWg=="],
+    "mediabunny": ["mediabunny@1.49.0", "", { "dependencies": { "@types/dom-mediacapture-transform": "^0.1.11", "@types/dom-webcodecs": "0.1.13" } }, "sha512-hDMtS/q22GFjyB3Yum+a6NHhDtVnye6hgaYTjx3DPUfnckRjzxFmXmCc3UQXdvo7d6PUCl7KM6Y9MRWzlvnAJQ=="],
 
     "memfs": ["memfs@4.39.0", "", { "dependencies": { "@jsonjoy.com/json-pack": "^1.11.0", "@jsonjoy.com/util": "^1.9.0", "glob-to-regex.js": "^1.0.1", "thingies": "^2.5.0", "tree-dump": "^1.0.3", "tslib": "^2.0.0" } }, "sha512-tFRr2IkSXl2B6IAJsxjHIMTOsfLt9W+8+t2uNxCeQcz4tFqgQR8DYk8hlLH2HsucTctLuoHq3U0G08atyBE3yw=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -136,7 +136,7 @@
     "marked-highlight": "^2.2.3",
     "marked-katex-extension": "^5.1.7",
     "matter-js": "^0.20.0",
-    "mediabunny": "^1.31.0",
+    "mediabunny": "^1.49.0",
     "memfs": "^4.39.0",
     "meyda": "^5.6.3",
     "midi-file": "^1.2.4",

--- a/ui/src/lib/components/nodes/VideoControlOverlay.svelte
+++ b/ui/src/lib/components/nodes/VideoControlOverlay.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { Pause, Play } from '@lucide/svelte/icons';
-  import { formatVideoOverlayTime } from '$lib/video/video-control-overlay';
+  import {
+    formatVideoOverlayTime,
+    getRangePointerTime,
+    VideoOverlayPointerFocusGate
+  } from '$lib/video/video-control-overlay';
 
   let {
     visible,
@@ -23,7 +27,7 @@
     progress: number;
     onTogglePause: () => void;
     onShowControls: () => void;
-    onSeekStart: () => void;
+    onSeekStart: (time?: number) => void;
     onSeekInput: (time: number) => void;
     onSeekEnd: () => void;
   } = $props();
@@ -32,6 +36,7 @@
   const currentTimeLabel = $derived(formatVideoOverlayTime(currentTime));
   const durationLabel = $derived(formatVideoOverlayTime(duration));
   const rangeValue = $derived(Math.min(currentTime, duration || currentTime));
+  const pointerFocusGate = new VideoOverlayPointerFocusGate();
 
   function handleSeekInput(event: Event) {
     const input = event.currentTarget as HTMLInputElement;
@@ -40,6 +45,34 @@
     if (!Number.isFinite(time)) return;
 
     onSeekInput(time);
+  }
+
+  function handleSeekPointerDown(event: PointerEvent) {
+    const input = event.currentTarget as HTMLInputElement;
+    const rect = input.getBoundingClientRect();
+    const time = getRangePointerTime({
+      clientX: event.clientX,
+      left: rect.left,
+      width: rect.width,
+      min: Number(input.min),
+      max: Number(input.max)
+    });
+
+    pointerFocusGate.startPointerSeek();
+    onSeekStart(time);
+  }
+
+  function handleSeekFocus() {
+    if (pointerFocusGate.shouldStartSeekOnFocus()) {
+      onSeekStart();
+    }
+
+    onShowControls();
+  }
+
+  function handleSeekEnd() {
+    pointerFocusGate.endPointerSeek();
+    onSeekEnd();
   }
 
   function handlePause() {
@@ -81,16 +114,13 @@
       class="video-overlay-seek h-1 min-w-0 flex-1 cursor-pointer"
       style={`--video-overlay-progress: ${progress}%`}
       disabled={duration <= 0}
-      onpointerdown={onSeekStart}
-      onpointerup={onSeekEnd}
-      onpointercancel={onSeekEnd}
-      onfocus={() => {
-        onSeekStart();
-        onShowControls();
-      }}
-      onblur={onSeekEnd}
+      onpointerdown={handleSeekPointerDown}
+      onpointerup={handleSeekEnd}
+      onpointercancel={handleSeekEnd}
+      onfocus={handleSeekFocus}
+      onblur={handleSeekEnd}
       oninput={handleSeekInput}
-      onchange={onSeekEnd}
+      onchange={handleSeekEnd}
     />
 
     <div class="w-8 shrink-0 font-mono text-[7px] leading-none text-zinc-300">

--- a/ui/src/lib/components/nodes/VideoControlOverlay.svelte
+++ b/ui/src/lib/components/nodes/VideoControlOverlay.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+  import { Pause, Play } from '@lucide/svelte/icons';
+  import { formatVideoOverlayTime } from '$lib/video/video-control-overlay';
+
+  let {
+    visible,
+    scrubbing,
+    paused,
+    currentTime,
+    duration,
+    progress,
+    onTogglePause,
+    onShowControls,
+    onSeekStart,
+    onSeekInput,
+    onSeekEnd
+  }: {
+    visible: boolean;
+    scrubbing: boolean;
+    paused: boolean;
+    currentTime: number;
+    duration: number;
+    progress: number;
+    onTogglePause: () => void;
+    onShowControls: () => void;
+    onSeekStart: () => void;
+    onSeekInput: (time: number) => void;
+    onSeekEnd: () => void;
+  } = $props();
+
+  const PauseIcon = $derived(paused ? Play : Pause);
+  const currentTimeLabel = $derived(formatVideoOverlayTime(currentTime));
+  const durationLabel = $derived(formatVideoOverlayTime(duration));
+  const rangeValue = $derived(Math.min(currentTime, duration || currentTime));
+
+  function handleSeekInput(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    const time = input.valueAsNumber;
+
+    if (!Number.isFinite(time)) return;
+
+    onSeekInput(time);
+  }
+
+  function handlePause() {
+    onShowControls();
+    onTogglePause();
+  }
+</script>
+
+<div
+  class="nodrag absolute bottom-2 left-1/2 z-10 w-[min(20rem,calc(100%_-_1rem))] -translate-x-1/2 transition-all duration-200 {visible ||
+  scrubbing
+    ? 'translate-y-0 opacity-100'
+    : 'pointer-events-none translate-y-1 opacity-0'}"
+>
+  <div
+    class="flex items-center gap-1.5 rounded-lg bg-zinc-950/60 px-1.5 py-1 text-white shadow-md backdrop-blur-xs"
+  >
+    <button
+      type="button"
+      aria-label={paused ? 'Play video' : 'Pause video'}
+      class="ml-3 flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded-full bg-zinc-200 text-zinc-700 transition hover:bg-white focus-visible:ring-1 focus-visible:ring-blue-300 focus-visible:outline-none"
+      onclick={handlePause}
+      onfocus={onShowControls}
+    >
+      <PauseIcon class="h-3 w-3" />
+    </button>
+
+    <div class="w-8 shrink-0 text-right font-mono text-[7px] leading-none text-zinc-300">
+      {currentTimeLabel}
+    </div>
+
+    <input
+      type="range"
+      min="0"
+      max={Math.max(duration, 0)}
+      step="0.001"
+      value={rangeValue}
+      aria-label="Seek video"
+      class="video-overlay-seek h-1 min-w-0 flex-1 cursor-pointer"
+      style={`--video-overlay-progress: ${progress}%`}
+      disabled={duration <= 0}
+      onpointerdown={onSeekStart}
+      onpointerup={onSeekEnd}
+      onpointercancel={onSeekEnd}
+      onfocus={() => {
+        onSeekStart();
+        onShowControls();
+      }}
+      onblur={onSeekEnd}
+      oninput={handleSeekInput}
+      onchange={onSeekEnd}
+    />
+
+    <div class="w-8 shrink-0 font-mono text-[7px] leading-none text-zinc-300">
+      {durationLabel}
+    </div>
+  </div>
+</div>
+
+<style>
+  .video-overlay-seek {
+    appearance: none;
+    border-radius: 9999px;
+    background: linear-gradient(
+      to right,
+      rgb(255 255 255 / 0.8) 0%,
+      rgb(255 255 255 / 0.8) var(--video-overlay-progress),
+      rgb(255 255 255 / 0.3) var(--video-overlay-progress),
+      rgb(255 255 255 / 0.3) 100%
+    );
+  }
+
+  .video-overlay-seek:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+
+  .video-overlay-seek::-webkit-slider-runnable-track {
+    height: 2px;
+    border-radius: 9999px;
+    background: transparent;
+  }
+
+  .video-overlay-seek::-webkit-slider-thumb {
+    appearance: none;
+    width: 8px;
+    height: 8px;
+    margin-top: -3px;
+    border-radius: 9999px;
+    background: white;
+    box-shadow: 0 1px 5px rgb(0 0 0 / 0.35);
+  }
+
+  .video-overlay-seek::-moz-range-track {
+    height: 2px;
+    border-radius: 9999px;
+    background: transparent;
+  }
+
+  .video-overlay-seek::-moz-range-progress {
+    height: 2px;
+    border-radius: 9999px;
+    background: white;
+  }
+
+  .video-overlay-seek::-moz-range-thumb {
+    width: 8px;
+    height: 8px;
+    border: 0;
+    border-radius: 9999px;
+    background: white;
+    box-shadow: 0 1px 5px rgb(0 0 0 / 0.35);
+  }
+</style>

--- a/ui/src/lib/components/nodes/VideoNode.svelte
+++ b/ui/src/lib/components/nodes/VideoNode.svelte
@@ -95,6 +95,7 @@
   const LoadingIcon = $derived(errorMessage ? OctagonX : Loader);
   let bitmapFrameId: number | undefined;
   let videoFrameCallbackId: number | undefined;
+  let nativeSeekPreviewFrameCallbackId: number | undefined;
   let useVideoFrameCallback = false;
   let lastRecordedMediaTime = -1;
 
@@ -602,6 +603,15 @@
     }
   }
 
+  function stopNativeSeekPreviewFrameCallback() {
+    if (nativeSeekPreviewFrameCallbackId === undefined || !videoElement) return;
+
+    (videoElement as HTMLVideoElementWithRVFC).cancelVideoFrameCallback(
+      nativeSeekPreviewFrameCallbackId
+    );
+    nativeSeekPreviewFrameCallbackId = undefined;
+  }
+
   /**
    * Handle video frame callback - called when a new video frame is presented.
    * This is more efficient than requestAnimationFrame as it syncs with actual video frames.
@@ -731,9 +741,14 @@
       .requestVideoFrameCallback;
 
     if (requestVideoFrameCallback) {
-      requestVideoFrameCallback.call(element, (_now, metadata) => {
-        void uploadNativeSeekPreview(generation, metadata.mediaTime);
-      });
+      stopNativeSeekPreviewFrameCallback();
+      nativeSeekPreviewFrameCallbackId = requestVideoFrameCallback.call(
+        element,
+        (_now, metadata) => {
+          nativeSeekPreviewFrameCallbackId = undefined;
+          void uploadNativeSeekPreview(generation, metadata.mediaTime);
+        }
+      );
 
       return;
     }
@@ -874,6 +889,7 @@
   onDestroy(() => {
     // Clean up frame loop (handles both requestVideoFrameCallback and requestAnimationFrame)
     stopFallbackFrameLoop();
+    stopNativeSeekPreviewFrameCallback();
 
     // Clean up WebCodecs timeout
     if (webCodecsTimeoutId !== null) {

--- a/ui/src/lib/components/nodes/VideoNode.svelte
+++ b/ui/src/lib/components/nodes/VideoNode.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Loader, OctagonX, Pause, Play, SkipBack, Upload, Video } from '@lucide/svelte/icons';
+  import { Loader, OctagonX, SkipBack, Upload, Video } from '@lucide/svelte/icons';
   import { NodeResizer, useSvelteFlow } from '@xyflow/svelte';
   import { onMount, onDestroy } from 'svelte';
   import { get } from 'svelte/store';
@@ -22,6 +22,13 @@
   import { VfsRelinkOverlay, VfsDropZone } from '$lib/vfs/components';
   import { VideoProfiler, type VideoStats } from '$lib/video';
   import { LatestVideoSeek } from '$lib/video/latest-video-seek';
+  import {
+    getVideoOverlayDisplayTime,
+    getVideoOverlayDuration,
+    VideoControlOverlayVisibility,
+    VIDEO_OVERLAY_IDLE_MS
+  } from '$lib/video/video-control-overlay';
+  import VideoControlOverlay from './VideoControlOverlay.svelte';
   import type {
     MediaBunnyMetadataEvent,
     MediaBunnyFirstFrameEvent,
@@ -84,7 +91,6 @@
   let isVideoLoaded = $state(false);
   let isPaused = $state(true);
   let errorMessage = $state<string | null>(null);
-  const PauseIcon = $derived(isPaused ? Play : Pause);
   const LoadingIcon = $derived(errorMessage ? OctagonX : Loader);
   let bitmapFrameId: number | undefined;
   let videoFrameCallbackId: number | undefined;
@@ -99,7 +105,14 @@
   let currentSourceUrl: string | undefined = undefined; // For URL streaming
   let webCodecsFirstFrameReceived = $state(false);
   let webCodecsTimeoutId: ReturnType<typeof setTimeout> | null = null;
-  let workerCurrentTime = 0; // Track time from worker for profiling
+  let workerCurrentTime = $state(0); // Track time from worker for profiling
+  let overlayCurrentTime = $state(0);
+  let overlayDuration = $state(0);
+  let overlaySeekTime = $state(0);
+  let isOverlayScrubbing = $state(false);
+  let showMediaOverlay = $state(false);
+  let mediaOverlayHideTimeout: ReturnType<typeof setTimeout> | null = null;
+  const mediaOverlayVisibility = new VideoControlOverlayVisibility();
   let showNativeSeekPreview = $state(false);
   const nativeSeekPreview = new LatestVideoSeek();
 
@@ -114,6 +127,20 @@
   let profiler: VideoProfiler | null = null;
   let videoStats = $state<VideoStats | null>(null);
   let statsIntervalId: ReturnType<typeof setInterval> | null = null;
+  const mediaOverlayTime = $derived.by(() => {
+    if (isOverlayScrubbing) {
+      return overlaySeekTime;
+    }
+
+    return getVideoOverlayDisplayTime({
+      workerTime: workerCurrentTime,
+      elementTime: overlayCurrentTime,
+      hasWorkerFrame: webCodecsFirstFrameReceived
+    });
+  });
+  const mediaOverlayProgress = $derived(
+    overlayDuration > 0 ? Math.min(100, Math.max(0, (mediaOverlayTime / overlayDuration) * 100)) : 0
+  );
 
   // Initialize bitmaprenderer context when canvas is bound
   $effect(() => {
@@ -165,6 +192,8 @@
 
     const safeTime = Math.max(0, time);
 
+    overlayCurrentTime = safeTime;
+    workerCurrentTime = safeTime;
     lastRecordedMediaTime = -1;
     seekNativeVideoPreview(safeTime);
 
@@ -173,6 +202,64 @@
     }
 
     audioService.send(nodeId, 'message', { type: 'seek', time: safeTime });
+  }
+
+  function showMediaControls() {
+    if (!isVideoLoaded) return;
+
+    mediaOverlayVisibility.show(performance.now());
+    showMediaOverlay = mediaOverlayVisibility.visible;
+    scheduleMediaOverlayHide();
+  }
+
+  function hideMediaControls() {
+    if (mediaOverlayHideTimeout !== null) {
+      clearTimeout(mediaOverlayHideTimeout);
+      mediaOverlayHideTimeout = null;
+    }
+
+    mediaOverlayVisibility.hide();
+    showMediaOverlay = mediaOverlayVisibility.visible;
+  }
+
+  function scheduleMediaOverlayHide() {
+    if (mediaOverlayHideTimeout !== null) {
+      clearTimeout(mediaOverlayHideTimeout);
+    }
+
+    mediaOverlayHideTimeout = setTimeout(() => {
+      if (mediaOverlayVisibility.shouldHide(performance.now())) {
+        mediaOverlayVisibility.hide();
+        showMediaOverlay = mediaOverlayVisibility.visible;
+      }
+
+      mediaOverlayHideTimeout = null;
+    }, VIDEO_OVERLAY_IDLE_MS);
+  }
+
+  function handleOverlaySeekStart() {
+    if (!isVideoLoaded) return;
+
+    isOverlayScrubbing = true;
+    overlaySeekTime = mediaOverlayTime;
+    mediaOverlayVisibility.startScrubbing();
+    showMediaOverlay = mediaOverlayVisibility.visible;
+  }
+
+  function handleOverlaySeekInput(time: number) {
+    if (!isVideoLoaded) return;
+
+    overlaySeekTime = time;
+    seekToTime(time);
+  }
+
+  function handleOverlaySeekEnd() {
+    if (!isOverlayScrubbing) return;
+
+    isOverlayScrubbing = false;
+    mediaOverlayVisibility.stopScrubbing(performance.now());
+    showMediaOverlay = mediaOverlayVisibility.visible;
+    scheduleMediaOverlayHide();
   }
 
   function seekNativeVideoPreview(time: number) {
@@ -239,6 +326,12 @@
 
           isVideoLoaded = true;
           isPaused = true;
+          overlayCurrentTime = 0;
+          workerCurrentTime = 0;
+          overlayDuration = getVideoOverlayDuration({
+            metadataDuration: undefined,
+            elementDuration: videoElement.duration
+          });
           errorMessage = null;
 
           // Send file to audio system
@@ -411,6 +504,7 @@
 
     // Get current time from appropriate source
     const currentTime = workerCurrentTime || videoElement?.currentTime || 0;
+    overlayCurrentTime = currentTime;
 
     if (isPaused) {
       audioService.send(nodeId, 'message', { type: 'play' });
@@ -493,6 +587,7 @@
     // Only record when mediaTime actually changes (deduplicate same-frame callbacks)
     if (metadata.mediaTime !== lastRecordedMediaTime) {
       lastRecordedMediaTime = metadata.mediaTime;
+      overlayCurrentTime = metadata.mediaTime;
       profiler?.recordFrame(metadata.mediaTime * 1_000_000, metadata.mediaTime);
 
       // Calculate actual frame rate from metadata (presentedFrames / mediaTime)
@@ -530,6 +625,7 @@
 
       if (currentMediaTime !== lastRecordedMediaTime) {
         lastRecordedMediaTime = currentMediaTime;
+        overlayCurrentTime = currentMediaTime;
 
         profiler?.recordFrame(currentMediaTime * 1_000_000, currentMediaTime);
       }
@@ -625,6 +721,7 @@
     }
 
     workerCurrentTime = mediaTime;
+    overlayCurrentTime = mediaTime;
     profiler?.recordFrame(mediaTime * 1_000_000, mediaTime);
 
     if (glSystem.hasOutgoingVideoConnections(nodeId)) {
@@ -652,6 +749,10 @@
       height: event.metadata.height,
       codec: event.metadata.codec
     });
+    overlayDuration = getVideoOverlayDuration({
+      metadataDuration: event.metadata.duration,
+      elementDuration: videoElement?.duration
+    });
   }
 
   function handleWorkerFirstFrame(event: MediaBunnyFirstFrameEvent) {
@@ -677,6 +778,8 @@
     }
 
     isPaused = true;
+    overlayCurrentTime = 0;
+    workerCurrentTime = 0;
 
     if (videoElement) {
       videoElement.pause();
@@ -694,6 +797,7 @@
     if (event.nodeId !== nodeId) return;
 
     workerCurrentTime = event.currentTime;
+    overlayCurrentTime = event.currentTime;
 
     if (
       showNativeSeekPreview &&
@@ -755,6 +859,11 @@
       statsIntervalId = null;
     }
 
+    if (mediaOverlayHideTimeout !== null) {
+      clearTimeout(mediaOverlayHideTimeout);
+      mediaOverlayHideTimeout = null;
+    }
+
     // Clean up worker MediaBunny player
     glSystem.destroyMediaBunnyPlayer(nodeId);
 
@@ -797,13 +906,6 @@
         <div></div>
         <div class="flex gap-1">
           {#if isVideoLoaded}
-            <button
-              title={isPaused ? 'Play video' : 'Pause video'}
-              class="node-floating-button"
-              onclick={togglePause}
-            >
-              <PauseIcon class="h-4 w-4 text-zinc-300" />
-            </button>
             <button title="Restart video" class="node-floating-button" onclick={restartVideo}>
               <SkipBack class="h-4 w-4 text-zinc-300" />
             </button>
@@ -832,7 +934,13 @@
           class={`rounded-lg border-1 ${selected ? 'shadow-glow-md border-zinc-400' : 'hover:shadow-glow-sm'}`}
         >
           {#if !errorMessage}
-            <div class="relative">
+            <div
+              class="relative"
+              role="presentation"
+              onmouseenter={showMediaControls}
+              onmousemove={showMediaControls}
+              onmouseleave={hideMediaControls}
+            >
               <!-- Canvas preview when MediaBunny is active (worker sends frames via bitmaprenderer) -->
               <canvas
                 bind:this={previewCanvas}
@@ -888,6 +996,22 @@
                     <div class="text-zinc-400">{videoStats.codec}</div>
                   {/if}
                 </div>
+              {/if}
+
+              {#if isVideoLoaded}
+                <VideoControlOverlay
+                  visible={showMediaOverlay}
+                  scrubbing={isOverlayScrubbing}
+                  paused={isPaused}
+                  currentTime={mediaOverlayTime}
+                  duration={overlayDuration}
+                  progress={mediaOverlayProgress}
+                  onTogglePause={togglePause}
+                  onShowControls={showMediaControls}
+                  onSeekStart={handleOverlaySeekStart}
+                  onSeekInput={handleOverlaySeekInput}
+                  onSeekEnd={handleOverlaySeekEnd}
+                />
               {/if}
             </div>
           {/if}

--- a/ui/src/lib/components/nodes/VideoNode.svelte
+++ b/ui/src/lib/components/nodes/VideoNode.svelte
@@ -22,9 +22,11 @@
   import { VfsRelinkOverlay, VfsDropZone } from '$lib/vfs/components';
   import { VideoProfiler, type VideoStats } from '$lib/video';
   import { LatestVideoSeek } from '$lib/video/latest-video-seek';
+  import { getVideoNodeDisplaySize } from '$lib/video/video-node-size';
   import {
     getVideoOverlayDisplayTime,
     getVideoOverlayDuration,
+    isPendingSeekComplete,
     VideoOverlaySeekPlaybackGate,
     VideoControlOverlayVisibility,
     VIDEO_OVERLAY_IDLE_MS
@@ -103,7 +105,6 @@
   let resizerCtx: OffscreenCanvasRenderingContext2D | null = null;
 
   // MediaBunny player runs in render worker for zero main thread blocking
-  let currentFile: File | null = null;
   let currentSourceUrl: string | undefined = undefined; // For URL streaming
   let webCodecsFirstFrameReceived = $state(false);
   let webCodecsTimeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -111,6 +112,8 @@
   let overlayCurrentTime = $state(0);
   let overlayDuration = $state(0);
   let overlaySeekTime = $state(0);
+  let pendingOverlaySeekTime = $state<number | null>(null);
+  let resumeOverlayPlaybackAfterPendingSeek = false;
   let isOverlayScrubbing = $state(false);
   let showMediaOverlay = $state(false);
   let mediaOverlayHideTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -130,6 +133,7 @@
   let profiler: VideoProfiler | null = null;
   let videoStats = $state<VideoStats | null>(null);
   let statsIntervalId: ReturnType<typeof setInterval> | null = null;
+
   const mediaOverlayTime = $derived.by(() => {
     if (isOverlayScrubbing) {
       return overlaySeekTime;
@@ -138,9 +142,11 @@
     return getVideoOverlayDisplayTime({
       workerTime: workerCurrentTime,
       elementTime: overlayCurrentTime,
-      hasWorkerFrame: webCodecsFirstFrameReceived
+      hasWorkerFrame: webCodecsFirstFrameReceived,
+      pendingSeekTime: pendingOverlaySeekTime
     });
   });
+
   const mediaOverlayProgress = $derived(
     overlayDuration > 0 ? Math.min(100, Math.max(0, (mediaOverlayTime / overlayDuration) * 100)) : 0
   );
@@ -240,7 +246,7 @@
     }, VIDEO_OVERLAY_IDLE_MS);
   }
 
-  function handleOverlaySeekStart() {
+  function handleOverlaySeekStart(time?: number) {
     if (!isVideoLoaded) return;
 
     const gate = overlaySeekPlaybackGate.start({ paused: isPaused });
@@ -250,9 +256,14 @@
     }
 
     isOverlayScrubbing = true;
-    overlaySeekTime = mediaOverlayTime;
+    overlaySeekTime = Number.isFinite(time) ? Math.max(0, time ?? 0) : mediaOverlayTime;
+    pendingOverlaySeekTime = null;
     mediaOverlayVisibility.startScrubbing();
     showMediaOverlay = mediaOverlayVisibility.visible;
+
+    if (Number.isFinite(time)) {
+      seekToTime(overlaySeekTime);
+    }
   }
 
   function handleOverlaySeekInput(time: number) {
@@ -266,13 +277,31 @@
     if (!isOverlayScrubbing) return;
 
     isOverlayScrubbing = false;
+    pendingOverlaySeekTime = overlaySeekTime;
     mediaOverlayVisibility.stopScrubbing(performance.now());
     showMediaOverlay = mediaOverlayVisibility.visible;
     scheduleMediaOverlayHide();
 
     if (overlaySeekPlaybackGate.stop().shouldResume) {
+      resumeOverlayPlaybackAfterPendingSeek = true;
+    }
+  }
+
+  function completePendingOverlaySeek(currentTime: number) {
+    if (!isPendingSeekComplete({ pendingSeekTime: pendingOverlaySeekTime, currentTime })) {
+      return false;
+    }
+
+    pendingOverlaySeekTime = null;
+    workerCurrentTime = currentTime;
+    overlayCurrentTime = currentTime;
+
+    if (resumeOverlayPlaybackAfterPendingSeek) {
+      resumeOverlayPlaybackAfterPendingSeek = false;
       playVideoPlayback();
     }
+
+    return true;
   }
 
   function seekNativeVideoPreview(time: number) {
@@ -302,7 +331,6 @@
         return;
       }
 
-      currentFile = file;
       currentSourceUrl = sourceUrl; // Store for MediaBunny streaming
 
       const objectUrl = URL.createObjectURL(file);
@@ -312,40 +340,31 @@
           const videoWidth = videoElement.videoWidth;
           const videoHeight = videoElement.videoHeight;
 
-          // Scale down for preview while maintaining aspect ratio
-          const aspectRatio = videoWidth / videoHeight;
-
-          const previewWidthValue = get(previewWidth);
-          const previewHeightValue = get(previewHeight);
-
-          let scaledW = previewWidthValue;
-          let scaledH = previewWidthValue / aspectRatio;
-
-          if (scaledH > previewHeightValue) {
-            scaledH = previewHeightValue;
-            scaledW = previewHeightValue * aspectRatio;
-          }
+          const displaySize = getVideoNodeDisplaySize({
+            nodeWidth,
+            nodeHeight,
+            videoWidth,
+            videoHeight,
+            previewWidth: get(previewWidth),
+            previewHeight: get(previewHeight)
+          });
 
           updateNode(nodeId, {
-            width: Math.round(scaledW),
-            height: Math.round(scaledH),
-            data: {
-              ...data,
-              fileName: file.name,
-              width: videoWidth,
-              height: videoHeight
-            }
+            width: displaySize.width,
+            height: displaySize.height,
+            data: { ...data, fileName: file.name, width: videoWidth, height: videoHeight }
           });
 
           isVideoLoaded = true;
           isPaused = true;
           overlayCurrentTime = 0;
           workerCurrentTime = 0;
+          errorMessage = null;
+
           overlayDuration = getVideoOverlayDuration({
             metadataDuration: undefined,
             elementDuration: videoElement.duration
           });
-          errorMessage = null;
 
           // Send file to audio system
           audioService.send(nodeId, 'file', file);
@@ -609,6 +628,7 @@
     (videoElement as HTMLVideoElementWithRVFC).cancelVideoFrameCallback(
       nativeSeekPreviewFrameCallbackId
     );
+
     nativeSeekPreviewFrameCallbackId = undefined;
   }
 
@@ -717,11 +737,11 @@
 
         // Create flipped ImageBitmap to match pipeline orientation
         const bitmap = await createImageBitmap(resizerCanvas);
-        await glSystem.setBitmap(nodeId, bitmap);
+        glSystem.setBitmap(nodeId, bitmap);
       }
     } else {
       // Video is already small enough, upload directly
-      await glSystem.setBitmapSource(nodeId, videoElement);
+      glSystem.setBitmapSource(nodeId, videoElement);
     }
   }
 
@@ -746,7 +766,7 @@
         element,
         (_now, metadata) => {
           nativeSeekPreviewFrameCallbackId = undefined;
-          void uploadNativeSeekPreview(generation, metadata.mediaTime);
+          uploadNativeSeekPreview(generation, metadata.mediaTime);
         }
       );
 
@@ -762,6 +782,8 @@
     if (Math.abs(mediaTime - nativeSeekPreview.currentTargetTime) > 0.1) {
       return;
     }
+
+    completePendingOverlaySeek(mediaTime);
 
     workerCurrentTime = mediaTime;
     overlayCurrentTime = mediaTime;
@@ -792,6 +814,7 @@
       height: event.metadata.height,
       codec: event.metadata.codec
     });
+
     overlayDuration = getVideoOverlayDuration({
       metadataDuration: event.metadata.duration,
       elementDuration: videoElement?.duration
@@ -823,6 +846,8 @@
     isPaused = true;
     overlayCurrentTime = 0;
     workerCurrentTime = 0;
+    pendingOverlaySeekTime = null;
+    resumeOverlayPlaybackAfterPendingSeek = false;
 
     if (videoElement) {
       videoElement.pause();
@@ -838,6 +863,11 @@
 
   function handleWorkerTimeUpdate(event: MediaBunnyTimeUpdateEvent) {
     if (event.nodeId !== nodeId) return;
+
+    if (pendingOverlaySeekTime !== null && !completePendingOverlaySeek(event.currentTime)) {
+      profiler?.recordFrame(event.currentTime * 1_000_000, event.currentTime);
+      return;
+    }
 
     workerCurrentTime = event.currentTime;
     overlayCurrentTime = event.currentTime;
@@ -953,6 +983,7 @@
             <button title="Restart video" class="node-floating-button" onclick={restartVideo}>
               <SkipBack class="h-4 w-4 text-zinc-300" />
             </button>
+
             <button
               title="Change video"
               class="node-floating-button"
@@ -1033,9 +1064,11 @@
                   >
                     {videoStats.pipeline === 'webcodecs' ? 'MEDIABUNNY' : 'FALLBACK'}
                   </div>
+
                   <div>{videoStats.fps}/{Math.round(videoStats.targetFps)} FPS</div>
                   <div>Dropped: {videoStats.droppedFrames}</div>
                   <div>{videoStats.width}x{videoStats.height}</div>
+
                   {#if videoStats.codec !== 'unknown'}
                     <div class="text-zinc-400">{videoStats.codec}</div>
                   {/if}

--- a/ui/src/lib/components/nodes/VideoNode.svelte
+++ b/ui/src/lib/components/nodes/VideoNode.svelte
@@ -25,6 +25,7 @@
   import {
     getVideoOverlayDisplayTime,
     getVideoOverlayDuration,
+    VideoOverlaySeekPlaybackGate,
     VideoControlOverlayVisibility,
     VIDEO_OVERLAY_IDLE_MS
   } from '$lib/video/video-control-overlay';
@@ -113,6 +114,7 @@
   let showMediaOverlay = $state(false);
   let mediaOverlayHideTimeout: ReturnType<typeof setTimeout> | null = null;
   const mediaOverlayVisibility = new VideoControlOverlayVisibility();
+  const overlaySeekPlaybackGate = new VideoOverlaySeekPlaybackGate();
   let showNativeSeekPreview = $state(false);
   const nativeSeekPreview = new LatestVideoSeek();
 
@@ -240,6 +242,12 @@
   function handleOverlaySeekStart() {
     if (!isVideoLoaded) return;
 
+    const gate = overlaySeekPlaybackGate.start({ paused: isPaused });
+
+    if (gate.shouldPause) {
+      pauseVideoPlayback();
+    }
+
     isOverlayScrubbing = true;
     overlaySeekTime = mediaOverlayTime;
     mediaOverlayVisibility.startScrubbing();
@@ -260,6 +268,10 @@
     mediaOverlayVisibility.stopScrubbing(performance.now());
     showMediaOverlay = mediaOverlayVisibility.visible;
     scheduleMediaOverlayHide();
+
+    if (overlaySeekPlaybackGate.stop().shouldResume) {
+      playVideoPlayback();
+    }
   }
 
   function seekNativeVideoPreview(time: number) {
@@ -502,42 +514,58 @@
   function togglePause() {
     if (!isVideoLoaded) return;
 
+    if (isPaused) {
+      playVideoPlayback();
+    } else {
+      pauseVideoPlayback();
+    }
+  }
+
+  function playVideoPlayback() {
+    if (!isVideoLoaded || !isPaused) return;
+
     // Get current time from appropriate source
     const currentTime = workerCurrentTime || videoElement?.currentTime || 0;
     overlayCurrentTime = currentTime;
 
-    if (isPaused) {
-      audioService.send(nodeId, 'message', { type: 'play' });
+    audioService.send(nodeId, 'message', { type: 'play' });
 
-      if (webCodecsFirstFrameReceived) {
-        // Worker MediaBunny mode
-        glSystem.mediaBunnyPlay(nodeId);
-        showNativeSeekPreview = false;
-      } else if (videoElement) {
-        // Fallback mode - control HTMLVideoElement
-        videoElement.play();
-      }
-
-      // Mark playback start for accurate drop detection
-      profiler?.markPlaybackStart(currentTime);
-
-      isPaused = false;
-    } else {
-      // Mark playback stop before pausing (calculates drops)
-      profiler?.markPlaybackStop(currentTime);
-
-      audioService.send(nodeId, 'message', { type: 'pause' });
-
-      if (webCodecsFirstFrameReceived) {
-        // Worker MediaBunny mode
-        glSystem.mediaBunnyPause(nodeId);
-      } else if (videoElement) {
-        // Fallback mode - control HTMLVideoElement
-        videoElement.pause();
-      }
-
-      isPaused = true;
+    if (webCodecsFirstFrameReceived) {
+      // Worker MediaBunny mode
+      glSystem.mediaBunnyPlay(nodeId);
+      showNativeSeekPreview = false;
+    } else if (videoElement) {
+      // Fallback mode - control HTMLVideoElement
+      videoElement.play();
     }
+
+    // Mark playback start for accurate drop detection
+    profiler?.markPlaybackStart(currentTime);
+
+    isPaused = false;
+  }
+
+  function pauseVideoPlayback() {
+    if (!isVideoLoaded || isPaused) return;
+
+    // Get current time from appropriate source
+    const currentTime = workerCurrentTime || videoElement?.currentTime || 0;
+    overlayCurrentTime = currentTime;
+
+    // Mark playback stop before pausing (calculates drops)
+    profiler?.markPlaybackStop(currentTime);
+
+    audioService.send(nodeId, 'message', { type: 'pause' });
+
+    if (webCodecsFirstFrameReceived) {
+      // Worker MediaBunny mode
+      glSystem.mediaBunnyPause(nodeId);
+    } else if (videoElement) {
+      // Fallback mode - control HTMLVideoElement
+      videoElement.pause();
+    }
+
+    isPaused = true;
   }
 
   /**

--- a/ui/src/lib/components/nodes/VideoNode.svelte
+++ b/ui/src/lib/components/nodes/VideoNode.svelte
@@ -21,6 +21,7 @@
   import { useVfsMedia } from '$lib/vfs';
   import { VfsRelinkOverlay, VfsDropZone } from '$lib/vfs/components';
   import { VideoProfiler, type VideoStats } from '$lib/video';
+  import { LatestVideoSeek } from '$lib/video/latest-video-seek';
   import type {
     MediaBunnyMetadataEvent,
     MediaBunnyFirstFrameEvent,
@@ -99,6 +100,8 @@
   let webCodecsFirstFrameReceived = $state(false);
   let webCodecsTimeoutId: ReturnType<typeof setTimeout> | null = null;
   let workerCurrentTime = 0; // Track time from worker for profiling
+  let showNativeSeekPreview = $state(false);
+  const nativeSeekPreview = new LatestVideoSeek();
 
   // Canvas preview
   let previewCanvas = $state<HTMLCanvasElement | undefined>();
@@ -163,14 +166,29 @@
     const safeTime = Math.max(0, time);
 
     lastRecordedMediaTime = -1;
+    seekNativeVideoPreview(safeTime);
 
     if (webCodecsFirstFrameReceived) {
       glSystem.mediaBunnySeek(nodeId, safeTime);
-    } else if (videoElement) {
-      videoElement.currentTime = safeTime;
     }
 
     audioService.send(nodeId, 'message', { type: 'seek', time: safeTime });
+  }
+
+  function seekNativeVideoPreview(time: number) {
+    if (!videoElement) return;
+
+    const seekRequest = nativeSeekPreview.requestNativeSeek(time);
+
+    if (webCodecsFirstFrameReceived) {
+      showNativeSeekPreview = true;
+    }
+
+    if (!seekRequest.shouldStartSeek || videoElement.seeking) {
+      return;
+    }
+
+    videoElement.currentTime = time;
   }
 
   /**
@@ -400,6 +418,7 @@
       if (webCodecsFirstFrameReceived) {
         // Worker MediaBunny mode
         glSystem.mediaBunnyPlay(nodeId);
+        showNativeSeekPreview = false;
       } else if (videoElement) {
         // Fallback mode - control HTMLVideoElement
         videoElement.play();
@@ -572,6 +591,47 @@
     }
   }
 
+  function handleNativeVideoSeeked() {
+    if (!videoElement || !isVideoLoaded || !webCodecsFirstFrameReceived) return;
+
+    const element = videoElement;
+    const generation = nativeSeekPreview.currentGeneration;
+    const nextSeek = nativeSeekPreview.completeNativeSeek(element.currentTime);
+
+    if (nextSeek.shouldStartNextSeek) {
+      element.currentTime = nextSeek.targetTime;
+      return;
+    }
+
+    const requestVideoFrameCallback = (element as Partial<HTMLVideoElementWithRVFC>)
+      .requestVideoFrameCallback;
+
+    if (requestVideoFrameCallback) {
+      requestVideoFrameCallback.call(element, (_now, metadata) => {
+        void uploadNativeSeekPreview(generation, metadata.mediaTime);
+      });
+
+      return;
+    }
+
+    void uploadNativeSeekPreview(generation, element.currentTime);
+  }
+
+  async function uploadNativeSeekPreview(generation: number, mediaTime: number) {
+    if (!videoElement || !nativeSeekPreview.isLatest(generation)) return;
+
+    if (Math.abs(mediaTime - nativeSeekPreview.currentTargetTime) > 0.1) {
+      return;
+    }
+
+    workerCurrentTime = mediaTime;
+    profiler?.recordFrame(mediaTime * 1_000_000, mediaTime);
+
+    if (glSystem.hasOutgoingVideoConnections(nodeId)) {
+      await uploadFallbackVideoFrame();
+    }
+  }
+
   // Event handlers for worker MediaBunny
   function handleWorkerMetadata(event: MediaBunnyMetadataEvent) {
     if (event.nodeId !== nodeId) return;
@@ -634,6 +694,13 @@
     if (event.nodeId !== nodeId) return;
 
     workerCurrentTime = event.currentTime;
+
+    if (
+      showNativeSeekPreview &&
+      Math.abs(event.currentTime - nativeSeekPreview.currentTargetTime) <= 0.1
+    ) {
+      showNativeSeekPreview = false;
+    }
 
     // Notify profiler of frame delivery for FPS tracking
     // MediaBunnyPlayer sends timeUpdate for each displayed frame
@@ -773,7 +840,8 @@
                 height={data.height || $previewHeight}
                 class="rounded-lg {vfsMedia.hasVfsPath &&
                 isVideoLoaded &&
-                webCodecsFirstFrameReceived
+                webCodecsFirstFrameReceived &&
+                !showNativeSeekPreview
                   ? ''
                   : 'hidden'}"
                 style="width: {nodeWidth || $previewWidth}px; height: {nodeHeight ||
@@ -788,13 +856,14 @@
                 bind:this={videoElement}
                 class="rounded-lg object-cover {vfsMedia.hasVfsPath &&
                 isVideoLoaded &&
-                !webCodecsFirstFrameReceived
+                (!webCodecsFirstFrameReceived || showNativeSeekPreview)
                   ? ''
                   : 'hidden'}"
                 style="width: {nodeWidth || $previewWidth}px; height: {nodeHeight ||
                   $previewHeight}px"
                 muted
                 loop={data.loop ?? true}
+                onseeked={handleNativeVideoSeeked}
                 ondragover={vfsMedia.handleDragOver}
                 ondragleave={vfsMedia.handleDragLeave}
                 ondrop={vfsMedia.handleDrop}

--- a/ui/src/lib/video/MediaBunnyPlayer.test.ts
+++ b/ui/src/lib/video/MediaBunnyPlayer.test.ts
@@ -31,6 +31,7 @@ function nextTick() {
 describe('MediaBunnyPlayer', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it('ignores stale preview frames from overlapping seeks', async () => {
@@ -178,6 +179,61 @@ describe('MediaBunnyPlayer', () => {
 
     expect(emittedFrames).toEqual([1, 1]);
     expect(samplesAtTimestamps).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps playback paused while seek messages are still arriving', async () => {
+    vi.useFakeTimers();
+
+    const samples = new Map<number, Promise<ReturnType<typeof createSample>>>([
+      [1, Promise.resolve(createSample(1))],
+      [2, Promise.resolve(createSample(2))]
+    ]);
+    const samplesAtTimestamps = vi.fn((times: Iterable<number>) => samplesForTimes(times, samples));
+
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 1)
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn((frame: { timestamp: number }) =>
+        Promise.resolve({ close: vi.fn(), timestamp: frame.timestamp })
+      )
+    );
+
+    const player = new MediaBunnyPlayer({
+      nodeId: 'video-1',
+      onFrame: vi.fn(),
+      onMetadata: vi.fn(),
+      onEnded: vi.fn(),
+      onError: vi.fn()
+    });
+
+    Object.assign(player as unknown as { _isLoaded: boolean; _metadata: unknown; sink: unknown }, {
+      _isLoaded: true,
+      _metadata: { frameRate: 30, duration: 10 },
+      sink: {
+        samplesAtTimestamps,
+        samples: async function* () {}
+      }
+    });
+
+    player.play();
+
+    await player.seek(1);
+
+    expect(player.paused).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(100);
+    await player.seek(2);
+    await vi.advanceTimersByTimeAsync(149);
+
+    expect(player.paused).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(player.paused).toBe(false);
   });
 });
 

--- a/ui/src/lib/video/MediaBunnyPlayer.test.ts
+++ b/ui/src/lib/video/MediaBunnyPlayer.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MediaBunnyPlayer } from './MediaBunnyPlayer';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+}
+
+function createSample(timestamp: number) {
+  const videoFrame = {
+    timestamp,
+    close: vi.fn()
+  };
+
+  return {
+    timestamp,
+    toVideoFrame: vi.fn(() => videoFrame),
+    close: vi.fn()
+  };
+}
+
+function nextTick() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('MediaBunnyPlayer', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('ignores stale preview frames from overlapping seeks', async () => {
+    const firstSeek = deferred<ReturnType<typeof createSample>>();
+    const secondSeek = deferred<ReturnType<typeof createSample>>();
+    const samples = new Map<number, Promise<ReturnType<typeof createSample>>>([
+      [1, firstSeek.promise],
+      [2, secondSeek.promise]
+    ]);
+    const emittedFrames: number[] = [];
+    const firstBitmap = { close: vi.fn(), timestamp: 1 };
+    const secondBitmap = { close: vi.fn(), timestamp: 2 };
+
+    vi.stubGlobal('createImageBitmap', bitmapForFrame([firstBitmap, secondBitmap]));
+
+    const player = new MediaBunnyPlayer({
+      nodeId: 'video-1',
+      onFrame: (_bitmap, timestamp) => emittedFrames.push(timestamp / 1_000_000),
+      onMetadata: vi.fn(),
+      onEnded: vi.fn(),
+      onError: vi.fn()
+    });
+    const firstSample = createSample(1);
+    const secondSample = createSample(2);
+    const samplesAtTimestamps = vi.fn((times: Iterable<number>) => samplesForTimes(times, samples));
+
+    Object.assign(player as unknown as { _isLoaded: boolean; sink: unknown }, {
+      _isLoaded: true,
+      sink: {
+        samplesAtTimestamps,
+        samples: async function* () {}
+      }
+    });
+
+    const staleSeek = player.seek(1);
+    const latestSeek = player.seek(2);
+
+    firstSeek.resolve(firstSample);
+    await nextTick();
+
+    expect(emittedFrames).toEqual([]);
+
+    secondSeek.resolve(secondSample);
+    await Promise.all([staleSeek, latestSeek]);
+
+    expect(emittedFrames).toEqual([2]);
+    expect(firstSample.close).toHaveBeenCalledTimes(1);
+    expect(firstBitmap.close).not.toHaveBeenCalled();
+    expect(samplesAtTimestamps).toHaveBeenCalledWith([1]);
+    expect(samplesAtTimestamps).toHaveBeenCalledWith([2]);
+    expect(player.currentTime).toBe(2);
+  });
+
+  it('coalesces intermediate seeks while a preview frame is loading', async () => {
+    const firstSeek = deferred<ReturnType<typeof createSample>>();
+    const thirdSeek = deferred<ReturnType<typeof createSample>>();
+    const samplePromises = new Map<number, Promise<ReturnType<typeof createSample>>>([
+      [1, firstSeek.promise],
+      [3, thirdSeek.promise]
+    ]);
+    const emittedFrames: number[] = [];
+    const firstBitmap = { close: vi.fn(), timestamp: 1 };
+    const thirdBitmap = { close: vi.fn(), timestamp: 3 };
+    const samplesAtTimestamps = vi.fn((times: Iterable<number>) =>
+      samplesForTimes(times, samplePromises)
+    );
+
+    vi.stubGlobal('createImageBitmap', bitmapForFrame([firstBitmap, thirdBitmap]));
+
+    const player = new MediaBunnyPlayer({
+      nodeId: 'video-1',
+      onFrame: (_bitmap, timestamp) => emittedFrames.push(timestamp / 1_000_000),
+      onMetadata: vi.fn(),
+      onEnded: vi.fn(),
+      onError: vi.fn()
+    });
+
+    Object.assign(player as unknown as { _isLoaded: boolean; sink: unknown }, {
+      _isLoaded: true,
+      sink: {
+        samplesAtTimestamps,
+        samples: async function* () {}
+      }
+    });
+
+    const firstSeekPromise = player.seek(1);
+    const secondSeekPromise = player.seek(2);
+    const thirdSeekPromise = player.seek(3);
+
+    expect(samplesAtTimestamps).toHaveBeenCalledTimes(1);
+    expect(samplesAtTimestamps).toHaveBeenLastCalledWith([1]);
+
+    const firstSample = createSample(1);
+
+    firstSeek.resolve(firstSample);
+    await nextTick();
+
+    expect(samplesAtTimestamps).toHaveBeenCalledTimes(2);
+    expect(samplesAtTimestamps).toHaveBeenLastCalledWith([3]);
+
+    thirdSeek.resolve(createSample(3));
+    await Promise.all([firstSeekPromise, secondSeekPromise, thirdSeekPromise]);
+
+    expect(emittedFrames).toEqual([3]);
+    expect(firstSample.close).toHaveBeenCalledTimes(1);
+    expect(firstBitmap.close).not.toHaveBeenCalled();
+    expect(player.currentTime).toBe(3);
+  });
+
+  it('reuses cached seek frames without decoding the same frame again', async () => {
+    const firstSeek = deferred<ReturnType<typeof createSample>>();
+    const samples = new Map<number, Promise<ReturnType<typeof createSample>>>([
+      [1, firstSeek.promise]
+    ]);
+    const emittedFrames: number[] = [];
+    const decodedBitmap = { close: vi.fn(), timestamp: 1 };
+    const cachedClone = { close: vi.fn(), timestamp: 1 };
+    const samplesAtTimestamps = vi.fn((times: Iterable<number>) => samplesForTimes(times, samples));
+
+    vi.stubGlobal('createImageBitmap', bitmapForFrame([decodedBitmap, cachedClone]));
+
+    const player = new MediaBunnyPlayer({
+      nodeId: 'video-1',
+      onFrame: (_bitmap, timestamp) => emittedFrames.push(timestamp / 1_000_000),
+      onMetadata: vi.fn(),
+      onEnded: vi.fn(),
+      onError: vi.fn()
+    });
+
+    Object.assign(player as unknown as { _isLoaded: boolean; _metadata: unknown; sink: unknown }, {
+      _isLoaded: true,
+      _metadata: { frameRate: 30, duration: 10 },
+      sink: {
+        samplesAtTimestamps,
+        samples: async function* () {}
+      }
+    });
+
+    const firstSeekPromise = player.seek(1);
+
+    firstSeek.resolve(createSample(1));
+    await firstSeekPromise;
+
+    await player.seek(1);
+
+    expect(emittedFrames).toEqual([1, 1]);
+    expect(samplesAtTimestamps).toHaveBeenCalledTimes(1);
+  });
+});
+
+async function* samplesForTimes(
+  times: Iterable<number>,
+  samples: Map<number, Promise<ReturnType<typeof createSample>>>
+) {
+  for (const time of times) {
+    yield await samples.get(time);
+  }
+}
+
+function bitmapForFrame(bitmaps: Array<{ close: () => void; timestamp: number }>) {
+  return vi.fn((frame: { timestamp: number }) => {
+    const bitmap = bitmaps.find((item) => item.timestamp === frame.timestamp);
+
+    if (!bitmap) {
+      throw new Error(`No bitmap for frame timestamp ${frame.timestamp}`);
+    }
+
+    return Promise.resolve(bitmap);
+  });
+}

--- a/ui/src/lib/video/MediaBunnyPlayer.test.ts
+++ b/ui/src/lib/video/MediaBunnyPlayer.test.ts
@@ -24,6 +24,16 @@ function createSample(timestamp: number) {
   };
 }
 
+function createThrowingSample(timestamp: number) {
+  return {
+    timestamp,
+    toVideoFrame: vi.fn(() => {
+      throw new Error('toVideoFrame failed');
+    }),
+    close: vi.fn()
+  };
+}
+
 function nextTick() {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
@@ -234,6 +244,97 @@ describe('MediaBunnyPlayer', () => {
     await vi.advanceTimersByTimeAsync(1);
 
     expect(player.paused).toBe(false);
+  });
+
+  it('closes a seek sample when converting it to a video frame fails', async () => {
+    const sample = createThrowingSample(1);
+    const samples = new Map<number, Promise<typeof sample>>([[1, Promise.resolve(sample)]]);
+
+    const player = new MediaBunnyPlayer({
+      nodeId: 'video-1',
+      onFrame: vi.fn(),
+      onMetadata: vi.fn(),
+      onEnded: vi.fn(),
+      onError: vi.fn()
+    });
+
+    Object.assign(player as unknown as { _isLoaded: boolean; sink: unknown }, {
+      _isLoaded: true,
+      sink: {
+        samplesAtTimestamps: (times: Iterable<number>) => samplesForTimes(times, samples),
+        samples: async function* () {}
+      }
+    });
+
+    await player.seek(1);
+
+    expect(sample.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes a prefetched seek sample when converting it to a video frame fails', async () => {
+    const sample = createThrowingSample(1);
+
+    const player = new MediaBunnyPlayer({
+      nodeId: 'video-1',
+      onFrame: vi.fn(),
+      onMetadata: vi.fn(),
+      onEnded: vi.fn(),
+      onError: vi.fn()
+    });
+
+    Object.assign(player as unknown as { _isLoaded: boolean; _metadata: unknown; sink: unknown }, {
+      _isLoaded: true,
+      _metadata: { frameRate: 30, duration: 10 },
+      sink: {
+        samplesAtTimestamps: async function* () {},
+        samples: async function* () {
+          yield sample;
+        }
+      }
+    });
+
+    await player.seek(1);
+    await nextTick();
+
+    expect(sample.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit a seek frame after the player is destroyed', async () => {
+    const seek = deferred<ReturnType<typeof createSample>>();
+    const samples = new Map<number, Promise<ReturnType<typeof createSample>>>([[1, seek.promise]]);
+    const onFrame = vi.fn();
+
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn((frame: { timestamp: number }) =>
+        Promise.resolve({ close: vi.fn(), timestamp: frame.timestamp })
+      )
+    );
+
+    const player = new MediaBunnyPlayer({
+      nodeId: 'video-1',
+      onFrame,
+      onMetadata: vi.fn(),
+      onEnded: vi.fn(),
+      onError: vi.fn()
+    });
+
+    Object.assign(player as unknown as { _isLoaded: boolean; sink: unknown; input: unknown }, {
+      _isLoaded: true,
+      input: { dispose: vi.fn() },
+      sink: {
+        samplesAtTimestamps: (times: Iterable<number>) => samplesForTimes(times, samples),
+        samples: async function* () {}
+      }
+    });
+
+    const seekPromise = player.seek(1);
+
+    player.destroy();
+    seek.resolve(createSample(1));
+    await seekPromise;
+
+    expect(onFrame).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/lib/video/MediaBunnyPlayer.ts
+++ b/ui/src/lib/video/MediaBunnyPlayer.ts
@@ -39,8 +39,15 @@ interface BufferedFrame {
   timestamp: number; // seconds
 }
 
+interface CachedSeekFrame extends BufferedFrame {
+  key: number;
+}
+
 // How many frames to buffer ahead
 const FRAME_BUFFER_SIZE = 10;
+const SEEK_FRAME_CACHE_SIZE = 72;
+const SEEK_PREFETCH_RADIUS_SECONDS = 0.35;
+const SEEK_PREFETCH_MAX_FRAMES = 24;
 
 // Profiling
 const PROFILE_ENABLED = false;
@@ -80,6 +87,15 @@ export class MediaBunnyPlayer {
   private frameBuffer: BufferedFrame[] = [];
   private isBuffering = false;
   private bufferAbortController: AbortController | null = null;
+
+  // Seek coalescing. Random-access frame decoding can be slower than slider input,
+  // so keep only the newest pending target while one seek is active.
+  private activeSeekPromise: Promise<void> | null = null;
+  private pendingSeekTime: number | null = null;
+  private seekGeneration = 0;
+  private resumePlaybackAfterSeek = false;
+  private seekFrameCache = new Map<number, CachedSeekFrame>();
+  private seekPrefetchAbortController: AbortController | null = null;
 
   constructor(config: MediaBunnyPlayerConfig) {
     this.nodeId = config.nodeId;
@@ -174,8 +190,10 @@ export class MediaBunnyPlayer {
       // Reset all state to avoid stale values from a partial load
       this.input?.dispose();
       this.input = null;
+
       this.videoTrack = null;
       this.sink = null;
+
       this._isLoaded = false;
       this._metadata = null;
       this._currentTime = 0;
@@ -197,7 +215,7 @@ export class MediaBunnyPlayer {
    * Show a single frame at the specified time (for preview/seeking).
    * Uses getSample() which is slower but necessary for random access.
    */
-  private async showPreviewFrame(timeSeconds: number): Promise<void> {
+  private async showPreviewFrame(timeSeconds: number, seekGeneration?: number): Promise<void> {
     if (!this.sink) return;
 
     try {
@@ -207,13 +225,24 @@ export class MediaBunnyPlayer {
 
       // Cache timestamp before any operations that might close the sample
       const timestamp = sample.timestamp;
-      this._currentTime = timestamp;
+
+      if (seekGeneration !== undefined && seekGeneration !== this.seekGeneration) {
+        sample.close();
+        return;
+      }
 
       // Convert to ImageBitmap with guaranteed cleanup
       const videoFrame = sample.toVideoFrame();
       try {
         // Skip flipY here - let CSS/GL handle it (flipY in createImageBitmap is slow ~11ms)
         const bitmap = await createImageBitmap(videoFrame);
+
+        if (seekGeneration !== undefined && seekGeneration !== this.seekGeneration) {
+          bitmap.close();
+          return;
+        }
+
+        this._currentTime = timestamp;
 
         // Send to renderer
         this.onFrame(bitmap, timestamp * 1_000_000); // convert to microseconds
@@ -230,6 +259,116 @@ export class MediaBunnyPlayer {
     } catch (error) {
       console.error('[MediaBunnyPlayer] Error showing preview frame:', error);
     }
+  }
+
+  private async showSeekFrame(timeSeconds: number, seekGeneration: number): Promise<void> {
+    const cachedFrame = this.seekFrameCache.get(this.getSeekFrameKey(timeSeconds));
+
+    if (cachedFrame) {
+      await this.emitCachedSeekFrame(cachedFrame, seekGeneration);
+      return;
+    }
+
+    if (!this.sink) return;
+
+    try {
+      for await (const sample of this.sink.samplesAtTimestamps([timeSeconds])) {
+        if (!sample) return;
+
+        await this.cacheAndMaybeEmitSeekSample(sample, timeSeconds, seekGeneration);
+        return;
+      }
+    } catch (error) {
+      console.error('[MediaBunnyPlayer] Error showing seek frame:', error);
+    }
+  }
+
+  private async cacheAndMaybeEmitSeekSample(
+    sample: NonNullable<Awaited<ReturnType<VideoSampleSink['getSample']>>>,
+    requestedTime: number,
+    seekGeneration: number
+  ): Promise<void> {
+    const timestamp = sample.timestamp;
+
+    if (seekGeneration !== this.seekGeneration) {
+      sample.close();
+      return;
+    }
+
+    const videoFrame = sample.toVideoFrame();
+
+    try {
+      const bitmap = await createImageBitmap(videoFrame);
+
+      if (seekGeneration !== this.seekGeneration) {
+        bitmap.close();
+        return;
+      }
+
+      const cachedFrame = this.cacheSeekFrame(requestedTime, timestamp, bitmap);
+
+      await this.emitCachedSeekFrame(cachedFrame, seekGeneration);
+    } finally {
+      videoFrame.close();
+      sample.close();
+    }
+  }
+
+  private async emitCachedSeekFrame(
+    cachedFrame: CachedSeekFrame,
+    seekGeneration: number
+  ): Promise<void> {
+    if (seekGeneration !== this.seekGeneration) return;
+
+    const bitmap = await createImageBitmap(cachedFrame.bitmap);
+
+    if (seekGeneration !== this.seekGeneration) {
+      bitmap.close();
+      return;
+    }
+
+    this._currentTime = cachedFrame.timestamp;
+    this.onFrame(bitmap, cachedFrame.timestamp * 1_000_000);
+
+    if (!this.firstFrameSent) {
+      this.firstFrameSent = true;
+      this.onFirstFrame?.();
+    }
+
+    this.onTimeUpdate?.(this._currentTime);
+  }
+
+  private cacheSeekFrame(
+    requestedTime: number,
+    timestamp: number,
+    bitmap: ImageBitmap
+  ): CachedSeekFrame {
+    const key = this.getSeekFrameKey(requestedTime);
+    const existing = this.seekFrameCache.get(key);
+
+    if (existing) {
+      existing.bitmap.close();
+      this.seekFrameCache.delete(key);
+    }
+
+    const cachedFrame = { key, bitmap, timestamp };
+
+    this.seekFrameCache.set(key, cachedFrame);
+
+    while (this.seekFrameCache.size > SEEK_FRAME_CACHE_SIZE) {
+      const oldest = this.seekFrameCache.values().next().value;
+
+      if (!oldest) break;
+
+      oldest.bitmap.close();
+      this.seekFrameCache.delete(oldest.key);
+    }
+
+    return cachedFrame;
+  }
+
+  private getSeekFrameKey(timeSeconds: number): number {
+    return Math.round(timeSeconds * (this._metadata?.frameRate ?? 30));
   }
 
   /**
@@ -294,6 +433,7 @@ export class MediaBunnyPlayer {
           // Skip flipY here - let CSS/GL handle it (flipY in createImageBitmap is slow ~11ms)
           const bitmap = await createImageBitmap(videoFrame);
           const bitmapEnd = PROFILE_ENABLED ? performance.now() : 0;
+
           videoFrame.close();
 
           // Profile logging
@@ -308,6 +448,7 @@ export class MediaBunnyPlayer {
                   `toVideoFrame=${(profileTotalDecodeTime / profileFrameCount).toFixed(2)}ms, ` +
                   `createImageBitmap=${(profileTotalBitmapTime / profileFrameCount).toFixed(2)}ms`
               );
+
               profileFrameCount = 0;
               profileTotalDecodeTime = 0;
               profileTotalBitmapTime = 0;
@@ -315,10 +456,7 @@ export class MediaBunnyPlayer {
           }
 
           // Add to buffer
-          this.frameBuffer.push({
-            bitmap,
-            timestamp: sample.timestamp
-          });
+          this.frameBuffer.push({ bitmap, timestamp: sample.timestamp });
 
           sample.close();
         } catch (error) {
@@ -356,7 +494,21 @@ export class MediaBunnyPlayer {
     for (const frame of this.frameBuffer) {
       frame.bitmap.close();
     }
+
     this.frameBuffer = [];
+  }
+
+  private clearSeekFrameCache(): void {
+    for (const frame of this.seekFrameCache.values()) {
+      frame.bitmap.close();
+    }
+
+    this.seekFrameCache.clear();
+  }
+
+  private stopSeekPrefetch(): void {
+    this.seekPrefetchAbortController?.abort();
+    this.seekPrefetchAbortController = null;
   }
 
   /**
@@ -386,13 +538,16 @@ export class MediaBunnyPlayer {
         this.startBuffering(0);
       } else {
         this._paused = true;
+
         if (this.animationFrameId !== null) {
           cancelAnimationFrame(this.animationFrameId);
           this.animationFrameId = null;
         }
+
         this.stopBuffering();
         this.onEnded();
       }
+
       return;
     }
 
@@ -408,6 +563,7 @@ export class MediaBunnyPlayer {
 
     // Find frames that are at or before target time
     let bestFrameIndex = -1;
+
     for (let i = 0; i < this.frameBuffer.length; i++) {
       if (this.frameBuffer[i].timestamp <= targetTime) {
         bestFrameIndex = i;
@@ -425,13 +581,17 @@ export class MediaBunnyPlayer {
     for (let i = 0; i < bestFrameIndex; i++) {
       this.frameBuffer[i].bitmap.close();
     }
+
     this.frameBuffer.splice(0, bestFrameIndex);
 
     // Display the best frame
     const frame = this.frameBuffer.shift();
+
     if (frame) {
       this._currentTime = frame.timestamp;
-      this.onFrame(frame.bitmap, frame.timestamp * 1_000_000); // convert to microseconds
+
+      // convert to microseconds
+      this.onFrame(frame.bitmap, frame.timestamp * 1_000_000);
 
       // Notify first frame
       if (!this.firstFrameSent) {
@@ -448,6 +608,11 @@ export class MediaBunnyPlayer {
    * Pause playback.
    */
   pause(): void {
+    this.resumePlaybackAfterSeek = false;
+    this.pausePlaybackForSeek();
+  }
+
+  private pausePlaybackForSeek(): void {
     this._paused = true;
 
     if (this.animationFrameId !== null) {
@@ -465,9 +630,33 @@ export class MediaBunnyPlayer {
   async seek(timeSeconds: number): Promise<void> {
     if (!this._isLoaded) return;
 
-    const wasPlaying = !this._paused;
-    if (wasPlaying) {
-      this.pause();
+    this.pendingSeekTime = Math.max(0, timeSeconds);
+    this.seekGeneration += 1;
+    this.resumePlaybackAfterSeek ||= !this._paused;
+
+    if (!this.activeSeekPromise) {
+      this.activeSeekPromise = this.drainSeekQueue().finally(() => {
+        this.activeSeekPromise = null;
+      });
+    }
+
+    await this.activeSeekPromise;
+  }
+
+  private async drainSeekQueue(): Promise<void> {
+    while (this.pendingSeekTime !== null) {
+      const timeSeconds = this.pendingSeekTime;
+      const seekGeneration = this.seekGeneration;
+
+      this.pendingSeekTime = null;
+
+      await this.performSeek(timeSeconds, seekGeneration);
+    }
+  }
+
+  private async performSeek(timeSeconds: number, seekGeneration: number): Promise<void> {
+    if (!this._paused) {
+      this.pausePlaybackForSeek();
     }
 
     // Clear buffer for new position
@@ -475,19 +664,94 @@ export class MediaBunnyPlayer {
     this.clearBuffer();
 
     // Show preview frame at seek position
-    await this.showPreviewFrame(timeSeconds);
+    await this.showSeekFrame(timeSeconds, seekGeneration);
+
+    if (seekGeneration !== this.seekGeneration) {
+      return;
+    }
+
+    this.prefetchSeekFrames(timeSeconds, seekGeneration);
 
     // Force exact time when seeking to beginning (keyframe may not be at 0)
     if (timeSeconds === 0) {
       this._currentTime = 0;
     }
 
-    if (wasPlaying) {
+    if (this.resumePlaybackAfterSeek) {
+      this.resumePlaybackAfterSeek = false;
       this.playbackStartTime = performance.now();
       this.playbackStartVideoTime = this._currentTime;
       this._paused = false;
+
       this.startBuffering(this._currentTime);
       this.playbackLoop();
+    } else {
+      this.resumePlaybackAfterSeek = false;
+    }
+  }
+
+  private prefetchSeekFrames(centerTime: number, seekGeneration: number): void {
+    if (!this.sink || !this._metadata) return;
+
+    this.stopSeekPrefetch();
+
+    this.seekPrefetchAbortController = new AbortController();
+    const signal = this.seekPrefetchAbortController.signal;
+    const startTime = Math.max(0, centerTime - SEEK_PREFETCH_RADIUS_SECONDS);
+    const endTime = Math.min(this._metadata.duration, centerTime + SEEK_PREFETCH_RADIUS_SECONDS);
+
+    void this.prefetchSeekFramesInRange(startTime, endTime, seekGeneration, signal);
+  }
+
+  private async prefetchSeekFramesInRange(
+    startTime: number,
+    endTime: number,
+    seekGeneration: number,
+    signal: AbortSignal
+  ): Promise<void> {
+    if (!this.sink) return;
+
+    let frameCount = 0;
+
+    try {
+      for await (const sample of this.sink.samples(startTime, endTime)) {
+        if (signal.aborted || seekGeneration !== this.seekGeneration) {
+          sample.close();
+          break;
+        }
+
+        const key = this.getSeekFrameKey(sample.timestamp);
+
+        if (this.seekFrameCache.has(key)) {
+          sample.close();
+          continue;
+        }
+
+        const videoFrame = sample.toVideoFrame();
+
+        try {
+          const bitmap = await createImageBitmap(videoFrame);
+
+          if (signal.aborted || seekGeneration !== this.seekGeneration) {
+            bitmap.close();
+            break;
+          }
+
+          this.cacheSeekFrame(sample.timestamp, sample.timestamp, bitmap);
+          frameCount += 1;
+
+          if (frameCount >= SEEK_PREFETCH_MAX_FRAMES) {
+            break;
+          }
+        } finally {
+          videoFrame.close();
+          sample.close();
+        }
+      }
+    } catch (error) {
+      if (!signal.aborted) {
+        console.error('[MediaBunnyPlayer] Error prefetching seek frames:', error);
+      }
     }
   }
 
@@ -525,6 +789,8 @@ export class MediaBunnyPlayer {
 
     this.stopBuffering();
     this.clearBuffer();
+    this.stopSeekPrefetch();
+    this.clearSeekFrameCache();
 
     // Dispose Input to cancel ongoing reads, close decoders, and free resources
     this.input?.dispose();
@@ -540,6 +806,7 @@ export class MediaBunnyPlayer {
    */
   destroy(): void {
     this.cleanup();
+
     this._metadata = null;
     this._isLoaded = false;
   }

--- a/ui/src/lib/video/MediaBunnyPlayer.ts
+++ b/ui/src/lib/video/MediaBunnyPlayer.ts
@@ -48,6 +48,7 @@ const FRAME_BUFFER_SIZE = 10;
 const SEEK_FRAME_CACHE_SIZE = 72;
 const SEEK_PREFETCH_RADIUS_SECONDS = 0.35;
 const SEEK_PREFETCH_MAX_FRAMES = 24;
+const SEEK_PLAYBACK_RESUME_DELAY_MS = 150;
 
 // Profiling
 const PROFILE_ENABLED = false;
@@ -94,6 +95,7 @@ export class MediaBunnyPlayer {
   private pendingSeekTime: number | null = null;
   private seekGeneration = 0;
   private resumePlaybackAfterSeek = false;
+  private seekPlaybackResumeTimeout: ReturnType<typeof setTimeout> | null = null;
   private seekFrameCache = new Map<number, CachedSeekFrame>();
   private seekPrefetchAbortController: AbortController | null = null;
 
@@ -609,6 +611,7 @@ export class MediaBunnyPlayer {
    */
   pause(): void {
     this.resumePlaybackAfterSeek = false;
+    this.clearSeekPlaybackResumeTimeout();
     this.pausePlaybackForSeek();
   }
 
@@ -633,6 +636,10 @@ export class MediaBunnyPlayer {
     this.pendingSeekTime = Math.max(0, timeSeconds);
     this.seekGeneration += 1;
     this.resumePlaybackAfterSeek ||= !this._paused;
+
+    if (this.resumePlaybackAfterSeek) {
+      this.clearSeekPlaybackResumeTimeout();
+    }
 
     if (!this.activeSeekPromise) {
       this.activeSeekPromise = this.drainSeekQueue().finally(() => {
@@ -678,15 +685,32 @@ export class MediaBunnyPlayer {
     }
 
     if (this.resumePlaybackAfterSeek) {
+      this.scheduleSeekPlaybackResume();
+    }
+  }
+
+  private scheduleSeekPlaybackResume(): void {
+    this.clearSeekPlaybackResumeTimeout();
+
+    this.seekPlaybackResumeTimeout = setTimeout(() => {
+      this.seekPlaybackResumeTimeout = null;
       this.resumePlaybackAfterSeek = false;
+
+      if (!this._isLoaded || !this._paused) return;
+
       this.playbackStartTime = performance.now();
       this.playbackStartVideoTime = this._currentTime;
       this._paused = false;
 
       this.startBuffering(this._currentTime);
       this.playbackLoop();
-    } else {
-      this.resumePlaybackAfterSeek = false;
+    }, SEEK_PLAYBACK_RESUME_DELAY_MS);
+  }
+
+  private clearSeekPlaybackResumeTimeout(): void {
+    if (this.seekPlaybackResumeTimeout !== null) {
+      clearTimeout(this.seekPlaybackResumeTimeout);
+      this.seekPlaybackResumeTimeout = null;
     }
   }
 
@@ -791,6 +815,7 @@ export class MediaBunnyPlayer {
     this.clearBuffer();
     this.stopSeekPrefetch();
     this.clearSeekFrameCache();
+    this.clearSeekPlaybackResumeTimeout();
 
     // Dispose Input to cancel ongoing reads, close decoders, and free resources
     this.input?.dispose();

--- a/ui/src/lib/video/MediaBunnyPlayer.ts
+++ b/ui/src/lib/video/MediaBunnyPlayer.ts
@@ -297,9 +297,10 @@ export class MediaBunnyPlayer {
       return;
     }
 
-    const videoFrame = sample.toVideoFrame();
+    let videoFrame: VideoFrame | null = null;
 
     try {
+      videoFrame = sample.toVideoFrame();
       const bitmap = await createImageBitmap(videoFrame);
 
       if (seekGeneration !== this.seekGeneration) {
@@ -311,7 +312,7 @@ export class MediaBunnyPlayer {
 
       await this.emitCachedSeekFrame(cachedFrame, seekGeneration);
     } finally {
-      videoFrame.close();
+      videoFrame?.close();
       sample.close();
     }
   }
@@ -662,6 +663,10 @@ export class MediaBunnyPlayer {
   }
 
   private async performSeek(timeSeconds: number, seekGeneration: number): Promise<void> {
+    if (seekGeneration !== this.seekGeneration) {
+      return;
+    }
+
     if (!this._paused) {
       this.pausePlaybackForSeek();
     }
@@ -751,9 +756,10 @@ export class MediaBunnyPlayer {
           continue;
         }
 
-        const videoFrame = sample.toVideoFrame();
+        let videoFrame: VideoFrame | null = null;
 
         try {
+          videoFrame = sample.toVideoFrame();
           const bitmap = await createImageBitmap(videoFrame);
 
           if (signal.aborted || seekGeneration !== this.seekGeneration) {
@@ -768,7 +774,7 @@ export class MediaBunnyPlayer {
             break;
           }
         } finally {
-          videoFrame.close();
+          videoFrame?.close();
           sample.close();
         }
       }
@@ -806,6 +812,11 @@ export class MediaBunnyPlayer {
    * Clean up internal resources.
    */
   private cleanup(): void {
+    this.seekGeneration += 1;
+    this.pendingSeekTime = null;
+    this.activeSeekPromise = null;
+    this.resumePlaybackAfterSeek = false;
+
     if (this.animationFrameId !== null) {
       cancelAnimationFrame(this.animationFrameId);
       this.animationFrameId = null;

--- a/ui/src/lib/video/latest-video-seek.test.ts
+++ b/ui/src/lib/video/latest-video-seek.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { LatestVideoSeek } from './latest-video-seek';
+
+describe('LatestVideoSeek', () => {
+  it('invalidates older seek generations when a newer time is requested', () => {
+    const seek = new LatestVideoSeek();
+
+    const first = seek.request(1);
+    const second = seek.request(2);
+
+    expect(seek.isLatest(first)).toBe(false);
+    expect(seek.isLatest(second)).toBe(true);
+    expect(seek.currentGeneration).toBe(second);
+    expect(seek.currentTargetTime).toBe(2);
+  });
+
+  it('coalesces native video seeks to one in flight plus the latest pending time', () => {
+    const seek = new LatestVideoSeek();
+
+    expect(seek.requestNativeSeek(1)).toEqual({ generation: 1, shouldStartSeek: true });
+    expect(seek.requestNativeSeek(2)).toEqual({ generation: 2, shouldStartSeek: false });
+    expect(seek.requestNativeSeek(3)).toEqual({ generation: 3, shouldStartSeek: false });
+    expect(seek.isNativeSeekInFlight).toBe(true);
+
+    expect(seek.completeNativeSeek(1)).toEqual({ shouldStartNextSeek: true, targetTime: 3 });
+    expect(seek.isNativeSeekInFlight).toBe(true);
+
+    expect(seek.completeNativeSeek(3)).toEqual({ shouldStartNextSeek: false, targetTime: 3 });
+    expect(seek.isNativeSeekInFlight).toBe(false);
+  });
+});

--- a/ui/src/lib/video/latest-video-seek.ts
+++ b/ui/src/lib/video/latest-video-seek.ts
@@ -1,0 +1,51 @@
+export class LatestVideoSeek {
+  private generation = 0;
+  private targetTime = 0;
+  private inFlight = false;
+
+  request(time: number): number {
+    this.generation += 1;
+    this.targetTime = time;
+
+    return this.generation;
+  }
+
+  requestNativeSeek(time: number): { generation: number; shouldStartSeek: boolean } {
+    const generation = this.request(time);
+    const shouldStartSeek = !this.inFlight;
+
+    if (shouldStartSeek) {
+      this.inFlight = true;
+    }
+
+    return { generation, shouldStartSeek };
+  }
+
+  completeNativeSeek(currentTime: number): { shouldStartNextSeek: boolean; targetTime: number } {
+    this.inFlight = false;
+
+    if (Math.abs(currentTime - this.targetTime) <= 0.001) {
+      return { shouldStartNextSeek: false, targetTime: this.targetTime };
+    }
+
+    this.inFlight = true;
+
+    return { shouldStartNextSeek: true, targetTime: this.targetTime };
+  }
+
+  isLatest(generation: number): boolean {
+    return generation === this.generation;
+  }
+
+  get currentGeneration(): number {
+    return this.generation;
+  }
+
+  get currentTargetTime(): number {
+    return this.targetTime;
+  }
+
+  get isNativeSeekInFlight(): boolean {
+    return this.inFlight;
+  }
+}

--- a/ui/src/lib/video/video-control-overlay.test.ts
+++ b/ui/src/lib/video/video-control-overlay.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import {
   VIDEO_OVERLAY_IDLE_MS,
+  VideoOverlayPointerFocusGate,
   VideoOverlaySeekPlaybackGate,
   VideoControlOverlayVisibility,
   formatVideoOverlayTime,
+  getRangePointerTime,
+  isPendingSeekComplete,
   getVideoOverlayDisplayTime,
   getVideoOverlayDuration
 } from './video-control-overlay';
@@ -24,6 +27,23 @@ describe('video control overlay', () => {
     expect(
       getVideoOverlayDisplayTime({ workerTime: 0, elementTime: 3, hasWorkerFrame: false })
     ).toBe(3);
+  });
+
+  it('keeps an optimistic seek target visible until the worker catches up', () => {
+    expect(
+      getVideoOverlayDisplayTime({
+        workerTime: 5,
+        elementTime: 5,
+        hasWorkerFrame: true,
+        pendingSeekTime: 20
+      })
+    ).toBe(20);
+  });
+
+  it('treats a pending seek as complete only when playback time reaches the target', () => {
+    expect(isPendingSeekComplete({ pendingSeekTime: 20, currentTime: 19.95 })).toBe(true);
+    expect(isPendingSeekComplete({ pendingSeekTime: 20, currentTime: 5 })).toBe(false);
+    expect(isPendingSeekComplete({ pendingSeekTime: null, currentTime: 5 })).toBe(false);
   });
 
   it('uses metadata duration before falling back to the native element duration', () => {
@@ -66,5 +86,50 @@ describe('video control overlay', () => {
 
     expect(gate.start({ paused: true })).toEqual({ shouldPause: false });
     expect(gate.stop()).toEqual({ shouldResume: false });
+  });
+
+  it('skips focus-triggered seek start immediately after pointer seek start', () => {
+    const gate = new VideoOverlayPointerFocusGate();
+
+    gate.startPointerSeek();
+
+    expect(gate.shouldStartSeekOnFocus()).toBe(false);
+
+    gate.endPointerSeek();
+
+    expect(gate.shouldStartSeekOnFocus()).toBe(true);
+  });
+
+  it('maps a range pointer position to the clicked video time', () => {
+    expect(
+      getRangePointerTime({
+        clientX: 75,
+        left: 50,
+        width: 100,
+        min: 0,
+        max: 44
+      })
+    ).toBe(11);
+  });
+
+  it('clamps range pointer seek times to the range bounds', () => {
+    expect(
+      getRangePointerTime({
+        clientX: 10,
+        left: 50,
+        width: 100,
+        min: 2,
+        max: 10
+      })
+    ).toBe(2);
+    expect(
+      getRangePointerTime({
+        clientX: 200,
+        left: 50,
+        width: 100,
+        min: 2,
+        max: 10
+      })
+    ).toBe(10);
   });
 });

--- a/ui/src/lib/video/video-control-overlay.test.ts
+++ b/ui/src/lib/video/video-control-overlay.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   VIDEO_OVERLAY_IDLE_MS,
+  VideoOverlaySeekPlaybackGate,
   VideoControlOverlayVisibility,
   formatVideoOverlayTime,
   getVideoOverlayDisplayTime,
@@ -54,5 +55,16 @@ describe('video control overlay', () => {
     visibility.stopScrubbing(100 + VIDEO_OVERLAY_IDLE_MS);
 
     expect(visibility.shouldHide(100 + VIDEO_OVERLAY_IDLE_MS * 2)).toBe(true);
+  });
+
+  it('resumes playback after overlay scrubbing only when video was playing before', () => {
+    const gate = new VideoOverlaySeekPlaybackGate();
+
+    expect(gate.start({ paused: false })).toEqual({ shouldPause: true });
+    expect(gate.start({ paused: true })).toEqual({ shouldPause: false });
+    expect(gate.stop()).toEqual({ shouldResume: true });
+
+    expect(gate.start({ paused: true })).toEqual({ shouldPause: false });
+    expect(gate.stop()).toEqual({ shouldResume: false });
   });
 });

--- a/ui/src/lib/video/video-control-overlay.test.ts
+++ b/ui/src/lib/video/video-control-overlay.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  VIDEO_OVERLAY_IDLE_MS,
+  VideoControlOverlayVisibility,
+  formatVideoOverlayTime,
+  getVideoOverlayDisplayTime,
+  getVideoOverlayDuration
+} from './video-control-overlay';
+
+describe('video control overlay', () => {
+  it('formats video times as clock labels', () => {
+    expect(formatVideoOverlayTime(6)).toBe('00:06');
+    expect(formatVideoOverlayTime(74)).toBe('01:14');
+    expect(formatVideoOverlayTime(3671)).toBe('1:01:11');
+    expect(formatVideoOverlayTime(Number.NaN)).toBe('00:00');
+  });
+
+  it('prefers worker time after MediaBunny starts delivering frames', () => {
+    expect(
+      getVideoOverlayDisplayTime({ workerTime: 12, elementTime: 3, hasWorkerFrame: true })
+    ).toBe(12);
+    expect(
+      getVideoOverlayDisplayTime({ workerTime: 0, elementTime: 3, hasWorkerFrame: false })
+    ).toBe(3);
+  });
+
+  it('uses metadata duration before falling back to the native element duration', () => {
+    expect(getVideoOverlayDuration({ metadataDuration: 44, elementDuration: 30 })).toBe(44);
+    expect(getVideoOverlayDuration({ metadataDuration: undefined, elementDuration: 30 })).toBe(30);
+    expect(
+      getVideoOverlayDuration({ metadataDuration: Number.NaN, elementDuration: Infinity })
+    ).toBe(0);
+  });
+
+  it('keeps the overlay visible while there is recent mouse activity', () => {
+    const visibility = new VideoControlOverlayVisibility();
+
+    visibility.show(100);
+
+    expect(visibility.visible).toBe(true);
+    expect(visibility.shouldHide(100 + VIDEO_OVERLAY_IDLE_MS - 1)).toBe(false);
+    expect(visibility.shouldHide(100 + VIDEO_OVERLAY_IDLE_MS)).toBe(true);
+  });
+
+  it('does not auto-hide while the seek bar is being dragged', () => {
+    const visibility = new VideoControlOverlayVisibility();
+
+    visibility.show(100);
+    visibility.startScrubbing();
+
+    expect(visibility.shouldHide(100 + VIDEO_OVERLAY_IDLE_MS)).toBe(false);
+
+    visibility.stopScrubbing(100 + VIDEO_OVERLAY_IDLE_MS);
+
+    expect(visibility.shouldHide(100 + VIDEO_OVERLAY_IDLE_MS * 2)).toBe(true);
+  });
+});

--- a/ui/src/lib/video/video-control-overlay.ts
+++ b/ui/src/lib/video/video-control-overlay.ts
@@ -82,6 +82,31 @@ export class VideoControlOverlayVisibility {
   }
 }
 
+export class VideoOverlaySeekPlaybackGate {
+  private active = false;
+  private resumeAfterSeek = false;
+
+  start({ paused }: { paused: boolean }): { shouldPause: boolean } {
+    if (this.active) {
+      return { shouldPause: false };
+    }
+
+    this.active = true;
+    this.resumeAfterSeek = !paused;
+
+    return { shouldPause: this.resumeAfterSeek };
+  }
+
+  stop(): { shouldResume: boolean } {
+    const shouldResume = this.resumeAfterSeek;
+
+    this.active = false;
+    this.resumeAfterSeek = false;
+
+    return { shouldResume };
+  }
+}
+
 function padClockPart(value: number): string {
   return value.toString().padStart(2, '0');
 }

--- a/ui/src/lib/video/video-control-overlay.ts
+++ b/ui/src/lib/video/video-control-overlay.ts
@@ -1,0 +1,87 @@
+export const VIDEO_OVERLAY_IDLE_MS = 1800;
+
+export function formatVideoOverlayTime(timeSeconds: number): string {
+  if (!Number.isFinite(timeSeconds) || timeSeconds <= 0) {
+    return '00:00';
+  }
+
+  const totalSeconds = Math.floor(timeSeconds);
+  const seconds = totalSeconds % 60;
+  const minutes = Math.floor(totalSeconds / 60) % 60;
+  const hours = Math.floor(totalSeconds / 3600);
+
+  if (hours > 0) {
+    return `${hours}:${padClockPart(minutes)}:${padClockPart(seconds)}`;
+  }
+
+  return `${padClockPart(minutes)}:${padClockPart(seconds)}`;
+}
+
+export function getVideoOverlayDisplayTime({
+  workerTime,
+  elementTime,
+  hasWorkerFrame
+}: {
+  workerTime: number;
+  elementTime: number | undefined;
+  hasWorkerFrame: boolean;
+}): number {
+  if (hasWorkerFrame && Number.isFinite(workerTime)) {
+    return Math.max(0, workerTime);
+  }
+
+  return Number.isFinite(elementTime) ? Math.max(0, elementTime ?? 0) : 0;
+}
+
+export function getVideoOverlayDuration({
+  metadataDuration,
+  elementDuration
+}: {
+  metadataDuration: number | undefined;
+  elementDuration: number | undefined;
+}): number {
+  if (Number.isFinite(metadataDuration)) {
+    return Math.max(0, metadataDuration ?? 0);
+  }
+
+  if (Number.isFinite(elementDuration)) {
+    return Math.max(0, elementDuration ?? 0);
+  }
+
+  return 0;
+}
+
+export class VideoControlOverlayVisibility {
+  visible = false;
+  private scrubbing = false;
+  private lastActivityTime = 0;
+
+  show(now: number): void {
+    this.visible = true;
+    this.lastActivityTime = now;
+  }
+
+  hide(): void {
+    if (this.scrubbing) return;
+
+    this.visible = false;
+  }
+
+  startScrubbing(): void {
+    this.visible = true;
+    this.scrubbing = true;
+  }
+
+  stopScrubbing(now: number): void {
+    this.scrubbing = false;
+    this.show(now);
+  }
+
+  shouldHide(now: number): boolean {
+    return this.visible && !this.scrubbing && now - this.lastActivityTime >= VIDEO_OVERLAY_IDLE_MS;
+  }
+}
+
+function padClockPart(value: number): string {
+  return value.toString().padStart(2, '0');
+}

--- a/ui/src/lib/video/video-control-overlay.ts
+++ b/ui/src/lib/video/video-control-overlay.ts
@@ -20,12 +20,18 @@ export function formatVideoOverlayTime(timeSeconds: number): string {
 export function getVideoOverlayDisplayTime({
   workerTime,
   elementTime,
-  hasWorkerFrame
+  hasWorkerFrame,
+  pendingSeekTime
 }: {
   workerTime: number;
   elementTime: number | undefined;
   hasWorkerFrame: boolean;
+  pendingSeekTime?: number | null;
 }): number {
+  if (Number.isFinite(pendingSeekTime)) {
+    return Math.max(0, pendingSeekTime ?? 0);
+  }
+
   if (hasWorkerFrame && Number.isFinite(workerTime)) {
     return Math.max(0, workerTime);
   }
@@ -49,6 +55,44 @@ export function getVideoOverlayDuration({
   }
 
   return 0;
+}
+
+export function getRangePointerTime({
+  clientX,
+  left,
+  width,
+  min,
+  max
+}: {
+  clientX: number;
+  left: number;
+  width: number;
+  min: number;
+  max: number;
+}): number {
+  if (!Number.isFinite(width) || width <= 0) {
+    return min;
+  }
+
+  const progress = Math.min(1, Math.max(0, (clientX - left) / width));
+
+  return min + (max - min) * progress;
+}
+
+export function isPendingSeekComplete({
+  pendingSeekTime,
+  currentTime,
+  tolerance = 0.1
+}: {
+  pendingSeekTime: number | null;
+  currentTime: number;
+  tolerance?: number;
+}): boolean {
+  return (
+    Number.isFinite(pendingSeekTime) &&
+    Number.isFinite(currentTime) &&
+    Math.abs(currentTime - (pendingSeekTime ?? 0)) <= tolerance
+  );
 }
 
 export class VideoControlOverlayVisibility {
@@ -104,6 +148,22 @@ export class VideoOverlaySeekPlaybackGate {
     this.resumeAfterSeek = false;
 
     return { shouldResume };
+  }
+}
+
+export class VideoOverlayPointerFocusGate {
+  private pointerSeekStarted = false;
+
+  startPointerSeek(): void {
+    this.pointerSeekStarted = true;
+  }
+
+  shouldStartSeekOnFocus(): boolean {
+    return !this.pointerSeekStarted;
+  }
+
+  endPointerSeek(): void {
+    this.pointerSeekStarted = false;
   }
 }
 

--- a/ui/src/lib/video/video-node-size.test.ts
+++ b/ui/src/lib/video/video-node-size.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { getVideoNodeDisplaySize } from './video-node-size';
+
+describe('video node display size', () => {
+  it('keeps the persisted resized dimensions when they already exist', () => {
+    expect(
+      getVideoNodeDisplaySize({
+        nodeWidth: 320,
+        nodeHeight: 180,
+        videoWidth: 1280,
+        videoHeight: 720,
+        previewWidth: 160,
+        previewHeight: 120
+      })
+    ).toEqual({ width: 320, height: 180 });
+  });
+
+  it('auto-sizes new video nodes from intrinsic video aspect ratio', () => {
+    expect(
+      getVideoNodeDisplaySize({
+        nodeWidth: undefined,
+        nodeHeight: undefined,
+        videoWidth: 1280,
+        videoHeight: 720,
+        previewWidth: 160,
+        previewHeight: 120
+      })
+    ).toEqual({ width: 160, height: 90 });
+  });
+
+  it('fits portrait videos within the preview height on first load', () => {
+    expect(
+      getVideoNodeDisplaySize({
+        nodeWidth: undefined,
+        nodeHeight: undefined,
+        videoWidth: 720,
+        videoHeight: 1280,
+        previewWidth: 160,
+        previewHeight: 120
+      })
+    ).toEqual({ width: 68, height: 120 });
+  });
+});

--- a/ui/src/lib/video/video-node-size.ts
+++ b/ui/src/lib/video/video-node-size.ts
@@ -1,0 +1,47 @@
+export interface VideoNodeDisplaySizeInput {
+  nodeWidth: number | undefined;
+  nodeHeight: number | undefined;
+  videoWidth: number;
+  videoHeight: number;
+  previewWidth: number;
+  previewHeight: number;
+}
+
+export interface VideoNodeDisplaySize {
+  width: number;
+  height: number;
+}
+
+export function getVideoNodeDisplaySize({
+  nodeWidth,
+  nodeHeight,
+  videoWidth,
+  videoHeight,
+  previewWidth,
+  previewHeight
+}: VideoNodeDisplaySizeInput): VideoNodeDisplaySize {
+  if (isPositiveFinite(nodeWidth) && isPositiveFinite(nodeHeight)) {
+    return {
+      width: Math.round(nodeWidth),
+      height: Math.round(nodeHeight)
+    };
+  }
+
+  const aspectRatio = videoWidth / videoHeight;
+  let width = previewWidth;
+  let height = previewWidth / aspectRatio;
+
+  if (height > previewHeight) {
+    height = previewHeight;
+    width = previewHeight * aspectRatio;
+  }
+
+  return {
+    width: Math.round(width),
+    height: Math.round(height)
+  };
+}
+
+function isPositiveFinite(value: number | undefined): value is number {
+  return Number.isFinite(value) && value !== undefined && value > 0;
+}


### PR DESCRIPTION
Speed up video seeking, both in MediaBunny decoder mode and native HTML5 video mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native seek preview support for video seeking, including automatic preview timing and visibility handling.
  * Added a new video control overlay with play/pause, time display, and a seek bar with scrubbing behavior.
  * Introduced automatic display sizing for video nodes based on intrinsic aspect ratio when dimensions aren’t provided.
* **Bug Fixes**
  * Reduced stale/out-of-order seek preview frames via seek caching/coalescing.
  * Improved overlay timing synchronization and more complete seek/cleanup behavior during resume/end and teardown.
* **Tests**
  * Expanded coverage for native seek coalescing, seek caching, and overlay interaction logic.
* **Chores**
  * Updated the MediaBunny dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->