### PR TITLE
feat(dom, vue, p5, canvas.dom): hide border function

### DIFF
--- a/docs/design-docs/specs/166-hide-border.md
+++ b/docs/design-docs/specs/166-hide-border.md
@@ -1,0 +1,30 @@
+# 166. Hide Border
+
+## Goal
+
+Let JS-authored UI nodes opt out of Patchies preview border/chrome when the node should visually blend into its own interface.
+
+## API
+
+Expose `hideBorder()` in `dom`, `vue`, `p5`, `canvas.dom`, and `three.dom` JavaScript contexts.
+
+Calling it persists `hideBorder: true` on the node data. The node remains selected, movable, deletable, and editable through existing canvas behavior, but Patchies stops drawing preview border/chrome for that node in both idle and selected states.
+
+Each run starts by restoring `hideBorder: false`. If user code still calls
+`hideBorder()`, the flag is set again during that run. Removing the call and
+running the node restores the default border/chrome.
+
+## Behavior
+
+- Hide idle border, selected border, ring, glow, and hover glow on the preview surface.
+- Keep the title and floating preview action controls visible, since the title is often the explicit drag handle.
+- Restore default border/chrome on the next run when user code no longer calls `hideBorder()`.
+- Keep port handles visible. Port visibility already has separate controls such as `setHidePorts(true)` where supported.
+- Error styling still overrides hidden border chrome so runtime errors stay visible.
+
+## Implementation Notes
+
+- Add a small shared presentation helper for border chrome class decisions.
+- Thread the persisted flag through `DomRuntimeNode`, `P5CanvasNode`, and `CanvasPreviewLayout`.
+- Add `hideBorder()` to the relevant runtime contexts and CodeMirror completions.
+- Document the helper in the four object docs.

--- a/ui/src/lib/ai/object-prompts/canvas.dom.ts
+++ b/ui/src/lib/ai/object-prompts/canvas.dom.ts
@@ -8,6 +8,7 @@ Interactive Canvas on main thread. Use for mouse/keyboard input and instant FFT.
 - ctx: 2D canvas context
 - width, height, mouse: {x, y, down, buttons}
 - noDrag(), noPan(), noWheel(), noInteract() - Interaction control
+- hideBorder() - Hide Patchies border and selected glow
 - noOutput() - Hide video output (call this when the sketch does not feed video to other nodes)
 - setCanvasSize(w, h) - Resize canvas
 - onKeyDown(event => {}) - Keyboard down events (event.key, event.code)

--- a/ui/src/lib/ai/object-prompts/dom.ts
+++ b/ui/src/lib/ai/object-prompts/dom.ts
@@ -13,6 +13,7 @@ DOM manipulation node with direct JavaScript access to a root div element. Conta
 - htmlCanvas.glslLayer(fragmentShader): Experimental API that locally post-processes the live DOM interface with a WebGL2 GLSL ES 3 fragment shader and source sampler; use texture(source, uv), mainImage(out vec4 fragColor, in vec2 fragCoord), source, iResolution, iTime, iTimeDelta, and iFrame; supports #include directives; mutually exclusive with videoOutput and canvasLayer
 - setHidePorts(hide): Hide/show ports
 - noDrag(), noPan(), noWheel(), noInteract() - Interaction control (whole node)
+- hideBorder(): Hide Patchies border and selected glow
 - tailwind(enabled): Enable/disable Tailwind CSS (enabled by default)
 
 **Selective canvas interaction (CSS classes):**

--- a/ui/src/lib/ai/object-prompts/p5.ts
+++ b/ui/src/lib/ai/object-prompts/p5.ts
@@ -15,6 +15,7 @@ ${esmInstructions}
 - noPan() - Disable XYFlow canvas panning when interacting
 - noWheel() - Disable XYFlow canvas wheel zoom when interacting
 - noInteract() - Disable all XYFlow canvas interactions (drag, pan, wheel)
+- hideBorder() - Hide Patchies border and selected glow
 - noOutput() - Hide video output port (call this when the sketch is self-contained and does not need to feed video to other nodes)
 - createSurfaceCanvas(renderer?) - Create a transparent renderer-output-sized canvas and enable Expand so the p5 sketch can run as a fullscreen surface overlay. Do NOT also call createCanvas() when using this.
 - expandSurface() / collapseSurface() - In p5 surface mode, enter or exit fullscreen surface mode from code.

--- a/ui/src/lib/ai/object-prompts/three.dom.ts
+++ b/ui/src/lib/ai/object-prompts/three.dom.ts
@@ -13,6 +13,7 @@ Three.js 3D graphics on the main thread. Use for interactive 3D with mouse/keybo
 **Three.dom-specific methods:**
 - setCanvasSize(w, h) - Resize canvas and renderer
 - noDrag(), noPan(), noWheel(), noInteract() - Interaction control
+- hideBorder() - Hide Patchies border and selected glow
 - noOutput() - Hide video output port
 - setHidePorts(bool) - Toggle port visibility
 - onKeyDown(event => {}) - Keyboard down events (event.key, event.code)

--- a/ui/src/lib/ai/object-prompts/vue.ts
+++ b/ui/src/lib/ai/object-prompts/vue.ts
@@ -13,6 +13,7 @@ Vue 3 reactive components with Composition API. Container is fluid-sized by defa
 - htmlCanvas.glslLayer(fragmentShader): Experimental API that locally post-processes the live Vue interface with a WebGL2 GLSL ES 3 fragment shader and source sampler; use texture(source, uv), mainImage(out vec4 fragColor, in vec2 fragCoord), source, iResolution, iTime, iTimeDelta, and iFrame; supports #include directives; mutually exclusive with videoOutput and canvasLayer
 - setHidePorts(hide): Hide/show ports
 - noDrag(), noPan(), noWheel(), noInteract() - Interaction control (whole node)
+- hideBorder(): Hide Patchies border and selected glow
 - tailwind(enabled): Enable/disable Tailwind CSS (enabled by default)
 
 **Selective canvas interaction (CSS classes):**

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -155,6 +155,16 @@ describe('patchies completions', () => {
     expect(getCompletionLabels('canvas.dom', 'setP')).toContain('setPrimaryButton');
   });
 
+  it('shows hideBorder completions only for native UI nodes', () => {
+    expect(getCompletionLabels('dom', 'hideB')).toContain('hideBorder');
+    expect(getCompletionLabels('vue', 'hideB')).toContain('hideBorder');
+    expect(getCompletionLabels('p5', 'hideB')).toContain('hideBorder');
+    expect(getCompletionLabels('canvas.dom', 'hideB')).toContain('hideBorder');
+    expect(getCompletionLabels('three.dom', 'hideB')).toContain('hideBorder');
+    expect(getCompletionLabels('js', 'hideB')).not.toContain('hideBorder');
+    expect(getCompletionLabels('hydra', 'hideB')).not.toContain('hideBorder');
+  });
+
   it('shows showAudioInput completions only for simple DSP audio nodes', () => {
     expect(getCompletionLabels('tone~', 'show')).toContain('showAudioInput');
     expect(getCompletionLabels('sonic~', 'show')).toContain('showAudioInput');

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -142,6 +142,13 @@ const patchiesAPICompletions: Completion[] = [
     apply: 'setHidePorts(true)'
   },
   {
+    label: 'hideBorder',
+    type: 'function',
+    detail: '() => void',
+    info: 'Hide Patchies border, selected glow, and floating preview controls for this node',
+    apply: 'hideBorder()'
+  },
+  {
     label: 'htmlCanvas.videoOutput',
     type: 'function',
     detail: '(options?: boolean | { size: "free" }) => boolean',
@@ -470,6 +477,7 @@ const topLevelOnlyFunctions = new Set([
   'noOutput',
   'noPan',
   'noWheel',
+  'hideBorder',
   'onCleanup',
   'onKeyDown',
   'onKeyUp',
@@ -590,6 +598,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   expandSurface: ['surface', 'p5'],
   collapseSurface: ['surface', 'p5'],
   hideExitButton: ['surface', 'p5'],
+  hideBorder: ['dom', 'vue', 'p5', 'canvas.dom', 'three.dom'],
   setAudioPortCount: ['dsp~'],
   showAudioInput: ['tone~', 'sonic~', 'elem~'],
   setCanvasSize: ['canvas.dom', 'textmode.dom', 'three.dom'],

--- a/ui/src/lib/components/CanvasPreviewLayout.svelte
+++ b/ui/src/lib/components/CanvasPreviewLayout.svelte
@@ -8,6 +8,7 @@
   import type { SupportedLanguage } from '$lib/codemirror/types';
   import { useCookStatus } from '$lib/canvas/use-cook-status.svelte';
   import { COOK_DEBUG_RENDER_NODE_TYPES } from '../../workers/rendering/cooking/policies';
+  import { getBorderChromeClass } from './border-chrome';
 
   const COOK_DEBUG_OBJECT_TYPES = new Set<string>(COOK_DEBUG_RENDER_NODE_TYPES);
 
@@ -54,6 +55,7 @@
     showBgOutputOption = true,
     showExpandOption = true,
     showCookDebugOption = undefined,
+    hideBorder = false,
     class: className = ''
   }: {
     title: string;
@@ -98,6 +100,7 @@
     showBgOutputOption?: boolean;
     showExpandOption?: boolean;
     showCookDebugOption?: boolean;
+    hideBorder?: boolean;
     class?: string;
   } = $props();
 
@@ -108,6 +111,18 @@
   const cookStatus = useCookStatus(
     () => nodeId,
     () => cookDebugSupported && $showCookStats
+  );
+
+  const chromeClass = $derived(
+    getBorderChromeClass({
+      hasError,
+      selected,
+      hideBorder,
+      errorClass: 'border-red-500/70',
+      selectedClass: 'shadow-glow-md border-zinc-300 [&>canvas]:rounded-[7px]',
+      idleClass: 'hover:shadow-glow-sm border-zinc-400 [&>canvas]:rounded-md',
+      borderlessClass: 'border-transparent shadow-none [&>canvas]:rounded-md'
+    })
   );
 
   // Build the interaction class string based on individual flags
@@ -157,15 +172,7 @@
     <div class="relative">
       <canvas
         bind:this={previewCanvas}
-        class={[
-          'rounded-md border',
-          hasError
-            ? 'border-red-500/70'
-            : selected
-              ? 'shadow-glow-md border-zinc-300 [&>canvas]:rounded-[7px]'
-              : 'hover:shadow-glow-sm border-zinc-400 [&>canvas]:rounded-md',
-          interactionClass
-        ]}
+        class={['rounded-md border', chromeClass, interactionClass]}
         {tabindex}
         width={typeof width === 'number' ? width : undefined}
         height={typeof height === 'number' ? height : undefined}

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -489,7 +489,7 @@
                     <button
                       class="node-floating-button"
                       aria-label="Run code (shift+enter)"
-                      onclick={handleRun}
+                      onclick={() => handleRun()}
                     >
                       <Play class="h-4 w-4 text-zinc-300" />
                     </button>
@@ -571,7 +571,10 @@
           {#if onrun}
             <Tooltip.Root>
               <Tooltip.Trigger>
-                <button onclick={handleRun} class="cursor-pointer rounded p-1 hover:bg-zinc-700">
+                <button
+                  onclick={() => handleRun()}
+                  class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+                >
                   <Play class="h-4 w-4 text-zinc-300" />
                 </button>
               </Tooltip.Trigger>

--- a/ui/src/lib/components/border-chrome.test.ts
+++ b/ui/src/lib/components/border-chrome.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBorderChromeClass, getBorderResetDataForRun } from './border-chrome';
+
+describe('border chrome helpers', () => {
+  it('uses borderless chrome when selected border is hidden', () => {
+    expect(
+      getBorderChromeClass({
+        selected: true,
+        hideBorder: true,
+        borderlessClass: 'borderless',
+        idleClass: 'idle',
+        selectedClass: 'selected',
+        errorClass: 'error'
+      })
+    ).toBe('borderless');
+  });
+
+  it('uses borderless chrome when idle border is hidden', () => {
+    expect(
+      getBorderChromeClass({
+        selected: false,
+        hideBorder: true,
+        borderlessClass: 'borderless',
+        idleClass: 'idle',
+        selectedClass: 'selected',
+        errorClass: 'error'
+      })
+    ).toBe('borderless');
+  });
+
+  it('keeps error chrome visible when border is hidden', () => {
+    expect(
+      getBorderChromeClass({
+        hasError: true,
+        selected: true,
+        hideBorder: true,
+        borderlessClass: 'borderless',
+        idleClass: 'idle',
+        selectedClass: 'selected',
+        errorClass: 'error'
+      })
+    ).toBe('error');
+  });
+
+  it('restores the border at run start when hideBorder is no longer called', () => {
+    expect(getBorderResetDataForRun({ hideBorder: true })).toEqual({ hideBorder: false });
+    expect(getBorderResetDataForRun({ hideBorder: false })).toEqual({});
+    expect(getBorderResetDataForRun({})).toEqual({});
+  });
+});

--- a/ui/src/lib/components/border-chrome.ts
+++ b/ui/src/lib/components/border-chrome.ts
@@ -1,0 +1,27 @@
+export function getBorderChromeClass({
+  hasError = false,
+  selected = false,
+  hideBorder = false,
+  errorClass,
+  selectedClass,
+  idleClass,
+  borderlessClass
+}: {
+  hasError?: boolean;
+  selected?: boolean;
+  hideBorder?: boolean;
+  errorClass: string;
+  selectedClass: string;
+  idleClass: string;
+  borderlessClass: string;
+}) {
+  if (hasError) return errorClass;
+  if (hideBorder) return borderlessClass;
+  if (selected && !hideBorder) return selectedClass;
+
+  return idleClass;
+}
+
+export function getBorderResetDataForRun({ hideBorder = false }: { hideBorder?: boolean }) {
+  return hideBorder ? { hideBorder: false } : {};
+}

--- a/ui/src/lib/components/nodes/CanvasDom.svelte
+++ b/ui/src/lib/components/nodes/CanvasDom.svelte
@@ -23,6 +23,7 @@
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
   import { resetCanvasSize } from './runtime-size';
+  import { getBorderResetDataForRun } from '$lib/components/border-chrome';
 
   let {
     id: nodeId,
@@ -41,6 +42,7 @@
       paused?: boolean;
       settingsSchema?: SettingsSchema;
       settings?: Record<string, unknown>;
+      hideBorder?: boolean;
     };
     selected?: boolean;
   } = $props();
@@ -359,6 +361,7 @@
     panEnabled = true;
     wheelEnabled = true;
     videoOutputEnabled = true;
+    updateNodeData(nodeId, getBorderResetDataForRun(data));
 
     const resetSize = resetCanvasSize(canvas, DEFAULT_OUTPUT_SIZE);
 
@@ -413,6 +416,9 @@
             dragEnabled = false;
             panEnabled = false;
             wheelEnabled = false;
+          },
+          hideBorder: () => {
+            updateNodeData(nodeId, { hideBorder: true });
           },
           noOutput: () => {
             videoOutputEnabled = false;
@@ -533,6 +539,7 @@
   settingsValues={data.settings ?? {}}
   onSettingsValueChange={(key, value) => settingsManager.setValue(key, value)}
   onSettingsRevertAll={() => settingsManager.revertAll()}
+  hideBorder={data.hideBorder}
 >
   {#snippet topHandle()}
     {#each Array.from({ length: inletCount }) as _, index (index)}

--- a/ui/src/lib/components/nodes/DomNode.svelte
+++ b/ui/src/lib/components/nodes/DomNode.svelte
@@ -29,6 +29,7 @@
       height?: number;
       settingsSchema?: SettingsSchema;
       settings?: Record<string, unknown>;
+      hideBorder?: boolean;
     };
     selected?: boolean;
   } = $props();

--- a/ui/src/lib/components/nodes/DomRuntimeNode.svelte
+++ b/ui/src/lib/components/nodes/DomRuntimeNode.svelte
@@ -19,6 +19,7 @@
   import { SettingsManager, createSettingsAPI } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
+  import { getBorderChromeClass, getBorderResetDataForRun } from '$lib/components/border-chrome';
   import {
     getDomSizeResetData,
     measureDomSize,
@@ -51,6 +52,7 @@
     height?: number;
     settingsSchema?: SettingsSchema;
     settings?: Record<string, unknown>;
+    hideBorder?: boolean;
   };
 
   let {
@@ -214,6 +216,7 @@
     dragEnabled = true;
     panEnabled = true;
     wheelEnabled = true;
+    updateNodeData(nodeId, getBorderResetDataForRun(data));
 
     const resetSize = shouldResetDomSize(data.code);
 
@@ -276,6 +279,9 @@
             dragEnabled = false;
             panEnabled = false;
             wheelEnabled = false;
+          },
+          hideBorder: () => {
+            updateNodeData(nodeId, { hideBorder: true });
           },
           tailwind: container.tailwind,
           ...extraContext({ runCode }),
@@ -352,11 +358,15 @@
       bind:this={previewContainer}
       class={[
         'overflow-hidden rounded-md',
-        lineErrors !== undefined
-          ? 'border-red-500/70'
-          : selected
-            ? 'shadow-glow-md ring ring-zinc-400'
-            : 'hover:shadow-glow-sm',
+        getBorderChromeClass({
+          hasError: lineErrors !== undefined,
+          selected,
+          hideBorder: data.hideBorder,
+          errorClass: 'border-red-500/70',
+          selectedClass: 'shadow-glow-md ring ring-zinc-400',
+          idleClass: 'hover:shadow-glow-sm',
+          borderlessClass: 'shadow-none ring-0'
+        }),
         !dragEnabled && 'nodrag',
         !panEnabled && 'nopan',
         !wheelEnabled && 'nowheel'

--- a/ui/src/lib/components/nodes/P5CanvasNode.svelte
+++ b/ui/src/lib/components/nodes/P5CanvasNode.svelte
@@ -23,6 +23,7 @@
   import { SettingsManager, createSettingsAPI } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
+  import { getBorderChromeClass, getBorderResetDataForRun } from '$lib/components/border-chrome';
 
   let consoleRef: VirtualConsole | null = $state(null);
 
@@ -44,6 +45,7 @@
       surfaceMode?: boolean;
       settingsSchema?: SettingsSchema;
       settings?: Record<string, unknown>;
+      hideBorder?: boolean;
     };
     selected: boolean;
   } = $props();
@@ -295,6 +297,7 @@
         settingsManager.clearCallbacks();
         p5Manager.shouldSendBitmap = true;
         surfaceMode.setMouseForwarding();
+        updateNodeData(nodeId, getBorderResetDataForRun(data));
 
         await p5Manager.updateCode({
           code: nextCode,
@@ -321,6 +324,9 @@
             setPortCount,
             setTitle: (title: string) => {
               updateNodeData(nodeId, { title });
+            },
+            hideBorder: () => {
+              updateNodeData(nodeId, { hideBorder: true });
             }
           },
           setHidePorts: (hide: boolean) => {
@@ -445,11 +451,15 @@
                 !enablePan && 'nopan',
                 !enableWheel && 'nowheel'
               ],
-          errorMessage
-            ? 'border-red-500 [&>canvas]:rounded-[7px]'
-            : selected
-              ? 'shadow-glow-md border-zinc-200 [&>canvas]:rounded-[7px]'
-              : 'hover:shadow-glow-sm border-transparent [&>canvas]:rounded-md'
+          getBorderChromeClass({
+            hasError: Boolean(errorMessage),
+            selected,
+            hideBorder: data.hideBorder,
+            errorClass: 'border-red-500 [&>canvas]:rounded-[7px]',
+            selectedClass: 'shadow-glow-md border-zinc-200 [&>canvas]:rounded-[7px]',
+            idleClass: 'hover:shadow-glow-sm border-transparent [&>canvas]:rounded-md',
+            borderlessClass: 'border-transparent shadow-none [&>canvas]:rounded-md'
+          })
         ]}
         style={preloadCanvasWidth && preloadCanvasHeight
           ? `min-width: ${preloadCanvasWidth}px; min-height: ${preloadCanvasHeight}px;`

--- a/ui/src/lib/components/nodes/ThreeDom.svelte
+++ b/ui/src/lib/components/nodes/ThreeDom.svelte
@@ -24,6 +24,7 @@
   import { SettingsManager, createSettingsAPI } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
+  import { getBorderResetDataForRun } from '$lib/components/border-chrome';
 
   let {
     id: nodeId,
@@ -42,6 +43,7 @@
       paused?: boolean;
       settingsSchema?: SettingsSchema;
       settings?: Record<string, unknown>;
+      hideBorder?: boolean;
     };
     selected?: boolean;
   } = $props();
@@ -343,6 +345,7 @@
     panEnabled = true;
     wheelEnabled = true;
     videoOutputEnabled = true;
+    updateNodeData(nodeId, getBorderResetDataForRun(data));
 
     // Clear keyboard callbacks when code is re-run
     keyboardCallbacks = {};
@@ -413,6 +416,9 @@
             dragEnabled = false;
             panEnabled = false;
             wheelEnabled = false;
+          },
+          hideBorder: () => {
+            updateNodeData(nodeId, { hideBorder: true });
           }
         }
       });
@@ -509,6 +515,7 @@
   settingsValues={data.settings ?? {}}
   onSettingsValueChange={(key, value) => settingsManager.setValue(key, value)}
   onSettingsRevertAll={() => settingsManager.revertAll()}
+  hideBorder={data.hideBorder}
 >
   {#snippet topHandle()}
     {#each Array.from({ length: inletCount }) as _, index}

--- a/ui/src/lib/components/nodes/VueNode.svelte
+++ b/ui/src/lib/components/nodes/VueNode.svelte
@@ -29,6 +29,7 @@
       height?: number;
       settingsSchema?: SettingsSchema;
       settings?: Record<string, unknown>;
+      hideBorder?: boolean;
     };
     selected?: boolean;
   } = $props();

--- a/ui/src/lib/messages/MessageContext.ts
+++ b/ui/src/lib/messages/MessageContext.ts
@@ -59,6 +59,9 @@ export interface UserFnRunContext {
   /** Disables all interactions (drag, pan, wheel) - convenience for noDrag + noPan + noWheel. */
   noInteract: () => void;
 
+  /** Hides Patchies border, selected glow, and floating preview controls for this node. */
+  hideBorder?: () => void;
+
   /** Hides the video output port in canvas/p5 nodes. */
   noOutput?: () => void;
 

--- a/ui/src/lib/p5/P5Manager.ts
+++ b/ui/src/lib/p5/P5Manager.ts
@@ -464,6 +464,7 @@ export class P5Manager {
         noPan: config.messageContext?.noPan,
         noWheel: config.messageContext?.noWheel,
         noInteract: config.messageContext?.noInteract,
+        hideBorder: config.messageContext?.hideBorder,
         noOutput: config.messageContext?.noOutput,
         setHidePorts: config.setHidePorts,
         settings: config.settings,

--- a/ui/static/content/objects/canvas.dom.md
+++ b/ui/static/content/objects/canvas.dom.md
@@ -69,6 +69,7 @@ All [Patchies JavaScript Runner](/docs/javascript-runner) functions are availabl
 
 - `noOutput()` - hide video output port
 - `noDrag()`, `noPan()`, `noWheel()`, `noInteract()` - see [Canvas Interaction](/docs/canvas-interaction)
+- `hideBorder()` - hides Patchies' border and selected glow until the call is removed and the node runs again
 - `fft()` - audio analysis with low latency
 
 ## Presets

--- a/ui/static/content/objects/dom.md
+++ b/ui/static/content/objects/dom.md
@@ -12,6 +12,10 @@ root.innerHTML = 'hello';
 
 TailwindCSS is enabled by default. Call `tailwind(false)` to disable it.
 
+Call `hideBorder()` when the DOM UI should blend into the patch without
+showing Patchies' border or selected glow. Remove
+the call and run the node again to restore the border.
+
 ## Canvas Interaction
 
 - `noDrag()`, `noPan()`, `noWheel()`, `noInteract()` - see

--- a/ui/static/content/objects/p5.md
+++ b/ui/static/content/objects/p5.md
@@ -37,6 +37,7 @@ P5-specific functions:
 - `hideExitButton()` - hides the fullscreen surface exit badge when the p5 sketch is expanded
 - `setMouseForwarding({ enabled, only, except })` - in surface mode, forwards p5 mouse and wheel interaction to mouse-aware render nodes such as `hydra`, `glsl`, `shaderpark`, and `three`
 - `setPrimaryButton('code' | 'settings' | 'run')` - chooses which action button is shown next to the overflow menu
+- `hideBorder()` - hides Patchies' border and selected glow until the call is removed and the node runs again
 
 ## Surface Overlay Mode
 

--- a/ui/static/content/objects/three.dom.md
+++ b/ui/static/content/objects/three.dom.md
@@ -64,6 +64,7 @@ See the [Patchies JavaScript Runner](/docs/javascript-runner) for all available 
 - `noOutput()` - hides video output port
 - `setHidePorts(true | false)` - hide/show all ports
 - `noDrag()`, `noPan()`, `noWheel()`, `noInteract()` - see [Canvas Interaction](/docs/canvas-interaction)
+- `hideBorder()` - hides Patchies' border and selected glow until the call is removed and the node runs again
 - `fft()` - audio analysis with low latency
 
 ## Resources

--- a/ui/static/content/objects/vue.md
+++ b/ui/static/content/objects/vue.md
@@ -20,6 +20,10 @@ These Vue.js objects and modules are exposed:
 
 TailwindCSS is enabled by default. Call `tailwind(false)` to disable it.
 
+Call `hideBorder()` when the Vue UI should blend into the patch without
+showing Patchies' border or selected glow. Remove
+the call and run the node again to restore the border.
+
 ## Canvas Interaction
 
 - `noDrag()`, `noPan()`, `noWheel()`, `noInteract()` - see


### PR DESCRIPTION
Add `hideBorder()` function to hide borders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `hideBorder()` option for supported UI node types so their preview can blend in without showing the border/chrome.
  * The hidden state persists while enabled and resets back to the default look when the node is run again without it.

* **Bug Fixes**
  * Error styling still remains visible when needed, even if the border is hidden.
  * Preview controls and interactions continue to work normally while the border is hidden.

* **Tests**
  * Added coverage for the new border-hiding behavior and its availability in supported node types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->