### PR TITLE
feat(sampler~, sequencer): use bang messages with metadata instead

### DIFF
--- a/docs/design-docs/specs/104-sequencer-single-outlet-mode.md
+++ b/docs/design-docs/specs/104-sequencer-single-outlet-mode.md
@@ -19,18 +19,22 @@ outletMode?: 'multi' | 'single';  // default: 'multi'
 ### Output modes per outlet mode
 
 **Multi outlet** (`outletMode: 'multi'`, default): existing behavior unchanged.
+
 - bang: `{type: 'bang'}`
 - value: velocity number (0–1)
-- audio: `{type: 'set', time, value}`
+- audio value: `{type: 'bang', time, value}`
 
 **Single outlet** (`outletMode: 'single'`): new output format, one outlet.
+
 - **index**: sends track index as a number (0–N)
 - **midi**: sends `{type: 'noteOn', note: BASE_NOTE + trackIndex, index: trackIndex, velocity: 0–127}`
-- **audio**: sends `{type: 'noteOn', note: BASE_NOTE + trackIndex, index: trackIndex, velocity: 0–127, time}`
+- **audio index**: sends `{type: 'bang', index: trackIndex, value, time}`
+- **audio midi**: sends `{type: 'noteOn', note: BASE_NOTE + trackIndex, index: trackIndex, velocity: 0–127, time}`
 
 `note` uses GM drum mapping (BASE_NOTE = 36, same as pads~). `velocity` is standard MIDI 0–127 (converted from internal 0–1). `index` is the raw track index.
 
 The `outputMode` field changes meaning based on `outletMode`:
+
 - When `multi`: `'bang' | 'value' | 'audio'` (existing)
 - When `single`: `'index' | 'midi' | 'audio'`
 
@@ -63,7 +67,7 @@ When a step fires in single-outlet mode, for each active track at that step, a m
 // index mode
 fireAtStep(step, time) → send(trackIndex, { to: 0 })
 
-// midi mode  
+// midi mode
 fireAtStep(step, time) → send({type: 'noteOn', note: BASE_NOTE + trackIndex, index: trackIndex, velocity: round(v * 127)}, { to: 0 })
 
 // audio mode

--- a/docs/design-docs/specs/163-sampler-scheduled-playback.md
+++ b/docs/design-docs/specs/163-sampler-scheduled-playback.md
@@ -1,13 +1,10 @@
 # 163. sampler~ scheduled playback
 
-Allow `sampler~` to play buffers at a target Web Audio time by accepting timed
-`bang` messages and optional `time`, `offset`, and `duration` fields on the
-`play` message:
+Allow `sampler~` to play buffers at a target Web Audio time by accepting
+`bang` messages with optional playback fields:
 
 ```ts
-{ type: 'bang', time?: number }
-{ type: 'play', time?: number, offset?: number, duration?: number, gain?: number }
-{ type: 'set', time: number, value: number }
+{ type: 'bang', time?: number, offset?: number, duration?: number, value?: number }
 { type: 'noteOn', note: number, velocity: number, time?: number }
 { type: 'noteOff', note: number, time?: number }
 { type: 'setGain', value: number }
@@ -17,7 +14,7 @@ number // play immediately with gain multiplier
 
 ## Behavior
 
-- Bare `{ type: 'bang' }` and `{ type: 'play' }` keep the current behavior.
+- Bare `{ type: 'bang' }` keeps the current one-shot playback behavior.
 - Bare non-negative numbers trigger playback with per-voice gain: `0` is silent,
   `1` is normal amplitude, and `2` is twice the amplitude.
 - `noteOn` triggers pitched playback. Note `60` plays the sample at original
@@ -34,20 +31,20 @@ number // play immediately with gain multiplier
 - `offset` is the position in the sample buffer to start playback from, in
   seconds.
 - `duration` is the amount of source-buffer audio to play, in seconds.
-- `gain` is a per-playback amplitude multiplier.
-- Scheduled `set` messages trigger playback with `value` as per-playback gain.
-  This lets sequencer value output drive sampler velocity without a mapper.
-  Untimed `set` messages are ignored by `sampler~`.
+- `value` is a per-playback amplitude multiplier. This lets sequencer value
+  output drive sampler velocity without a mapper.
+- `sampler~` does not treat `set` messages as triggers; `set` remains reserved
+  for value-setting semantics.
 - `setGain` sets the sampler's built-in output gain. It scales all playback
   voices after per-trigger gain, number gain, and MIDI velocity gain.
 - Missing `offset`/`duration` fall back to the sampler's configured start/end
-  points. Missing `gain` uses normal amplitude.
+  points. Missing `value` uses normal amplitude.
 - Negative values are ignored instead of being passed to Web Audio, because
   `AudioBufferSourceNode.start()` throws for negative time parameters.
 
 ## Implementation
 
-- Update the V2 `SamplerNode` bang/play handler to read the optional fields and
+- Update the V2 `SamplerNode` bang handler to read the optional fields and
   pass them to `AudioBufferSourceNode.start(time, offset, duration)`.
 - Route each playback through a per-voice gain node so number-triggered playback
   can scale amplitude without changing other active voices.

--- a/docs/design-docs/specs/164-sequencer-audio-lookahead.md
+++ b/docs/design-docs/specs/164-sequencer-audio-lookahead.md
@@ -9,12 +9,12 @@ Separate sequencer payload choice from Web Audio lookahead timing.
   - `value` sends the step velocity number
 - **Audio lookahead** is an independent boolean setting:
   - `bang` + lookahead sends `{ type: 'bang', time }`
-  - `value` + lookahead sends `{ type: 'set', time, value }`
+  - `value` + lookahead sends `{ type: 'bang', time, value }`
 - Single-outlet mode keeps `index` and `midi`; with audio lookahead enabled,
-  `index` sends `{ type: 'set', index, value, time }` and `midi` sends
+  `index` sends `{ type: 'bang', index, value, time }` and `midi` sends
   `{ type: 'noteOn', note, index, velocity, time }`.
-- `sampler~` accepts timed `bang`, so a sequencer in `bang` + lookahead mode can
-  trigger samples directly without a mapper.
+- `sampler~` accepts timed `bang` with optional `value`, so sequencer
+  bang/value lookahead modes can trigger samples directly without a mapper.
 
 ## Implementation
 

--- a/ui/src/lib/ai/object-prompts/sampler~.ts
+++ b/ui/src/lib/ai/object-prompts/sampler~.ts
@@ -9,9 +9,8 @@ CRITICAL RULES:
 
 Messages:
 - string: load sample from URL
-- bang: trigger sample playback
+- bang: trigger sample playback; optional {type: 'bang', time, value, offset, duration}
 - number: trigger sample playback with gain multiplier (0=silent, 1=normal, 2=twice as loud)
-- {type: 'set', time, value}: trigger scheduled playback with value as gain
 - {type: 'setGain', value}: set built-in output gain for all sampler playback
 - {type: 'noteOn', note, velocity, time?}: trigger pitched playback (note 60=original pitch, velocity 0-127 controls gain)
 - {type: 'noteOff', note, time?}: stop active voices for that note when note-off mode is held

--- a/ui/src/lib/ai/object-prompts/sequencer.ts
+++ b/ui/src/lib/ai/object-prompts/sequencer.ts
@@ -14,14 +14,14 @@ OUTLET MODES:
 OUTPUT MODES (multi outlet):
 - \`"bang"\` (default): sends \`{type:"bang"}\`
 - \`"value"\`: sends velocity as number (0–1)
-- With \`audioRate: true\`, bang sends \`{type:"bang", time}\` and value sends \`{type:"set", time, value}\` for Web Audio scheduling
+- With \`audioRate: true\`, bang sends \`{type:"bang", time}\` and value sends \`{type:"bang", time, value}\` for Web Audio scheduling
 
 OUTPUT MODES (single outlet):
 - \`"index"\` (default): sends track index as number (0–N)
 - \`"midi"\`: sends \`{type:"noteOn", note, index, velocity}\` — note uses GM drum mapping (36=kick), velocity is MIDI 0–127
-- With \`audioRate: true\`, index sends \`{type:"set", index, value, time}\` and midi sends \`{type:"noteOn", note, index, velocity, time}\` for Web Audio scheduling
+- With \`audioRate: true\`, index sends \`{type:"bang", index, value, time}\` and midi sends \`{type:"noteOn", note, index, velocity, time}\` for Web Audio scheduling
 
-Use single outlet + midi mode to connect directly to pads~ with one wire. Enable \`audioRate\` when scheduled Web Audio time is needed.
+Use single outlet + midi mode to connect directly to pads~ with one wire. Enable \`audioRate\` when scheduled audio time is needed.
 
 Node data shape:
 \`\`\`json

--- a/ui/src/lib/audio/sampler-playback-message.test.ts
+++ b/ui/src/lib/audio/sampler-playback-message.test.ts
@@ -24,7 +24,7 @@ describe('createSamplerPlaybackMessage', () => {
   it('preserves scheduled trigger fields when loop playback is enabled', () => {
     expect(
       createSamplerPlaybackMessage(
-        { type: 'play', time: 12.5, offset: 0.25, duration: 1.5, gain: 0.75 },
+        { type: 'bang', time: 12.5, offset: 0.25, duration: 1.5, value: 0.75 },
         { hasRecording: true, loopEnabled: true, loopStart: 0.1, loopEnd: 0.9 }
       )
     ).toEqual({
@@ -34,7 +34,7 @@ describe('createSamplerPlaybackMessage', () => {
       time: 12.5,
       offset: 0.25,
       duration: 1.5,
-      gain: 0.75
+      value: 0.75
     });
   });
 });

--- a/ui/src/lib/audio/sampler-playback-message.ts
+++ b/ui/src/lib/audio/sampler-playback-message.ts
@@ -1,9 +1,9 @@
 export type SamplerPlaybackTrigger = {
-  type: 'bang' | 'play';
+  type: 'bang';
   time?: unknown;
   offset?: unknown;
   duration?: unknown;
-  gain?: unknown;
+  value?: unknown;
 };
 
 type SamplerPlaybackState = {
@@ -20,7 +20,7 @@ type SamplerLoopPlaybackMessage = {
   time?: unknown;
   offset?: unknown;
   duration?: unknown;
-  gain?: unknown;
+  value?: unknown;
 };
 
 export function createSamplerPlaybackMessage(
@@ -39,7 +39,7 @@ export function createSamplerPlaybackMessage(
     if ('time' in trigger) loopMessage.time = trigger.time;
     if ('offset' in trigger) loopMessage.offset = trigger.offset;
     if ('duration' in trigger) loopMessage.duration = trigger.duration;
-    if ('gain' in trigger) loopMessage.gain = trigger.gain;
+    if ('value' in trigger) loopMessage.value = trigger.value;
 
     return loopMessage;
   }

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.test.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.test.ts
@@ -77,7 +77,7 @@ describe('SamplerNode', () => {
     expect(node.audioNode.gain.value).toBe(0.25);
   });
 
-  it('plays scheduled set messages as gain-scaled triggers', () => {
+  it('plays bang value messages as gain-scaled triggers', () => {
     const source = createFakeSource();
     const outputGain = createFakeGain();
     const voiceGain = createFakeGain();
@@ -85,24 +85,24 @@ describe('SamplerNode', () => {
     const node = new SamplerNode('sampler-1', audioContext);
 
     node.audioBuffer = { duration: 4 } as AudioBuffer;
-    node.send('message', { type: 'set', time: 12.5, value: 0.75 });
+    node.send('message', { type: 'bang', time: 12.5, value: 0.75 });
 
     expect(voiceGain.gain.value).toBe(0.75);
     expect(source.start).toHaveBeenCalledWith(12.5, 0, undefined);
   });
 
-  it('ignores scheduled set messages with invalid gain', () => {
+  it('ignores bang messages with invalid value gain', () => {
     const source = createFakeSource();
     const audioContext = createFakeAudioContext([source]);
     const node = new SamplerNode('sampler-1', audioContext);
 
     node.audioBuffer = { duration: 4 } as AudioBuffer;
-    node.send('message', { type: 'set', time: 12.5, value: -1 });
+    node.send('message', { type: 'bang', time: 12.5, value: -1 });
 
     expect(source.start).not.toHaveBeenCalled();
   });
 
-  it('ignores untimed set messages', () => {
+  it('ignores scheduled set messages', () => {
     const source = createFakeSource();
     const audioContext = createFakeAudioContext([source]);
     const node = new SamplerNode('sampler-1', audioContext);
@@ -124,7 +124,7 @@ describe('SamplerNode', () => {
     expect(source.start).toHaveBeenCalledWith(12.5, 0, undefined);
   });
 
-  it('schedules play messages with time, offset, duration, and gain', () => {
+  it('schedules bang messages with time, offset, duration, and value gain', () => {
     const source = createFakeSource();
     const outputGain = createFakeGain();
     const voiceGain = createFakeGain();
@@ -132,7 +132,7 @@ describe('SamplerNode', () => {
     const node = new SamplerNode('sampler-1', audioContext);
 
     node.audioBuffer = { duration: 4 } as AudioBuffer;
-    node.send('message', { type: 'play', time: 12.5, offset: 0.25, duration: 1.5, gain: 0.5 });
+    node.send('message', { type: 'bang', time: 12.5, offset: 0.25, duration: 1.5, value: 0.5 });
 
     expect(voiceGain.gain.value).toBe(0.5);
     expect(source.start).toHaveBeenCalledWith(12.5, 0.25, 1.5);

--- a/ui/src/lib/audio/v2/nodes/SamplerNode.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNode.ts
@@ -5,13 +5,13 @@ import { SamplerNoteVoiceManager } from './SamplerNoteVoiceManager';
 import { samplerMessages } from '$lib/objects/schemas';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 
-type PlayMessage = {
-  type: 'bang' | 'play';
+type BangMessage = {
+  type: 'bang';
 
   time?: unknown;
   offset?: unknown;
   duration?: unknown;
-  gain?: unknown;
+  value?: unknown;
   playbackRate?: unknown;
   replaceImmediate?: boolean;
 };
@@ -23,13 +23,7 @@ type LoopMessage = {
   time?: unknown;
   offset?: unknown;
   duration?: unknown;
-  gain?: unknown;
-};
-
-type ScheduledSetMessage = {
-  type: 'set';
-  time: number;
-  value: number;
+  value?: unknown;
 };
 
 const getNonNegativeNumber = (value: unknown): number | undefined =>
@@ -47,7 +41,7 @@ export class SamplerNode implements AudioNodeV2 {
       name: 'message',
       type: 'message',
       description:
-        'Control messages: record, play, stop, loop, loopOff, setStart, setEnd, playbackRate, detune. Also accepts Float32Array directly to set buffer.'
+        'Control messages: record, bang, stop, loop, loopOff, setStart, setEnd, playbackRate, detune. Also accepts Float32Array directly to set buffer.'
     }
   ];
 
@@ -87,7 +81,7 @@ export class SamplerNode implements AudioNodeV2 {
     this.noteVoices = new SamplerNoteVoiceManager({
       currentTime: () => this.audioContext.currentTime,
       getBasePlaybackRate: () => this.playbackRate,
-      play: (message) => this.handlePlay(message),
+      play: (message) => this.handleBang(message),
       stop: (source, time) => this.stopSource(source, time)
     });
   }
@@ -106,7 +100,7 @@ export class SamplerNode implements AudioNodeV2 {
     if (typeof message === 'number') {
       const gain = getNonNegativeNumber(message);
       if (gain !== undefined) {
-        this.handlePlay({ type: 'play', gain });
+        this.handleBang({ type: 'bang', value: gain });
       }
       return;
     }
@@ -124,9 +118,7 @@ export class SamplerNode implements AudioNodeV2 {
           this.mediaRecorder.stop();
         }
       })
-      .with({ type: 'bang' }, this.handlePlay.bind(this))
-      .with({ type: 'play' }, this.handlePlay.bind(this))
-      .with(samplerMessages.setScheduled, this.handleScheduledSet.bind(this))
+      .with(samplerMessages.bang, this.handleBang.bind(this))
       .with(samplerMessages.noteOn, (message) => {
         this.noteVoices.handleNoteOn(message);
       })
@@ -253,7 +245,7 @@ export class SamplerNode implements AudioNodeV2 {
     const time = getNonNegativeNumber(message.time) ?? 0;
     const offset = getNonNegativeNumber(message.offset) ?? start;
     const duration = getNonNegativeNumber(message.duration);
-    const gain = getNonNegativeNumber(message.gain) ?? 1;
+    const gain = getNonNegativeNumber(message.value) ?? 1;
     const isFutureScheduled = time > this.audioContext.currentTime;
 
     if (!isFutureScheduled) {
@@ -294,17 +286,6 @@ export class SamplerNode implements AudioNodeV2 {
     newSource.start(time, offset, duration);
   }
 
-  private handleScheduledSet(message: ScheduledSetMessage): void {
-    const gain = getNonNegativeNumber(message.value);
-    if (gain === undefined) return;
-
-    this.handlePlay({
-      type: 'play',
-      time: message.time,
-      gain
-    });
-  }
-
   private async handleRecord(): Promise<void> {
     if (this.mediaRecorder) {
       return;
@@ -343,7 +324,7 @@ export class SamplerNode implements AudioNodeV2 {
     this.mediaRecorder = recorder;
   }
 
-  private handlePlay(message: PlayMessage): AudioBufferSourceNode | null {
+  private handleBang(message: BangMessage): AudioBufferSourceNode | null {
     if (!this.audioBuffer) {
       return null;
     }
@@ -356,7 +337,11 @@ export class SamplerNode implements AudioNodeV2 {
 
     const time = getNonNegativeNumber(message.time) ?? 0;
     const offset = getNonNegativeNumber(message.offset) ?? this.loopStart;
-    const gain = getNonNegativeNumber(message.gain) ?? 1;
+    if ('value' in message && getNonNegativeNumber(message.value) === undefined) {
+      return null;
+    }
+
+    const gain = getNonNegativeNumber(message.value) ?? 1;
 
     const duration =
       getNonNegativeNumber(message.duration) ??

--- a/ui/src/lib/audio/v2/nodes/SamplerNoteVoiceManager.ts
+++ b/ui/src/lib/audio/v2/nodes/SamplerNoteVoiceManager.ts
@@ -14,9 +14,9 @@ export type SamplerNoteOffMessage = {
 };
 
 type SamplerNotePlayMessage = {
-  type: 'play';
+  type: 'bang';
   time?: unknown;
-  gain: number;
+  value: number;
   playbackRate: number;
   replaceImmediate: false;
 };
@@ -70,9 +70,9 @@ export class SamplerNoteVoiceManager {
 
     const playbackRateMultiplier = noteToPlaybackRate(note);
     const source = this.play({
-      type: 'play',
+      type: 'bang',
       time: message.time,
-      gain: velocity / 127,
+      value: velocity / 127,
       playbackRate: this.getBasePlaybackRate() * playbackRateMultiplier,
       replaceImmediate: false
     });

--- a/ui/src/lib/components/nodes/SamplerNode.svelte
+++ b/ui/src/lib/components/nodes/SamplerNode.svelte
@@ -170,7 +170,7 @@
     }
 
     if (typeof message === 'number' && Number.isFinite(message) && message >= 0) {
-      playRecording({ type: 'play', gain: message });
+      playRecording({ type: 'bang', value: message });
       return;
     }
 
@@ -178,7 +178,6 @@
       .with(samplerMessages.record, () => startRecording())
       .with(samplerMessages.end, () => stopRecording())
       .with(samplerMessages.bang, (msg) => playRecording(msg))
-      .with(samplerMessages.play, (msg) => playRecording(msg))
       .with(samplerMessages.stop, () => stopPlayback())
       .with(samplerMessages.loopWithOptionalPoints, (msg) => {
         updateNodeData(node.id, {
@@ -333,7 +332,7 @@
     console.error('Failed to retrieve audio buffer after recording');
   }
 
-  function playRecording(trigger: SamplerPlaybackTrigger = { type: 'play' }) {
+  function playRecording(trigger: SamplerPlaybackTrigger = { type: 'bang' }) {
     const message = createSamplerPlaybackMessage(trigger, {
       hasRecording,
       loopEnabled,

--- a/ui/src/lib/components/settings/SequencerSettings.svelte
+++ b/ui/src/lib/components/settings/SequencerSettings.svelte
@@ -179,7 +179,7 @@
             </button>
           </Tooltip.Trigger>
 
-          <Tooltip.Content>Add Web Audio time to output messages</Tooltip.Content>
+          <Tooltip.Content>Add audio time to output messages</Tooltip.Content>
         </Tooltip.Root>
       </div>
     </div>

--- a/ui/src/lib/generated/object-schemas.generated.ts
+++ b/ui/src/lib/generated/object-schemas.generated.ts
@@ -3074,12 +3074,12 @@ export const generatedObjectSchemas: ObjectSchemaRegistry = {
         id: 'message',
         type: 'message',
         description:
-          'Control messages: record, play, stop, loop, loopOff, setStart, setEnd, playbackRate, detune. Also accepts Float32Array directly to set buffer.',
+          'Control messages: record, bang, stop, loop, loopOff, setStart, setEnd, playbackRate, detune. Also accepts Float32Array directly to set buffer.',
         messages: [
           {
             schema: Type.Any(),
             description:
-              'Control messages: record, play, stop, loop, loopOff, setStart, setEnd, playbackRate, detune. Also accepts Float32Array directly to set buffer.'
+              'Control messages: record, bang, stop, loop, loopOff, setStart, setEnd, playbackRate, detune. Also accepts Float32Array directly to set buffer.'
           }
         ],
         handle: { handleType: 'message', handleId: 0 }

--- a/ui/src/lib/objects/schemas/sampler.ts
+++ b/ui/src/lib/objects/schemas/sampler.ts
@@ -3,22 +3,14 @@ import { Type } from '@sinclair/typebox';
 import type { ObjectSchema } from './types';
 import { schema } from './types';
 import { msg, sym } from './helpers';
-import { Bang, Stop, LoadBySrc, NoteOn, NoteOff, messages } from './common';
+import { Stop, LoadBySrc, NoteOn, NoteOff, messages } from './common';
 
 // Sampler-specific message schemas
-const Play = sym('play');
-const BangScheduled = msg('bang', { time: Type.Number() });
-
-const PlayScheduled = msg('play', {
+const BangTrigger = msg('bang', {
   time: Type.Optional(Type.Number()),
+  value: Type.Optional(Type.Number({ minimum: 0 })),
   offset: Type.Optional(Type.Number()),
-  duration: Type.Optional(Type.Number()),
-  gain: Type.Optional(Type.Number({ minimum: 0 }))
-});
-
-const SetScheduled = msg('set', {
-  time: Type.Number(),
-  value: Type.Number({ minimum: 0 })
+  duration: Type.Optional(Type.Number())
 });
 
 const Record = sym('record');
@@ -65,10 +57,7 @@ const Float32ArraySamples = Type.Unsafe<Float32Array>({ type: 'Float32Array' });
 /** Pre-wrapped matchers for use with ts-pattern */
 export const samplerMessages = {
   ...messages,
-  bangScheduled: schema(BangScheduled),
-  play: schema(Play),
-  playScheduled: schema(PlayScheduled),
-  setScheduled: schema(SetScheduled),
+  bang: schema(BangTrigger),
   record: schema(Record),
   end: schema(End),
   loop: schema(Loop),
@@ -109,12 +98,8 @@ export const samplerSchema: ObjectSchema = {
       handle: { handleType: 'message' },
       messages: [
         {
-          schema: Bang,
-          description: 'Play the sample'
-        },
-        {
-          schema: BangScheduled,
-          description: 'Schedule playback of the recorded sample'
+          schema: BangTrigger,
+          description: 'Trigger sample playback with optional time, gain, offset, and duration'
         },
         {
           schema: Type.Number({ minimum: 0 }),
@@ -129,17 +114,8 @@ export const samplerSchema: ObjectSchema = {
           description: 'Stop active sampler voices when Note Off mode is held'
         },
         {
-          schema: PlayScheduled,
-          description:
-            'Play the sample with optional gain, audio time, buffer offset, duration (seconds)'
-        },
-        {
           schema: Stop,
           description: 'Stop playback'
-        },
-        {
-          schema: SetScheduled,
-          description: 'Schedule playback with gain'
         },
         {
           schema: Record,

--- a/ui/src/lib/objects/schemas/sequencer.ts
+++ b/ui/src/lib/objects/schemas/sequencer.ts
@@ -67,33 +67,17 @@ const SetClockMode = msg('setClockMode', {
 const SetStepCount = msg('setStepCount', { value: Type.Number() });
 
 // --- Output (for outlet schema doc) ---
-const BangScheduled = msg('bang', {
-  time: Type.Number()
+const BangOutput = msg('bang', {
+  time: Type.Optional(Type.Number()),
+  value: Type.Optional(Type.Number({ minimum: 0, maximum: 1 })),
+  index: Type.Optional(Type.Number({ minimum: 0 }))
 });
 
-const SetSchedule = msg('set', {
-  time: Type.Number(),
-  value: Type.Number({ minimum: 0, maximum: 1 })
-});
-
-const SetIndexedSchedule = msg('set', {
-  index: Type.Number({ minimum: 0 }),
-  time: Type.Number(),
-  value: Type.Number({ minimum: 0, maximum: 1 })
-});
-
-// Single-outlet output schemas
-const NoteOn = msg('noteOn', {
-  note: Type.Number(),
-  index: Type.Number(),
-  velocity: Type.Number({ minimum: 0, maximum: 127 })
-});
-
-const NoteOnScheduled = msg('noteOn', {
+const NoteOnOutput = msg('noteOn', {
   note: Type.Number(),
   index: Type.Number(),
   velocity: Type.Number({ minimum: 0, maximum: 127 }),
-  time: Type.Number()
+  time: Type.Optional(Type.Number())
 });
 
 /**
@@ -154,7 +138,7 @@ export const sequencerSchema: ObjectSchema = {
         },
         {
           schema: SetAudioRate,
-          description: 'Enable or disable Web Audio lookahead timestamps on output'
+          description: 'Enable or disable audio lookahead timestamps on output'
         },
         {
           schema: SetOutletMode,
@@ -202,39 +186,19 @@ export const sequencerSchema: ObjectSchema = {
         'Multi-outlet mode: per-track trigger outlet (one per track, numbered 0–7). Single-outlet mode: one merged outlet.',
       messages: [
         {
-          schema: Bang,
-          description: 'Multi/bang: fired on active step'
-        },
-        {
-          schema: BangScheduled,
-          description: 'Multi/bang + audio lookahead: fired with Web Audio time'
-        },
-        {
-          schema: Type.Number({ minimum: 0, maximum: 1 }),
-          description: 'Multi/value: velocity value 0–1'
-        },
-        {
-          schema: SetSchedule,
+          schema: BangOutput,
           description:
-            'Multi/value + audio lookahead: scheduled set event with Web Audio time and velocity'
+            'Bang output. Audio lookahead adds time; value mode adds velocity; single/index mode also adds track index.'
         },
         {
           schema: Type.Number({ minimum: 0 }),
-          description: 'Single/index: track index (0–N)'
-        },
-        {
-          schema: SetIndexedSchedule,
           description:
-            'Single/index + audio lookahead: scheduled set event with track index, velocity, and Web Audio time'
+            'Number output: multi/value sends velocity 0–1; single/index sends track index.'
         },
         {
-          schema: NoteOn,
-          description: 'Single/midi: noteOn with GM note, track index, and MIDI velocity 0–127'
-        },
-        {
-          schema: NoteOnScheduled,
+          schema: NoteOnOutput,
           description:
-            'Single/midi + audio lookahead: noteOn with GM note, track index, MIDI velocity 0–127, and Web Audio time'
+            'Single/midi output. Audio lookahead adds time; velocity is MIDI 0–127 and note follows the GM drum map.'
         }
       ]
     }

--- a/ui/src/lib/sequencer/sequencer-output.test.ts
+++ b/ui/src/lib/sequencer/sequencer-output.test.ts
@@ -52,10 +52,10 @@ describe('sequencer output payloads', () => {
         velocity: 0.75,
         time: 12.5
       })
-    ).toEqual({ type: 'set', time: 12.5, value: 0.75 });
+    ).toEqual({ type: 'bang', time: 12.5, value: 0.75 });
   });
 
-  it('adds scheduled set metadata to single index output when audio lookahead is enabled', () => {
+  it('adds scheduled bang metadata to single index output when audio lookahead is enabled', () => {
     const options = {
       outletMode: 'single' as const,
       outputMode: 'index' as const,
@@ -66,7 +66,7 @@ describe('sequencer output payloads', () => {
 
     expect(createSequencerPayload({ ...options, audioRate: false })).toBe(2);
     expect(createSequencerPayload({ ...options, audioRate: true })).toEqual({
-      type: 'set',
+      type: 'bang',
       index: 2,
       value: 0.75,
       time: 12.5

--- a/ui/src/lib/sequencer/sequencer-output.ts
+++ b/ui/src/lib/sequencer/sequencer-output.ts
@@ -72,7 +72,7 @@ export function createSequencerPayload({
     }
 
     if (outputMode === 'index') {
-      return audioRate ? { type: 'set', index: trackIndex, value: velocity, time } : trackIndex;
+      return audioRate ? { type: 'bang', index: trackIndex, value: velocity, time } : trackIndex;
     }
 
     throw new Error(`Invalid sequencer output mode "${outputMode}" for single outlet mode`);
@@ -80,7 +80,7 @@ export function createSequencerPayload({
 
   if (outletMode === 'multi') {
     if (outputMode === 'value') {
-      return audioRate ? { type: 'set', time, value: velocity } : velocity;
+      return audioRate ? { type: 'bang', time, value: velocity } : velocity;
     }
 
     if (outputMode === 'bang') {

--- a/ui/static/content/objects/sampler~.md
+++ b/ui/static/content/objects/sampler~.md
@@ -19,39 +19,37 @@ Drop an audio file into the sampler to load it.
 
 ## Playback Messages
 
-Send `{ type: "bang" }` or `{ type: "play" }` to play immediately. For
-sample-accurate triggering from sequencers and clocks, send a timed bang:
+Send `{ type: "bang" }` to play immediately. For sample-accurate triggering
+from sequencers and clocks, include `time`:
 
 ```js
 { type: "bang", time: audioContextTime }
 ```
 
-For explicit sample playback control, `play` also accepts optional Web Audio
-timing and gain fields:
+`bang` also accepts optional playback fields:
 
 ```js
-{ type: "play", time: audioContextTime, offset: 0, duration: 0.25, gain: 0.5 }
+{ type: "bang", time: audioContextTime, offset: 0, duration: 0.25, value: 0.5 }
 ```
 
 - `time` schedules playback at an absolute `AudioContext.currentTime` timestamp
 - `offset` starts from a position in the sample buffer, in seconds
 - `duration` plays a specific amount of source-buffer audio, in seconds
-- `gain` scales this playback voice's amplitude
+- `value` scales this playback voice's amplitude
 
 All four fields are optional. When omitted, playback uses the sampler's current
 start/end settings and normal gain.
 
-`sampler~` also treats scheduled `set` messages as playback triggers with
-`value` as gain. This matches the sequencer's audio lookahead value output:
+Sequencer value output with **Audio lookahead** sends timed `bang` messages
+with `value`, so it can drive sampler velocity directly:
 
 ```js
-{ type: "set", time: audioContextTime, value: 0.75 }
+{ type: "bang", time: audioContextTime, value: 0.75 }
 ```
 
-Untimed `set` messages are ignored.
-
-Use `setGain` to set the sampler's built-in output level. This scales all
-voices after per-trigger gain and MIDI velocity:
+`set` messages are not playback triggers. Use `setGain` to set the sampler's
+built-in output level. This scales all voices after per-trigger value and MIDI
+velocity:
 
 ```js
 { type: "setGain", value: 0.75 }

--- a/ui/static/content/objects/sequencer.md
+++ b/ui/static/content/objects/sequencer.md
@@ -39,11 +39,11 @@ Enable **Audio lookahead** to include precise Web Audio timing:
 
 - **bang + Audio lookahead** — sends `{type: "bang", time}` for
   sample-accurate triggering with `sampler~`.
-- **value + Audio lookahead** — sends `{type: "set", time, value}` for
-  parameter automation and custom `dsp~` nodes.
+- **value + Audio lookahead** — sends `{type: "bang", time, value}` for
+  sample-accurate velocity-style triggering with `sampler~`.
 - **single outlet index + Audio lookahead** — sends
-  `{type: "set", index, value, time}` for scheduled parameter automation with
-  track routing metadata.
+  `{type: "bang", index, value, time}` for scheduled triggering with track
+  routing metadata.
 - **single outlet midi + Audio lookahead** — sends
   `{type: "noteOn", note, index, velocity, time}` for scheduled drum-pad or MIDI
   triggering. `note` follows the GM drum map from 36 upward, `index` is the


### PR DESCRIPTION
Both `sampler~` and `sequencer` should use `bang` message with additional timing and triggering metadata, instead of using scheduled `set` and `play` messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sequencer audio lookahead outputs now schedule playback via timed `bang` messages (value and index variants).
  * Sampler playback now uses a unified timed `bang` trigger with optional `time`, `offset`, `duration`, and `value`.
* **Bug Fixes**
  * Improved validation: negative timing-related values are ignored; numeric triggers follow the same `bang` playback path.
* **Documentation**
  * Updated sampler and sequencer docs to match the new `bang`/`value` formats and clarify that `set` isn’t a playback trigger.
* **Tests**
  * Updated expectations for the revised scheduled trigger payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->