### PR TITLE
feat(group): add group object for grouping objects

### DIFF
--- a/docs/design-docs/specs/165-explicit-group-object.md
+++ b/docs/design-docs/specs/165-explicit-group-object.md
@@ -67,9 +67,10 @@ When a group is resized smaller, direct children whose centers are outside the r
 - Empty space inside a group behaves like empty canvas space for canvas insertion and selection clearing.
 - Drag-select gestures that start inside a group select objects inside the group without selecting the group frame itself.
 - Users select or drag a group by its border, resize handles, or title pill, not by the transparent interior.
-- The title pill follows the small `node-title-drag-handle` visual convention used by other visual nodes.
-- A settings button at the top-right opens predefined color swatches for the group frame. The settings panel opens outside the group frame so it does not cover grouped objects.
+- The title pill follows the small `node-title-drag-handle` visual convention used by other visual nodes and displays `node.data.title` with `group` as the fallback title.
+- A settings button at the top-right opens a title input and predefined color swatches for the group frame. The settings panel opens outside the group frame so it does not cover grouped objects.
 - Group color is optional. Omitting `node.data.color` uses the default gray frame; choosing a swatch stores `node.data.color` and supports undo/redo as a discrete node data change.
+- Group title is optional. Editing it stores `node.data.title` and supports undo/redo as a continuous node data change on blur.
 - The rendered group frame uses explicit pixel dimensions from `node.width` and `node.height` so resize observation cannot collapse the group back to its content size.
 - The Svelte Flow group wrapper must override the library's built-in group-node width so first resize measurement comes from the Patchies frame, not the default 150px XYFlow group style.
 

--- a/docs/design-docs/specs/165-explicit-group-object.md
+++ b/docs/design-docs/specs/165-explicit-group-object.md
@@ -16,7 +16,7 @@ Add a `group` object that visually frames related canvas objects and updates mem
 ## Non-Goals
 
 - No nested group authoring beyond preserving existing parent relationships where possible.
-- No collapse/expand, labels, colors, or locking controls in the first pass.
+- No collapse/expand, editable labels, or locking controls in the first pass.
 - No new message, audio, or video behavior.
 - No automatic group deletion when it becomes empty.
 
@@ -65,6 +65,8 @@ When a group is resized smaller, direct children whose centers are outside the r
 - Empty space inside a group behaves like empty canvas space for canvas insertion and selection clearing.
 - Users select or drag a group by its border, resize handles, or title pill, not by the transparent interior.
 - The title pill follows the small `node-title-drag-handle` visual convention used by other visual nodes.
+- A settings button at the top-right opens predefined color swatches for the group frame.
+- Group color is optional. Omitting `node.data.color` uses the default gray frame; choosing a swatch stores `node.data.color` and supports undo/redo as a discrete node data change.
 
 ## Testing
 
@@ -76,5 +78,6 @@ Pure tests cover:
 - preserving parent-before-child node order after membership changes
 - not sweeping unrelated objects into a group when the group itself is dragged
 - keeping the group interior pointer-transparent while border/title hit zones stay pointer-active
+- deriving group frame styles from the selected predefined color
 
 Focused Svelte/type checks should cover component wiring and object registration.

--- a/docs/design-docs/specs/165-explicit-group-object.md
+++ b/docs/design-docs/specs/165-explicit-group-object.md
@@ -1,0 +1,80 @@
+# 165. Visual Group Object
+
+## Goal
+
+Add a `group` object that visually frames related canvas objects and updates membership from spatial placement.
+
+## Scope
+
+- Users add objects to a group by moving objects into the group's frame or resizing the group around them.
+- Users remove objects from a group by moving them outside the group's frame.
+- Group membership is stored with Svelte Flow `parentId` relationships.
+- A group is a normal canvas node with a translucent border, resize handles, and no ports.
+- Dragging the group moves all child objects together through Svelte Flow's parent/child behavior.
+- Membership changes are committed on drag/resize release, not continuously while dragging.
+
+## Non-Goals
+
+- No nested group authoring beyond preserving existing parent relationships where possible.
+- No collapse/expand, labels, colors, or locking controls in the first pass.
+- No new message, audio, or video behavior.
+- No automatic group deletion when it becomes empty.
+
+## Behavior
+
+### Create A Group
+
+Creating a `group` object from the object browser inserts an empty resizable frame. It does not capture objects until the user releases a resize or moves objects into it.
+
+### Add Objects To A Group
+
+When a top-level non-group object is released with its center inside a group frame, it becomes a child of that group.
+
+The child receives:
+
+- `parentId: <group-id>`
+- a position converted from absolute canvas coordinates to the group's relative coordinate space
+
+The group node appears before its children in the `nodes` array because Svelte Flow requires parents to appear before child nodes.
+
+When a group is resized, all top-level non-group objects whose centers are inside the resized frame are added to that group.
+
+### Move Group
+
+Dragging the group moves the group node. Svelte Flow keeps child nodes visually attached because child positions are relative to the parent.
+
+Moving a group does not sweep up unrelated top-level objects. This avoids accidental membership changes while repositioning an existing group.
+
+### Remove Objects From A Group
+
+When a child object is released with its center outside its parent group frame, it becomes a top-level canvas object.
+
+The object receives:
+
+- no `parentId`
+- no `extent`
+- absolute position equal to group position plus child relative position
+
+When a group is resized smaller, direct children whose centers are outside the resized frame are removed from that group.
+
+## UI
+
+- Add `group` to the Starters pack and object browser.
+- Do not require command palette actions or keyboard shortcuts for grouping.
+- The visible frame and resize handles must overlap exactly.
+- Empty space inside a group behaves like empty canvas space for canvas insertion and selection clearing.
+- Users select or drag a group by its border, resize handles, or title pill, not by the transparent interior.
+- The title pill follows the small `node-title-drag-handle` visual convention used by other visual nodes.
+
+## Testing
+
+Pure tests cover:
+
+- adding a top-level object whose center is inside a group
+- removing a child object whose center is outside its group
+- keeping a child inside its group when its center remains inside
+- preserving parent-before-child node order after membership changes
+- not sweeping unrelated objects into a group when the group itself is dragged
+- keeping the group interior pointer-transparent while border/title hit zones stay pointer-active
+
+Focused Svelte/type checks should cover component wiring and object registration.

--- a/docs/design-docs/specs/165-explicit-group-object.md
+++ b/docs/design-docs/specs/165-explicit-group-object.md
@@ -26,6 +26,8 @@ Add a `group` object that visually frames related canvas objects and updates mem
 
 Creating a `group` object from the object browser inserts an empty resizable frame. It does not capture objects until the user releases a resize or moves objects into it.
 
+New group nodes store their default frame size as top-level `width` and `height` immediately. The first resize therefore starts from the same dimensions the user sees, even before the group has ever been manually resized.
+
 ### Add Objects To A Group
 
 When a top-level non-group object is released with its center inside a group frame, it becomes a child of that group.
@@ -65,8 +67,10 @@ When a group is resized smaller, direct children whose centers are outside the r
 - Empty space inside a group behaves like empty canvas space for canvas insertion and selection clearing.
 - Users select or drag a group by its border, resize handles, or title pill, not by the transparent interior.
 - The title pill follows the small `node-title-drag-handle` visual convention used by other visual nodes.
-- A settings button at the top-right opens predefined color swatches for the group frame.
+- A settings button at the top-right opens predefined color swatches for the group frame. The settings panel opens outside the group frame so it does not cover grouped objects.
 - Group color is optional. Omitting `node.data.color` uses the default gray frame; choosing a swatch stores `node.data.color` and supports undo/redo as a discrete node data change.
+- The rendered group frame uses explicit pixel dimensions from `node.width` and `node.height` so resize observation cannot collapse the group back to its content size.
+- The Svelte Flow group wrapper must override the library's built-in group-node width so first resize measurement comes from the Patchies frame, not the default 150px XYFlow group style.
 
 ## Testing
 
@@ -79,5 +83,6 @@ Pure tests cover:
 - not sweeping unrelated objects into a group when the group itself is dragged
 - keeping the group interior pointer-transparent while border/title hit zones stay pointer-active
 - deriving group frame styles from the selected predefined color
+- preserving resized group dimensions even when measured dimensions lag behind explicit node dimensions
 
 Focused Svelte/type checks should cover component wiring and object registration.

--- a/docs/design-docs/specs/165-explicit-group-object.md
+++ b/docs/design-docs/specs/165-explicit-group-object.md
@@ -65,6 +65,7 @@ When a group is resized smaller, direct children whose centers are outside the r
 - Do not require command palette actions or keyboard shortcuts for grouping.
 - The visible frame and resize handles must overlap exactly.
 - Empty space inside a group behaves like empty canvas space for canvas insertion and selection clearing.
+- Drag-select gestures that start inside a group select objects inside the group without selecting the group frame itself.
 - Users select or drag a group by its border, resize handles, or title pill, not by the transparent interior.
 - The title pill follows the small `node-title-drag-handle` visual convention used by other visual nodes.
 - A settings button at the top-right opens predefined color swatches for the group frame. The settings panel opens outside the group frame so it does not cover grouped objects.

--- a/docs/design-docs/specs/165-explicit-group-object.md
+++ b/docs/design-docs/specs/165-explicit-group-object.md
@@ -71,6 +71,8 @@ When a group is resized smaller, direct children whose centers are outside the r
 - A settings button at the top-right opens a title input and predefined color swatches for the group frame. The settings panel opens outside the group frame so it does not cover grouped objects.
 - Group color is optional. Omitting `node.data.color` uses the default gray frame; choosing a swatch stores `node.data.color` and supports undo/redo as a discrete node data change.
 - Group title is optional. Editing it stores `node.data.title` and supports undo/redo as a continuous node data change on blur.
+- Group resize can be disabled with `node.data.canResize: false`; resizing is enabled when the value is absent.
+- Group locking stores `node.data.locked` and disables movement of the group frame itself by setting the node-level `draggable` state.
 - The rendered group frame uses explicit pixel dimensions from `node.width` and `node.height` so resize observation cannot collapse the group back to its content size.
 - The Svelte Flow group wrapper must override the library's built-in group-node width so first resize measurement comes from the Patchies frame, not the default 150px XYFlow group style.
 

--- a/ui/src/lib/ai/handle-multi-object-insert.test.ts
+++ b/ui/src/lib/ai/handle-multi-object-insert.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+
+import { DEFAULT_GROUP_HEIGHT, DEFAULT_GROUP_WIDTH } from '$lib/nodes/defaultNodeDimensions';
+import { handleMultiObjectInsert } from './handle-multi-object-insert';
+
+describe('handleMultiObjectInsert', () => {
+  test('creates group nodes with explicit top-level dimensions', async () => {
+    const result = await handleMultiObjectInsert({
+      objectNodes: [{ type: 'group', data: {}, position: { x: 0, y: 0 } }],
+      simplifiedEdges: [],
+      basePosition: { x: 10, y: 20 },
+      nodeIdCounter: 1,
+      edgeIdCounter: 1
+    });
+
+    expect(result.newNodes[0]).toMatchObject({
+      id: 'group-1',
+      type: 'group',
+      width: DEFAULT_GROUP_WIDTH,
+      height: DEFAULT_GROUP_HEIGHT,
+      data: {}
+    });
+  });
+});

--- a/ui/src/lib/ai/handle-multi-object-insert.ts
+++ b/ui/src/lib/ai/handle-multi-object-insert.ts
@@ -1,5 +1,6 @@
 import type { Node, Edge } from '@xyflow/svelte';
 import { getDefaultNodeData } from '$lib/nodes/defaultNodeData';
+import { getDefaultNodeDimensions } from '$lib/nodes/defaultNodeDimensions';
 import { shaderCodeToUniformDefs } from '$lib/canvas/shader-code-to-uniform-def';
 import type { AiObjectNode, SimplifiedEdge } from './types';
 import { validateEdgeHandles } from './validate-edge-handles';
@@ -105,6 +106,7 @@ export async function handleMultiObjectInsert(
       id,
       type: objNode.type,
       position,
+      ...getDefaultNodeDimensions(objNode.type),
       data: nodeData
     };
 

--- a/ui/src/lib/ai/object-descriptions-types.ts
+++ b/ui/src/lib/ai/object-descriptions-types.ts
@@ -9,6 +9,7 @@ export const OBJECT_TYPE_LIST = `## Basic Control & UI
 - textbox: Text input and display
 - curve: Breakpoint curve editor
 - sheet: Editable spreadsheet-style grid that outputs a 2D array by default
+- group: Visual frame for explicitly grouping and moving related canvas objects together
 
 ## Audio I/O (Dedicated node types)
 - mic~: Audio input from microphone
@@ -102,6 +103,7 @@ export const OBJECT_TYPE_LIST = `## Basic Control & UI
 - sheet: Editable spreadsheet-style grid; bang outputs a 2D array with headers first, optional row-object output
 - keyboard: Keyboard input controller
 - label: Text label for annotations
+- group: Visual frame for organizing related objects; use parentId for grouped child nodes
 - link: Clickable link button
 - sequencer: Multi-track step sequencer synced to transport clock (drum machine style; one outlet per track)
 

--- a/ui/src/lib/ai/object-prompts/group.ts
+++ b/ui/src/lib/ai/object-prompts/group.ts
@@ -1,0 +1,26 @@
+export const groupPrompt = `## group Object Instructions
+
+Visual organization frame for grouping related canvas objects.
+
+Use group when the user asks to organize, frame, cluster, or move several objects together.
+
+Properties:
+- type: "group"
+- data: {}
+- width/height: set to cover the objects being organized
+
+Grouping behavior:
+- A group has no inlets or outlets.
+- Child objects should use parentId set to the group node id and positions relative to the group's top-left corner.
+- The group node must appear before its child nodes in the nodes array.
+
+Example:
+\`\`\`json
+{
+  "type": "group",
+  "position": { "x": 80, "y": 80 },
+  "width": 360,
+  "height": 240,
+  "data": {}
+}
+\`\`\``;

--- a/ui/src/lib/ai/object-prompts/group.ts
+++ b/ui/src/lib/ai/object-prompts/group.ts
@@ -6,13 +6,14 @@ Use group when the user asks to organize, frame, cluster, or move several object
 
 Properties:
 - type: "group"
-- data: { color?: string } where color is an optional hex frame color; omit it for the default gray frame
+- data: { color?: string, title?: string } where color is an optional hex frame color and title is an optional label shown above the group
 - width/height: set to cover the objects being organized
 
 Grouping behavior:
 - A group has no inlets or outlets.
 - Child objects should use parentId set to the group node id and positions relative to the group's top-left corner.
 - The group node must appear before its child nodes in the nodes array.
+- Set data.title when the user names the group or when a clear organizational label would make the generated patch easier to scan; omit it to use the default "group" title.
 
 Example:
 \`\`\`json

--- a/ui/src/lib/ai/object-prompts/group.ts
+++ b/ui/src/lib/ai/object-prompts/group.ts
@@ -6,7 +6,7 @@ Use group when the user asks to organize, frame, cluster, or move several object
 
 Properties:
 - type: "group"
-- data: {}
+- data: { color?: string } where color is an optional hex frame color; omit it for the default gray frame
 - width/height: set to cover the objects being organized
 
 Grouping behavior:

--- a/ui/src/lib/ai/object-prompts/index.ts
+++ b/ui/src/lib/ai/object-prompts/index.ts
@@ -19,6 +19,7 @@ import { exprPrompt } from './expr';
 import { exprTildePrompt } from './expr~';
 import { glslPrompt } from './glsl';
 import { floatTexPrompt } from './float.tex';
+import { groupPrompt } from './group';
 import { hydraPrompt } from './hydra';
 import { jsPrompt } from './js';
 import { markdownPrompt } from './markdown';
@@ -88,6 +89,7 @@ export const objectPrompts: Record<string, string> = {
   p5: p5Prompt,
   hydra: hydraPrompt,
   glsl: glslPrompt,
+  group: groupPrompt,
   'float.tex': floatTexPrompt,
   shaderpark: shaderparkPrompt,
   'canvas.dom': canvasDomPrompt,

--- a/ui/src/lib/canvas/group-hit-zones.test.ts
+++ b/ui/src/lib/canvas/group-hit-zones.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  GROUP_BORDER_HIT_ZONES,
+  getGroupTitleClasses,
+  getGroupVisualFrameClasses
+} from './group-hit-zones';
+
+describe('group hit zones', () => {
+  test('keeps the visual frame transparent to pointer events', () => {
+    expect(getGroupVisualFrameClasses(false).join(' ')).toContain('pointer-events-none');
+  });
+
+  test('keeps title and border strips available for selecting and dragging the group', () => {
+    expect(getGroupTitleClasses()).toContain('pointer-events-auto');
+    expect(GROUP_BORDER_HIT_ZONES).toHaveLength(4);
+    expect(
+      GROUP_BORDER_HIT_ZONES.every((zone) => zone.className.includes('pointer-events-auto'))
+    ).toBe(true);
+  });
+});

--- a/ui/src/lib/canvas/group-hit-zones.test.ts
+++ b/ui/src/lib/canvas/group-hit-zones.test.ts
@@ -8,6 +8,7 @@ import {
   getGroupColorGridClasses,
   getGroupFrameStyle,
   getGroupSettingsPanelClasses,
+  getGroupTitle,
   getGroupTitleClasses,
   getGroupVisualFrameStyle,
   getGroupVisualFrameClasses
@@ -24,6 +25,12 @@ describe('group hit zones', () => {
     expect(
       GROUP_BORDER_HIT_ZONES.every((zone) => zone.className.includes('pointer-events-auto'))
     ).toBe(true);
+  });
+
+  test('uses a custom group title with a default fallback', () => {
+    expect(getGroupTitle(undefined)).toBe('group');
+    expect(getGroupTitle('')).toBe('group');
+    expect(getGroupTitle('  visuals  ')).toBe('visuals');
   });
 
   test('exposes predefined group colors with a default selected color', () => {

--- a/ui/src/lib/canvas/group-hit-zones.test.ts
+++ b/ui/src/lib/canvas/group-hit-zones.test.ts
@@ -7,6 +7,8 @@ import {
   getGroupColorPreset,
   getGroupColorGridClasses,
   getGroupFrameStyle,
+  getGroupCanResize,
+  getGroupIsLocked,
   getGroupSettingsPanelClasses,
   getGroupTitle,
   getGroupTitleClasses,
@@ -33,6 +35,13 @@ describe('group hit zones', () => {
     expect(getGroupTitle('  visuals  ')).toBe('visuals');
   });
 
+  test('uses default group interaction settings', () => {
+    expect(getGroupCanResize(undefined)).toBe(true);
+    expect(getGroupCanResize(false)).toBe(false);
+    expect(getGroupIsLocked(undefined)).toBe(false);
+    expect(getGroupIsLocked(true)).toBe(true);
+  });
+
   test('exposes predefined group colors with a default selected color', () => {
     expect(GROUP_COLOR_PRESETS).toHaveLength(10);
     expect(GROUP_COLOR_PRESETS.some((preset) => preset.value === DEFAULT_GROUP_COLOR)).toBe(true);
@@ -46,6 +55,15 @@ describe('group hit zones', () => {
 
     expect(style).toContain('border-color: rgba(244, 63, 94, 0.55);');
     expect(style).toContain('background-color: rgba(244, 63, 94, 0.08);');
+  });
+
+  test('falls back to the default color for malformed persisted colors', () => {
+    const style = getGroupVisualFrameStyle('not-a-color', false);
+
+    expect(getGroupColorPreset('not-a-color').value).toBe(DEFAULT_GROUP_COLOR);
+    expect(style).not.toContain('NaN');
+    expect(style).toContain('border-color: rgba(113, 113, 122, 0.55);');
+    expect(style).toContain('background-color: rgba(113, 113, 122, 0.08);');
   });
 
   test('uses explicit pixel dimensions for the group frame', () => {

--- a/ui/src/lib/canvas/group-hit-zones.test.ts
+++ b/ui/src/lib/canvas/group-hit-zones.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  DEFAULT_GROUP_COLOR,
+  GROUP_COLOR_PRESETS,
   GROUP_BORDER_HIT_ZONES,
+  getGroupColorPreset,
   getGroupTitleClasses,
+  getGroupVisualFrameStyle,
   getGroupVisualFrameClasses
 } from './group-hit-zones';
 
@@ -17,5 +21,19 @@ describe('group hit zones', () => {
     expect(
       GROUP_BORDER_HIT_ZONES.every((zone) => zone.className.includes('pointer-events-auto'))
     ).toBe(true);
+  });
+
+  test('exposes predefined group colors with a default selected color', () => {
+    expect(GROUP_COLOR_PRESETS.some((preset) => preset.value === DEFAULT_GROUP_COLOR)).toBe(true);
+    expect(getGroupColorPreset(undefined).value).toBe(DEFAULT_GROUP_COLOR);
+    expect(getGroupColorPreset(undefined).name).toBe('Gray');
+    expect(GROUP_COLOR_PRESETS[0].name).toBe('Gray');
+  });
+
+  test('derives frame style from group color', () => {
+    const style = getGroupVisualFrameStyle('#f43f5e', false);
+
+    expect(style).toContain('border-color: rgba(244, 63, 94, 0.55);');
+    expect(style).toContain('background-color: rgba(244, 63, 94, 0.08);');
   });
 });

--- a/ui/src/lib/canvas/group-hit-zones.test.ts
+++ b/ui/src/lib/canvas/group-hit-zones.test.ts
@@ -5,6 +5,9 @@ import {
   GROUP_COLOR_PRESETS,
   GROUP_BORDER_HIT_ZONES,
   getGroupColorPreset,
+  getGroupColorGridClasses,
+  getGroupFrameStyle,
+  getGroupSettingsPanelClasses,
   getGroupTitleClasses,
   getGroupVisualFrameStyle,
   getGroupVisualFrameClasses
@@ -24,6 +27,7 @@ describe('group hit zones', () => {
   });
 
   test('exposes predefined group colors with a default selected color', () => {
+    expect(GROUP_COLOR_PRESETS).toHaveLength(10);
     expect(GROUP_COLOR_PRESETS.some((preset) => preset.value === DEFAULT_GROUP_COLOR)).toBe(true);
     expect(getGroupColorPreset(undefined).value).toBe(DEFAULT_GROUP_COLOR);
     expect(getGroupColorPreset(undefined).name).toBe('Gray');
@@ -35,5 +39,20 @@ describe('group hit zones', () => {
 
     expect(style).toContain('border-color: rgba(244, 63, 94, 0.55);');
     expect(style).toContain('background-color: rgba(244, 63, 94, 0.08);');
+  });
+
+  test('uses explicit pixel dimensions for the group frame', () => {
+    expect(getGroupFrameStyle(420, 260)).toBe('width: 420px; height: 260px;');
+  });
+
+  test('anchors the settings panel outside the group frame', () => {
+    const classes = getGroupSettingsPanelClasses();
+
+    expect(classes).toContain('left-[calc(100%+0.5rem)]');
+    expect(classes).not.toContain('right-0');
+  });
+
+  test('lays out group colors as two rows of five swatches', () => {
+    expect(getGroupColorGridClasses()).toContain('grid-cols-5');
   });
 });

--- a/ui/src/lib/canvas/group-hit-zones.ts
+++ b/ui/src/lib/canvas/group-hit-zones.ts
@@ -13,6 +13,8 @@ export const GROUP_COLOR_PRESETS = [
   { name: 'Indigo', value: '#6366f1' }
 ] as const;
 
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
 export const GROUP_BORDER_HIT_ZONES = [
   {
     id: 'top',
@@ -37,7 +39,7 @@ export const GROUP_BORDER_HIT_ZONES = [
 ] as const;
 
 export function getGroupColorPreset(color: string | undefined): { name: string; value: string } {
-  if (!color) return GROUP_COLOR_PRESETS[0];
+  if (!color || !HEX_COLOR_PATTERN.test(color)) return GROUP_COLOR_PRESETS[0];
 
   return (
     GROUP_COLOR_PRESETS.find((preset) => preset.value === color) ?? { name: 'Custom', value: color }
@@ -48,8 +50,16 @@ export function getGroupTitle(title: string | undefined): string {
   return title?.trim() || 'group';
 }
 
+export function getGroupCanResize(canResize: boolean | undefined): boolean {
+  return canResize ?? true;
+}
+
+export function getGroupIsLocked(locked: boolean | undefined): boolean {
+  return locked ?? false;
+}
+
 function hexToRgb(hexColor: string): { r: number; g: number; b: number } {
-  const normalized = hexColor.replace('#', '');
+  const normalized = getGroupColorPreset(hexColor).value.slice(1);
 
   return {
     r: parseInt(normalized.slice(0, 2), 16),

--- a/ui/src/lib/canvas/group-hit-zones.ts
+++ b/ui/src/lib/canvas/group-hit-zones.ts
@@ -1,3 +1,17 @@
+export const DEFAULT_GROUP_COLOR = '#71717a';
+
+export const GROUP_COLOR_PRESETS = [
+  { name: 'Gray', value: DEFAULT_GROUP_COLOR },
+  { name: 'Sky', value: '#38bdf8' },
+  { name: 'Violet', value: '#8b5cf6' },
+  { name: 'Rose', value: '#f43f5e' },
+  { name: 'Amber', value: '#f59e0b' },
+  { name: 'Emerald', value: '#10b981' },
+  { name: 'Cyan', value: '#06b6d4' },
+  { name: 'Lime', value: '#84cc16' },
+  { name: 'Slate', value: '#94a3b8' }
+] as const;
+
 export const GROUP_BORDER_HIT_ZONES = [
   {
     id: 'top',
@@ -21,6 +35,29 @@ export const GROUP_BORDER_HIT_ZONES = [
   }
 ] as const;
 
+export function getGroupColorPreset(color: string | undefined): { name: string; value: string } {
+  if (!color) return GROUP_COLOR_PRESETS[0];
+
+  return (
+    GROUP_COLOR_PRESETS.find((preset) => preset.value === color) ?? { name: 'Custom', value: color }
+  );
+}
+
+function hexToRgb(hexColor: string): { r: number; g: number; b: number } {
+  const normalized = hexColor.replace('#', '');
+
+  return {
+    r: parseInt(normalized.slice(0, 2), 16),
+    g: parseInt(normalized.slice(2, 4), 16),
+    b: parseInt(normalized.slice(4, 6), 16)
+  };
+}
+
+function rgba(hexColor: string, alpha: number): string {
+  const { r, g, b } = hexToRgb(hexColor);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
 export function getGroupTitleClasses(): string {
   return [
     'node-title-drag-handle',
@@ -40,9 +77,20 @@ export function getGroupTitleClasses(): string {
 
 export function getGroupVisualFrameClasses(selected: boolean): string[] {
   return [
-    'pointer-events-none h-full w-full rounded border border-dashed bg-zinc-500/6 transition-colors',
-    selected
-      ? 'border-sky-300/80 bg-sky-500/8 shadow-[0_0_0_1px_rgba(125,211,252,0.35)]'
-      : 'border-zinc-500/70'
+    'pointer-events-none h-full w-full rounded border border-dashed transition-colors',
+    selected ? 'shadow-[0_0_0_1px_var(--group-glow-color)]' : ''
   ];
+}
+
+export function getGroupVisualFrameStyle(color: string | undefined, selected: boolean): string {
+  const resolvedColor = getGroupColorPreset(color).value;
+  const borderAlpha = selected ? 0.85 : 0.55;
+  const backgroundAlpha = selected ? 0.12 : 0.08;
+  const glowAlpha = selected ? 0.35 : 0;
+
+  return [
+    `border-color: ${rgba(resolvedColor, borderAlpha)};`,
+    `background-color: ${rgba(resolvedColor, backgroundAlpha)};`,
+    `--group-glow-color: ${rgba(resolvedColor, glowAlpha)};`
+  ].join(' ');
 }

--- a/ui/src/lib/canvas/group-hit-zones.ts
+++ b/ui/src/lib/canvas/group-hit-zones.ts
@@ -44,6 +44,10 @@ export function getGroupColorPreset(color: string | undefined): { name: string; 
   );
 }
 
+export function getGroupTitle(title: string | undefined): string {
+  return title?.trim() || 'group';
+}
+
 function hexToRgb(hexColor: string): { r: number; g: number; b: number } {
   const normalized = hexColor.replace('#', '');
 

--- a/ui/src/lib/canvas/group-hit-zones.ts
+++ b/ui/src/lib/canvas/group-hit-zones.ts
@@ -9,7 +9,8 @@ export const GROUP_COLOR_PRESETS = [
   { name: 'Emerald', value: '#10b981' },
   { name: 'Cyan', value: '#06b6d4' },
   { name: 'Lime', value: '#84cc16' },
-  { name: 'Slate', value: '#94a3b8' }
+  { name: 'Slate', value: '#94a3b8' },
+  { name: 'Indigo', value: '#6366f1' }
 ] as const;
 
 export const GROUP_BORDER_HIT_ZONES = [
@@ -73,6 +74,32 @@ export function getGroupTitleClasses(): string {
     'px-2',
     'py-1'
   ].join(' ');
+}
+
+export function getGroupSettingsPanelClasses(): string {
+  return [
+    'nodrag',
+    'pointer-events-auto',
+    'absolute',
+    'top-0',
+    'left-[calc(100%+0.5rem)]',
+    'z-20',
+    'w-44',
+    'rounded-md',
+    'border',
+    'border-zinc-700',
+    'bg-zinc-900',
+    'p-3',
+    'shadow-xl'
+  ].join(' ');
+}
+
+export function getGroupColorGridClasses(): string {
+  return 'grid grid-cols-5 gap-2';
+}
+
+export function getGroupFrameStyle(width: number, height: number): string {
+  return `width: ${width}px; height: ${height}px;`;
 }
 
 export function getGroupVisualFrameClasses(selected: boolean): string[] {

--- a/ui/src/lib/canvas/group-hit-zones.ts
+++ b/ui/src/lib/canvas/group-hit-zones.ts
@@ -1,0 +1,48 @@
+export const GROUP_BORDER_HIT_ZONES = [
+  {
+    id: 'top',
+    ariaLabel: 'Select group top border',
+    className: 'pointer-events-auto absolute top-0 right-0 left-0 h-3 cursor-move'
+  },
+  {
+    id: 'right',
+    ariaLabel: 'Select group right border',
+    className: 'pointer-events-auto absolute top-3 right-0 bottom-3 w-3 cursor-move'
+  },
+  {
+    id: 'bottom',
+    ariaLabel: 'Select group bottom border',
+    className: 'pointer-events-auto absolute right-0 bottom-0 left-0 h-3 cursor-move'
+  },
+  {
+    id: 'left',
+    ariaLabel: 'Select group left border',
+    className: 'pointer-events-auto absolute top-3 bottom-3 left-0 w-3 cursor-move'
+  }
+] as const;
+
+export function getGroupTitleClasses(): string {
+  return [
+    'node-title-drag-handle',
+    'pointer-events-auto',
+    'absolute',
+    '-top-7',
+    'left-0',
+    'z-10',
+    'w-fit',
+    'cursor-move',
+    'rounded-lg',
+    'bg-zinc-900',
+    'px-2',
+    'py-1'
+  ].join(' ');
+}
+
+export function getGroupVisualFrameClasses(selected: boolean): string[] {
+  return [
+    'pointer-events-none h-full w-full rounded border border-dashed bg-zinc-500/6 transition-colors',
+    selected
+      ? 'border-sky-300/80 bg-sky-500/8 shadow-[0_0_0_1px_rgba(125,211,252,0.35)]'
+      : 'border-zinc-500/70'
+  ];
+}

--- a/ui/src/lib/canvas/grouping.test.ts
+++ b/ui/src/lib/canvas/grouping.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'vitest';
+import type { Node } from '@xyflow/svelte';
+
+import { syncVisualGroupMembership } from './grouping';
+
+function node(
+  id: string,
+  type: string,
+  position: { x: number; y: number },
+  options: Partial<Node> = {}
+): Node {
+  return {
+    id,
+    type,
+    position,
+    data: {},
+    ...options
+  };
+}
+
+function group(id: string, position: { x: number; y: number }, options: Partial<Node> = {}): Node {
+  return node(id, 'group', position, { width: 200, height: 160, ...options });
+}
+
+describe('syncVisualGroupMembership', () => {
+  test('adds a moved top-level object when its center is inside a group', () => {
+    const nodes = [
+      node('a', 'js', { x: 120, y: 110 }, { width: 40, height: 30 }),
+      group('group-1', { x: 100, y: 100 })
+    ];
+
+    const result = syncVisualGroupMembership(nodes, { activeNodeIds: ['a'] });
+
+    expect(result.changed).toBe(true);
+    expect(result.nodes.map((n) => n.id)).toEqual(['group-1', 'a']);
+    expect(result.nodes.find((n) => n.id === 'a')).toMatchObject({
+      parentId: 'group-1',
+      position: { x: 20, y: 10 }
+    });
+  });
+
+  test('removes a moved child object when its center is outside its parent group', () => {
+    const nodes = [
+      group('group-1', { x: 100, y: 100 }),
+      node('a', 'js', { x: 230, y: 170 }, { parentId: 'group-1', width: 40, height: 30 })
+    ];
+
+    const result = syncVisualGroupMembership(nodes, { activeNodeIds: ['a'] });
+
+    expect(result.changed).toBe(true);
+    expect(result.nodes.find((n) => n.id === 'a')).toMatchObject({
+      position: { x: 330, y: 270 }
+    });
+    expect(result.nodes.find((n) => n.id === 'a')?.parentId).toBeUndefined();
+  });
+
+  test('keeps a moved child object grouped while its center remains inside its parent group', () => {
+    const nodes = [
+      group('group-1', { x: 100, y: 100 }),
+      node('a', 'js', { x: 120, y: 40 }, { parentId: 'group-1', width: 40, height: 30 })
+    ];
+
+    const result = syncVisualGroupMembership(nodes, { activeNodeIds: ['a'] });
+
+    expect(result.changed).toBe(false);
+    expect(result.nodes.find((n) => n.id === 'a')).toMatchObject({
+      parentId: 'group-1',
+      position: { x: 120, y: 40 }
+    });
+  });
+
+  test('resizing a group adds top-level objects inside and removes children outside', () => {
+    const nodes = [
+      node('before', 'js', { x: 0, y: 0 }, { width: 40, height: 40 }),
+      node('incoming', 'js', { x: 120, y: 120 }, { width: 40, height: 40 }),
+      group('group-1', { x: 100, y: 100 }, { width: 140, height: 120 }),
+      node('leaving', 'js', { x: 180, y: 130 }, { parentId: 'group-1', width: 40, height: 30 }),
+      node('after', 'js', { x: 400, y: 400 }, { width: 40, height: 40 })
+    ];
+
+    const result = syncVisualGroupMembership(nodes, { activeGroupIds: ['group-1'] });
+
+    expect(result.changed).toBe(true);
+    expect(result.nodes.map((n) => n.id)).toEqual([
+      'before',
+      'group-1',
+      'incoming',
+      'leaving',
+      'after'
+    ]);
+    expect(result.nodes.find((n) => n.id === 'incoming')).toMatchObject({
+      parentId: 'group-1',
+      position: { x: 20, y: 20 }
+    });
+    expect(result.nodes.find((n) => n.id === 'leaving')).toMatchObject({
+      position: { x: 280, y: 230 }
+    });
+    expect(result.nodes.find((n) => n.id === 'leaving')?.parentId).toBeUndefined();
+  });
+
+  test('does not sweep top-level objects into a group when only the group was moved', () => {
+    const nodes = [
+      group('group-1', { x: 100, y: 100 }),
+      node('a', 'js', { x: 120, y: 120 }, { width: 40, height: 40 })
+    ];
+
+    const result = syncVisualGroupMembership(nodes, { activeNodeIds: ['group-1'] });
+
+    expect(result.changed).toBe(false);
+    expect(result.nodes.find((n) => n.id === 'a')?.parentId).toBeUndefined();
+  });
+});

--- a/ui/src/lib/canvas/grouping.test.ts
+++ b/ui/src/lib/canvas/grouping.test.ts
@@ -98,6 +98,25 @@ describe('syncVisualGroupMembership', () => {
     expect(result.nodes.find((n) => n.id === 'leaving')?.parentId).toBeUndefined();
   });
 
+  test('resizing a group uses explicit node dimensions over stale measured dimensions', () => {
+    const nodes = [
+      node('incoming', 'js', { x: 280, y: 120 }, { width: 40, height: 40 }),
+      group(
+        'group-1',
+        { x: 100, y: 100 },
+        { width: 240, height: 120, measured: { width: 80, height: 80 } }
+      )
+    ];
+
+    const result = syncVisualGroupMembership(nodes, { activeGroupIds: ['group-1'] });
+
+    expect(result.changed).toBe(true);
+    expect(result.nodes.find((n) => n.id === 'incoming')).toMatchObject({
+      parentId: 'group-1',
+      position: { x: 180, y: 20 }
+    });
+  });
+
   test('does not sweep top-level objects into a group when only the group was moved', () => {
     const nodes = [
       group('group-1', { x: 100, y: 100 }),

--- a/ui/src/lib/canvas/grouping.test.ts
+++ b/ui/src/lib/canvas/grouping.test.ts
@@ -121,6 +121,27 @@ describe('syncVisualGroupMembership', () => {
     });
   });
 
+  test('orders nested descendants after each ancestor when membership changes', () => {
+    const nodes = [
+      group('group-1', { x: 100, y: 100 }),
+      node('intermediate', 'js', { x: 10, y: 10 }, { parentId: 'group-1', width: 80, height: 80 }),
+      node('grandchild', 'js', { x: 4, y: 4 }, { parentId: 'child', width: 20, height: 20 }),
+      node('child', 'js', { x: 8, y: 8 }, { parentId: 'intermediate', width: 40, height: 40 }),
+      node('incoming', 'js', { x: 120, y: 120 }, { width: 40, height: 40 })
+    ];
+
+    const result = syncVisualGroupMembership(nodes, { activeGroupIds: ['group-1'] });
+
+    expect(result.changed).toBe(true);
+    expect(result.nodes.map((n) => n.id)).toEqual([
+      'group-1',
+      'intermediate',
+      'child',
+      'grandchild',
+      'incoming'
+    ]);
+  });
+
   test('does not sweep top-level objects into a group when only the group was moved', () => {
     const nodes = [
       group('group-1', { x: 100, y: 100 }),

--- a/ui/src/lib/canvas/grouping.test.ts
+++ b/ui/src/lib/canvas/grouping.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from 'vitest';
 import type { Node } from '@xyflow/svelte';
 
-import { syncVisualGroupMembership } from './grouping';
+import {
+  clearVisualGroupSelections,
+  getVisualGroupIdsContainingPoint,
+  syncVisualGroupMembership
+} from './grouping';
 
 function node(
   id: string,
@@ -127,5 +131,46 @@ describe('syncVisualGroupMembership', () => {
 
     expect(result.changed).toBe(false);
     expect(result.nodes.find((n) => n.id === 'a')?.parentId).toBeUndefined();
+  });
+});
+
+describe('getVisualGroupIdsContainingPoint', () => {
+  test('finds a group whose frame contains a selection start point', () => {
+    const nodes = [
+      group('group-1', { x: 100, y: 100 }, { width: 200, height: 160 }),
+      group('group-2', { x: 400, y: 100 }, { width: 200, height: 160 })
+    ];
+
+    expect(getVisualGroupIdsContainingPoint(nodes, { x: 150, y: 140 })).toEqual(['group-1']);
+  });
+
+  test('does not match points outside group frames', () => {
+    expect(
+      getVisualGroupIdsContainingPoint([group('group-1', { x: 100, y: 100 })], { x: 20, y: 20 })
+    ).toEqual([]);
+  });
+});
+
+describe('clearVisualGroupSelections', () => {
+  test('clears selection on groups that contained the selection start point', () => {
+    const nodes = [
+      group('group-1', { x: 100, y: 100 }, { selected: true }),
+      node('child', 'js', { x: 20, y: 20 }, { parentId: 'group-1', selected: true })
+    ];
+
+    const result = clearVisualGroupSelections(nodes, ['group-1']);
+
+    expect(result.changed).toBe(true);
+    expect(result.nodes.find((item) => item.id === 'group-1')?.selected).toBe(false);
+    expect(result.nodes.find((item) => item.id === 'child')?.selected).toBe(true);
+  });
+
+  test('leaves groups selected when they did not contain the selection start point', () => {
+    const nodes = [group('group-1', { x: 100, y: 100 }, { selected: true })];
+
+    expect(clearVisualGroupSelections(nodes, ['group-2'])).toEqual({
+      nodes,
+      changed: false
+    });
   });
 });

--- a/ui/src/lib/canvas/grouping.ts
+++ b/ui/src/lib/canvas/grouping.ts
@@ -1,0 +1,210 @@
+import type { Node } from '@xyflow/svelte';
+
+const DEFAULT_NODE_WIDTH = 300;
+const DEFAULT_NODE_HEIGHT = 200;
+
+export interface VisualGroupSyncOptions {
+  activeNodeIds?: string[];
+  activeGroupIds?: string[];
+}
+
+export interface VisualGroupSyncResult {
+  nodes: Node[];
+  changed: boolean;
+  changedNodeIds: string[];
+}
+
+interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function getNodeWidth(node: Node): number {
+  return node.measured?.width ?? node.width ?? DEFAULT_NODE_WIDTH;
+}
+
+function getNodeHeight(node: Node): number {
+  return node.measured?.height ?? node.height ?? DEFAULT_NODE_HEIGHT;
+}
+
+function isGroupNode(node: Node): boolean {
+  return node.type === 'group';
+}
+
+function getAbsolutePosition(node: Node, nodeById: Map<string, Node>): { x: number; y: number } {
+  if (!node.parentId) return node.position;
+
+  const parent = nodeById.get(node.parentId);
+  if (!parent) return node.position;
+
+  const parentPosition = getAbsolutePosition(parent, nodeById);
+  return {
+    x: parentPosition.x + node.position.x,
+    y: parentPosition.y + node.position.y
+  };
+}
+
+function getAbsoluteRect(node: Node, nodeById: Map<string, Node>): Rect {
+  const position = getAbsolutePosition(node, nodeById);
+  return {
+    x: position.x,
+    y: position.y,
+    width: getNodeWidth(node),
+    height: getNodeHeight(node)
+  };
+}
+
+function getCenter(rect: Rect): { x: number; y: number } {
+  return {
+    x: rect.x + rect.width / 2,
+    y: rect.y + rect.height / 2
+  };
+}
+
+function containsPoint(rect: Rect, point: { x: number; y: number }): boolean {
+  return (
+    point.x >= rect.x &&
+    point.x <= rect.x + rect.width &&
+    point.y >= rect.y &&
+    point.y <= rect.y + rect.height
+  );
+}
+
+function samePosition(a: { x: number; y: number }, b: { x: number; y: number }): boolean {
+  return a.x === b.x && a.y === b.y;
+}
+
+function orderParentsBeforeChildren(nodes: Node[]): Node[] {
+  const childrenByParent = new Map<string, Node[]>();
+  const nodeIds = new Set(nodes.map((node) => node.id));
+
+  for (const node of nodes) {
+    if (!node.parentId || !nodeIds.has(node.parentId)) continue;
+
+    const children = childrenByParent.get(node.parentId) ?? [];
+    children.push(node);
+    childrenByParent.set(node.parentId, children);
+  }
+
+  const emitted = new Set<string>();
+  const ordered: Node[] = [];
+
+  for (const node of nodes) {
+    if (emitted.has(node.id)) continue;
+    if (node.parentId && nodeIds.has(node.parentId)) continue;
+
+    ordered.push(node);
+    emitted.add(node.id);
+
+    for (const child of childrenByParent.get(node.id) ?? []) {
+      ordered.push(child);
+      emitted.add(child.id);
+    }
+  }
+
+  for (const node of nodes) {
+    if (!emitted.has(node.id)) ordered.push(node);
+  }
+
+  return ordered;
+}
+
+function pickContainingGroup(
+  node: Node,
+  groupRects: Map<string, Rect>,
+  center: { x: number; y: number },
+  eligibleGroupIds: Set<string>
+): string | undefined {
+  if (node.parentId && eligibleGroupIds.has(node.parentId)) {
+    const currentRect = groupRects.get(node.parentId);
+    if (currentRect && containsPoint(currentRect, center)) return node.parentId;
+  }
+
+  return [...eligibleGroupIds]
+    .map((id) => ({ id, rect: groupRects.get(id) }))
+    .filter((entry): entry is { id: string; rect: Rect } => !!entry.rect)
+    .filter((entry) => containsPoint(entry.rect, center))
+    .sort((a, b) => a.rect.width * a.rect.height - b.rect.width * b.rect.height)[0]?.id;
+}
+
+export function syncVisualGroupMembership(
+  nodes: Node[],
+  options: VisualGroupSyncOptions
+): VisualGroupSyncResult {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const groups = nodes.filter(isGroupNode);
+  const groupIds = new Set(groups.map((node) => node.id));
+  const activeNodeIds = new Set(options.activeNodeIds ?? []);
+  const activeGroupIds = new Set((options.activeGroupIds ?? []).filter((id) => groupIds.has(id)));
+  const groupRects = new Map(groups.map((node) => [node.id, getAbsoluteRect(node, nodeById)]));
+  const changedNodeIds: string[] = [];
+
+  const candidateNodeIds = new Set<string>();
+
+  for (const id of activeNodeIds) {
+    const node = nodeById.get(id);
+    if (node && !isGroupNode(node)) candidateNodeIds.add(id);
+  }
+
+  for (const groupId of activeGroupIds) {
+    for (const node of nodes) {
+      if (isGroupNode(node)) continue;
+      if (!node.parentId || node.parentId === groupId) candidateNodeIds.add(node.id);
+    }
+  }
+
+  const nextNodes = nodes.map((node) => {
+    if (!candidateNodeIds.has(node.id)) return node;
+
+    const absoluteRect = getAbsoluteRect(node, nodeById);
+    const center = getCenter(absoluteRect);
+    const eligibleGroupIds = activeGroupIds.size > 0 ? activeGroupIds : groupIds;
+    const nextParentId = pickContainingGroup(node, groupRects, center, eligibleGroupIds);
+
+    if (nextParentId) {
+      const parentRect = groupRects.get(nextParentId);
+      if (!parentRect) return node;
+
+      const nextPosition = {
+        x: absoluteRect.x - parentRect.x,
+        y: absoluteRect.y - parentRect.y
+      };
+
+      if (node.parentId === nextParentId && samePosition(node.position, nextPosition)) {
+        return node;
+      }
+
+      changedNodeIds.push(node.id);
+      return {
+        ...node,
+        parentId: nextParentId,
+        position: nextPosition
+      };
+    }
+
+    if (!node.parentId && samePosition(node.position, absoluteRect)) {
+      return node;
+    }
+
+    const { parentId, extent, ...rest } = node;
+    void parentId;
+    void extent;
+    changedNodeIds.push(node.id);
+
+    return {
+      ...rest,
+      position: {
+        x: absoluteRect.x,
+        y: absoluteRect.y
+      }
+    };
+  });
+
+  return {
+    nodes: changedNodeIds.length > 0 ? orderParentsBeforeChildren(nextNodes) : nodes,
+    changed: changedNodeIds.length > 0,
+    changedNodeIds
+  };
+}

--- a/ui/src/lib/canvas/grouping.ts
+++ b/ui/src/lib/canvas/grouping.ts
@@ -21,17 +21,13 @@ interface Rect {
   height: number;
 }
 
-function getNodeWidth(node: Node): number {
-  return node.width ?? node.measured?.width ?? DEFAULT_NODE_WIDTH;
-}
+const getNodeWidth = (node: Node): number =>
+  node.width ?? node.measured?.width ?? DEFAULT_NODE_WIDTH;
 
-function getNodeHeight(node: Node): number {
-  return node.height ?? node.measured?.height ?? DEFAULT_NODE_HEIGHT;
-}
+const getNodeHeight = (node: Node): number =>
+  node.height ?? node.measured?.height ?? DEFAULT_NODE_HEIGHT;
 
-function isGroupNode(node: Node): boolean {
-  return node.type === 'group';
-}
+const isGroupNode = (node: Node): boolean => node.type === 'group';
 
 function getAbsolutePosition(node: Node, nodeById: Map<string, Node>): { x: number; y: number } {
   if (!node.parentId) return node.position;
@@ -40,6 +36,7 @@ function getAbsolutePosition(node: Node, nodeById: Map<string, Node>): { x: numb
   if (!parent) return node.position;
 
   const parentPosition = getAbsolutePosition(parent, nodeById);
+
   return {
     x: parentPosition.x + node.position.x,
     y: parentPosition.y + node.position.y
@@ -48,6 +45,7 @@ function getAbsolutePosition(node: Node, nodeById: Map<string, Node>): { x: numb
 
 function getAbsoluteRect(node: Node, nodeById: Map<string, Node>): Rect {
   const position = getAbsolutePosition(node, nodeById);
+
   return {
     x: position.x,
     y: position.y,
@@ -56,25 +54,19 @@ function getAbsoluteRect(node: Node, nodeById: Map<string, Node>): Rect {
   };
 }
 
-function getCenter(rect: Rect): { x: number; y: number } {
-  return {
-    x: rect.x + rect.width / 2,
-    y: rect.y + rect.height / 2
-  };
-}
+const getCenter = (rect: Rect): { x: number; y: number } => ({
+  x: rect.x + rect.width / 2,
+  y: rect.y + rect.height / 2
+});
 
-function containsPoint(rect: Rect, point: { x: number; y: number }): boolean {
-  return (
-    point.x >= rect.x &&
-    point.x <= rect.x + rect.width &&
-    point.y >= rect.y &&
-    point.y <= rect.y + rect.height
-  );
-}
+const containsPoint = (rect: Rect, point: { x: number; y: number }): boolean =>
+  point.x >= rect.x &&
+  point.x <= rect.x + rect.width &&
+  point.y >= rect.y &&
+  point.y <= rect.y + rect.height;
 
-function samePosition(a: { x: number; y: number }, b: { x: number; y: number }): boolean {
-  return a.x === b.x && a.y === b.y;
-}
+const samePosition = (a: { x: number; y: number }, b: { x: number; y: number }): boolean =>
+  a.x === b.x && a.y === b.y;
 
 function orderParentsBeforeChildren(nodes: Node[]): Node[] {
   const childrenByParent = new Map<string, Node[]>();
@@ -105,7 +97,9 @@ function orderParentsBeforeChildren(nodes: Node[]): Node[] {
   }
 
   for (const node of nodes) {
-    if (!emitted.has(node.id)) ordered.push(node);
+    if (!emitted.has(node.id)) {
+      ordered.push(node);
+    }
   }
 
   return ordered;
@@ -129,6 +123,42 @@ function pickContainingGroup(
     .sort((a, b) => a.rect.width * a.rect.height - b.rect.width * b.rect.height)[0]?.id;
 }
 
+export function getVisualGroupIdsContainingPoint(
+  nodes: Node[],
+  point: { x: number; y: number }
+): string[] {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+
+  return nodes
+    .filter(isGroupNode)
+    .filter((node) => containsPoint(getAbsoluteRect(node, nodeById), point))
+    .map((node) => node.id);
+}
+
+export function clearVisualGroupSelections(
+  nodes: Node[],
+  groupIds: string[]
+): { nodes: Node[]; changed: boolean } {
+  if (groupIds.length === 0) {
+    return { nodes, changed: false };
+  }
+
+  const groupIdSet = new Set(groupIds);
+  let changed = false;
+
+  const nextNodes = nodes.map((node) => {
+    if (!node.selected || !groupIdSet.has(node.id) || !isGroupNode(node)) {
+      return node;
+    }
+
+    changed = true;
+
+    return { ...node, selected: false };
+  });
+
+  return { nodes: changed ? nextNodes : nodes, changed };
+}
+
 export function syncVisualGroupMembership(
   nodes: Node[],
   options: VisualGroupSyncOptions
@@ -145,13 +175,19 @@ export function syncVisualGroupMembership(
 
   for (const id of activeNodeIds) {
     const node = nodeById.get(id);
-    if (node && !isGroupNode(node)) candidateNodeIds.add(id);
+
+    if (node && !isGroupNode(node)) {
+      candidateNodeIds.add(id);
+    }
   }
 
   for (const groupId of activeGroupIds) {
     for (const node of nodes) {
       if (isGroupNode(node)) continue;
-      if (!node.parentId || node.parentId === groupId) candidateNodeIds.add(node.id);
+
+      if (!node.parentId || node.parentId === groupId) {
+        candidateNodeIds.add(node.id);
+      }
     }
   }
 
@@ -177,6 +213,7 @@ export function syncVisualGroupMembership(
       }
 
       changedNodeIds.push(node.id);
+
       return {
         ...node,
         parentId: nextParentId,
@@ -191,15 +228,10 @@ export function syncVisualGroupMembership(
     const { parentId, extent, ...rest } = node;
     void parentId;
     void extent;
+
     changedNodeIds.push(node.id);
 
-    return {
-      ...rest,
-      position: {
-        x: absoluteRect.x,
-        y: absoluteRect.y
-      }
-    };
+    return { ...rest, position: { x: absoluteRect.x, y: absoluteRect.y } };
   });
 
   return {

--- a/ui/src/lib/canvas/grouping.ts
+++ b/ui/src/lib/canvas/grouping.ts
@@ -83,22 +83,27 @@ function orderParentsBeforeChildren(nodes: Node[]): Node[] {
   const emitted = new Set<string>();
   const ordered: Node[] = [];
 
-  for (const node of nodes) {
-    if (emitted.has(node.id)) continue;
-    if (node.parentId && nodeIds.has(node.parentId)) continue;
+  const emitNodeAndDescendants = (node: Node) => {
+    if (emitted.has(node.id)) return;
 
     ordered.push(node);
     emitted.add(node.id);
 
     for (const child of childrenByParent.get(node.id) ?? []) {
-      ordered.push(child);
-      emitted.add(child.id);
+      emitNodeAndDescendants(child);
     }
+  };
+
+  for (const node of nodes) {
+    if (emitted.has(node.id)) continue;
+    if (node.parentId && nodeIds.has(node.parentId)) continue;
+
+    emitNodeAndDescendants(node);
   }
 
   for (const node of nodes) {
     if (!emitted.has(node.id)) {
-      ordered.push(node);
+      emitNodeAndDescendants(node);
     }
   }
 

--- a/ui/src/lib/canvas/grouping.ts
+++ b/ui/src/lib/canvas/grouping.ts
@@ -22,11 +22,11 @@ interface Rect {
 }
 
 function getNodeWidth(node: Node): number {
-  return node.measured?.width ?? node.width ?? DEFAULT_NODE_WIDTH;
+  return node.width ?? node.measured?.width ?? DEFAULT_NODE_WIDTH;
 }
 
 function getNodeHeight(node: Node): number {
-  return node.measured?.height ?? node.height ?? DEFAULT_NODE_HEIGHT;
+  return node.height ?? node.measured?.height ?? DEFAULT_NODE_HEIGHT;
 }
 
 function isGroupNode(node: Node): boolean {

--- a/ui/src/lib/components/CommandPalette.svelte
+++ b/ui/src/lib/components/CommandPalette.svelte
@@ -353,7 +353,7 @@
     if (saved) {
       try {
         savedPatches = JSON.parse(saved);
-      } catch (e) {
+      } catch {
         savedPatches = [];
       }
     }
@@ -676,42 +676,6 @@
     };
 
     input.click();
-  }
-
-  function loadFromLocalStorage(patchName: string) {
-    const patchData = localStorage.getItem(`patchies-patch-${patchName}`);
-    if (patchData) {
-      try {
-        const data = JSON.parse(patchData);
-        loadPatchData(data);
-        onCancel();
-      } catch (error) {
-        console.error('Error loading patch from storage:', error);
-      }
-    }
-  }
-
-  function loadPatchData(patchSave: PatchSaveFormat) {
-    try {
-      if (!patchSave || !patchSave.nodes || !patchSave.edges) {
-        throw new Error('Invalid patch data format');
-      }
-
-      // Apply migrations to upgrade old patch formats
-      const migrated = migratePatch(patchSave) as PatchSaveFormat;
-
-      setNodes(migrated.nodes);
-      setEdges(migrated.edges);
-
-      console.log(`[load] found ${migrated.nodes.length} nodes and ${migrated.edges.length} edges`);
-
-      AudioService.getInstance().getAudioContext().resume();
-
-      patchName = migrated.name || 'Untitled';
-    } catch (error) {
-      console.error('Error deserializing patch data:', error);
-      throw error;
-    }
   }
 
   function deleteFromLocalStorage(patchName: string) {

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -376,10 +376,7 @@
   let groupResizeStartNodes: Node[] | null = null;
 
   function cloneNodesForHistory(source: Node[]): Node[] {
-    return source.map((node) => ({
-      ...node,
-      position: { ...node.position }
-    }));
+    return structuredClone(source);
   }
 
   function haveNodesChangedForHistory(before: Node[], after: Node[]): boolean {

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -88,7 +88,9 @@
     CodeCommitEvent,
     NodeDataCommitEvent,
     NodeDataBatchCommitEvent,
-    ObjectDataCommitEvent
+    ObjectDataCommitEvent,
+    VisualGroupResizeStartedEvent,
+    VisualGroupSyncRequestedEvent
   } from '$lib/eventbus/events';
   import { WorkerNodeSystem } from '$lib/js-runner/WorkerNodeSystem';
   import { MediaPipeNodeSystem } from '$objects/mediapipe/MediaPipeNodeSystem';
@@ -96,6 +98,7 @@
   import { WorkletDirectChannelService } from '$lib/audio/WorkletDirectChannelService';
   import { buildAudioSourceConnections } from '$lib/composables/checkHandleConnections';
   import { getSurfaceMouseForwardingKey } from '$lib/canvas/surfaceMouseForwarding';
+  import { syncVisualGroupMembership } from '$lib/canvas/grouping';
   import { useDetachedCodeEditorOverlay } from '$lib/canvas/use-detached-code-editor-overlay.svelte';
   import { useSecondaryOutputCodeOverlay } from '$lib/canvas/use-secondary-output-code-overlay.svelte';
 
@@ -117,7 +120,7 @@
     HistoryManager,
     AddNodeCommand,
     DeleteNodesCommand,
-    MoveNodesCommand,
+    ReplaceNodesCommand,
     UpdateNodeDataCommand,
     UpdateObjectDataCommand,
     AddEdgeCommand,
@@ -364,7 +367,35 @@
   let selectedEdgeIds = $state.raw<string[]>([]);
 
   // Track node positions at drag start for undo/redo
-  let dragStartPositions: Map<string, { x: number; y: number }> | null = null;
+  let dragStartNodes: Node[] | null = null;
+  let groupResizeStartNodes: Node[] | null = null;
+
+  function cloneNodesForHistory(source: Node[]): Node[] {
+    return source.map((node) => ({
+      ...node,
+      position: { ...node.position }
+    }));
+  }
+
+  function haveNodesChangedForHistory(before: Node[], after: Node[]): boolean {
+    if (before.length !== after.length) return true;
+
+    return before.some((node, index) => {
+      const next = after[index];
+      if (!next) return true;
+
+      return (
+        node.id !== next.id ||
+        node.parentId !== next.parentId ||
+        node.position.x !== next.position.x ||
+        node.position.y !== next.position.y ||
+        node.width !== next.width ||
+        node.height !== next.height ||
+        node.measured?.width !== next.measured?.width ||
+        node.measured?.height !== next.measured?.height
+      );
+    });
+  }
 
   let isLoadingFromUrl = $state(false);
   let urlLoadError = $state<string | null>(null);
@@ -564,6 +595,38 @@
       return false;
     }
     return true;
+  }
+
+  function handleVisualGroupResizeStarted(event: VisualGroupResizeStartedEvent) {
+    if (!nodes.some((node) => node.id === event.groupId && node.type === 'group')) return;
+    groupResizeStartNodes = cloneNodesForHistory(nodes);
+  }
+
+  async function handleVisualGroupSyncRequested(event: VisualGroupSyncRequestedEvent) {
+    await tick();
+
+    const beforeSyncNodes = cloneNodesForHistory(nodes);
+    const oldNodes = groupResizeStartNodes ?? beforeSyncNodes;
+    groupResizeStartNodes = null;
+
+    const result = syncVisualGroupMembership(nodes, { activeGroupIds: [event.groupId] });
+    const nextNodes = result.changed ? result.nodes : nodes;
+
+    if (result.changed) {
+      nodes = nextNodes;
+    }
+
+    const nextSnapshot = cloneNodesForHistory(nextNodes);
+    if (!haveNodesChangedForHistory(oldNodes, nextSnapshot)) return;
+
+    historyManager.record(
+      new ReplaceNodesCommand(
+        oldNodes,
+        nextSnapshot,
+        canvasAccessors,
+        result.changed ? 'Resize and group objects' : 'Resize group'
+      )
+    );
   }
 
   function onGeminiApiKeySaved() {
@@ -854,6 +917,8 @@
     eventBus.addEventListener('codeCommit', handleCodeCommit);
     eventBus.addEventListener('nodeDataCommit', handleNodeDataCommit);
     eventBus.addEventListener('nodeDataBatchCommit', handleNodeDataBatchCommit);
+    eventBus.addEventListener('visualGroupResizeStarted', handleVisualGroupResizeStarted);
+    eventBus.addEventListener('visualGroupSyncRequested', handleVisualGroupSyncRequested);
 
     autosaveInterval = setInterval(performAutosave, AUTOSAVE_INTERVAL);
 
@@ -886,6 +951,8 @@
     eventBus.removeEventListener('codeCommit', handleCodeCommit);
     eventBus.removeEventListener('nodeDataCommit', handleNodeDataCommit);
     eventBus.removeEventListener('nodeDataBatchCommit', handleNodeDataBatchCommit);
+    eventBus.removeEventListener('visualGroupResizeStarted', handleVisualGroupResizeStarted);
+    eventBus.removeEventListener('visualGroupSyncRequested', handleVisualGroupSyncRequested);
 
     // Clean up autosave interval
     if (autosaveInterval) {
@@ -1456,27 +1523,33 @@
         proOptions={{ hideAttribution: true }}
         clickConnect={$isConnectionMode}
         {isValidConnection}
-        onnodedragstart={(event) => {
-          // Capture starting positions of all dragged nodes
-          dragStartPositions = new Map(event.nodes.map((n) => [n.id, { ...n.position }]));
+        onnodedragstart={() => {
+          dragStartNodes = cloneNodesForHistory(nodes);
         }}
         onnodedragstop={(event) => {
-          if (!dragStartPositions) return;
+          if (!dragStartNodes) return;
 
-          // Only record if positions actually changed
-          const hasChanged = event.nodes.some((n) => {
-            const start = dragStartPositions?.get(n.id);
-            return start && (start.x !== n.position.x || start.y !== n.position.y);
-          });
+          const draggedNodeIds = event.nodes.map((node) => node.id);
+          const result = syncVisualGroupMembership(nodes, { activeNodeIds: draggedNodeIds });
+          const nextNodes = result.changed ? result.nodes : nodes;
 
-          if (hasChanged) {
-            const newPositions = new Map(event.nodes.map((n) => [n.id, { ...n.position }]));
+          if (result.changed) {
+            nodes = nextNodes;
+          }
+
+          const nextSnapshot = cloneNodesForHistory(nextNodes);
+          if (haveNodesChangedForHistory(dragStartNodes, nextSnapshot)) {
             historyManager.record(
-              new MoveNodesCommand(dragStartPositions, newPositions, canvasAccessors)
+              new ReplaceNodesCommand(
+                dragStartNodes,
+                nextSnapshot,
+                canvasAccessors,
+                result.changed ? 'Move and group objects' : 'Move nodes'
+              )
             );
           }
 
-          dragStartPositions = null;
+          dragStartNodes = null;
         }}
         onconnect={(connection) => {
           // XYFlow already added the edge, we just need to record it for undo

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -98,7 +98,11 @@
   import { WorkletDirectChannelService } from '$lib/audio/WorkletDirectChannelService';
   import { buildAudioSourceConnections } from '$lib/composables/checkHandleConnections';
   import { getSurfaceMouseForwardingKey } from '$lib/canvas/surfaceMouseForwarding';
-  import { syncVisualGroupMembership } from '$lib/canvas/grouping';
+  import {
+    clearVisualGroupSelections,
+    getVisualGroupIdsContainingPoint,
+    syncVisualGroupMembership
+  } from '$lib/canvas/grouping';
   import { useDetachedCodeEditorOverlay } from '$lib/canvas/use-detached-code-editor-overlay.svelte';
   import { useSecondaryOutputCodeOverlay } from '$lib/canvas/use-secondary-output-code-overlay.svelte';
 
@@ -365,6 +369,7 @@
 
   let selectedNodeIds = $state.raw<string[]>([]);
   let selectedEdgeIds = $state.raw<string[]>([]);
+  let visualGroupSelectionStartIds = $state.raw<string[]>([]);
 
   // Track node positions at drag start for undo/redo
   let dragStartNodes: Node[] | null = null;
@@ -395,6 +400,20 @@
         node.measured?.height !== next.measured?.height
       );
     });
+  }
+
+  function handleSelectionStart(event: PointerEvent) {
+    const point = screenToFlowPosition({ x: event.clientX, y: event.clientY });
+    visualGroupSelectionStartIds = getVisualGroupIdsContainingPoint(nodes, point);
+  }
+
+  function handleSelectionEnd() {
+    const result = clearVisualGroupSelections(nodes, visualGroupSelectionStartIds);
+    visualGroupSelectionStartIds = [];
+
+    if (result.changed) {
+      nodes = result.nodes;
+    }
   }
 
   let isLoadingFromUrl = $state(false);
@@ -1566,6 +1585,8 @@
         }}
         onconnectstart={(event, params) => handleConnectStart(params)}
         onconnectend={handleConnectEnd}
+        onselectionstart={handleSelectionStart}
+        onselectionend={handleSelectionEnd}
         onclickconnectstart={(event, params) => handleConnectStart(params)}
         onclickconnectend={(event, connectionState) => {
           handleConnectEnd();

--- a/ui/src/lib/components/nodes/GroupNode.svelte
+++ b/ui/src/lib/components/nodes/GroupNode.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Settings, X } from '@lucide/svelte/icons';
+  import { Lock, LockOpen, Settings, X } from '@lucide/svelte/icons';
   import { NodeResizer, useSvelteFlow } from '@xyflow/svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import {
@@ -7,7 +7,9 @@
     GROUP_COLOR_PRESETS,
     GROUP_BORDER_HIT_ZONES,
     getGroupColorGridClasses,
+    getGroupCanResize,
     getGroupFrameStyle,
+    getGroupIsLocked,
     getGroupSettingsPanelClasses,
     getGroupTitle,
     getGroupTitleClasses,
@@ -23,13 +25,17 @@
     data: {
       color?: string;
       title?: string;
+      canResize?: boolean;
+      locked?: boolean;
     };
     selected: boolean;
     width?: number;
     height?: number;
+    draggable?: boolean;
+    class?: string;
   } = $props();
 
-  const { updateNodeData } = useSvelteFlow();
+  const { updateNode, updateNodeData } = useSvelteFlow();
   const eventBus = PatchiesEventBus.getInstance();
   const tracker = useNodeDataTracker(node.id);
   const titleTracker = tracker.track('title', () => node.data.title ?? '');
@@ -40,9 +46,18 @@
   const height = $derived(node.height ?? DEFAULT_GROUP_HEIGHT);
   const color = $derived(node.data.color ?? DEFAULT_GROUP_COLOR);
   const title = $derived(getGroupTitle(node.data.title));
+  const canResize = $derived(getGroupCanResize(node.data.canResize));
+  const isLocked = $derived(getGroupIsLocked(node.data.locked));
   const frameStyle = $derived(getGroupFrameStyle(width, height));
   const visualFrameClasses = $derived(getGroupVisualFrameClasses(node.selected));
   const visualFrameStyle = $derived(getGroupVisualFrameStyle(color, node.selected));
+
+  $effect(() => {
+    const nextDraggable = isLocked ? false : true;
+    if (node.draggable !== nextDraggable) {
+      updateNode(node.id, { draggable: nextDraggable });
+    }
+  });
 
   function updateConfig(updates: Partial<typeof node.data>) {
     updateNodeData(node.id, { ...node.data, ...updates });
@@ -69,6 +84,22 @@
     updateConfig({ title: nextTitle });
   }
 
+  function handleCanResizeChange(event: Event) {
+    const oldCanResize = canResize;
+    const nextCanResize = (event.target as HTMLInputElement).checked;
+    updateConfig({ canResize: nextCanResize });
+    tracker.commit('canResize', oldCanResize, nextCanResize);
+  }
+
+  function toggleLocked() {
+    const oldLocked = isLocked;
+    const nextLocked = !oldLocked;
+
+    updateNode(node.id, { draggable: !nextLocked });
+    updateConfig({ locked: nextLocked });
+    tracker.commit('locked', oldLocked, nextLocked);
+  }
+
   function handleResizeEnd() {
     eventBus.dispatch({ type: 'visualGroupSyncRequested', groupId: node.id });
   }
@@ -78,10 +109,10 @@
   }
 </script>
 
-<div class="pointer-events-none relative" style={frameStyle}>
+<div class={['pointer-events-none relative', node.class]} style={frameStyle}>
   <NodeResizer
     class="pointer-events-auto z-1"
-    isVisible={node.selected}
+    isVisible={node.selected && canResize && !isLocked}
     minWidth={160}
     minHeight={120}
     keepAspectRatio={false}
@@ -124,6 +155,27 @@
     <div class={getGroupSettingsPanelClasses()} onclick={(event) => event.stopPropagation()}>
       <div class="mb-3 flex items-center justify-between gap-2">
         <div class="text-xs font-medium text-zinc-300">Group Settings</div>
+
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button
+              class={[
+                'cursor-pointer rounded p-1 hover:bg-zinc-800',
+                isLocked ? 'text-zinc-100' : 'text-zinc-500 hover:text-zinc-200'
+              ]}
+              onclick={toggleLocked}
+              aria-label={isLocked ? 'Unlock group' : 'Lock group'}
+              aria-pressed={isLocked}
+            >
+              {#if isLocked}
+                <Lock class="h-3.5 w-3.5" />
+              {:else}
+                <LockOpen class="h-3.5 w-3.5" />
+              {/if}
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>{isLocked ? 'Unlock Group' : 'Lock Group'}</Tooltip.Content>
+        </Tooltip.Root>
 
         <Tooltip.Root>
           <Tooltip.Trigger>
@@ -176,6 +228,17 @@
           </Tooltip.Root>
         {/each}
       </div>
+
+      <label class="mt-3 flex items-center justify-between gap-3 border-t border-zinc-800 pt-3">
+        <span class="text-xs font-medium text-zinc-300">Can Resize</span>
+        <input
+          type="checkbox"
+          class="h-4 w-4 cursor-pointer accent-zinc-200"
+          checked={canResize}
+          onchange={handleCanResizeChange}
+          aria-label="Can resize group"
+        />
+      </label>
     </div>
   {/if}
 </div>
@@ -196,8 +259,13 @@
 
   :global(.svelte-flow__node-group.selectable:hover),
   :global(.svelte-flow__node-group.selectable.selected),
-  :global(.svelte-flow__node-group.selectable:focus),
+  :global(.svelte-flow__node-group.selectable:focus) {
+    box-shadow: none !important;
+  }
+
   :global(.svelte-flow__node-group.selectable:focus-visible) {
+    outline: 2px solid rgb(96 165 250 / 0.95) !important;
+    outline-offset: 4px !important;
     box-shadow: none !important;
   }
 </style>

--- a/ui/src/lib/components/nodes/GroupNode.svelte
+++ b/ui/src/lib/components/nodes/GroupNode.svelte
@@ -6,10 +6,14 @@
     DEFAULT_GROUP_COLOR,
     GROUP_COLOR_PRESETS,
     GROUP_BORDER_HIT_ZONES,
+    getGroupColorGridClasses,
+    getGroupFrameStyle,
+    getGroupSettingsPanelClasses,
     getGroupTitleClasses,
     getGroupVisualFrameClasses,
     getGroupVisualFrameStyle
   } from '$lib/canvas/group-hit-zones';
+  import { DEFAULT_GROUP_HEIGHT, DEFAULT_GROUP_WIDTH } from '$lib/nodes/defaultNodeDimensions';
   import { useNodeDataTracker } from '$lib/history';
   import * as Tooltip from '$lib/components/ui/tooltip';
 
@@ -29,14 +33,10 @@
 
   let showSettings = $state(false);
 
-  const width = $derived(node.width ?? 360);
-  const height = $derived(node.height ?? 240);
+  const width = $derived(node.width ?? DEFAULT_GROUP_WIDTH);
+  const height = $derived(node.height ?? DEFAULT_GROUP_HEIGHT);
   const color = $derived(node.data.color ?? DEFAULT_GROUP_COLOR);
-  const frameStyle = $derived(
-    node.width !== undefined && node.height !== undefined
-      ? 'width: 100%; height: 100%;'
-      : `width: ${width}px; height: ${height}px;`
-  );
+  const frameStyle = $derived(getGroupFrameStyle(width, height));
   const visualFrameClasses = $derived(getGroupVisualFrameClasses(node.selected));
   const visualFrameStyle = $derived(getGroupVisualFrameStyle(color, node.selected));
 
@@ -112,10 +112,7 @@
   {#if showSettings}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div
-      class="nodrag pointer-events-auto absolute top-0 right-0 z-20 w-44 rounded-md border border-zinc-700 bg-zinc-900 p-3 shadow-xl"
-      onclick={(event) => event.stopPropagation()}
-    >
+    <div class={getGroupSettingsPanelClasses()} onclick={(event) => event.stopPropagation()}>
       <div class="mb-3 flex items-center justify-between gap-2">
         <div class="text-xs font-medium text-zinc-300">Group Color</div>
 
@@ -133,7 +130,7 @@
         </Tooltip.Root>
       </div>
 
-      <div class="flex flex-wrap gap-2">
+      <div class={getGroupColorGridClasses()}>
         {#each GROUP_COLOR_PRESETS as preset (preset.name)}
           <Tooltip.Root>
             <Tooltip.Trigger>
@@ -160,6 +157,10 @@
 <style>
   :global(.svelte-flow__node-group) {
     pointer-events: none !important;
+    width: auto !important;
+    height: auto !important;
+    min-width: 0 !important;
+    min-height: 0 !important;
     padding: 0 !important;
     border: 0 !important;
     background: transparent !important;

--- a/ui/src/lib/components/nodes/GroupNode.svelte
+++ b/ui/src/lib/components/nodes/GroupNode.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { NodeResizer } from '@xyflow/svelte';
+  import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+  import {
+    GROUP_BORDER_HIT_ZONES,
+    getGroupTitleClasses,
+    getGroupVisualFrameClasses
+  } from '$lib/canvas/group-hit-zones';
+
+  let node: {
+    id: string;
+    selected: boolean;
+    width?: number;
+    height?: number;
+  } = $props();
+
+  const eventBus = PatchiesEventBus.getInstance();
+  const width = $derived(node.width ?? 360);
+  const height = $derived(node.height ?? 240);
+  const frameStyle = $derived(
+    node.width !== undefined && node.height !== undefined
+      ? 'width: 100%; height: 100%;'
+      : `width: ${width}px; height: ${height}px;`
+  );
+  const visualFrameClasses = $derived(getGroupVisualFrameClasses(node.selected));
+
+  function handleResizeEnd() {
+    eventBus.dispatch({ type: 'visualGroupSyncRequested', groupId: node.id });
+  }
+
+  function handleResizeStart() {
+    eventBus.dispatch({ type: 'visualGroupResizeStarted', groupId: node.id });
+  }
+</script>
+
+<div class="pointer-events-none relative" style={frameStyle}>
+  <NodeResizer
+    class="pointer-events-auto z-1"
+    isVisible={node.selected}
+    minWidth={160}
+    minHeight={120}
+    keepAspectRatio={false}
+    onResizeStart={handleResizeStart}
+    onResizeEnd={handleResizeEnd}
+  />
+
+  <div class={getGroupTitleClasses()} aria-label="Select group">
+    <div class="font-mono text-xs font-medium text-zinc-400">group</div>
+  </div>
+
+  <div class={visualFrameClasses} aria-hidden="true"></div>
+
+  {#each GROUP_BORDER_HIT_ZONES as zone (zone.id)}
+    <div class={zone.className} aria-label={zone.ariaLabel}></div>
+  {/each}
+</div>
+
+<style>
+  :global(.svelte-flow__node-group) {
+    pointer-events: none !important;
+    padding: 0 !important;
+    border: 0 !important;
+    background: transparent !important;
+    color: inherit !important;
+    text-align: initial !important;
+  }
+
+  :global(.svelte-flow__node-group.selectable:hover),
+  :global(.svelte-flow__node-group.selectable.selected),
+  :global(.svelte-flow__node-group.selectable:focus),
+  :global(.svelte-flow__node-group.selectable:focus-visible) {
+    box-shadow: none !important;
+  }
+</style>

--- a/ui/src/lib/components/nodes/GroupNode.svelte
+++ b/ui/src/lib/components/nodes/GroupNode.svelte
@@ -9,6 +9,7 @@
     getGroupColorGridClasses,
     getGroupFrameStyle,
     getGroupSettingsPanelClasses,
+    getGroupTitle,
     getGroupTitleClasses,
     getGroupVisualFrameClasses,
     getGroupVisualFrameStyle
@@ -21,6 +22,7 @@
     id: string;
     data: {
       color?: string;
+      title?: string;
     };
     selected: boolean;
     width?: number;
@@ -30,12 +32,14 @@
   const { updateNodeData } = useSvelteFlow();
   const eventBus = PatchiesEventBus.getInstance();
   const tracker = useNodeDataTracker(node.id);
+  const titleTracker = tracker.track('title', () => node.data.title ?? '');
 
   let showSettings = $state(false);
 
   const width = $derived(node.width ?? DEFAULT_GROUP_WIDTH);
   const height = $derived(node.height ?? DEFAULT_GROUP_HEIGHT);
   const color = $derived(node.data.color ?? DEFAULT_GROUP_COLOR);
+  const title = $derived(getGroupTitle(node.data.title));
   const frameStyle = $derived(getGroupFrameStyle(width, height));
   const visualFrameClasses = $derived(getGroupVisualFrameClasses(node.selected));
   const visualFrameStyle = $derived(getGroupVisualFrameStyle(color, node.selected));
@@ -60,6 +64,11 @@
     tracker.commit('color', oldColor, nextColor);
   }
 
+  function handleTitleInput(event: Event) {
+    const nextTitle = (event.target as HTMLInputElement).value;
+    updateConfig({ title: nextTitle });
+  }
+
   function handleResizeEnd() {
     eventBus.dispatch({ type: 'visualGroupSyncRequested', groupId: node.id });
   }
@@ -81,7 +90,7 @@
   />
 
   <div class={getGroupTitleClasses()} aria-label="Select group">
-    <div class="font-mono text-xs font-medium text-zinc-400">group</div>
+    <div class="max-w-56 truncate font-mono text-xs font-medium text-zinc-400">{title}</div>
   </div>
 
   <div class="pointer-events-auto absolute -top-7 right-0 z-10 flex gap-x-1">
@@ -114,7 +123,7 @@
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div class={getGroupSettingsPanelClasses()} onclick={(event) => event.stopPropagation()}>
       <div class="mb-3 flex items-center justify-between gap-2">
-        <div class="text-xs font-medium text-zinc-300">Group Color</div>
+        <div class="text-xs font-medium text-zinc-300">Group Settings</div>
 
         <Tooltip.Root>
           <Tooltip.Trigger>
@@ -129,6 +138,23 @@
           <Tooltip.Content>Close</Tooltip.Content>
         </Tooltip.Root>
       </div>
+
+      <label class="mb-3 block">
+        <span class="mb-1 block text-[10px] font-medium tracking-wide text-zinc-500 uppercase">
+          Title
+        </span>
+        <input
+          class="nodrag w-full rounded border border-zinc-700 bg-zinc-950 px-2 py-1 text-xs text-zinc-200 transition-colors outline-none placeholder:text-zinc-600 focus:border-zinc-500"
+          value={node.data.title ?? ''}
+          placeholder="group"
+          oninput={handleTitleInput}
+          onfocus={titleTracker.onFocus}
+          onblur={titleTracker.onBlur}
+          aria-label="Group title"
+        />
+      </label>
+
+      <div class="mb-2 text-[10px] font-medium tracking-wide text-zinc-500 uppercase">Color</div>
 
       <div class={getGroupColorGridClasses()}>
         {#each GROUP_COLOR_PRESETS as preset (preset.name)}

--- a/ui/src/lib/components/nodes/GroupNode.svelte
+++ b/ui/src/lib/components/nodes/GroupNode.svelte
@@ -1,28 +1,64 @@
 <script lang="ts">
-  import { NodeResizer } from '@xyflow/svelte';
+  import { Settings, X } from '@lucide/svelte/icons';
+  import { NodeResizer, useSvelteFlow } from '@xyflow/svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import {
+    DEFAULT_GROUP_COLOR,
+    GROUP_COLOR_PRESETS,
     GROUP_BORDER_HIT_ZONES,
     getGroupTitleClasses,
-    getGroupVisualFrameClasses
+    getGroupVisualFrameClasses,
+    getGroupVisualFrameStyle
   } from '$lib/canvas/group-hit-zones';
+  import { useNodeDataTracker } from '$lib/history';
+  import * as Tooltip from '$lib/components/ui/tooltip';
 
   let node: {
     id: string;
+    data: {
+      color?: string;
+    };
     selected: boolean;
     width?: number;
     height?: number;
   } = $props();
 
+  const { updateNodeData } = useSvelteFlow();
   const eventBus = PatchiesEventBus.getInstance();
+  const tracker = useNodeDataTracker(node.id);
+
+  let showSettings = $state(false);
+
   const width = $derived(node.width ?? 360);
   const height = $derived(node.height ?? 240);
+  const color = $derived(node.data.color ?? DEFAULT_GROUP_COLOR);
   const frameStyle = $derived(
     node.width !== undefined && node.height !== undefined
       ? 'width: 100%; height: 100%;'
       : `width: ${width}px; height: ${height}px;`
   );
   const visualFrameClasses = $derived(getGroupVisualFrameClasses(node.selected));
+  const visualFrameStyle = $derived(getGroupVisualFrameStyle(color, node.selected));
+
+  function updateConfig(updates: Partial<typeof node.data>) {
+    updateNodeData(node.id, { ...node.data, ...updates });
+  }
+
+  function toggleSettings(event: MouseEvent) {
+    event.stopPropagation();
+    showSettings = !showSettings;
+  }
+
+  function closeSettings(event: MouseEvent) {
+    event.stopPropagation();
+    showSettings = false;
+  }
+
+  function handleColorChange(nextColor: string) {
+    const oldColor = color;
+    updateConfig({ color: nextColor });
+    tracker.commit('color', oldColor, nextColor);
+  }
 
   function handleResizeEnd() {
     eventBus.dispatch({ type: 'visualGroupSyncRequested', groupId: node.id });
@@ -48,11 +84,77 @@
     <div class="font-mono text-xs font-medium text-zinc-400">group</div>
   </div>
 
-  <div class={visualFrameClasses} aria-hidden="true"></div>
+  <div class="pointer-events-auto absolute -top-7 right-0 z-10 flex gap-x-1">
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          class={[
+            'cursor-pointer rounded bg-zinc-900/80 p-1 transition-colors hover:bg-zinc-700',
+            showSettings && 'bg-zinc-700'
+          ]}
+          onclick={toggleSettings}
+          aria-label={showSettings ? 'Close group settings' : 'Open group settings'}
+          aria-pressed={showSettings}
+        >
+          <Settings class="h-4 w-4 text-zinc-300" />
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content>{showSettings ? 'Close Settings' : 'Settings'}</Tooltip.Content>
+    </Tooltip.Root>
+  </div>
+
+  <div class={visualFrameClasses} style={visualFrameStyle} aria-hidden="true"></div>
 
   {#each GROUP_BORDER_HIT_ZONES as zone (zone.id)}
     <div class={zone.className} aria-label={zone.ariaLabel}></div>
   {/each}
+
+  {#if showSettings}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="nodrag pointer-events-auto absolute top-0 right-0 z-20 w-44 rounded-md border border-zinc-700 bg-zinc-900 p-3 shadow-xl"
+      onclick={(event) => event.stopPropagation()}
+    >
+      <div class="mb-3 flex items-center justify-between gap-2">
+        <div class="text-xs font-medium text-zinc-300">Group Color</div>
+
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button
+              class="cursor-pointer rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
+              onclick={closeSettings}
+              aria-label="Close group settings"
+            >
+              <X class="h-3.5 w-3.5" />
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>Close</Tooltip.Content>
+        </Tooltip.Root>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+        {#each GROUP_COLOR_PRESETS as preset (preset.name)}
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                onclick={() => handleColorChange(preset.value)}
+                class={[
+                  'h-6 w-6 cursor-pointer rounded-full border-2 transition-all',
+                  color === preset.value
+                    ? 'scale-110 border-white shadow-md'
+                    : 'border-zinc-700 hover:scale-105 hover:border-zinc-400'
+                ]}
+                style="background-color: {preset.value};"
+                aria-label={preset.name}
+              ></button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>{preset.name}</Tooltip.Content>
+          </Tooltip.Root>
+        {/each}
+      </div>
+    </div>
+  {/if}
 </div>
 
 <style>

--- a/ui/src/lib/eventbus/events.ts
+++ b/ui/src/lib/eventbus/events.ts
@@ -44,6 +44,8 @@ export type PatchiesEvent =
   | NodeDataBatchCommitEvent
   | ObjectDataCommitEvent
   | NodeSetPausedEvent
+  | VisualGroupResizeStartedEvent
+  | VisualGroupSyncRequestedEvent
   | SurfaceMouseForwardingGraphChangedEvent
   | IncludeProcessingEvent
   | CookStatusUpdateEvent
@@ -158,6 +160,16 @@ export interface NodeReplaceEvent {
 
   /** Maps old handle IDs to new handle IDs for edge reconnection */
   handleMapping?: Record<string, string>;
+}
+
+export interface VisualGroupSyncRequestedEvent {
+  type: 'visualGroupSyncRequested';
+  groupId: string;
+}
+
+export interface VisualGroupResizeStartedEvent {
+  type: 'visualGroupResizeStarted';
+  groupId: string;
 }
 
 export interface IframePostMessageEvent {

--- a/ui/src/lib/extensions/object-packs.ts
+++ b/ui/src/lib/extensions/object-packs.ts
@@ -19,6 +19,7 @@ export const BUILT_IN_PACKS: ExtensionPack[] = [
       'textbox',
       'peek',
       'label',
+      'group',
       'note',
       'title'
     ]

--- a/ui/src/lib/history/commands/index.ts
+++ b/ui/src/lib/history/commands/index.ts
@@ -9,3 +9,4 @@ export { AddEdgesCommand } from './add-edges.command';
 export { DeleteEdgesCommand } from './delete-edges.command';
 export { BatchCommand } from './batch-command';
 export { ReplaceNodeDataCommand } from './replace-node-data.command';
+export { ReplaceNodesCommand } from './replace-nodes.command';

--- a/ui/src/lib/history/commands/node-commands.test.ts
+++ b/ui/src/lib/history/commands/node-commands.test.ts
@@ -5,6 +5,7 @@ import { AddNodeCommand } from './add-node.command';
 import { AddNodesCommand } from './add-nodes.command';
 import { DeleteNodesCommand } from './delete-nodes.command';
 import { MoveNodesCommand } from './move-nodes.command';
+import { ReplaceNodesCommand } from './replace-nodes.command';
 
 function createMockAccessors(
   initialNodes: Node[] = [],
@@ -104,5 +105,21 @@ describe('MoveNodesCommand', () => {
     cmd.undo();
     expect(accessors.getNodes()[0].position).toEqual({ x: 0, y: 0 });
     expect(accessors.getNodes()[1].position).toEqual({ x: 10, y: 10 });
+  });
+});
+
+describe('ReplaceNodesCommand', () => {
+  test('execute replaces all nodes, undo restores previous nodes', () => {
+    const oldNodes = [createNode('1', 0, 0), createNode('2', 10, 10)];
+    const newNodes = [createNode('group-1', 0, 0), createNode('1', 20, 20)];
+    const accessors = createMockAccessors(oldNodes);
+
+    const cmd = new ReplaceNodesCommand(oldNodes, newNodes, accessors, 'Group selection');
+
+    cmd.execute();
+    expect(accessors.getNodes().map((n) => n.id)).toEqual(['group-1', '1']);
+
+    cmd.undo();
+    expect(accessors.getNodes().map((n) => n.id)).toEqual(['1', '2']);
   });
 });

--- a/ui/src/lib/history/commands/replace-nodes.command.ts
+++ b/ui/src/lib/history/commands/replace-nodes.command.ts
@@ -1,0 +1,23 @@
+import type { Node } from '@xyflow/svelte';
+import type { CanvasStateAccessors, Command } from '../types';
+
+/**
+ * Command to atomically replace the canvas node list.
+ * Useful for structural edits such as grouping that update parent/child relationships.
+ */
+export class ReplaceNodesCommand implements Command {
+  constructor(
+    private oldNodes: Node[],
+    private newNodes: Node[],
+    private accessors: CanvasStateAccessors,
+    readonly description: string
+  ) {}
+
+  execute(): void {
+    this.accessors.setNodes(this.newNodes);
+  }
+
+  undo(): void {
+    this.accessors.setNodes(this.oldNodes);
+  }
+}

--- a/ui/src/lib/nodes/defaultNodeData.test.ts
+++ b/ui/src/lib/nodes/defaultNodeData.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+
+import { getDefaultNodeData } from './defaultNodeData';
+
+describe('getDefaultNodeData', () => {
+  test('keeps group color optional by default', () => {
+    expect(getDefaultNodeData('group')).toEqual({});
+  });
+});

--- a/ui/src/lib/nodes/defaultNodeData.ts
+++ b/ui/src/lib/nodes/defaultNodeData.ts
@@ -311,6 +311,7 @@ export function getDefaultNodeData(nodeType: string): NodeData {
       bordered: false,
       font: 'default'
     }))
+    .with('group', () => ({}))
     .with('uiua', () => ({
       expr: `Life ← ↥∩=₃⟜+⊸(/+↻⊂A₂C₂)
 ⁅×0.6 gen⊙⚂ ˙⊟30 # Init

--- a/ui/src/lib/nodes/defaultNodeDimensions.test.ts
+++ b/ui/src/lib/nodes/defaultNodeDimensions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  DEFAULT_GROUP_HEIGHT,
+  DEFAULT_GROUP_WIDTH,
+  getDefaultNodeDimensions
+} from './defaultNodeDimensions';
+
+describe('getDefaultNodeDimensions', () => {
+  test('creates group nodes with explicit top-level dimensions', () => {
+    expect(getDefaultNodeDimensions('group')).toEqual({
+      width: DEFAULT_GROUP_WIDTH,
+      height: DEFAULT_GROUP_HEIGHT
+    });
+  });
+
+  test('leaves regular node dimensions implicit', () => {
+    expect(getDefaultNodeDimensions('js')).toEqual({});
+  });
+});

--- a/ui/src/lib/nodes/defaultNodeDimensions.ts
+++ b/ui/src/lib/nodes/defaultNodeDimensions.ts
@@ -1,0 +1,15 @@
+import type { Node } from '@xyflow/svelte';
+
+export const DEFAULT_GROUP_WIDTH = 360;
+export const DEFAULT_GROUP_HEIGHT = 240;
+
+export function getDefaultNodeDimensions(type: string): Pick<Node, 'width' | 'height'> {
+  if (type === 'group') {
+    return {
+      width: DEFAULT_GROUP_WIDTH,
+      height: DEFAULT_GROUP_HEIGHT
+    };
+  }
+
+  return {};
+}

--- a/ui/src/lib/nodes/node-types.ts
+++ b/ui/src/lib/nodes/node-types.ts
@@ -111,6 +111,7 @@ import NgeaNode from '$objects/ngea/components/NgeaNode.svelte';
 import AnuparsNode from '$objects/anupars/components/AnuparsNode.svelte';
 import SurfaceNode from '$lib/components/nodes/SurfaceNode.svelte';
 import SheetNode from '$objects/sheet/SheetNode.svelte';
+import GroupNode from '$lib/components/nodes/GroupNode.svelte';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const nodeTypes: Record<string, any> = {
@@ -226,7 +227,8 @@ export const nodeTypes: Record<string, any> = {
   ngea: NgeaNode,
   anupars: AnuparsNode,
   surface: SurfaceNode,
-  sheet: SheetNode
+  sheet: SheetNode,
+  group: GroupNode
 } as const;
 
 export const nodeNames = Object.keys(nodeTypes) as (keyof typeof nodeTypes)[];

--- a/ui/src/lib/objects/schemas/group.ts
+++ b/ui/src/lib/objects/schemas/group.ts
@@ -1,0 +1,10 @@
+import type { ObjectSchema } from './types';
+
+export const groupSchema: ObjectSchema = {
+  type: 'group',
+  category: 'ui',
+  description: 'A resizable frame that visually groups objects and moves them together.',
+  inlets: [],
+  outlets: [],
+  tags: ['group', 'organization', 'annotation', 'ui']
+};

--- a/ui/src/lib/objects/schemas/index.ts
+++ b/ui/src/lib/objects/schemas/index.ts
@@ -85,6 +85,7 @@ export * from './bg-out';
 export * from './send-vdo';
 export * from './recv-vdo';
 export * from './note';
+export * from './group';
 export * from './label';
 export * from './title';
 export * from './link';
@@ -185,6 +186,7 @@ import { bgOutSchema } from './bg-out';
 import { sendVdoSchema } from './send-vdo';
 import { recvVdoSchema } from './recv-vdo';
 import { noteSchema } from './note';
+import { groupSchema } from './group';
 import { labelSchema } from './label';
 import { titleSchema } from './title';
 import { linkSchema } from './link';
@@ -304,6 +306,7 @@ export const objectSchemas: ObjectSchemaRegistry = {
   'send.vdo': sendVdoSchema,
   'recv.vdo': recvVdoSchema,
   note: noteSchema,
+  group: groupSchema,
   label: labelSchema,
   title: titleSchema,
   link: linkSchema,

--- a/ui/src/lib/services/AiOperationsService.ts
+++ b/ui/src/lib/services/AiOperationsService.ts
@@ -4,6 +4,7 @@ import { toast } from 'svelte-sonner';
 import type { CanvasContext } from './CanvasContext';
 import type { NodeOperationsService } from './NodeOperationsService';
 import type { AiObjectNode, SimplifiedEdge } from '$lib/ai/types';
+import { getDefaultNodeDimensions } from '$lib/nodes/defaultNodeDimensions';
 import {
   AddNodeCommand,
   AddNodesCommand,
@@ -170,6 +171,7 @@ export class AiOperationsService {
       id: newNodeId,
       type: newType,
       position,
+      ...getDefaultNodeDimensions(newType),
       data: newData
     };
     const addNodeCmd = new AddNodeCommand(newNode, this.ctx.canvasAccessors);

--- a/ui/src/lib/services/CanvasContext.test.ts
+++ b/ui/src/lib/services/CanvasContext.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import type { Edge, Node } from '@xyflow/svelte';
+
+import { CanvasContext } from './CanvasContext';
+
+function createContext(initialNodes: Node[] = []): CanvasContext {
+  let nodes = initialNodes;
+  let edges: Edge[] = [];
+
+  return new CanvasContext(
+    {
+      get: () => nodes,
+      set: (next) => {
+        nodes = next;
+      }
+    },
+    {
+      get: () => edges,
+      set: (next) => {
+        edges = next;
+      }
+    }
+  );
+}
+
+describe('CanvasContext', () => {
+  test('sets node id counter after the highest numeric suffix, not the last node', () => {
+    const ctx = createContext([
+      { id: 'group-4', type: 'group', position: { x: 0, y: 0 }, data: {} },
+      { id: 'js-1', type: 'js', position: { x: 0, y: 0 }, data: {} }
+    ]);
+
+    ctx.setNodeIdCounterFromNodes(ctx.nodes);
+
+    expect(ctx.nextNodeId('msg')).toBe('msg-5');
+  });
+});

--- a/ui/src/lib/services/CanvasContext.ts
+++ b/ui/src/lib/services/CanvasContext.ts
@@ -99,11 +99,11 @@ export class CanvasContext {
       return;
     }
 
-    const lastNodeId = parseInt(nodes.at(-1)?.id.match(/.*-(\d+)$/)?.[1] ?? '');
-    if (isNaN(lastNodeId)) {
+    const nodeIds = nodes.map((node) => parseInt(node.id.match(/.*-(\d+)$/)?.[1] ?? ''));
+    if (nodeIds.some((id) => isNaN(id))) {
       throw new Error('corrupted save - cannot get last node id');
     }
 
-    this._nodeIdCounter = lastNodeId + 1;
+    this._nodeIdCounter = Math.max(...nodeIds) + 1;
   }
 }

--- a/ui/src/lib/services/NodeOperationsService.test.ts
+++ b/ui/src/lib/services/NodeOperationsService.test.ts
@@ -1,0 +1,94 @@
+import type { Edge, Node } from '@xyflow/svelte';
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('$lib/history', () => ({
+  AddNodeCommand: class {},
+  BatchCommand: class {},
+  DeleteEdgesCommand: class {},
+  DeleteNodesCommand: class {}
+}));
+
+vi.mock('$lib/nodes/node-types', () => ({ nodeTypes: {} }));
+vi.mock('$lib/presets/presets', () => ({ PRESETS: {} }));
+vi.mock('$lib/objects/parse-object-param', () => ({ parseObjectParamFromString: vi.fn() }));
+vi.mock('$lib/registry/AudioRegistry', () => ({
+  AudioRegistry: { getInstance: () => ({ isDefined: () => false }) }
+}));
+vi.mock('$lib/registry/ObjectRegistry', () => ({
+  ObjectRegistry: { getInstance: () => ({ isDefined: () => false }) }
+}));
+vi.mock('$lib/registry/ObjectShorthandRegistry', () => ({
+  ObjectShorthandRegistry: { getInstance: () => ({ tryTransform: () => undefined }) }
+}));
+
+import { DEFAULT_GROUP_HEIGHT, DEFAULT_GROUP_WIDTH } from '$lib/nodes/defaultNodeDimensions';
+import { NodeOperationsService } from './NodeOperationsService';
+
+function createContext() {
+  let nodes: Node[] = [];
+  let edges: Edge[] = [];
+
+  return {
+    ctx: {
+      get nodes() {
+        return nodes;
+      },
+      set nodes(next: Node[]) {
+        nodes = next;
+      },
+      get edges() {
+        return edges;
+      },
+      set edges(next: Edge[]) {
+        edges = next;
+      },
+      nextNodeId: (type: string) => `${type}-1`,
+      historyManager: { execute: vi.fn() },
+      canvasAccessors: {}
+    },
+    getNodes: () => nodes
+  };
+}
+
+describe('NodeOperationsService', () => {
+  test('creates new group nodes with explicit top-level dimensions', () => {
+    const { ctx, getNodes } = createContext();
+    const service = new NodeOperationsService(
+      ctx as unknown as ConstructorParameters<typeof NodeOperationsService>[0]
+    );
+
+    const id = service.createNode('group', { x: 10, y: 20 }, undefined, { skipHistory: true });
+
+    expect(getNodes().find((node) => node.id === id)).toMatchObject({
+      type: 'group',
+      width: DEFAULT_GROUP_WIDTH,
+      height: DEFAULT_GROUP_HEIGHT,
+      data: {}
+    });
+  });
+
+  test('replaces nodes with group nodes that have explicit top-level dimensions', () => {
+    const { ctx, getNodes } = createContext();
+    ctx.nodes = [{ id: 'old-1', type: 'js', position: { x: 10, y: 20 }, data: {} }];
+    const service = new NodeOperationsService(
+      ctx as unknown as ConstructorParameters<typeof NodeOperationsService>[0]
+    );
+
+    service.replaceNode({
+      type: 'nodeReplace',
+      nodeId: 'old-1',
+      newType: 'group',
+      newData: {},
+      handleMapping: {}
+    });
+
+    expect(getNodes()).toHaveLength(1);
+    expect(getNodes()[0]).toMatchObject({
+      id: 'group-1',
+      type: 'group',
+      width: DEFAULT_GROUP_WIDTH,
+      height: DEFAULT_GROUP_HEIGHT,
+      data: {}
+    });
+  });
+});

--- a/ui/src/lib/services/NodeOperationsService.ts
+++ b/ui/src/lib/services/NodeOperationsService.ts
@@ -1,5 +1,6 @@
 import type { Node } from '@xyflow/svelte';
 import { getDefaultNodeData } from '$lib/nodes/defaultNodeData';
+import { getDefaultNodeDimensions } from '$lib/nodes/defaultNodeDimensions';
 import { nodeTypes } from '$lib/nodes/node-types';
 import { PRESETS } from '$lib/presets/presets';
 import { ObjectShorthandRegistry } from '$lib/registry/ObjectShorthandRegistry';
@@ -47,6 +48,7 @@ export class NodeOperationsService {
       id,
       type,
       position,
+      ...getDefaultNodeDimensions(type),
       data: (customData as Record<string, unknown>) ?? getDefaultNodeData(type)
     };
 
@@ -119,6 +121,7 @@ export class NodeOperationsService {
       id: newId,
       type: newType,
       position: oldNode.position,
+      ...getDefaultNodeDimensions(newType),
       data: newData
     };
 

--- a/ui/static/content/objects/group.md
+++ b/ui/static/content/objects/group.md
@@ -1,0 +1,22 @@
+A resizable frame for organizing related objects on the canvas.
+
+## Features
+
+- **Visual grouping**: Draws a translucent frame around related objects
+- **Move together**: Drag the group to move its grouped objects
+- **Resizable**: Drag corners to resize the frame
+- **Spatial membership**: Move objects into the frame to add them, or outside to remove them
+- **Click-through interior**: Empty space inside the group still behaves like canvas space
+
+## Usage
+
+1. Create a `group` object
+2. Move objects into the group frame, or resize the group around them
+3. Drag the group border or `group` title to move grouped objects together
+4. Move an object outside the group frame to remove it from the group
+
+## See Also
+
+- [note](/docs/objects/note) - sticky note with color presets
+- [title](/docs/objects/title) - large section title
+- [label](/docs/objects/label) - simple text label

--- a/ui/static/content/objects/group.md
+++ b/ui/static/content/objects/group.md
@@ -8,6 +8,7 @@ A resizable frame for organizing related objects on the canvas.
 - **Spatial membership**: Move objects into the frame to add them, or outside to remove them
 - **Click-through interior**: Empty space inside the group still behaves like canvas space
 - **Color presets**: Use the settings button to change the frame color
+- **Custom title**: Use the settings button to rename the group title
 
 ## Usage
 
@@ -15,7 +16,7 @@ A resizable frame for organizing related objects on the canvas.
 2. Move objects into the group frame, or resize the group around them
 3. Drag the group border or `group` title to move grouped objects together
 4. Move an object outside the group frame to remove it from the group
-5. Use the settings button at the top-right to choose a group color
+5. Use the settings button at the top-right to choose a group color or rename the group
 
 ## See Also
 

--- a/ui/static/content/objects/group.md
+++ b/ui/static/content/objects/group.md
@@ -7,6 +7,7 @@ A resizable frame for organizing related objects on the canvas.
 - **Resizable**: Drag corners to resize the frame
 - **Spatial membership**: Move objects into the frame to add them, or outside to remove them
 - **Click-through interior**: Empty space inside the group still behaves like canvas space
+- **Color presets**: Use the settings button to change the frame color
 
 ## Usage
 
@@ -14,6 +15,7 @@ A resizable frame for organizing related objects on the canvas.
 2. Move objects into the group frame, or resize the group around them
 3. Drag the group border or `group` title to move grouped objects together
 4. Move an object outside the group frame to remove it from the group
+5. Use the settings button at the top-right to choose a group color
 
 ## See Also
 


### PR DESCRIPTION
Add group object for grouping objects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new **group** canvas object that frames related items, moves them together, and supports resizing with optional **color** and **title** settings (including lock/unlock and “can resize” control).
  - Improved group interactions: empty interior click-through, and more precise hit zones for selecting/dragging the group frame versus working with contained items.
  - Group objects are now available in the object browser/starters pack and supported across creation/replacement/editing flows.
- **Bug Fixes**
  - Improved group membership syncing so items stay grouped while inside the frame, and automatically return/ungroup when moved outside, with more reliable sizing and undo/redo behavior.
- **Documentation**
  - Added user-facing guidance for working with group objects on the canvas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->