### PR TITLE
feat(sampler~): add midi note, scheduled set input and built-in gain

### DIFF
--- a/docs/design-docs/specs/163-sampler-scheduled-playback.md
+++ b/docs/design-docs/specs/163-sampler-scheduled-playback.md
@@ -9,6 +9,7 @@ Allow `sampler~` to play buffers at a target Web Audio time by accepting timed
 { type: 'play', time?: number, offset?: number, duration?: number, gain?: number }
 { type: 'noteOn', note: number, velocity: number, time?: number }
 { type: 'noteOff', note: number, time?: number }
+{ type: 'setGain', value: number }
 { type: 'setNoteOffMode', value: 'one-shot' | 'held' }
 number // play immediately with gain multiplier
 ```
@@ -33,6 +34,8 @@ number // play immediately with gain multiplier
   seconds.
 - `duration` is the amount of source-buffer audio to play, in seconds.
 - `gain` is a per-playback amplitude multiplier.
+- `setGain` sets the sampler's built-in output gain. It scales all playback
+  voices after per-trigger gain, number gain, and MIDI velocity gain.
 - Missing `offset`/`duration` fall back to the sampler's configured start/end
   points. Missing `gain` uses normal amplitude.
 - Negative values are ignored instead of being passed to Web Audio, because

--- a/docs/design-docs/specs/163-sampler-scheduled-playback.md
+++ b/docs/design-docs/specs/163-sampler-scheduled-playback.md
@@ -7,6 +7,9 @@ Allow `sampler~` to play buffers at a target Web Audio time by accepting timed
 ```ts
 { type: 'bang', time?: number }
 { type: 'play', time?: number, offset?: number, duration?: number, gain?: number }
+{ type: 'noteOn', note: number, velocity: number, time?: number }
+{ type: 'noteOff', note: number, time?: number }
+{ type: 'setNoteOffMode', value: 'one-shot' | 'held' }
 number // play immediately with gain multiplier
 ```
 
@@ -15,6 +18,15 @@ number // play immediately with gain multiplier
 - Bare `{ type: 'bang' }` and `{ type: 'play' }` keep the current behavior.
 - Bare non-negative numbers trigger playback with per-voice gain: `0` is silent,
   `1` is normal amplitude, and `2` is twice the amplitude.
+- `noteOn` triggers pitched playback. Note `60` plays the sample at original
+  pitch; each semitone maps to `2 ** ((note - 60) / 12)` playback rate.
+- `noteOn.velocity` maps to gain as `velocity / 127`.
+- The default note-off mode is `one-shot`: `noteOff` is ignored, and velocity
+  `0` note-on messages do not trigger playback.
+- In `held` mode, `noteOff` stops active voices for the matching note and
+  velocity `0` behaves like `noteOff`.
+- `noteOffMode?: 'one-shot' | 'held'` is persisted as node data and can be set
+  from the sampler settings UI or with `setNoteOffMode`.
 - `time` is an absolute `AudioContext.currentTime` timestamp, matching
   scheduled messages emitted by audio-mode sequencers.
 - `offset` is the position in the sample buffer to start playback from, in

--- a/docs/design-docs/specs/163-sampler-scheduled-playback.md
+++ b/docs/design-docs/specs/163-sampler-scheduled-playback.md
@@ -7,6 +7,7 @@ Allow `sampler~` to play buffers at a target Web Audio time by accepting timed
 ```ts
 { type: 'bang', time?: number }
 { type: 'play', time?: number, offset?: number, duration?: number, gain?: number }
+{ type: 'set', time: number, value: number }
 { type: 'noteOn', note: number, velocity: number, time?: number }
 { type: 'noteOff', note: number, time?: number }
 { type: 'setGain', value: number }
@@ -34,6 +35,9 @@ number // play immediately with gain multiplier
   seconds.
 - `duration` is the amount of source-buffer audio to play, in seconds.
 - `gain` is a per-playback amplitude multiplier.
+- Scheduled `set` messages trigger playback with `value` as per-playback gain.
+  This lets sequencer value output drive sampler velocity without a mapper.
+  Untimed `set` messages are ignored by `sampler~`.
 - `setGain` sets the sampler's built-in output gain. It scales all playback
   voices after per-trigger gain, number gain, and MIDI velocity gain.
 - Missing `offset`/`duration` fall back to the sampler's configured start/end

--- a/ui/src/lib/ai/object-prompts/sampler~.ts
+++ b/ui/src/lib/ai/object-prompts/sampler~.ts
@@ -11,6 +11,9 @@ Messages:
 - string: load sample from URL
 - bang: trigger sample playback
 - number: trigger sample playback with gain multiplier (0=silent, 1=normal, 2=twice as loud)
+- {type: 'noteOn', note, velocity}: trigger pitched playback (note 60=original pitch, velocity 0-127 controls gain)
+- {type: 'noteOff', note}: stop active voices for that note when note-off mode is held
+- {type: 'setNoteOffMode', value: 'one-shot' | 'held'}: set whether noteOff is ignored for one-shots or stops held voices
 - {type: 'load', url: '...'}: load sample
 
 Example - Drum Sample:

--- a/ui/src/lib/ai/object-prompts/sampler~.ts
+++ b/ui/src/lib/ai/object-prompts/sampler~.ts
@@ -13,8 +13,8 @@ Messages:
 - number: trigger sample playback with gain multiplier (0=silent, 1=normal, 2=twice as loud)
 - {type: 'set', time, value}: trigger scheduled playback with value as gain
 - {type: 'setGain', value}: set built-in output gain for all sampler playback
-- {type: 'noteOn', note, velocity}: trigger pitched playback (note 60=original pitch, velocity 0-127 controls gain)
-- {type: 'noteOff', note}: stop active voices for that note when note-off mode is held
+- {type: 'noteOn', note, velocity, time?}: trigger pitched playback (note 60=original pitch, velocity 0-127 controls gain)
+- {type: 'noteOff', note, time?}: stop active voices for that note when note-off mode is held
 - {type: 'setNoteOffMode', value: 'one-shot' | 'held'}: set whether noteOff is ignored for one-shots or stops held voices
 - {type: 'load', url: '...'}: load sample
 

--- a/ui/src/lib/ai/object-prompts/sampler~.ts
+++ b/ui/src/lib/ai/object-prompts/sampler~.ts
@@ -11,6 +11,7 @@ Messages:
 - string: load sample from URL
 - bang: trigger sample playback
 - number: trigger sample playback with gain multiplier (0=silent, 1=normal, 2=twice as loud)
+- {type: 'setGain', value}: set built-in output gain for all sampler playback
 - {type: 'noteOn', note, velocity}: trigger pitched playback (note 60=original pitch, velocity 0-127 controls gain)
 - {type: 'noteOff', note}: stop active voices for that note when note-off mode is held
 - {type: 'setNoteOffMode', value: 'one-shot' | 'held'}: set whether noteOff is ignored for one-shots or stops held voices

--- a/ui/src/lib/ai/object-prompts/sampler~.ts
+++ b/ui/src/lib/ai/object-prompts/sampler~.ts
@@ -11,6 +11,7 @@ Messages:
 - string: load sample from URL
 - bang: trigger sample playback
 - number: trigger sample playback with gain multiplier (0=silent, 1=normal, 2=twice as loud)
+- {type: 'set', time, value}: trigger scheduled playback with value as gain
 - {type: 'setGain', value}: set built-in output gain for all sampler playback
 - {type: 'noteOn', note, velocity}: trigger pitched playback (note 60=original pitch, velocity 0-127 controls gain)
 - {type: 'noteOff', note}: stop active voices for that note when note-off mode is held

--- a/ui/src/lib/audio/sampler-playback-message.ts
+++ b/ui/src/lib/audio/sampler-playback-message.ts
@@ -1,5 +1,4 @@
 export type SamplerPlaybackTrigger = {
-  [key: string]: unknown;
   type: 'bang' | 'play';
   time?: unknown;
   offset?: unknown;

--- a/ui/src/lib/audio/v2/AudioService.test.ts
+++ b/ui/src/lib/audio/v2/AudioService.test.ts
@@ -30,4 +30,21 @@ describe('AudioService', () => {
 
     expect(node.send).toHaveBeenCalledWith('message', message);
   });
+
+  it('forwards scheduled messages to node send when scheduler has not started', () => {
+    const service = new AudioService();
+    const audioParam = { value: 0 } as AudioParam;
+    const node: AudioNodeV2 = {
+      nodeId: 'node-1',
+      audioNode: null,
+      send: vi.fn(),
+      getAudioParam: () => audioParam
+    };
+    const message = { type: 'set', time: 12.5, value: 0.75 };
+
+    registerFakeNode(service, node);
+    service.send(node.nodeId, 'gain', message);
+
+    expect(node.send).toHaveBeenCalledWith('gain', message);
+  });
 });

--- a/ui/src/lib/audio/v2/AudioService.test.ts
+++ b/ui/src/lib/audio/v2/AudioService.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./nodes', () => ({
+  registerAudioNodes: vi.fn()
+}));
+
+import { AudioService } from './AudioService';
+import type { AudioNodeV2 } from './interfaces/audio-nodes';
+
+function registerFakeNode(service: AudioService, node: AudioNodeV2): void {
+  (
+    service as unknown as {
+      nodesById: Map<string, AudioNodeV2>;
+    }
+  ).nodesById.set(node.nodeId, node);
+}
+
+describe('AudioService', () => {
+  it('forwards scheduled messages to node send when no AudioParam handles the key', () => {
+    const service = new AudioService();
+    const node: AudioNodeV2 = {
+      nodeId: 'node-1',
+      audioNode: null,
+      send: vi.fn()
+    };
+    const message = { type: 'set', time: 12.5, value: 0.75 };
+
+    registerFakeNode(service, node);
+    service.send(node.nodeId, 'message', message);
+
+    expect(node.send).toHaveBeenCalledWith('message', message);
+  });
+});

--- a/ui/src/lib/audio/v2/AudioService.ts
+++ b/ui/src/lib/audio/v2/AudioService.ts
@@ -168,11 +168,13 @@ export class AudioService {
     if (isScheduledMessage(message)) {
       const audioParam = this.getAudioParamByNode(node, key);
 
-      if (audioParam && this.timeScheduler) {
-        this.timeScheduler.processMessage(audioParam, message);
-      }
+      if (audioParam) {
+        if (this.timeScheduler) {
+          this.timeScheduler.processMessage(audioParam, message);
+        }
 
-      return;
+        return;
+      }
     }
 
     if (node.send) {

--- a/ui/src/lib/audio/v2/AudioService.ts
+++ b/ui/src/lib/audio/v2/AudioService.ts
@@ -168,11 +168,8 @@ export class AudioService {
     if (isScheduledMessage(message)) {
       const audioParam = this.getAudioParamByNode(node, key);
 
-      if (audioParam) {
-        if (this.timeScheduler) {
-          this.timeScheduler.processMessage(audioParam, message);
-        }
-
+      if (audioParam && this.timeScheduler) {
+        this.timeScheduler.processMessage(audioParam, message);
         return;
       }
     }

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.test.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.test.ts
@@ -91,6 +91,17 @@ describe('SamplerNode', () => {
     expect(source.start).toHaveBeenCalledWith(12.5, 0, undefined);
   });
 
+  it('ignores scheduled set messages with invalid gain', () => {
+    const source = createFakeSource();
+    const audioContext = createFakeAudioContext([source]);
+    const node = new SamplerNode('sampler-1', audioContext);
+
+    node.audioBuffer = { duration: 4 } as AudioBuffer;
+    node.send('message', { type: 'set', time: 12.5, value: -1 });
+
+    expect(source.start).not.toHaveBeenCalled();
+  });
+
   it('ignores untimed set messages', () => {
     const source = createFakeSource();
     const audioContext = createFakeAudioContext([source]);
@@ -204,6 +215,22 @@ describe('SamplerNode', () => {
 
     expect(source.playbackRate.value).toBe(1.5);
     expect(source.detune.value).toBe(1200);
+  });
+
+  it('preserves note pitch multiplier when updating playback rate', () => {
+    const source = createFakeSource();
+    const audioContext = createFakeAudioContext([source]);
+    const node = new SamplerNode('sampler-1', audioContext);
+
+    node.audioBuffer = { duration: 4 } as AudioBuffer;
+    node.send('message', { type: 'setPlaybackRate', value: 1.5 });
+    node.send('message', { type: 'noteOn', note: 72, velocity: 127 });
+
+    expect(source.playbackRate.value).toBe(3);
+
+    node.send('message', { type: 'setPlaybackRate', value: 2 });
+
+    expect(source.playbackRate.value).toBe(4);
   });
 
   it('keeps future noteOff voices tracked until they end', () => {

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.test.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.test.ts
@@ -77,6 +77,31 @@ describe('SamplerNode', () => {
     expect(node.audioNode.gain.value).toBe(0.25);
   });
 
+  it('plays scheduled set messages as gain-scaled triggers', () => {
+    const source = createFakeSource();
+    const outputGain = createFakeGain();
+    const voiceGain = createFakeGain();
+    const audioContext = createFakeAudioContext([source], [outputGain, voiceGain]);
+    const node = new SamplerNode('sampler-1', audioContext);
+
+    node.audioBuffer = { duration: 4 } as AudioBuffer;
+    node.send('message', { type: 'set', time: 12.5, value: 0.75 });
+
+    expect(voiceGain.gain.value).toBe(0.75);
+    expect(source.start).toHaveBeenCalledWith(12.5, 0, undefined);
+  });
+
+  it('ignores untimed set messages', () => {
+    const source = createFakeSource();
+    const audioContext = createFakeAudioContext([source]);
+    const node = new SamplerNode('sampler-1', audioContext);
+
+    node.audioBuffer = { duration: 4 } as AudioBuffer;
+    node.send('message', { type: 'set', value: 0.75 });
+
+    expect(source.start).not.toHaveBeenCalled();
+  });
+
   it('schedules bang messages with time', () => {
     const source = createFakeSource();
     const audioContext = createFakeAudioContext([source]);

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.test.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.test.ts
@@ -192,6 +192,40 @@ describe('SamplerNode', () => {
     expect(source.stop).toHaveBeenCalledOnce();
   });
 
+  it('updates playback parameters on active note voices', () => {
+    const source = createFakeSource();
+    const audioContext = createFakeAudioContext([source]);
+    const node = new SamplerNode('sampler-1', audioContext);
+
+    node.audioBuffer = { duration: 4 } as AudioBuffer;
+    node.send('message', { type: 'noteOn', note: 60, velocity: 127 });
+    node.send('message', { type: 'setPlaybackRate', value: 1.5 });
+    node.send('message', { type: 'setDetune', value: 1200 });
+
+    expect(source.playbackRate.value).toBe(1.5);
+    expect(source.detune.value).toBe(1200);
+  });
+
+  it('keeps future noteOff voices tracked until they end', () => {
+    const source = createFakeSource();
+    const audioContext = createFakeAudioContext([source]);
+    const node = new SamplerNode('sampler-1', audioContext);
+
+    node.audioBuffer = { duration: 4 } as AudioBuffer;
+    node.send('message', { type: 'setNoteOffMode', value: 'held' });
+    node.send('message', { type: 'noteOn', note: 60, velocity: 127, time: 12.5 });
+    node.send('message', { type: 'noteOff', note: 60, time: 13 });
+    node.send('message', { type: 'setPlaybackRate', value: 1.5 });
+
+    expect(source.stop).toHaveBeenCalledWith(13);
+    expect(source.playbackRate.value).toBe(1.5);
+
+    source.onended?.();
+    node.send('message', { type: 'setPlaybackRate', value: 2 });
+
+    expect(source.playbackRate.value).toBe(1.5);
+  });
+
   it('schedules loop messages with time, offset, and duration', () => {
     const source = createFakeSource();
     const audioContext = createFakeAudioContext([source]);

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.test.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.test.ts
@@ -67,6 +67,16 @@ describe('SamplerNode', () => {
     expect(source.start).not.toHaveBeenCalled();
   });
 
+  it('sets built-in output gain', () => {
+    const outputGain = createFakeGain();
+    const audioContext = createFakeAudioContext([], [outputGain]);
+    const node = new SamplerNode('sampler-1', audioContext);
+
+    node.send('message', { type: 'setGain', value: 0.25 });
+
+    expect(node.audioNode.gain.value).toBe(0.25);
+  });
+
   it('schedules bang messages with time', () => {
     const source = createFakeSource();
     const audioContext = createFakeAudioContext([source]);

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.test.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.test.ts
@@ -92,6 +92,71 @@ describe('SamplerNode', () => {
     expect(source.start).toHaveBeenCalledWith(12.5, 0.25, 1.5);
   });
 
+  it('maps noteOn note to playback rate and velocity to gain', () => {
+    const source = createFakeSource();
+    const outputGain = createFakeGain();
+    const voiceGain = createFakeGain();
+    const audioContext = createFakeAudioContext([source], [outputGain, voiceGain]);
+    const node = new SamplerNode('sampler-1', audioContext);
+
+    node.audioBuffer = { duration: 4 } as AudioBuffer;
+    node.send('message', { type: 'noteOn', note: 72, velocity: 64, time: 12.5 });
+
+    expect(source.playbackRate.value).toBe(2);
+    expect(voiceGain.gain.value).toBeCloseTo(64 / 127);
+    expect(source.start).toHaveBeenCalledWith(12.5, 0, undefined);
+  });
+
+  it('ignores noteOff in one-shot mode', () => {
+    const first = createFakeSource();
+    const second = createFakeSource();
+    const audioContext = createFakeAudioContext([first, second]);
+    const node = new SamplerNode('sampler-1', audioContext);
+
+    node.audioBuffer = { duration: 4 } as AudioBuffer;
+    node.send('message', { type: 'noteOn', note: 60, velocity: 127 });
+    node.send('message', { type: 'noteOn', note: 62, velocity: 127 });
+
+    expect(first.stop).not.toHaveBeenCalled();
+
+    node.send('message', { type: 'noteOff', note: 60 });
+
+    expect(first.stop).not.toHaveBeenCalled();
+    expect(second.stop).not.toHaveBeenCalled();
+  });
+
+  it('stops active note voices on noteOff in held mode', () => {
+    const first = createFakeSource();
+    const second = createFakeSource();
+    const audioContext = createFakeAudioContext([first, second]);
+    const node = new SamplerNode('sampler-1', audioContext);
+
+    node.audioBuffer = { duration: 4 } as AudioBuffer;
+    node.send('message', { type: 'setNoteOffMode', value: 'held' });
+    node.send('message', { type: 'noteOn', note: 60, velocity: 127 });
+    node.send('message', { type: 'noteOn', note: 62, velocity: 127 });
+
+    expect(first.stop).not.toHaveBeenCalled();
+
+    node.send('message', { type: 'noteOff', note: 60 });
+
+    expect(first.stop).toHaveBeenCalledOnce();
+    expect(second.stop).not.toHaveBeenCalled();
+  });
+
+  it('treats noteOn velocity 0 as noteOff in held mode', () => {
+    const source = createFakeSource();
+    const audioContext = createFakeAudioContext([source]);
+    const node = new SamplerNode('sampler-1', audioContext);
+
+    node.audioBuffer = { duration: 4 } as AudioBuffer;
+    node.send('message', { type: 'setNoteOffMode', value: 'held' });
+    node.send('message', { type: 'noteOn', note: 60, velocity: 127 });
+    node.send('message', { type: 'noteOn', note: 60, velocity: 0 });
+
+    expect(source.stop).toHaveBeenCalledOnce();
+  });
+
   it('schedules loop messages with time, offset, and duration', () => {
     const source = createFakeSource();
     const audioContext = createFakeAudioContext([source]);

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.ts
@@ -2,6 +2,7 @@ import { match, P } from 'ts-pattern';
 
 import type { AudioNodeV2, AudioNodeGroup } from '../interfaces/audio-nodes';
 import { SamplerNoteVoiceManager } from './SamplerNoteVoiceManager';
+import { samplerMessages } from '$lib/objects/schemas';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 
 type PlayMessage = {
@@ -85,6 +86,7 @@ export class SamplerNode implements AudioNodeV2 {
     this.recordingDestination = audioContext.createMediaStreamDestination();
     this.noteVoices = new SamplerNoteVoiceManager({
       currentTime: () => this.audioContext.currentTime,
+      getBasePlaybackRate: () => this.playbackRate,
       play: (message) => this.handlePlay(message),
       stop: (source, time) => this.stopSource(source, time)
     });
@@ -124,15 +126,17 @@ export class SamplerNode implements AudioNodeV2 {
       })
       .with({ type: 'bang' }, this.handlePlay.bind(this))
       .with({ type: 'play' }, this.handlePlay.bind(this))
-      .with({ type: 'set', time: P.number, value: P.number }, this.handleScheduledSet.bind(this))
-      .with({ type: 'noteOn', note: P.number, velocity: P.number }, (message) => {
+      .with(samplerMessages.setScheduled, this.handleScheduledSet.bind(this))
+      .with(samplerMessages.noteOn, (message) => {
         this.noteVoices.handleNoteOn(message);
       })
-      .with({ type: 'noteOff', note: P.number }, (message) => {
+      .with(samplerMessages.noteOff, (message) => {
         this.noteVoices.handleNoteOff(message);
       })
-      .with({ type: 'setNoteOffMode', value: P.union('one-shot', 'held') }, ({ value }) => {
-        this.noteVoices.setNoteOffMode(value);
+      .with(samplerMessages.setNoteOffMode, ({ value }) => {
+        if (value === 'one-shot' || value === 'held') {
+          this.noteVoices.setNoteOffMode(value);
+        }
       })
       .with({ type: 'stop' }, this.stopPlayback.bind(this))
       .with({ type: 'loop', start: P.number, end: P.number }, this.handleLoop.bind(this))
@@ -193,6 +197,8 @@ export class SamplerNode implements AudioNodeV2 {
         for (const source of this.activeSources) {
           source.playbackRate.value = value;
         }
+
+        this.noteVoices.updatePlaybackRates(value);
       })
       .with({ type: 'setDetune', value: P.number }, ({ value }) => {
         this.detune = value;
@@ -289,10 +295,13 @@ export class SamplerNode implements AudioNodeV2 {
   }
 
   private handleScheduledSet(message: ScheduledSetMessage): void {
+    const gain = getNonNegativeNumber(message.value);
+    if (gain === undefined) return;
+
     this.handlePlay({
       type: 'play',
       time: message.time,
-      gain: message.value
+      gain
     });
   }
 

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.ts
@@ -26,6 +26,13 @@ type LoopMessage = {
   gain?: unknown;
 };
 
+type ScheduledSetMessage = {
+  [key: string]: unknown;
+  type: 'set';
+  time: number;
+  value: number;
+};
+
 type NoteOnMessage = {
   [key: string]: unknown;
   type: 'noteOn';
@@ -137,6 +144,7 @@ export class SamplerNode implements AudioNodeV2 {
       })
       .with({ type: 'bang' }, this.handlePlay.bind(this))
       .with({ type: 'play' }, this.handlePlay.bind(this))
+      .with({ type: 'set', time: P.number, value: P.number }, this.handleScheduledSet.bind(this))
       .with({ type: 'noteOn', note: P.number, velocity: P.number }, this.handleNoteOn.bind(this))
       .with({ type: 'noteOff', note: P.number }, this.handleNoteOff.bind(this))
       .with({ type: 'setNoteOffMode', value: P.union('one-shot', 'held') }, ({ value }) => {
@@ -272,6 +280,14 @@ export class SamplerNode implements AudioNodeV2 {
     };
 
     newSource.start(time, offset, duration);
+  }
+
+  private handleScheduledSet(message: ScheduledSetMessage): void {
+    this.handlePlay({
+      type: 'play',
+      time: message.time,
+      gain: message.value
+    });
   }
 
   private handleNoteOn(message: NoteOnMessage): void {

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.ts
@@ -1,6 +1,7 @@
 import { match, P } from 'ts-pattern';
 
 import type { AudioNodeV2, AudioNodeGroup } from '../interfaces/audio-nodes';
+import { SamplerNoteVoiceManager } from './SamplerNoteVoiceManager';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 
 type PlayMessage = {
@@ -30,29 +31,8 @@ type ScheduledSetMessage = {
   value: number;
 };
 
-type NoteOnMessage = {
-  type: 'noteOn';
-  note: number;
-  velocity: number;
-  time?: unknown;
-};
-
-type NoteOffMessage = {
-  type: 'noteOff';
-  note: number;
-  time?: unknown;
-};
-
-type NoteOffMode = 'one-shot' | 'held';
-
 const getNonNegativeNumber = (value: unknown): number | undefined =>
   typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
-
-const ROOT_NOTE = 60;
-
-function noteToPlaybackRate(note: number): number {
-  return 2 ** ((note - ROOT_NOTE) / 12);
-}
 
 export class SamplerNode implements AudioNodeV2 {
   static type = 'sampler~';
@@ -86,12 +66,11 @@ export class SamplerNode implements AudioNodeV2 {
   private scheduledSources = new Set<AudioBufferSourceNode>();
   private activeSources = new Set<AudioBufferSourceNode>();
   private sourceGains = new WeakMap<AudioBufferSourceNode, GainNode>();
-  private noteSources = new Map<number, Set<AudioBufferSourceNode>>();
+  private noteVoices: SamplerNoteVoiceManager;
   private loopStart: number = 0;
   private loopEnd: number = 0;
   private playbackRate: number = 1;
   private detune: number = 0;
-  private noteOffMode: NoteOffMode = 'one-shot';
 
   constructor(nodeId: string, audioContext: AudioContext) {
     this.nodeId = nodeId;
@@ -104,6 +83,11 @@ export class SamplerNode implements AudioNodeV2 {
     // Create MediaStreamDestination for recording input
     // This captures audio into a MediaStream for the MediaRecorder
     this.recordingDestination = audioContext.createMediaStreamDestination();
+    this.noteVoices = new SamplerNoteVoiceManager({
+      currentTime: () => this.audioContext.currentTime,
+      play: (message) => this.handlePlay(message),
+      stop: (source, time) => this.stopSource(source, time)
+    });
   }
 
   send(key: string, message: unknown): void {
@@ -141,10 +125,14 @@ export class SamplerNode implements AudioNodeV2 {
       .with({ type: 'bang' }, this.handlePlay.bind(this))
       .with({ type: 'play' }, this.handlePlay.bind(this))
       .with({ type: 'set', time: P.number, value: P.number }, this.handleScheduledSet.bind(this))
-      .with({ type: 'noteOn', note: P.number, velocity: P.number }, this.handleNoteOn.bind(this))
-      .with({ type: 'noteOff', note: P.number }, this.handleNoteOff.bind(this))
+      .with({ type: 'noteOn', note: P.number, velocity: P.number }, (message) => {
+        this.noteVoices.handleNoteOn(message);
+      })
+      .with({ type: 'noteOff', note: P.number }, (message) => {
+        this.noteVoices.handleNoteOff(message);
+      })
       .with({ type: 'setNoteOffMode', value: P.union('one-shot', 'held') }, ({ value }) => {
-        this.noteOffMode = value;
+        this.noteVoices.setNoteOffMode(value);
       })
       .with({ type: 'stop' }, this.stopPlayback.bind(this))
       .with({ type: 'loop', start: P.number, end: P.number }, this.handleLoop.bind(this))
@@ -308,55 +296,6 @@ export class SamplerNode implements AudioNodeV2 {
     });
   }
 
-  private handleNoteOn(message: NoteOnMessage): void {
-    const note = getNonNegativeNumber(message.note);
-    const velocity = getNonNegativeNumber(message.velocity);
-
-    if (note === undefined || velocity === undefined) return;
-
-    if (velocity === 0) {
-      if (this.noteOffMode === 'held') {
-        this.handleNoteOff({ type: 'noteOff', note, time: message.time });
-      }
-      return;
-    }
-
-    const source = this.handlePlay({
-      type: 'play',
-      time: message.time,
-      gain: velocity / 127,
-      playbackRate: noteToPlaybackRate(note),
-      replaceImmediate: false
-    });
-
-    if (!source) return;
-
-    const sources = this.noteSources.get(note) ?? new Set<AudioBufferSourceNode>();
-    sources.add(source);
-    this.noteSources.set(note, sources);
-  }
-
-  private handleNoteOff(message: NoteOffMessage): void {
-    if (this.noteOffMode !== 'held') return;
-
-    const note = getNonNegativeNumber(message.note);
-    if (note === undefined) return;
-
-    const sources = this.noteSources.get(note);
-    if (!sources) return;
-
-    const time = getNonNegativeNumber(message.time);
-    const isFutureStop = time !== undefined && time > this.audioContext.currentTime;
-
-    for (const source of [...sources]) {
-      this.stopSource(source, time);
-    }
-
-    if (!isFutureStop) {
-      this.noteSources.delete(note);
-    }
-  }
-
   private async handleRecord(): Promise<void> {
     if (this.mediaRecorder) {
       return;
@@ -433,7 +372,7 @@ export class SamplerNode implements AudioNodeV2 {
       this.disconnectSource(newSource);
       this.scheduledSources.delete(newSource);
       this.activeSources.delete(newSource);
-      this.removeSourceFromNotes(newSource);
+      this.noteVoices.removeSource(newSource);
 
       if (this.sourceNode === newSource) {
         this.sourceNode = null;
@@ -470,7 +409,7 @@ export class SamplerNode implements AudioNodeV2 {
       this.disconnectSource(source);
       this.scheduledSources.delete(source);
       this.activeSources.delete(source);
-      this.removeSourceFromNotes(source);
+      this.noteVoices.removeSource(source);
     } catch {
       // Ignore errors if node already stopped
     }
@@ -486,12 +425,7 @@ export class SamplerNode implements AudioNodeV2 {
   private stopPlayback(): void {
     this.stopImmediatePlayback();
 
-    const sources = new Set<AudioBufferSourceNode>();
-    for (const noteSet of this.noteSources.values()) {
-      for (const source of noteSet) {
-        sources.add(source);
-      }
-    }
+    const sources = this.noteVoices.getSources();
 
     for (const source of this.activeSources) {
       sources.add(source);
@@ -507,17 +441,7 @@ export class SamplerNode implements AudioNodeV2 {
 
     this.scheduledSources.clear();
     this.activeSources.clear();
-    this.noteSources.clear();
-  }
-
-  private removeSourceFromNotes(source: AudioBufferSourceNode): void {
-    for (const [note, sources] of this.noteSources) {
-      sources.delete(source);
-
-      if (sources.size === 0) {
-        this.noteSources.delete(note);
-      }
-    }
+    this.noteVoices.clear();
   }
 
   private trimSilence(buffer: AudioBuffer, threshold = 0.01): AudioBuffer {

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.ts
@@ -196,6 +196,12 @@ export class SamplerNode implements AudioNodeV2 {
         for (const source of this.scheduledSources) {
           source.detune.value = value;
         }
+      })
+      .with({ type: 'setGain', value: P.number }, ({ value }) => {
+        const gain = getNonNegativeNumber(value);
+        if (gain !== undefined) {
+          this.audioNode.gain.value = gain;
+        }
       });
   }
 

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.ts
@@ -4,7 +4,6 @@ import type { AudioNodeV2, AudioNodeGroup } from '../interfaces/audio-nodes';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 
 type PlayMessage = {
-  [key: string]: unknown;
   type: 'bang' | 'play';
 
   time?: unknown;
@@ -16,7 +15,6 @@ type PlayMessage = {
 };
 
 type LoopMessage = {
-  [key: string]: unknown;
   type: 'loop';
   start: number;
   end: number;
@@ -27,14 +25,12 @@ type LoopMessage = {
 };
 
 type ScheduledSetMessage = {
-  [key: string]: unknown;
   type: 'set';
   time: number;
   value: number;
 };
 
 type NoteOnMessage = {
-  [key: string]: unknown;
   type: 'noteOn';
   note: number;
   velocity: number;
@@ -42,7 +38,6 @@ type NoteOnMessage = {
 };
 
 type NoteOffMessage = {
-  [key: string]: unknown;
   type: 'noteOff';
   note: number;
   time?: unknown;

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.ts
@@ -11,6 +11,8 @@ type PlayMessage = {
   offset?: unknown;
   duration?: unknown;
   gain?: unknown;
+  playbackRate?: unknown;
+  replaceImmediate?: boolean;
 };
 
 type LoopMessage = {
@@ -24,8 +26,31 @@ type LoopMessage = {
   gain?: unknown;
 };
 
+type NoteOnMessage = {
+  [key: string]: unknown;
+  type: 'noteOn';
+  note: number;
+  velocity: number;
+  time?: unknown;
+};
+
+type NoteOffMessage = {
+  [key: string]: unknown;
+  type: 'noteOff';
+  note: number;
+  time?: unknown;
+};
+
+type NoteOffMode = 'one-shot' | 'held';
+
 const getNonNegativeNumber = (value: unknown): number | undefined =>
   typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+
+const ROOT_NOTE = 60;
+
+function noteToPlaybackRate(note: number): number {
+  return 2 ** ((note - ROOT_NOTE) / 12);
+}
 
 export class SamplerNode implements AudioNodeV2 {
   static type = 'sampler~';
@@ -58,10 +83,12 @@ export class SamplerNode implements AudioNodeV2 {
   private sourceNode: AudioBufferSourceNode | null = null;
   private scheduledSources = new Set<AudioBufferSourceNode>();
   private sourceGains = new WeakMap<AudioBufferSourceNode, GainNode>();
+  private noteSources = new Map<number, Set<AudioBufferSourceNode>>();
   private loopStart: number = 0;
   private loopEnd: number = 0;
   private playbackRate: number = 1;
   private detune: number = 0;
+  private noteOffMode: NoteOffMode = 'one-shot';
 
   constructor(nodeId: string, audioContext: AudioContext) {
     this.nodeId = nodeId;
@@ -110,6 +137,11 @@ export class SamplerNode implements AudioNodeV2 {
       })
       .with({ type: 'bang' }, this.handlePlay.bind(this))
       .with({ type: 'play' }, this.handlePlay.bind(this))
+      .with({ type: 'noteOn', note: P.number, velocity: P.number }, this.handleNoteOn.bind(this))
+      .with({ type: 'noteOff', note: P.number }, this.handleNoteOff.bind(this))
+      .with({ type: 'setNoteOffMode', value: P.union('one-shot', 'held') }, ({ value }) => {
+        this.noteOffMode = value;
+      })
       .with({ type: 'stop' }, this.stopPlayback.bind(this))
       .with({ type: 'loop', start: P.number, end: P.number }, this.handleLoop.bind(this))
       .with({ type: 'loopOff' }, () => {
@@ -236,6 +268,53 @@ export class SamplerNode implements AudioNodeV2 {
     newSource.start(time, offset, duration);
   }
 
+  private handleNoteOn(message: NoteOnMessage): void {
+    const note = getNonNegativeNumber(message.note);
+    const velocity = getNonNegativeNumber(message.velocity);
+
+    if (note === undefined || velocity === undefined) return;
+
+    if (velocity === 0) {
+      if (this.noteOffMode === 'held') {
+        this.handleNoteOff({ type: 'noteOff', note, time: message.time });
+      }
+      return;
+    }
+
+    const source = this.handlePlay({
+      type: 'play',
+      time: message.time,
+      gain: velocity / 127,
+      playbackRate: noteToPlaybackRate(note),
+      replaceImmediate: false
+    });
+
+    if (!source) return;
+
+    const sources = this.noteSources.get(note) ?? new Set<AudioBufferSourceNode>();
+    sources.add(source);
+    this.noteSources.set(note, sources);
+  }
+
+  private handleNoteOff(message: NoteOffMessage): void {
+    if (this.noteOffMode !== 'held') return;
+
+    const note = getNonNegativeNumber(message.note);
+    if (note === undefined) return;
+
+    const sources = this.noteSources.get(note);
+    if (!sources) return;
+
+    const time = getNonNegativeNumber(message.time);
+
+    for (const source of sources) {
+      this.stopSource(source, time);
+      this.scheduledSources.delete(source);
+    }
+
+    this.noteSources.delete(note);
+  }
+
   private async handleRecord(): Promise<void> {
     if (this.mediaRecorder) {
       return;
@@ -274,15 +353,15 @@ export class SamplerNode implements AudioNodeV2 {
     this.mediaRecorder = recorder;
   }
 
-  private handlePlay(message: PlayMessage): void {
+  private handlePlay(message: PlayMessage): AudioBufferSourceNode | null {
     if (!this.audioBuffer) {
-      return;
+      return null;
     }
 
     // Create new source node
     const newSource = this.audioContext.createBufferSource();
     newSource.buffer = this.audioBuffer;
-    newSource.playbackRate.value = this.playbackRate;
+    newSource.playbackRate.value = getNonNegativeNumber(message.playbackRate) ?? this.playbackRate;
     newSource.detune.value = this.detune;
 
     const time = getNonNegativeNumber(message.time) ?? 0;
@@ -294,10 +373,11 @@ export class SamplerNode implements AudioNodeV2 {
       (this.loopEnd > offset ? this.loopEnd - offset : undefined);
 
     const isFutureScheduled = time > this.audioContext.currentTime;
+    const replaceImmediate = message.replaceImmediate ?? true;
 
     if (isFutureScheduled) {
       this.scheduledSources.add(newSource);
-    } else {
+    } else if (replaceImmediate) {
       this.stopImmediatePlayback();
       this.sourceNode = newSource;
     }
@@ -306,6 +386,7 @@ export class SamplerNode implements AudioNodeV2 {
     newSource.onended = () => {
       this.disconnectSource(newSource);
       this.scheduledSources.delete(newSource);
+      this.removeSourceFromNotes(newSource);
 
       if (this.sourceNode === newSource) {
         this.sourceNode = null;
@@ -314,6 +395,7 @@ export class SamplerNode implements AudioNodeV2 {
 
     this.connectSource(newSource, gain);
     newSource.start(time, offset, duration);
+    return newSource;
   }
 
   private connectSource(source: AudioBufferSourceNode, gainValue: number): void {
@@ -330,10 +412,16 @@ export class SamplerNode implements AudioNodeV2 {
     this.sourceGains.delete(source);
   }
 
-  private stopSource(source: AudioBufferSourceNode): void {
+  private stopSource(source: AudioBufferSourceNode, time?: number): void {
     try {
+      if (time !== undefined && time > this.audioContext.currentTime) {
+        source.stop(time);
+        return;
+      }
+
       source.stop();
       this.disconnectSource(source);
+      this.removeSourceFromNotes(source);
     } catch {
       // Ignore errors if node already stopped
     }
@@ -349,11 +437,33 @@ export class SamplerNode implements AudioNodeV2 {
   private stopPlayback(): void {
     this.stopImmediatePlayback();
 
+    const noteSources = new Set<AudioBufferSourceNode>();
+    for (const sources of this.noteSources.values()) {
+      for (const source of sources) {
+        noteSources.add(source);
+      }
+    }
+
+    for (const source of noteSources) {
+      this.stopSource(source);
+    }
+
     for (const source of this.scheduledSources) {
       this.stopSource(source);
     }
 
     this.scheduledSources.clear();
+    this.noteSources.clear();
+  }
+
+  private removeSourceFromNotes(source: AudioBufferSourceNode): void {
+    for (const [note, sources] of this.noteSources) {
+      sources.delete(source);
+
+      if (sources.size === 0) {
+        this.noteSources.delete(note);
+      }
+    }
   }
 
   private trimSilence(buffer: AudioBuffer, threshold = 0.01): AudioBuffer {

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.ts
@@ -89,6 +89,7 @@ export class SamplerNode implements AudioNodeV2 {
   private mediaRecorder: MediaRecorder | null = null;
   private sourceNode: AudioBufferSourceNode | null = null;
   private scheduledSources = new Set<AudioBufferSourceNode>();
+  private activeSources = new Set<AudioBufferSourceNode>();
   private sourceGains = new WeakMap<AudioBufferSourceNode, GainNode>();
   private noteSources = new Map<number, Set<AudioBufferSourceNode>>();
   private loopStart: number = 0;
@@ -169,6 +170,12 @@ export class SamplerNode implements AudioNodeV2 {
             source.loopStart = value;
           }
         }
+
+        for (const source of this.activeSources) {
+          if (source.loop) {
+            source.loopStart = value;
+          }
+        }
       })
       .with({ type: 'setEnd', value: P.number }, ({ value }) => {
         this.loopEnd = value;
@@ -178,6 +185,12 @@ export class SamplerNode implements AudioNodeV2 {
         }
 
         for (const source of this.scheduledSources) {
+          if (source.loop) {
+            source.loopEnd = value;
+          }
+        }
+
+        for (const source of this.activeSources) {
           if (source.loop) {
             source.loopEnd = value;
           }
@@ -193,6 +206,10 @@ export class SamplerNode implements AudioNodeV2 {
         for (const source of this.scheduledSources) {
           source.playbackRate.value = value;
         }
+
+        for (const source of this.activeSources) {
+          source.playbackRate.value = value;
+        }
       })
       .with({ type: 'setDetune', value: P.number }, ({ value }) => {
         this.detune = value;
@@ -202,6 +219,10 @@ export class SamplerNode implements AudioNodeV2 {
         }
 
         for (const source of this.scheduledSources) {
+          source.detune.value = value;
+        }
+
+        for (const source of this.activeSources) {
           source.detune.value = value;
         }
       })
@@ -268,11 +289,13 @@ export class SamplerNode implements AudioNodeV2 {
       this.scheduledSources.add(newSource);
     } else {
       this.sourceNode = newSource;
+      this.activeSources.add(newSource);
     }
 
     newSource.onended = () => {
       this.disconnectSource(newSource);
       this.scheduledSources.delete(newSource);
+      this.activeSources.delete(newSource);
 
       if (this.sourceNode === newSource) {
         this.sourceNode = null;
@@ -328,13 +351,15 @@ export class SamplerNode implements AudioNodeV2 {
     if (!sources) return;
 
     const time = getNonNegativeNumber(message.time);
+    const isFutureStop = time !== undefined && time > this.audioContext.currentTime;
 
-    for (const source of sources) {
+    for (const source of [...sources]) {
       this.stopSource(source, time);
-      this.scheduledSources.delete(source);
     }
 
-    this.noteSources.delete(note);
+    if (!isFutureStop) {
+      this.noteSources.delete(note);
+    }
   }
 
   private async handleRecord(): Promise<void> {
@@ -404,10 +429,15 @@ export class SamplerNode implements AudioNodeV2 {
       this.sourceNode = newSource;
     }
 
+    if (!isFutureScheduled) {
+      this.activeSources.add(newSource);
+    }
+
     // Clean up when playback ends naturally
     newSource.onended = () => {
       this.disconnectSource(newSource);
       this.scheduledSources.delete(newSource);
+      this.activeSources.delete(newSource);
       this.removeSourceFromNotes(newSource);
 
       if (this.sourceNode === newSource) {
@@ -443,6 +473,8 @@ export class SamplerNode implements AudioNodeV2 {
 
       source.stop();
       this.disconnectSource(source);
+      this.scheduledSources.delete(source);
+      this.activeSources.delete(source);
       this.removeSourceFromNotes(source);
     } catch {
       // Ignore errors if node already stopped
@@ -459,22 +491,27 @@ export class SamplerNode implements AudioNodeV2 {
   private stopPlayback(): void {
     this.stopImmediatePlayback();
 
-    const noteSources = new Set<AudioBufferSourceNode>();
-    for (const sources of this.noteSources.values()) {
-      for (const source of sources) {
-        noteSources.add(source);
+    const sources = new Set<AudioBufferSourceNode>();
+    for (const noteSet of this.noteSources.values()) {
+      for (const source of noteSet) {
+        sources.add(source);
       }
     }
 
-    for (const source of noteSources) {
-      this.stopSource(source);
+    for (const source of this.activeSources) {
+      sources.add(source);
     }
 
     for (const source of this.scheduledSources) {
+      sources.add(source);
+    }
+
+    for (const source of sources) {
       this.stopSource(source);
     }
 
     this.scheduledSources.clear();
+    this.activeSources.clear();
     this.noteSources.clear();
   }
 

--- a/ui/src/lib/audio/v2/nodes/SamplerNoteVoiceManager.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNoteVoiceManager.ts
@@ -1,0 +1,129 @@
+export type SamplerNoteOffMode = 'one-shot' | 'held';
+
+export type SamplerNoteOnMessage = {
+  type: 'noteOn';
+  note: number;
+  velocity: number;
+  time?: unknown;
+};
+
+export type SamplerNoteOffMessage = {
+  type: 'noteOff';
+  note: number;
+  time?: unknown;
+};
+
+type SamplerNotePlayMessage = {
+  type: 'play';
+  time?: unknown;
+  gain: number;
+  playbackRate: number;
+  replaceImmediate: false;
+};
+
+type SamplerNoteVoiceManagerOptions = {
+  currentTime: () => number;
+  play: (message: SamplerNotePlayMessage) => AudioBufferSourceNode | null;
+  stop: (source: AudioBufferSourceNode, time?: number) => void;
+};
+
+const ROOT_NOTE = 60;
+
+const getNonNegativeNumber = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+
+const noteToPlaybackRate = (note: number): number => 2 ** ((note - ROOT_NOTE) / 12);
+
+export class SamplerNoteVoiceManager {
+  private readonly currentTime: () => number;
+  private readonly play: (message: SamplerNotePlayMessage) => AudioBufferSourceNode | null;
+  private readonly stop: (source: AudioBufferSourceNode, time?: number) => void;
+  private readonly noteSources = new Map<number, Set<AudioBufferSourceNode>>();
+  private noteOffMode: SamplerNoteOffMode = 'one-shot';
+
+  constructor({ currentTime, play, stop }: SamplerNoteVoiceManagerOptions) {
+    this.currentTime = currentTime;
+    this.play = play;
+    this.stop = stop;
+  }
+
+  setNoteOffMode(mode: SamplerNoteOffMode): void {
+    this.noteOffMode = mode;
+  }
+
+  handleNoteOn(message: SamplerNoteOnMessage): void {
+    const note = getNonNegativeNumber(message.note);
+    const velocity = getNonNegativeNumber(message.velocity);
+
+    if (note === undefined || velocity === undefined) return;
+
+    if (velocity === 0) {
+      if (this.noteOffMode === 'held') {
+        this.handleNoteOff({ type: 'noteOff', note, time: message.time });
+      }
+      return;
+    }
+
+    const source = this.play({
+      type: 'play',
+      time: message.time,
+      gain: velocity / 127,
+      playbackRate: noteToPlaybackRate(note),
+      replaceImmediate: false
+    });
+
+    if (!source) return;
+
+    const sources = this.noteSources.get(note) ?? new Set<AudioBufferSourceNode>();
+    sources.add(source);
+
+    this.noteSources.set(note, sources);
+  }
+
+  handleNoteOff(message: SamplerNoteOffMessage): void {
+    if (this.noteOffMode !== 'held') return;
+
+    const note = getNonNegativeNumber(message.note);
+    if (note === undefined) return;
+
+    const sources = this.noteSources.get(note);
+    if (!sources) return;
+
+    const time = getNonNegativeNumber(message.time);
+    const isFutureStop = time !== undefined && time > this.currentTime();
+
+    for (const source of [...sources]) {
+      this.stop(source, time);
+    }
+
+    if (!isFutureStop) {
+      this.noteSources.delete(note);
+    }
+  }
+
+  removeSource(source: AudioBufferSourceNode): void {
+    for (const [note, sources] of this.noteSources) {
+      sources.delete(source);
+
+      if (sources.size === 0) {
+        this.noteSources.delete(note);
+      }
+    }
+  }
+
+  getSources(): Set<AudioBufferSourceNode> {
+    const sources = new Set<AudioBufferSourceNode>();
+
+    for (const noteSet of this.noteSources.values()) {
+      for (const source of noteSet) {
+        sources.add(source);
+      }
+    }
+
+    return sources;
+  }
+
+  clear(): void {
+    this.noteSources.clear();
+  }
+}

--- a/ui/src/lib/audio/v2/nodes/SamplerNoteVoiceManager.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNoteVoiceManager.ts
@@ -23,6 +23,7 @@ type SamplerNotePlayMessage = {
 
 type SamplerNoteVoiceManagerOptions = {
   currentTime: () => number;
+  getBasePlaybackRate: () => number;
   play: (message: SamplerNotePlayMessage) => AudioBufferSourceNode | null;
   stop: (source: AudioBufferSourceNode, time?: number) => void;
 };
@@ -36,13 +37,16 @@ const noteToPlaybackRate = (note: number): number => 2 ** ((note - ROOT_NOTE) / 
 
 export class SamplerNoteVoiceManager {
   private readonly currentTime: () => number;
+  private readonly getBasePlaybackRate: () => number;
   private readonly play: (message: SamplerNotePlayMessage) => AudioBufferSourceNode | null;
   private readonly stop: (source: AudioBufferSourceNode, time?: number) => void;
   private readonly noteSources = new Map<number, Set<AudioBufferSourceNode>>();
+  private readonly playbackRateMultipliers = new Map<AudioBufferSourceNode, number>();
   private noteOffMode: SamplerNoteOffMode = 'one-shot';
 
-  constructor({ currentTime, play, stop }: SamplerNoteVoiceManagerOptions) {
+  constructor({ currentTime, getBasePlaybackRate, play, stop }: SamplerNoteVoiceManagerOptions) {
     this.currentTime = currentTime;
+    this.getBasePlaybackRate = getBasePlaybackRate;
     this.play = play;
     this.stop = stop;
   }
@@ -64,11 +68,12 @@ export class SamplerNoteVoiceManager {
       return;
     }
 
+    const playbackRateMultiplier = noteToPlaybackRate(note);
     const source = this.play({
       type: 'play',
       time: message.time,
       gain: velocity / 127,
-      playbackRate: noteToPlaybackRate(note),
+      playbackRate: this.getBasePlaybackRate() * playbackRateMultiplier,
       replaceImmediate: false
     });
 
@@ -76,6 +81,7 @@ export class SamplerNoteVoiceManager {
 
     const sources = this.noteSources.get(note) ?? new Set<AudioBufferSourceNode>();
     sources.add(source);
+    this.playbackRateMultipliers.set(source, playbackRateMultiplier);
 
     this.noteSources.set(note, sources);
   }
@@ -102,6 +108,8 @@ export class SamplerNoteVoiceManager {
   }
 
   removeSource(source: AudioBufferSourceNode): void {
+    this.playbackRateMultipliers.delete(source);
+
     for (const [note, sources] of this.noteSources) {
       sources.delete(source);
 
@@ -123,7 +131,14 @@ export class SamplerNoteVoiceManager {
     return sources;
   }
 
+  updatePlaybackRates(basePlaybackRate: number): void {
+    for (const [source, multiplier] of this.playbackRateMultipliers) {
+      source.playbackRate.value = basePlaybackRate * multiplier;
+    }
+  }
+
   clear(): void {
     this.noteSources.clear();
+    this.playbackRateMultipliers.clear();
   }
 }

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -87,6 +87,7 @@
     VfsPathRenamedEvent,
     CodeCommitEvent,
     NodeDataCommitEvent,
+    NodeDataBatchCommitEvent,
     ObjectDataCommitEvent
   } from '$lib/eventbus/events';
   import { WorkerNodeSystem } from '$lib/js-runner/WorkerNodeSystem';
@@ -211,6 +212,21 @@
       eventBus.dispatch({ type: 'nodeSetPaused', nodeId: e.nodeId, paused: true });
       pausedByViewport.add(e.nodeId);
     }
+  };
+
+  const handleNodeDataBatchCommit = (e: NodeDataBatchCommitEvent) => {
+    const commands = e.changes.map(
+      (change) =>
+        new UpdateNodeDataCommand(
+          e.nodeId,
+          change.dataKey,
+          change.oldValue,
+          change.newValue,
+          canvasAccessors
+        )
+    );
+
+    historyManager.record(new BatchCommand(commands, e.description));
   };
 
   // Keyboard shortcut manager (created lazily in onMount to access component functions)
@@ -830,6 +846,7 @@
     eventBus.addEventListener('objectDataCommit', handleObjectDataCommit);
     eventBus.addEventListener('codeCommit', handleCodeCommit);
     eventBus.addEventListener('nodeDataCommit', handleNodeDataCommit);
+    eventBus.addEventListener('nodeDataBatchCommit', handleNodeDataBatchCommit);
 
     autosaveInterval = setInterval(performAutosave, AUTOSAVE_INTERVAL);
 
@@ -861,6 +878,7 @@
     eventBus.removeEventListener('objectDataCommit', handleObjectDataCommit);
     eventBus.removeEventListener('codeCommit', handleCodeCommit);
     eventBus.removeEventListener('nodeDataCommit', handleNodeDataCommit);
+    eventBus.removeEventListener('nodeDataBatchCommit', handleNodeDataBatchCommit);
 
     // Clean up autosave interval
     if (autosaveInterval) {

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -188,33 +188,40 @@
     );
   };
 
+  const syncViewportPausedCommit = (nodeId: string, dataKey: string, newValue: unknown): void => {
+    // Viewport-pause edge cases: keep pausedByViewport consistent when the user
+    // toggles pause on a DOM-backed node while it's offscreen.
+    if (dataKey !== 'paused') return;
+
+    const node = getNode(nodeId);
+    if (!node?.type || !cullableDomTypeSet.has(node.type)) return;
+
+    // Pause-while-offscreen: user takes ownership; drop our claim.
+    if (newValue === true && pausedByViewport.has(nodeId)) {
+      pausedByViewport.delete(nodeId);
+      return;
+    }
+
+    // Unpause-while-offscreen: re-pause ourselves so it doesn't waste CPU.
+    if (newValue === false && !prevVisibleDom.has(nodeId)) {
+      eventBus.dispatch({ type: 'nodeSetPaused', nodeId, paused: true });
+      pausedByViewport.add(nodeId);
+    }
+  };
+
   // Event handler for generic node data commit (undo tracking for non-code fields)
   const handleNodeDataCommit = (e: NodeDataCommitEvent) => {
     historyManager.record(
       new UpdateNodeDataCommand(e.nodeId, e.dataKey, e.oldValue, e.newValue, canvasAccessors)
     );
-
-    // Viewport-pause edge cases: keep pausedByViewport consistent when the user
-    // toggles pause on a DOM-backed node while it's offscreen.
-    if (e.dataKey !== 'paused') return;
-
-    const node = getNode(e.nodeId);
-    if (!node?.type || !cullableDomTypeSet.has(node.type)) return;
-
-    // Pause-while-offscreen: user takes ownership; drop our claim.
-    if (e.newValue === true && pausedByViewport.has(e.nodeId)) {
-      pausedByViewport.delete(e.nodeId);
-      return;
-    }
-
-    // Unpause-while-offscreen: re-pause ourselves so it doesn't waste CPU.
-    if (e.newValue === false && !prevVisibleDom.has(e.nodeId)) {
-      eventBus.dispatch({ type: 'nodeSetPaused', nodeId: e.nodeId, paused: true });
-      pausedByViewport.add(e.nodeId);
-    }
+    syncViewportPausedCommit(e.nodeId, e.dataKey, e.newValue);
   };
 
   const handleNodeDataBatchCommit = (e: NodeDataBatchCommitEvent) => {
+    for (const change of e.changes) {
+      syncViewportPausedCommit(e.nodeId, change.dataKey, change.newValue);
+    }
+
     const commands = e.changes.map(
       (change) =>
         new UpdateNodeDataCommand(

--- a/ui/src/lib/components/nodes/SamplerNode.svelte
+++ b/ui/src/lib/components/nodes/SamplerNode.svelte
@@ -30,6 +30,7 @@
       loop?: boolean;
       playbackRate?: number;
       detune?: number;
+      noteOffMode?: 'one-shot' | 'held';
 
       // Used when converting from soundfile~
       vfsPath?: string;
@@ -152,6 +153,7 @@
   const loopEnabled = $derived(node.data.loop || false);
   const playbackRate = $derived(node.data.playbackRate || 1);
   const detune = $derived(node.data.detune || 0);
+  const noteOffMode = $derived(node.data.noteOffMode ?? 'one-shot');
 
   // Use node dimensions if available, otherwise use defaults
   const width = $derived(node.width || 190);
@@ -216,6 +218,10 @@
       })
       .with(samplerMessages.setDetune, (msg) => {
         updateNodeData(node.id, { ...node.data, detune: msg.value });
+        audioService.send(node.id, 'message', msg);
+      })
+      .with(samplerMessages.setNoteOffMode, (msg) => {
+        updateNodeData(node.id, { ...node.data, noteOffMode: msg.value });
         audioService.send(node.id, 'message', msg);
       })
       .with(samplerMessages.download, (msg) => downloadBuffer(msg.name))
@@ -423,6 +429,13 @@
     audioService.send(node.id, 'message', { type: 'setDetune', value });
   }
 
+  function updateNoteOffMode(value: 'one-shot' | 'held') {
+    const oldValue = noteOffMode;
+    updateNodeData(node.id, { ...node.data, noteOffMode: value });
+    audioService.send(node.id, 'message', { type: 'setNoteOffMode', value });
+    tracker.commit('noteOffMode', oldValue, value);
+  }
+
   function downloadBuffer(name?: string) {
     if (audioBuffer) downloadAsWav(audioBuffer, name);
   }
@@ -434,7 +447,8 @@
       loopEnd: recordingDuration,
       loop: false,
       playbackRate: 1,
-      detune: 0
+      detune: 0,
+      noteOffMode: 'one-shot'
     });
 
     // Update AudioService
@@ -443,6 +457,7 @@
     audioService.send(node.id, 'message', { type: 'loopOff' });
     audioService.send(node.id, 'message', { type: 'setPlaybackRate', value: 1 });
     audioService.send(node.id, 'message', { type: 'setDetune', value: 0 });
+    audioService.send(node.id, 'message', { type: 'setNoteOffMode', value: 'one-shot' });
   }
 
   onMount(async () => {
@@ -467,6 +482,11 @@
       if (node.data.detune) {
         audioService.send(node.id, 'message', { type: 'setDetune', value: node.data.detune });
       }
+
+      audioService.send(node.id, 'message', {
+        type: 'setNoteOffMode',
+        value: node.data.noteOffMode ?? 'one-shot'
+      });
 
       // Get audio buffer if it exists
       if (v2Node.audioBuffer) {
@@ -661,10 +681,12 @@
         {loopEnabled}
         {playbackRate}
         {detune}
+        {noteOffMode}
         onLoopStartChange={updateLoopStart}
         onLoopEndChange={updateLoopEnd}
         onPlaybackRateChange={updatePlaybackRate}
         onDetuneChange={updateDetune}
+        onNoteOffModeChange={updateNoteOffMode}
         onToggleLoop={toggleLoop}
         onReset={resetSettings}
         onClose={() => (showSettings = false)}

--- a/ui/src/lib/components/nodes/SamplerNode.svelte
+++ b/ui/src/lib/components/nodes/SamplerNode.svelte
@@ -453,7 +453,7 @@
   }
 
   function resetSettings() {
-    updateNodeData(node.id, {
+    const nextSettings = {
       ...node.data,
       loopStart: 0,
       loopEnd: recordingDuration,
@@ -462,7 +462,27 @@
       playbackRate: 1,
       detune: 0,
       noteOffMode: 'one-shot'
-    });
+    };
+
+    tracker.commitMany('Reset sampler settings', [
+      { dataKey: 'loopStart', oldValue: node.data.loopStart, newValue: nextSettings.loopStart },
+      { dataKey: 'loopEnd', oldValue: node.data.loopEnd, newValue: nextSettings.loopEnd },
+      { dataKey: 'loop', oldValue: node.data.loop, newValue: nextSettings.loop },
+      { dataKey: 'gain', oldValue: node.data.gain, newValue: nextSettings.gain },
+      {
+        dataKey: 'playbackRate',
+        oldValue: node.data.playbackRate,
+        newValue: nextSettings.playbackRate
+      },
+      { dataKey: 'detune', oldValue: node.data.detune, newValue: nextSettings.detune },
+      {
+        dataKey: 'noteOffMode',
+        oldValue: node.data.noteOffMode,
+        newValue: nextSettings.noteOffMode
+      }
+    ]);
+
+    updateNodeData(node.id, nextSettings);
 
     // Update AudioService
     audioService.send(node.id, 'message', { type: 'setStart', value: 0 });

--- a/ui/src/lib/components/nodes/SamplerNode.svelte
+++ b/ui/src/lib/components/nodes/SamplerNode.svelte
@@ -28,6 +28,7 @@
       loopStart?: number;
       loopEnd?: number;
       loop?: boolean;
+      gain?: number;
       playbackRate?: number;
       detune?: number;
       noteOffMode?: 'one-shot' | 'held';
@@ -43,6 +44,7 @@
   const tracker = useNodeDataTracker(node.id);
   const loopStartTracker = tracker.track('loopStart', () => node.data.loopStart ?? 0);
   const loopEndTracker = tracker.track('loopEnd', () => node.data.loopEnd ?? recordingDuration);
+  const gainTracker = tracker.track('gain', () => node.data.gain ?? 1);
   const playbackRateTracker = tracker.track('playbackRate', () => node.data.playbackRate ?? 1);
   const detuneTracker = tracker.track('detune', () => node.data.detune ?? 0);
 
@@ -151,6 +153,7 @@
   const loopStart = $derived(node.data.loopStart || 0);
   const loopEnd = $derived(node.data.loopEnd || recordingDuration);
   const loopEnabled = $derived(node.data.loop || false);
+  const gain = $derived(node.data.gain ?? 1);
   const playbackRate = $derived(node.data.playbackRate || 1);
   const detune = $derived(node.data.detune || 0);
   const noteOffMode = $derived(node.data.noteOffMode ?? 'one-shot');
@@ -210,6 +213,10 @@
       })
       .with(samplerMessages.setEnd, (msg) => {
         updateNodeData(node.id, { ...node.data, loopEnd: msg.value });
+        audioService.send(node.id, 'message', msg);
+      })
+      .with(samplerMessages.setGain, (msg) => {
+        updateNodeData(node.id, { ...node.data, gain: msg.value });
         audioService.send(node.id, 'message', msg);
       })
       .with(samplerMessages.setPlaybackRate, (msg) => {
@@ -419,6 +426,11 @@
     audioService.send(node.id, 'message', { type: 'setEnd', value: newLoopEnd });
   }
 
+  function updateGain(value: number) {
+    updateNodeData(node.id, { ...node.data, gain: value });
+    audioService.send(node.id, 'message', { type: 'setGain', value });
+  }
+
   function updatePlaybackRate(value: number) {
     updateNodeData(node.id, { ...node.data, playbackRate: value });
     audioService.send(node.id, 'message', { type: 'setPlaybackRate', value });
@@ -446,6 +458,7 @@
       loopStart: 0,
       loopEnd: recordingDuration,
       loop: false,
+      gain: 1,
       playbackRate: 1,
       detune: 0,
       noteOffMode: 'one-shot'
@@ -455,6 +468,7 @@
     audioService.send(node.id, 'message', { type: 'setStart', value: 0 });
     audioService.send(node.id, 'message', { type: 'setEnd', value: recordingDuration });
     audioService.send(node.id, 'message', { type: 'loopOff' });
+    audioService.send(node.id, 'message', { type: 'setGain', value: 1 });
     audioService.send(node.id, 'message', { type: 'setPlaybackRate', value: 1 });
     audioService.send(node.id, 'message', { type: 'setDetune', value: 0 });
     audioService.send(node.id, 'message', { type: 'setNoteOffMode', value: 'one-shot' });
@@ -471,6 +485,10 @@
 
     // Initialize with playbackRate and detune from node.data
     if (v2Node) {
+      if (node.data.gain !== undefined) {
+        audioService.send(node.id, 'message', { type: 'setGain', value: node.data.gain });
+      }
+
       // Send initialization messages for playbackRate and detune
       if (node.data.playbackRate) {
         audioService.send(node.id, 'message', {
@@ -679,11 +697,13 @@
         {loopEnd}
         {recordingDuration}
         {loopEnabled}
+        {gain}
         {playbackRate}
         {detune}
         {noteOffMode}
         onLoopStartChange={updateLoopStart}
         onLoopEndChange={updateLoopEnd}
+        onGainChange={updateGain}
         onPlaybackRateChange={updatePlaybackRate}
         onDetuneChange={updateDetune}
         onNoteOffModeChange={updateNoteOffMode}
@@ -693,6 +713,7 @@
         {tracker}
         {loopStartTracker}
         {loopEndTracker}
+        {gainTracker}
         {playbackRateTracker}
         {detuneTracker}
       />

--- a/ui/src/lib/components/settings/SamplerSettings.svelte
+++ b/ui/src/lib/components/settings/SamplerSettings.svelte
@@ -31,7 +31,12 @@
     detuneTracker: ContinuousTracker;
   };
 
+  type PropsWithClass = Props & {
+    class?: string;
+  };
+
   let {
+    class: className = '',
     loopStart,
     loopEnd,
     recordingDuration,
@@ -55,10 +60,10 @@
     gainTracker,
     playbackRateTracker,
     detuneTracker
-  }: Props = $props();
+  }: PropsWithClass = $props();
 </script>
 
-<div class="relative">
+<div class={['relative', className]}>
   <div class="absolute -top-7 left-0 flex w-full justify-end gap-1">
     <button onclick={onReset} class="rounded p-1 hover:bg-zinc-700" title="Reset all settings">
       <RefreshCcw class="h-4 w-4 text-zinc-300" />
@@ -175,6 +180,7 @@
 
           <div class="flex flex-col gap-1">
             <button
+              aria-pressed={loopEnabled}
               class="flex cursor-pointer items-center gap-1.5 transition-colors"
               onclick={() => {
                 const oldValue = loopEnabled;
@@ -199,6 +205,7 @@
 
             <button
               type="button"
+              aria-pressed={noteOffMode === 'held'}
               class="flex cursor-pointer items-center gap-1.5 transition-colors"
               onclick={() => onNoteOffModeChange(noteOffMode === 'held' ? 'one-shot' : 'held')}
             >

--- a/ui/src/lib/components/settings/SamplerSettings.svelte
+++ b/ui/src/lib/components/settings/SamplerSettings.svelte
@@ -3,6 +3,8 @@
   import SettingsSlider from '$lib/components/SettingsSlider.svelte';
   import type { NodeDataTracker, ContinuousTracker } from '$lib/history';
 
+  type NoteOffMode = 'one-shot' | 'held';
+
   type Props = {
     loopStart: number;
     loopEnd: number;
@@ -10,10 +12,12 @@
     loopEnabled: boolean;
     playbackRate: number;
     detune: number;
+    noteOffMode: NoteOffMode;
     onLoopStartChange: (value: number) => void;
     onLoopEndChange: (value: number) => void;
     onPlaybackRateChange: (value: number) => void;
     onDetuneChange: (value: number) => void;
+    onNoteOffModeChange: (value: NoteOffMode) => void;
     onToggleLoop: () => void;
     onReset: () => void;
     onClose: () => void;
@@ -31,10 +35,12 @@
     loopEnabled,
     playbackRate,
     detune,
+    noteOffMode,
     onLoopStartChange,
     onLoopEndChange,
     onPlaybackRateChange,
     onDetuneChange,
+    onNoteOffModeChange,
     onToggleLoop,
     onReset,
     onClose,
@@ -60,7 +66,7 @@
   <div class="nodrag w-64 rounded-lg border border-zinc-600 bg-zinc-900 p-4 shadow-xl">
     <div class="space-y-4">
       <div>
-        <div class="mb-2 text-xs font-medium text-zinc-300">Playback Settings</div>
+        <div class="mb-2 text-xs font-medium text-zinc-300">Sample Range</div>
 
         <!-- Start Point -->
         <div class="mb-3">
@@ -100,26 +106,10 @@
           />
         </div>
 
-        <!-- Loop Toggle -->
-        <div class="mb-3 flex items-center justify-between border-t border-zinc-700 pt-3">
-          <span class="text-xs text-zinc-400">Loop</span>
-
-          <button
-            onclick={() => {
-              const oldValue = loopEnabled;
-              onToggleLoop();
-              tracker.commit('loop', oldValue, !oldValue);
-            }}
-            class="rounded px-2 py-1 text-xs {loopEnabled
-              ? 'bg-orange-500 text-white'
-              : 'bg-zinc-700 text-zinc-300'}"
-          >
-            {loopEnabled ? 'On' : 'Off'}
-          </button>
-        </div>
-
         <!-- Playback Rate -->
-        <div class="mb-3 border-t border-zinc-700 pt-3">
+        <div class="mb-3">
+          <div class="mb-2 text-xs font-medium text-zinc-300">Pitch & Speed</div>
+
           <div class="mb-1 flex items-center justify-between">
             <!-- svelte-ignore a11y_label_has_associated_control -->
             <label class="text-xs text-zinc-400">Playback Rate</label>
@@ -154,10 +144,60 @@
             onpointerup={detuneTracker.onBlur}
           />
         </div>
+
+        <!-- Behavior -->
+        <div class="mb-3">
+          <div class="mb-2 text-xs font-medium text-zinc-300">Behavior</div>
+
+          <div class="flex flex-col gap-1">
+            <button
+              class="flex cursor-pointer items-center gap-1.5 transition-colors"
+              onclick={() => {
+                const oldValue = loopEnabled;
+                onToggleLoop();
+                tracker.commit('loop', oldValue, !oldValue);
+              }}
+            >
+              <div
+                class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
+                class:border-zinc-500={loopEnabled}
+                class:bg-zinc-500={loopEnabled}
+                class:border-zinc-600={!loopEnabled}
+              ></div>
+              <span
+                class="text-xs"
+                class:text-zinc-400={loopEnabled}
+                class:text-zinc-500={!loopEnabled}
+              >
+                Loop
+              </span>
+            </button>
+
+            <button
+              type="button"
+              class="flex cursor-pointer items-center gap-1.5 transition-colors"
+              onclick={() => onNoteOffModeChange(noteOffMode === 'held' ? 'one-shot' : 'held')}
+            >
+              <div
+                class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
+                class:border-zinc-500={noteOffMode === 'held'}
+                class:bg-zinc-500={noteOffMode === 'held'}
+                class:border-zinc-600={noteOffMode !== 'held'}
+              ></div>
+              <span
+                class="text-xs"
+                class:text-zinc-400={noteOffMode === 'held'}
+                class:text-zinc-500={noteOffMode !== 'held'}
+              >
+                Held notes
+              </span>
+            </button>
+          </div>
+        </div>
       </div>
 
       <!-- Sample Info -->
-      <div class="border-t border-zinc-700 pt-3">
+      <div>
         <div class="text-xs text-zinc-500">
           Duration: {recordingDuration.toFixed(2)}s
         </div>

--- a/ui/src/lib/components/settings/SamplerSettings.svelte
+++ b/ui/src/lib/components/settings/SamplerSettings.svelte
@@ -10,11 +10,13 @@
     loopEnd: number;
     recordingDuration: number;
     loopEnabled: boolean;
+    gain: number;
     playbackRate: number;
     detune: number;
     noteOffMode: NoteOffMode;
     onLoopStartChange: (value: number) => void;
     onLoopEndChange: (value: number) => void;
+    onGainChange: (value: number) => void;
     onPlaybackRateChange: (value: number) => void;
     onDetuneChange: (value: number) => void;
     onNoteOffModeChange: (value: NoteOffMode) => void;
@@ -24,6 +26,7 @@
     tracker: NodeDataTracker;
     loopStartTracker: ContinuousTracker;
     loopEndTracker: ContinuousTracker;
+    gainTracker: ContinuousTracker;
     playbackRateTracker: ContinuousTracker;
     detuneTracker: ContinuousTracker;
   };
@@ -33,11 +36,13 @@
     loopEnd,
     recordingDuration,
     loopEnabled,
+    gain,
     playbackRate,
     detune,
     noteOffMode,
     onLoopStartChange,
     onLoopEndChange,
+    onGainChange,
     onPlaybackRateChange,
     onDetuneChange,
     onNoteOffModeChange,
@@ -47,6 +52,7 @@
     tracker,
     loopStartTracker,
     loopEndTracker,
+    gainTracker,
     playbackRateTracker,
     detuneTracker
   }: Props = $props();
@@ -108,7 +114,25 @@
 
         <!-- Playback Rate -->
         <div class="mb-3">
-          <div class="mb-2 text-xs font-medium text-zinc-300">Pitch & Speed</div>
+          <div class="mb-2 text-xs font-medium text-zinc-300">Playback</div>
+
+          <div class="mb-3">
+            <div class="mb-1 flex items-center justify-between">
+              <!-- svelte-ignore a11y_label_has_associated_control -->
+              <label class="text-xs text-zinc-400">Gain</label>
+              <span class="font-mono text-xs text-zinc-300">{gain.toFixed(2)}</span>
+            </div>
+
+            <SettingsSlider
+              min={0}
+              max={2}
+              step={0.01}
+              value={gain}
+              onchange={onGainChange}
+              onpointerdown={gainTracker.onFocus}
+              onpointerup={gainTracker.onBlur}
+            />
+          </div>
 
           <div class="mb-1 flex items-center justify-between">
             <!-- svelte-ignore a11y_label_has_associated_control -->

--- a/ui/src/lib/eventbus/events.ts
+++ b/ui/src/lib/eventbus/events.ts
@@ -41,6 +41,7 @@ export type PatchiesEvent =
   | QuickAddCancelledEvent
   | CodeCommitEvent
   | NodeDataCommitEvent
+  | NodeDataBatchCommitEvent
   | ObjectDataCommitEvent
   | NodeSetPausedEvent
   | SurfaceMouseForwardingGraphChangedEvent
@@ -374,6 +375,17 @@ export interface NodeDataCommitEvent {
   dataKey: string;
   oldValue: unknown;
   newValue: unknown;
+}
+
+export interface NodeDataBatchCommitEvent {
+  type: 'nodeDataBatchCommit';
+  nodeId: string;
+  description: string;
+  changes: Array<{
+    dataKey: string;
+    oldValue: unknown;
+    newValue: unknown;
+  }>;
 }
 
 /**

--- a/ui/src/lib/generated/object-schemas.generated.ts
+++ b/ui/src/lib/generated/object-schemas.generated.ts
@@ -2531,6 +2531,7 @@ export const generatedObjectSchemas: ObjectSchemaRegistry = {
               type: Type.Literal('noteOn'),
               note: Type.Number(),
               velocity: Type.Number(),
+              time: Type.Optional(Type.Number()),
               channel: Type.Optional(Type.Number())
             }),
             description: 'Trigger pad by MIDI note'
@@ -2540,6 +2541,7 @@ export const generatedObjectSchemas: ObjectSchemaRegistry = {
               type: Type.Literal('noteOff'),
               note: Type.Number(),
               velocity: Type.Optional(Type.Number()),
+              time: Type.Optional(Type.Number()),
               channel: Type.Optional(Type.Number())
             }),
             description: 'Release pad'
@@ -4147,6 +4149,7 @@ export const generatedObjectSchemas: ObjectSchemaRegistry = {
               type: Type.Literal('noteOn'),
               note: Type.Number(),
               velocity: Type.Number(),
+              time: Type.Optional(Type.Number()),
               channel: Type.Optional(Type.Number())
             }),
             description: 'Convert MIDI note on'
@@ -4156,6 +4159,7 @@ export const generatedObjectSchemas: ObjectSchemaRegistry = {
               type: Type.Literal('noteOff'),
               note: Type.Number(),
               velocity: Type.Optional(Type.Number()),
+              time: Type.Optional(Type.Number()),
               channel: Type.Optional(Type.Number())
             }),
             description: 'Convert MIDI note off'

--- a/ui/src/lib/history/useNodeDataTracker.svelte.ts
+++ b/ui/src/lib/history/useNodeDataTracker.svelte.ts
@@ -40,6 +40,21 @@ export function useNodeDataTracker(nodeId: string) {
     });
   }
 
+  function commitMany(
+    description: string,
+    changes: Array<{ dataKey: string; oldValue: unknown; newValue: unknown }>
+  ): void {
+    const changed = changes.filter(({ oldValue, newValue }) => oldValue !== newValue);
+    if (changed.length === 0) return;
+
+    eventBus.dispatch({
+      type: 'nodeDataBatchCommit',
+      nodeId,
+      description,
+      changes: changed
+    });
+  }
+
   /**
    * Create a tracker for continuous input (text fields, sliders).
    * Call onFocus when input gains focus, onBlur when it loses focus.
@@ -77,6 +92,7 @@ export function useNodeDataTracker(nodeId: string) {
 
   return {
     commit,
+    commitMany,
     track,
     tracked
   };

--- a/ui/src/lib/nodes/defaultNodeData.ts
+++ b/ui/src/lib/nodes/defaultNodeData.ts
@@ -249,7 +249,8 @@ export function getDefaultNodeData(nodeType: string): NodeData {
       loopEnd: 0,
       loop: false,
       playbackRate: 1,
-      detune: 0
+      detune: 0,
+      noteOffMode: 'one-shot'
     }))
     .with('anupars', () => ({
       cols: 80,

--- a/ui/src/lib/nodes/defaultNodeData.ts
+++ b/ui/src/lib/nodes/defaultNodeData.ts
@@ -248,6 +248,7 @@ export function getDefaultNodeData(nodeType: string): NodeData {
       loopStart: 0,
       loopEnd: 0,
       loop: false,
+      gain: 1,
       playbackRate: 1,
       detune: 0,
       noteOffMode: 'one-shot'

--- a/ui/src/lib/objects/schemas/midi-messages.test.ts
+++ b/ui/src/lib/objects/schemas/midi-messages.test.ts
@@ -1,0 +1,13 @@
+import { Value } from '@sinclair/typebox/value';
+import { describe, expect, it } from 'vitest';
+
+import { MidiNoteOff, MidiNoteOn } from './midi-messages';
+
+describe('MIDI message schemas', () => {
+  it('accept timed note messages', () => {
+    expect(Value.Check(MidiNoteOn, { type: 'noteOn', note: 60, velocity: 127, time: 12.5 })).toBe(
+      true
+    );
+    expect(Value.Check(MidiNoteOff, { type: 'noteOff', note: 60, time: 13 })).toBe(true);
+  });
+});

--- a/ui/src/lib/objects/schemas/midi-messages.test.ts
+++ b/ui/src/lib/objects/schemas/midi-messages.test.ts
@@ -8,6 +8,11 @@ describe('MIDI message schemas', () => {
     expect(Value.Check(MidiNoteOn, { type: 'noteOn', note: 60, velocity: 127, time: 12.5 })).toBe(
       true
     );
+
+    expect(Value.Check(MidiNoteOn, { type: 'noteOn', note: 60, velocity: 127, channel: 1 })).toBe(
+      true
+    );
+
     expect(Value.Check(MidiNoteOff, { type: 'noteOff', note: 60, time: 13 })).toBe(true);
   });
 });

--- a/ui/src/lib/objects/schemas/midi-messages.ts
+++ b/ui/src/lib/objects/schemas/midi-messages.ts
@@ -7,6 +7,7 @@ export const MidiNoteOn = Type.Object({
   type: Type.Literal('noteOn'),
   note: Type.Number(),
   velocity: Type.Number(),
+  time: Type.Optional(Type.Number()),
   channel: Type.Optional(Type.Number())
 });
 
@@ -14,6 +15,7 @@ export const MidiNoteOff = Type.Object({
   type: Type.Literal('noteOff'),
   note: Type.Number(),
   velocity: Type.Optional(Type.Number()),
+  time: Type.Optional(Type.Number()),
   channel: Type.Optional(Type.Number())
 });
 

--- a/ui/src/lib/objects/schemas/sampler.ts
+++ b/ui/src/lib/objects/schemas/sampler.ts
@@ -2,7 +2,7 @@ import { Type } from '@sinclair/typebox';
 import type { ObjectSchema } from './types';
 import { schema } from './types';
 import { msg, sym } from './helpers';
-import { Bang, Stop, LoadBySrc, messages } from './common';
+import { Bang, Stop, LoadBySrc, NoteOn, NoteOff, messages } from './common';
 
 // Sampler-specific message schemas
 const Play = sym('play');
@@ -38,6 +38,9 @@ const SetStart = msg('setStart', { value: Type.Number() });
 const SetEnd = msg('setEnd', { value: Type.Number() });
 const SetPlaybackRate = msg('setPlaybackRate', { value: Type.Number() });
 const SetDetune = msg('setDetune', { value: Type.Number() });
+const SetNoteOffMode = msg('setNoteOffMode', {
+  value: Type.String({ enum: ['one-shot', 'held'] })
+});
 const Download = msg('download', { name: Type.Optional(Type.String()) });
 
 // Float32Array for direct buffer setting (from uiua node, etc.)
@@ -62,6 +65,7 @@ export const samplerMessages = {
   setEnd: schema(SetEnd),
   setPlaybackRate: schema(SetPlaybackRate),
   setDetune: schema(SetDetune),
+  setNoteOffMode: schema(SetNoteOffMode),
   download: schema(Download),
   load: schema(LoadBySrc),
   float32Array: schema(Float32ArraySamples)
@@ -118,6 +122,19 @@ export const samplerSchema: ObjectSchema = {
         {
           schema: Stop,
           description: 'Stop playback'
+        },
+        {
+          schema: NoteOn,
+          description:
+            'Play the sample as a pitched MIDI note (note 60 = original pitch, velocity controls gain)'
+        },
+        {
+          schema: NoteOff,
+          description: 'Stop active sampler voices for the MIDI note when Note Off mode is held'
+        },
+        {
+          schema: SetNoteOffMode,
+          description: 'Set MIDI noteOff behavior to one-shot or held'
         },
         {
           schema: Loop,

--- a/ui/src/lib/objects/schemas/sampler.ts
+++ b/ui/src/lib/objects/schemas/sampler.ts
@@ -1,4 +1,5 @@
 import { Type } from '@sinclair/typebox';
+
 import type { ObjectSchema } from './types';
 import { schema } from './types';
 import { msg, sym } from './helpers';
@@ -7,41 +8,55 @@ import { Bang, Stop, LoadBySrc, NoteOn, NoteOff, messages } from './common';
 // Sampler-specific message schemas
 const Play = sym('play');
 const BangScheduled = msg('bang', { time: Type.Number() });
+
 const PlayScheduled = msg('play', {
   time: Type.Optional(Type.Number()),
   offset: Type.Optional(Type.Number()),
   duration: Type.Optional(Type.Number()),
   gain: Type.Optional(Type.Number({ minimum: 0 }))
 });
+
+const SetScheduled = msg('set', {
+  time: Type.Number(),
+  value: Type.Number({ minimum: 0 })
+});
+
 const Record = sym('record');
 const End = sym('end');
 const Loop = sym('loop');
 const LoopOn = sym('loopOn');
 const LoopOff = sym('loopOff');
+
 const LoopWithPoints = msg('loop', {
   start: Type.Number(),
   end: Type.Number()
 });
+
 const LoopWithOptionalPoints = msg('loop', {
   start: Type.Optional(Type.Number()),
   end: Type.Optional(Type.Number())
 });
+
 const LoopOnWithPoints = msg('loopOn', {
   start: Type.Number(),
   end: Type.Number()
 });
+
 const LoopOnWithOptionalPoints = msg('loopOn', {
   start: Type.Optional(Type.Number()),
   end: Type.Optional(Type.Number())
 });
+
 const SetStart = msg('setStart', { value: Type.Number() });
 const SetEnd = msg('setEnd', { value: Type.Number() });
 const SetGain = msg('setGain', { value: Type.Number({ minimum: 0 }) });
 const SetPlaybackRate = msg('setPlaybackRate', { value: Type.Number() });
 const SetDetune = msg('setDetune', { value: Type.Number() });
+
 const SetNoteOffMode = msg('setNoteOffMode', {
   value: Type.String({ enum: ['one-shot', 'held'] })
 });
+
 const Download = msg('download', { name: Type.Optional(Type.String()) });
 
 // Float32Array for direct buffer setting (from uiua node, etc.)
@@ -53,6 +68,7 @@ export const samplerMessages = {
   bangScheduled: schema(BangScheduled),
   play: schema(Play),
   playScheduled: schema(PlayScheduled),
+  setScheduled: schema(SetScheduled),
   record: schema(Record),
   end: schema(End),
   loop: schema(Loop),
@@ -94,24 +110,36 @@ export const samplerSchema: ObjectSchema = {
       messages: [
         {
           schema: Bang,
-          description: 'Play the recorded sample'
-        },
-        {
-          schema: Type.Number({ minimum: 0 }),
-          description: 'Play the recorded sample with gain multiplier (0 = silent, 1 = normal)'
+          description: 'Play the sample'
         },
         {
           schema: BangScheduled,
           description: 'Schedule playback of the recorded sample'
         },
         {
-          schema: Play,
-          description: 'Play the recorded sample'
+          schema: Type.Number({ minimum: 0 }),
+          description: 'Play the sample with gain multiplier (0 = silent, 1 = normal)'
+        },
+        {
+          schema: NoteOn,
+          description: 'Play the sample as pitched MIDI note (60 = original pitch, velocity = gain)'
+        },
+        {
+          schema: NoteOff,
+          description: 'Stop active sampler voices when Note Off mode is held'
         },
         {
           schema: PlayScheduled,
           description:
-            'Play the recorded sample with optional audio time, buffer offset, duration in seconds and gain'
+            'Play the sample with optional gain, audio time, buffer offset, duration (seconds)'
+        },
+        {
+          schema: Stop,
+          description: 'Stop playback'
+        },
+        {
+          schema: SetScheduled,
+          description: 'Schedule playback with gain'
         },
         {
           schema: Record,
@@ -120,19 +148,6 @@ export const samplerSchema: ObjectSchema = {
         {
           schema: End,
           description: 'Stop recording'
-        },
-        {
-          schema: Stop,
-          description: 'Stop playback'
-        },
-        {
-          schema: NoteOn,
-          description:
-            'Play the sample as a pitched MIDI note (note 60 = original pitch, velocity controls gain)'
-        },
-        {
-          schema: NoteOff,
-          description: 'Stop active sampler voices for the MIDI note when Note Off mode is held'
         },
         {
           schema: SetNoteOffMode,

--- a/ui/src/lib/objects/schemas/sampler.ts
+++ b/ui/src/lib/objects/schemas/sampler.ts
@@ -36,6 +36,7 @@ const LoopOnWithOptionalPoints = msg('loopOn', {
 });
 const SetStart = msg('setStart', { value: Type.Number() });
 const SetEnd = msg('setEnd', { value: Type.Number() });
+const SetGain = msg('setGain', { value: Type.Number({ minimum: 0 }) });
 const SetPlaybackRate = msg('setPlaybackRate', { value: Type.Number() });
 const SetDetune = msg('setDetune', { value: Type.Number() });
 const SetNoteOffMode = msg('setNoteOffMode', {
@@ -63,6 +64,7 @@ export const samplerMessages = {
   loopOff: schema(LoopOff),
   setStart: schema(SetStart),
   setEnd: schema(SetEnd),
+  setGain: schema(SetGain),
   setPlaybackRate: schema(SetPlaybackRate),
   setDetune: schema(SetDetune),
   setNoteOffMode: schema(SetNoteOffMode),
@@ -163,6 +165,10 @@ export const samplerSchema: ObjectSchema = {
         {
           schema: SetEnd,
           description: 'Set playback end position (seconds)'
+        },
+        {
+          schema: SetGain,
+          description: 'Set built-in output gain (1.0 = normal, 2.0 = double)'
         },
         {
           schema: SetPlaybackRate,

--- a/ui/static/content/objects/sampler~.md
+++ b/ui/static/content/objects/sampler~.md
@@ -11,7 +11,7 @@ control.
 
 - **Record** (circle): Start recording
 - **Play**: Play the sample
-- **Settings** (gear): Configure start/end, loop, rate, detune, and note-off behavior
+- **Settings** (gear): Configure start/end, gain, rate, detune, loop, and note-off behavior
 
 ## Loading Samples
 
@@ -40,6 +40,13 @@ timing and gain fields:
 
 All four fields are optional. When omitted, playback uses the sampler's current
 start/end settings and normal gain.
+
+Use `setGain` to set the sampler's built-in output level. This scales all
+voices after per-trigger gain and MIDI velocity:
+
+```js
+{ type: "setGain", value: 0.75 }
+```
 
 You can also send a non-negative number to trigger playback with that gain
 multiplier:

--- a/ui/static/content/objects/sampler~.md
+++ b/ui/static/content/objects/sampler~.md
@@ -41,6 +41,15 @@ timing and gain fields:
 All four fields are optional. When omitted, playback uses the sampler's current
 start/end settings and normal gain.
 
+`sampler~` also treats scheduled `set` messages as playback triggers with
+`value` as gain. This matches the sequencer's audio lookahead value output:
+
+```js
+{ type: "set", time: audioContextTime, value: 0.75 }
+```
+
+Untimed `set` messages are ignored.
+
 Use `setGain` to set the sampler's built-in output level. This scales all
 voices after per-trigger gain and MIDI velocity:
 

--- a/ui/static/content/objects/sampler~.md
+++ b/ui/static/content/objects/sampler~.md
@@ -11,7 +11,7 @@ control.
 
 - **Record** (circle): Start recording
 - **Play**: Play the sample
-- **Settings** (gear): Configure start/end, loop, rate, detune
+- **Settings** (gear): Configure start/end, loop, rate, detune, and note-off behavior
 
 ## Loading Samples
 
@@ -49,6 +49,21 @@ multiplier:
 1.0  // normal amplitude
 2.0  // twice the amplitude
 ```
+
+`sampler~` also accepts MIDI-style note messages:
+
+```js
+{ type: "noteOn", note: 60, velocity: 127 }
+{ type: "noteOff", note: 60 }
+{ type: "setNoteOffMode", value: "held" }
+```
+
+- `note` maps to playback rate, with note `60` playing the sample at original
+  pitch. Each semitone changes playback rate by `2 ** (1 / 12)`.
+- `velocity` maps to gain as `velocity / 127`.
+- `noteOff` is ignored by default for one-shot sampler behavior.
+- Set Note Off mode to `held` when you want `noteOff` to stop active voices for
+  the matching note.
 
 ## Float32Array Input
 


### PR DESCRIPTION
Add midi noteOn and noteOff input message, scheduled set message and built-in gain support to sampler~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added sampler **gain** control and **note-off mode** (one-shot vs held).
  * Added MIDI-style **noteOn/noteOff** playback with **setGain** and timed-scheduled **set**/**setNoteOffMode** messaging.
  * Improved undo/redo with **batched node setting commits**.

* **Bug Fixes**
  * Adjusted scheduled-message routing so playback updates proceed correctly when audio-param timing support isn’t available.

* **Documentation**
  * Updated sampler specs and on-screen settings to match the new controls and messaging.

* **Tests**
  * Expanded sampler, audio service, and MIDI schema coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->