### PR TITLE
refactor(runtime, audio): audio object reconcilation cleanup

### DIFF
--- a/docs/design-docs/specs/167-modular-patchies-roadmap.md
+++ b/docs/design-docs/specs/167-modular-patchies-roadmap.md
@@ -95,6 +95,21 @@ so message endpoints can route control messages into audio parameters. This is
 still a partial Phase 1 implementation: patch loading, graph-level connect APIs,
 video runtime ownership, plugins, and subpatches remain future work.
 
+Audio object lifecycle should follow the same reconciler-owned model as message
+objects. `EditorRuntimeReconciler` decides whether each editor node describes a
+message object, an object-box audio object, or a dedicated runtime-managed audio
+UI node. Object-box audio nodes such as `osc~ 440` must not be created by
+`ObjectNode.svelte`; the view may still update displayed params and suppress the
+next audio sync when the runtime message context has already updated the live
+audio node. Runtime-managed audio UI nodes such as `tap~` and object-box audio
+nodes should share the same audio descriptor reconciliation path.
+`RuntimeAudioObjectAdapter` should only
+apply audio node lifecycle changes, own runtime message contexts, and bridge
+messages into `AudioService.send()`. `AudioService` remains the sole owner of
+audio graph edges because `FlowCanvasInner.svelte` already forwards editor edge
+changes to `AudioService.updateEdges()`, and `AudioService.createNode()` connects
+pending edges for late-created nodes.
+
 The first UI-owned Svelte node validation slice is `button`. Its runtime
 behavior lives in `ui/src/objects/button/ButtonObject.ts`, registered through the
 same object service path as text objects. `ObjectService` owns the per-node

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -527,7 +527,7 @@
 
   $effect(() => {
     reconciler
-      .reconcile(nodes, edges)
+      .reconcile(nodes)
       .catch((error) => logger.error('failed to reconcile editor graph with patch runtime', error));
   });
 

--- a/ui/src/lib/runtime/EditorRuntimeReconciler.ts
+++ b/ui/src/lib/runtime/EditorRuntimeReconciler.ts
@@ -1,4 +1,4 @@
-import type { Edge, Node } from '@xyflow/svelte';
+import type { Node } from '@xyflow/svelte';
 import { hash } from 'ohash';
 import { AudioRegistry } from '$lib/registry/AudioRegistry';
 import type { ObjectInlet } from '$lib/objects/v2/object-metadata';
@@ -21,15 +21,24 @@ interface RuntimeObjectSnapshot {
 type NextRuntimeObjectSnapshot = RuntimeObjectSnapshot & { pendingIds: Set<string> };
 
 export interface EditorRuntime {
-  isObjectInRegistry(objectType: string): boolean;
+  isMessageObjectInRegistry(objectType: string): boolean;
+  isAudioObjectInRegistry(objectType: string): boolean;
   createObject(descriptor: RuntimeObjectDescriptor): Promise<void>;
   updateObject(nodeId: string, descriptor: RuntimeObjectDescriptor): Promise<void>;
   destroyObject(nodeId: string): void;
-  syncRuntimeManagedAudioNodes?(descriptors: Iterable<RuntimeAudioObjectDescriptor>): void;
+  upsertAudioObject(descriptor: RuntimeAudioObjectDescriptor): void;
+  destroyAudioObject(nodeId: string): void;
+  getAudioObject(nodeId: string): unknown | null;
+  consumeSuppressedAudioObjectSync(nodeId: string): boolean;
 }
 
 export class EditorRuntimeReconciler {
   private current: RuntimeObjectSnapshot = {
+    ids: new Set(),
+    descriptorKeys: new Map()
+  };
+
+  private currentAudio: RuntimeObjectSnapshot = {
     ids: new Set(),
     descriptorKeys: new Map()
   };
@@ -42,13 +51,13 @@ export class EditorRuntimeReconciler {
 
   constructor(private runtime: EditorRuntime) {}
 
-  async reconcile(nodes: Node[], edges: Edge[] = []): Promise<void> {
+  async reconcile(nodes: Node[]): Promise<void> {
     const nextObjectDescriptors = new Map<string, RuntimeObjectDescriptor>();
     const nextAudioDescriptors = new Map<string, RuntimeAudioObjectDescriptor>();
     const pendingRuntimeUpdates: Promise<void>[] = [];
 
     for (const node of nodes) {
-      const audioDescriptor = this.getRuntimeAudioObjectDescriptorFromEditorNode(node, edges);
+      const audioDescriptor = this.getRuntimeAudioObjectDescriptorFromEditorNode(node);
 
       if (audioDescriptor) {
         nextAudioDescriptors.set(audioDescriptor.id, audioDescriptor);
@@ -82,7 +91,7 @@ export class EditorRuntimeReconciler {
       }
     }
 
-    this.runtime.syncRuntimeManagedAudioNodes?.(nextAudioDescriptors.values());
+    this.syncAudioObjects(nextAudioDescriptors);
 
     for (const descriptor of nextObjectDescriptors.values()) {
       if (this.next.pendingIds.has(descriptor.id)) continue;
@@ -106,7 +115,7 @@ export class EditorRuntimeReconciler {
 
   private getRuntimeObjectDescriptor(node: Node): RuntimeObjectDescriptor | null {
     const objectType = getRuntimeObjectType(node);
-    if (!objectType || !this.runtime.isObjectInRegistry(objectType)) return null;
+    if (!objectType || !this.runtime.isMessageObjectInRegistry(objectType)) return null;
 
     const data = node.data as EditorRuntimeObjectData | undefined;
 
@@ -114,13 +123,20 @@ export class EditorRuntimeReconciler {
   }
 
   private getRuntimeAudioObjectDescriptorFromEditorNode(
-    node: Node,
-    edges: Edge[]
+    node: Node
   ): RuntimeAudioObjectDescriptor | null {
-    if (node.type === 'object') return null;
-
     const objectType = getRuntimeObjectType(node);
-    if (!objectType || !this.runtime.isObjectInRegistry(objectType)) return null;
+    if (!objectType || !this.runtime.isAudioObjectInRegistry(objectType)) return null;
+
+    const data = node.data as EditorRuntimeObjectData | undefined;
+
+    if (node.type === 'object') {
+      return {
+        id: node.id,
+        objectType,
+        params: getRuntimeObjectDescriptorFromNode(node.id, objectType, data).params
+      };
+    }
 
     const nodeClass = AudioRegistry.getInstance().get(objectType);
     if (!nodeClass) return null;
@@ -129,9 +145,46 @@ export class EditorRuntimeReconciler {
     return {
       id: node.id,
       objectType,
-      params: getAudioParamsFromNodeData(nodeClass.inlets ?? [], node.data),
-      edges
+      params: getAudioParamsFromNodeData(nodeClass.inlets ?? [], node.data)
     };
+  }
+
+  private syncAudioObjects(nextAudioDescriptors: Map<string, RuntimeAudioObjectDescriptor>): void {
+    for (const nodeId of [...this.currentAudio.ids]) {
+      if (!nextAudioDescriptors.has(nodeId)) {
+        this.runtime.destroyAudioObject(nodeId);
+        this.currentAudio.ids.delete(nodeId);
+        this.currentAudio.descriptorKeys.delete(nodeId);
+      }
+    }
+
+    for (const descriptor of nextAudioDescriptors.values()) {
+      const descriptorKey = getRuntimeAudioObjectDescriptorKey(descriptor);
+      const hasCommittedAudioObject = this.currentAudio.ids.has(descriptor.id);
+      const lastSyncedDescriptorKey = this.currentAudio.descriptorKeys.get(descriptor.id);
+
+      if (
+        hasCommittedAudioObject &&
+        lastSyncedDescriptorKey === descriptorKey &&
+        this.runtime.getAudioObject(descriptor.id)
+      ) {
+        continue;
+      }
+
+      if (this.runtime.consumeSuppressedAudioObjectSync(descriptor.id)) {
+        if (hasCommittedAudioObject) {
+          this.currentAudio.descriptorKeys.set(descriptor.id, descriptorKey);
+        } else {
+          this.currentAudio.descriptorKeys.delete(descriptor.id);
+        }
+
+        continue;
+      }
+
+      this.runtime.upsertAudioObject(descriptor);
+      this.currentAudio.ids.add(descriptor.id);
+      this.currentAudio.descriptorKeys.set(descriptor.id, descriptorKey);
+    }
   }
 
   private async syncRuntimeObject(
@@ -158,6 +211,9 @@ export class EditorRuntimeReconciler {
 
 const getRuntimeObjectDescriptorKey = (descriptor: RuntimeObjectDescriptor): string =>
   hash([descriptor.objectType, descriptor.params, descriptor.rawParams]);
+
+const getRuntimeAudioObjectDescriptorKey = (descriptor: RuntimeAudioObjectDescriptor): string =>
+  hash([descriptor.objectType, descriptor.params]);
 
 function getRuntimeObjectType(node: Node): string {
   if (node.type !== 'object') return node.type ?? '';

--- a/ui/src/lib/runtime/PatchRuntime.test-helpers.ts
+++ b/ui/src/lib/runtime/PatchRuntime.test-helpers.ts
@@ -111,7 +111,6 @@ export class FakeObjectService implements RuntimeObjectService {
 export class FakeAudioService {
   removeNodeById = vi.fn();
   createNode = vi.fn();
-  updateEdges = vi.fn();
   send = vi.fn();
 
   audioNode: AudioNodeV2 = {
@@ -165,11 +164,16 @@ export const tapTildeNode = (id: string, data: Record<string, unknown> = {}): No
 });
 
 export const createFakeEditorRuntime = (overrides: Partial<EditorRuntime> = {}) => ({
-  isObjectInRegistry: vi.fn(
+  isMessageObjectInRegistry: vi.fn(
     (objectType: string) => objectType === TEST_OBJECT_TYPE || objectType === 'button'
   ),
+  isAudioObjectInRegistry: vi.fn(() => false),
   createObject: vi.fn(),
   updateObject: vi.fn(),
   destroyObject: vi.fn(),
+  upsertAudioObject: vi.fn(),
+  destroyAudioObject: vi.fn(),
+  getAudioObject: vi.fn(() => null),
+  consumeSuppressedAudioObjectSync: vi.fn(() => false),
   ...overrides
 });

--- a/ui/src/lib/runtime/PatchRuntime.test-helpers.ts
+++ b/ui/src/lib/runtime/PatchRuntime.test-helpers.ts
@@ -110,7 +110,7 @@ export class FakeObjectService implements RuntimeObjectService {
 
 export class FakeAudioService {
   removeNodeById = vi.fn();
-  createNode = vi.fn();
+  createNode = vi.fn(() => Promise.resolve(this.audioNode));
   send = vi.fn();
 
   audioNode: AudioNodeV2 = {

--- a/ui/src/lib/runtime/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/PatchRuntime.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Edge } from '@xyflow/svelte';
 import { RuntimeAudioObjectAdapter } from './RuntimeAudioObjectAdapter';
 import { PatchMessageRuntime } from './PatchMessageRuntime';
 import { PatchRuntime } from './PatchRuntime';
@@ -276,18 +275,15 @@ describe('RuntimeAudioObjectAdapter', () => {
     const audioService = new FakeAudioService();
     const runtime = new RuntimeAudioObjectAdapter({ audioService });
     const nodeId = 'object-audio-runtime-test';
-    const edges = [{ id: 'audio-edge-1', source: nodeId, target: 'out' }] as Edge[];
 
     runtime.upsertAudioObject({
       id: nodeId,
       objectType: 'osc~',
-      params: [440],
-      edges
+      params: [440]
     });
 
     expect(audioService.removeNodeById).toHaveBeenCalledWith(nodeId);
     expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'osc~', [440]);
-    expect(audioService.updateEdges).toHaveBeenCalledWith(edges);
 
     runtime.sendAudioObjectMessage(nodeId, 'frequency', 220);
     expect(audioService.send).toHaveBeenCalledWith(nodeId, 'frequency', 220);
@@ -298,137 +294,15 @@ describe('RuntimeAudioObjectAdapter', () => {
     expect(audioService.removeNodeById).toHaveBeenLastCalledWith(nodeId);
   });
 
-  it('syncs audio object identity changes from view state', () => {
+  it('consumes suppressed audio sync markers once', () => {
     const audioService = new FakeAudioService();
-    const runtime = new RuntimeAudioObjectAdapter({ audioService, isAudioObject: isOsc });
-
+    const runtime = new RuntimeAudioObjectAdapter({ audioService });
     const nodeId = 'object-audio-sync-test';
-    const edges = [{ id: 'audio-edge-1', source: nodeId, target: 'out' }] as Edge[];
-
-    expect(
-      runtime.syncAudioObject({
-        id: nodeId,
-        objectType: 'osc~',
-        params: [440],
-        edges
-      })
-    ).toBe(true);
-
-    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'osc~', [440]);
-
-    expect(
-      runtime.syncAudioObject({
-        id: nodeId,
-        objectType: 'osc~',
-        params: [440],
-        edges
-      })
-    ).toBe(false);
-
-    expect(audioService.createNode).toHaveBeenCalledTimes(1);
 
     runtime.suppressNextAudioObjectSync(nodeId);
 
-    expect(
-      runtime.syncAudioObject({
-        id: nodeId,
-        objectType: 'osc~',
-        params: [220],
-        edges
-      })
-    ).toBe(false);
-
-    expect(audioService.createNode).toHaveBeenCalledTimes(1);
-
-    expect(
-      runtime.syncAudioObject({
-        id: nodeId,
-        objectType: 'gain~',
-        params: [0.5],
-        edges
-      })
-    ).toBe(true);
-
-    expect(audioService.removeNodeById).toHaveBeenLastCalledWith(nodeId);
-  });
-
-  it('syncs runtime-managed audio nodes as a desired descriptor set', () => {
-    const audioService = new FakeAudioService();
-    const runtime = new RuntimeAudioObjectAdapter({ audioService, isAudioObject: isTap });
-    const nodeId = 'tap-runtime-managed-set-test';
-    const edges = [{ id: 'audio-edge-1', source: nodeId, target: 'consumer' }] as Edge[];
-    const descriptor = {
-      id: nodeId,
-      objectType: 'tap~',
-      params: [null, null, 1024, 'xy', 30, false],
-      edges
-    };
-
-    runtime.syncRuntimeManagedAudioNodes([descriptor]);
-    runtime.syncRuntimeManagedAudioNodes([descriptor]);
-
-    expect(audioService.createNode).toHaveBeenCalledTimes(1);
-
-    runtime.syncRuntimeManagedAudioNodes([]);
-
-    expect(audioService.removeNodeById).toHaveBeenLastCalledWith(nodeId);
-  });
-
-  it('recreates an audio object when cached sync state outlives the service node', () => {
-    const audioService = new FakeAudioService();
-
-    const runtime = new RuntimeAudioObjectAdapter({
-      audioService,
-      isAudioObject: (objectType) => objectType === 'osc~'
-    });
-
-    const nodeId = 'object-audio-undo-test';
-    const edges = [{ id: 'audio-edge-1', source: nodeId, target: 'meter' }] as Edge[];
-    const descriptor = { id: nodeId, objectType: 'osc~', params: [440], edges };
-
-    expect(runtime.syncAudioObject(descriptor)).toBe(true);
-
-    audioService.getNodeById.mockReturnValueOnce(null);
-    expect(runtime.syncAudioObject(descriptor)).toBe(true);
-    expect(audioService.createNode).toHaveBeenCalledTimes(2);
-  });
-
-  it('does not record stale audio tracking state when a suppressed first sync is consumed', () => {
-    const audioService = new FakeAudioService();
-
-    const runtime = new RuntimeAudioObjectAdapter({
-      audioService,
-      isAudioObject: (objectType) => objectType === 'osc~'
-    });
-
-    const nodeId = 'object-audio-suppressed-first-sync-test';
-    const edges = [{ id: 'audio-edge-1', source: nodeId, target: 'out' }] as Edge[];
-
-    runtime.suppressNextAudioObjectSync(nodeId);
-
-    expect(
-      runtime.syncAudioObject({
-        id: nodeId,
-        objectType: 'osc~',
-        params: [440],
-        edges
-      })
-    ).toBe(false);
-
-    runtime.destroy();
-
-    expect(audioService.removeNodeById).not.toHaveBeenCalled();
-
-    expect(
-      runtime.syncAudioObject({
-        id: nodeId,
-        objectType: 'osc~',
-        params: [440],
-        edges
-      })
-    ).toBe(true);
-
-    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'osc~', [440]);
+    expect(runtime.consumeSuppressedAudioObjectSync(nodeId)).toBe(true);
+    expect(runtime.consumeSuppressedAudioObjectSync(nodeId)).toBe(false);
   });
 
   it('routes audio object command messages through runtime-owned message contexts', () => {
@@ -460,8 +334,7 @@ describe('RuntimeAudioObjectAdapter', () => {
     runtime.upsertAudioObject({
       id: tapNodeId,
       objectType: 'tap~',
-      params: [null, null, 512, 'wave', 0, true],
-      edges: []
+      params: [null, null, 512, 'wave', 0, true]
     });
     messageSystem.sendMessage(sourceNodeId, { type: 'setSamples', value: 1024 });
 
@@ -551,10 +424,11 @@ describe('PatchRuntime', () => {
 
   it('creates a message endpoint for audio objects', async () => {
     const objectService = new FakeObjectService();
+    const audioService = new FakeAudioService();
 
     const runtime = new PatchRuntime({
       objectService,
-      audioService: new FakeAudioService(),
+      audioService,
       isAudioObject: isOsc
     });
 
@@ -565,11 +439,10 @@ describe('PatchRuntime', () => {
 
     expect(runtime.isObjectInRegistry('osc~')).toBe(true);
 
-    await runtime.createObject({
+    runtime.upsertAudioObject({
       id: audioNodeId,
       objectType: 'osc~',
-      params: [440],
-      rawParams: ['440']
+      params: [440]
     });
 
     const unsubscribe = runtime.subscribeObjectMessages(audioNodeId, callback);
@@ -616,7 +489,6 @@ describe('PatchRuntime', () => {
     });
 
     const nodeId = 'object-patch-runtime-facade-test';
-    const edges = [{ id: 'audio-edge-1', source: nodeId, target: 'out' }] as Edge[];
 
     await runtime.createObject({
       id: nodeId,
@@ -627,8 +499,7 @@ describe('PatchRuntime', () => {
     runtime.upsertAudioObject({
       id: nodeId,
       objectType: 'osc~',
-      params: [440],
-      edges
+      params: [440]
     });
 
     expect(objectService.getObjectById(nodeId)).toBeInstanceOf(PatchRuntimeTestObject);
@@ -681,15 +552,10 @@ describe('EditorRuntimeReconciler', () => {
     runtime.destroy();
   });
 
-  it('delegates runtime-managed audio descriptor sets to the audio runtime', async () => {
-    const syncedDescriptorSets: unknown[][] = [];
-    const syncRuntimeManagedAudioNodes = vi.fn((descriptors: Iterable<unknown>) => {
-      syncedDescriptorSets.push([...descriptors]);
-    });
-
+  it('diffs runtime-managed audio nodes before calling the audio runtime', async () => {
     const runtime = createFakeEditorRuntime({
-      isObjectInRegistry: vi.fn(isTap),
-      syncRuntimeManagedAudioNodes
+      isAudioObjectInRegistry: vi.fn(isTap),
+      getAudioObject: vi.fn(() => ({ nodeId: 'tap-tilde-runtime-noop-test', audioNode: null }))
     });
 
     const reconciler = new EditorRuntimeReconciler(runtime);
@@ -707,15 +573,16 @@ describe('EditorRuntimeReconciler', () => {
     await reconciler.reconcile([node]);
     await reconciler.reconcile([node]);
 
-    expect(syncRuntimeManagedAudioNodes).toHaveBeenCalledTimes(2);
-    expect(syncedDescriptorSets[0]).toEqual([
-      {
-        id: nodeId,
-        objectType: 'tap~',
-        params: [null, null, 1024, 'xy', 30, false],
-        edges: []
-      }
-    ]);
+    expect(runtime.upsertAudioObject).toHaveBeenCalledTimes(1);
+    expect(runtime.upsertAudioObject).toHaveBeenCalledWith({
+      id: nodeId,
+      objectType: 'tap~',
+      params: [null, null, 1024, 'xy', 30, false]
+    });
+
+    await reconciler.reconcile([]);
+
+    expect(runtime.destroyAudioObject).toHaveBeenCalledWith(nodeId);
   });
 
   it('does not sync dedicated audio UI nodes that still own their view runtime', async () => {
@@ -742,6 +609,152 @@ describe('EditorRuntimeReconciler', () => {
     ]);
 
     expect(audioService.createNode).not.toHaveBeenCalled();
+
+    runtime.destroy();
+  });
+
+  it('syncs object-box audio nodes through the audio runtime lifecycle', async () => {
+    const objectService = new FakeObjectService();
+    const audioService = new FakeAudioService();
+    const createObject = vi.spyOn(objectService, 'createObject');
+
+    const runtime = new PatchRuntime({
+      objectService,
+      audioService,
+      isAudioObject: isOsc
+    });
+
+    const reconciler = new EditorRuntimeReconciler(runtime);
+    const nodeId = 'object-box-audio-reconciler-test';
+
+    await reconciler.reconcile([
+      objectNode(nodeId, {
+        expr: 'osc~ 440',
+        name: 'osc~',
+        params: [440]
+      })
+    ]);
+
+    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'osc~', [440]);
+    expect(createObject).not.toHaveBeenCalled();
+
+    await reconciler.reconcile([]);
+
+    expect(audioService.removeNodeById).toHaveBeenLastCalledWith(nodeId);
+
+    runtime.destroy();
+  });
+
+  it('replaces object-box audio nodes with message objects when the object type changes', async () => {
+    const objectService = new FakeObjectService();
+    const audioService = new FakeAudioService();
+
+    const runtime = new PatchRuntime({
+      objectService,
+      audioService,
+      isAudioObject: isOsc
+    });
+
+    const reconciler = new EditorRuntimeReconciler(runtime);
+    const nodeId = 'object-box-audio-to-message-test';
+
+    await reconciler.reconcile([
+      objectNode(nodeId, {
+        expr: 'osc~ 440',
+        name: 'osc~',
+        params: [440]
+      })
+    ]);
+
+    await reconciler.reconcile([
+      objectNode(nodeId, {
+        expr: `${TEST_OBJECT_TYPE} next`,
+        name: TEST_OBJECT_TYPE,
+        params: ['next']
+      })
+    ]);
+
+    expect(audioService.removeNodeById).toHaveBeenLastCalledWith(nodeId);
+    expect(objectService.getObjectById(nodeId)).toBeInstanceOf(PatchRuntimeTestObject);
+
+    runtime.destroy();
+  });
+
+  it('consumes suppressed object-box audio updates without recreating the audio node', async () => {
+    const audioService = new FakeAudioService();
+
+    const runtime = new PatchRuntime({
+      objectService: new FakeObjectService(),
+      audioService,
+      isAudioObject: isOsc
+    });
+
+    const reconciler = new EditorRuntimeReconciler(runtime);
+    const nodeId = 'object-box-audio-suppressed-reconcile-test';
+
+    await reconciler.reconcile([
+      objectNode(nodeId, {
+        expr: 'osc~ 440',
+        name: 'osc~',
+        params: [440]
+      })
+    ]);
+
+    runtime.suppressNextAudioObjectSync(nodeId);
+
+    await reconciler.reconcile([
+      objectNode(nodeId, {
+        expr: 'osc~ 220',
+        name: 'osc~',
+        params: [220]
+      })
+    ]);
+
+    await reconciler.reconcile([
+      objectNode(nodeId, {
+        expr: 'osc~ 220',
+        name: 'osc~',
+        params: [220]
+      })
+    ]);
+
+    expect(audioService.createNode).toHaveBeenCalledTimes(1);
+
+    await reconciler.reconcile([
+      objectNode(nodeId, {
+        expr: 'osc~ 330',
+        name: 'osc~',
+        params: [330]
+      })
+    ]);
+
+    expect(audioService.createNode).toHaveBeenCalledTimes(2);
+
+    runtime.destroy();
+  });
+
+  it('recreates an audio object when reconciler state outlives the service node', async () => {
+    const audioService = new FakeAudioService();
+
+    const runtime = new PatchRuntime({
+      objectService: new FakeObjectService(),
+      audioService,
+      isAudioObject: isOsc
+    });
+
+    const reconciler = new EditorRuntimeReconciler(runtime);
+    const node = objectNode('object-box-audio-undo-test', {
+      expr: 'osc~ 440',
+      name: 'osc~',
+      params: [440]
+    });
+
+    await reconciler.reconcile([node]);
+
+    audioService.getNodeById.mockReturnValueOnce(null);
+    await reconciler.reconcile([node]);
+
+    expect(audioService.createNode).toHaveBeenCalledTimes(2);
 
     runtime.destroy();
   });

--- a/ui/src/lib/runtime/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/PatchRuntime.test.ts
@@ -305,6 +305,33 @@ describe('RuntimeAudioObjectAdapter', () => {
     expect(runtime.consumeSuppressedAudioObjectSync(nodeId)).toBe(false);
   });
 
+  it('handles async audio node creation failures as fire-and-forget work', () => {
+    const audioService = new FakeAudioService();
+    const runtime = new RuntimeAudioObjectAdapter({ audioService });
+    const nodeId = 'object-audio-create-rejection-test';
+    const catchHandlers: Array<(error: unknown) => unknown> = [];
+
+    const createPromise = {
+      catch: vi.fn((handler: (error: unknown) => unknown) => {
+        catchHandlers.push(handler);
+
+        return Promise.resolve(null);
+      })
+    } as unknown as ReturnType<typeof audioService.createNode>;
+
+    audioService.createNode.mockReturnValueOnce(createPromise);
+
+    runtime.upsertAudioObject({
+      id: nodeId,
+      objectType: 'osc~',
+      params: [440]
+    });
+
+    expect(createPromise.catch).toHaveBeenCalledWith(expect.any(Function));
+    expect(catchHandlers).toHaveLength(1);
+    expect(() => catchHandlers[0](new Error('create failed'))).not.toThrow();
+  });
+
   it('routes audio object command messages through runtime-owned message contexts', () => {
     const audioService = new FakeAudioService();
     const onAudioObjectDataChange = vi.fn();

--- a/ui/src/lib/runtime/PatchRuntime.ts
+++ b/ui/src/lib/runtime/PatchRuntime.ts
@@ -26,7 +26,7 @@ export type {
 
 export type PatchRuntimeOptions = {
   objectService: RuntimeObjectService;
-  audioService?: RuntimeAudioObjectService;
+  audioService: RuntimeAudioObjectService;
   isAudioObject?: (objectType: string) => boolean;
   onObjectParamsChange?: (nodeId: string, params: unknown[]) => void;
   onAudioObjectDataChange?: (nodeId: string, updates: Record<string, unknown>) => void;
@@ -53,6 +53,14 @@ export class PatchRuntime {
     return this.message.isObjectInRegistry(objectType) || this.audio.isObjectInRegistry(objectType);
   }
 
+  isMessageObjectInRegistry(objectType: string): boolean {
+    return this.message.isObjectInRegistry(objectType);
+  }
+
+  isAudioObjectInRegistry(objectType: string): boolean {
+    return this.audio.isObjectInRegistry(objectType);
+  }
+
   async createObject(descriptor: RuntimeObjectDescriptor): Promise<void> {
     await this.message.createObject(descriptor);
   }
@@ -66,7 +74,10 @@ export class PatchRuntime {
   }
 
   subscribeObjectMessages(nodeId: string, callback: MessageCallbackFn): (() => void) | null {
-    return this.message.subscribeObjectMessages(nodeId, callback);
+    return (
+      this.message.subscribeObjectMessages(nodeId, callback) ??
+      this.audio.subscribeAudioObjectMessages(nodeId, callback)
+    );
   }
 
   getObjectPorts(
@@ -77,19 +88,17 @@ export class PatchRuntime {
   }
 
   trackObjectViewRevision(nodeId: string): number {
-    return this.message.trackObjectViewRevision(nodeId);
-  }
-
-  syncAudioObject(descriptor: RuntimeAudioObjectDescriptor): boolean {
-    return this.audio.syncAudioObject(descriptor);
-  }
-
-  syncRuntimeManagedAudioNodes(descriptors: Iterable<RuntimeAudioObjectDescriptor>): void {
-    this.audio.syncRuntimeManagedAudioNodes(descriptors);
+    return (
+      this.message.trackObjectViewRevision(nodeId) + this.audio.trackAudioObjectViewRevision(nodeId)
+    );
   }
 
   suppressNextAudioObjectSync(nodeId: string): void {
     this.audio.suppressNextAudioObjectSync(nodeId);
+  }
+
+  consumeSuppressedAudioObjectSync(nodeId: string): boolean {
+    return this.audio.consumeSuppressedAudioObjectSync(nodeId);
   }
 
   upsertAudioObject(descriptor: RuntimeAudioObjectDescriptor): void {

--- a/ui/src/lib/runtime/RuntimeAudioObjectAdapter.ts
+++ b/ui/src/lib/runtime/RuntimeAudioObjectAdapter.ts
@@ -73,7 +73,10 @@ export class RuntimeAudioObjectAdapter {
     this.audioService.removeNodeById(descriptor.id);
 
     // insert new nodes
-    this.audioService.createNode(descriptor.id, descriptor.objectType, descriptor.params);
+    this.audioService
+      .createNode(descriptor.id, descriptor.objectType, descriptor.params)
+      .catch(() => undefined);
+
     const messageContext = this.createAudioObjectMessageContext(
       descriptor.id,
       descriptor.objectType
@@ -81,6 +84,7 @@ export class RuntimeAudioObjectAdapter {
 
     this.audioObjects.set(descriptor.id, { messageContext });
     this.suppressedAudioObjectSyncs.delete(descriptor.id);
+
     this.bumpAudioObjectViewRevision(descriptor.id);
   }
 

--- a/ui/src/lib/runtime/RuntimeAudioObjectAdapter.ts
+++ b/ui/src/lib/runtime/RuntimeAudioObjectAdapter.ts
@@ -1,20 +1,19 @@
-import type { Edge } from '@xyflow/svelte';
-import { hash } from 'ohash';
+import { SvelteMap } from 'svelte/reactivity';
 import type { AudioNodeClass, AudioNodeV2 } from '$lib/audio/v2/interfaces/audio-nodes';
 import { MessageContext } from '$lib/messages/MessageContext';
 import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
+import { validateMessageToObject } from '$lib/objects/validate-object-message';
 import { AudioRegistry } from '$lib/registry/AudioRegistry';
 
 export interface RuntimeAudioObjectService {
   removeNodeById(nodeId: string): void;
   createNode(nodeId: string, objectType: string, params: unknown[]): Promise<AudioNodeV2 | null>;
-  updateEdges(edges: Edge[]): void;
   send(nodeId: string, key: string, message: unknown): void;
   getNodeById(nodeId: string): AudioNodeV2 | null;
 }
 
 export interface RuntimeAudioObjectAdapterOptions {
-  audioService?: RuntimeAudioObjectService;
+  audioService: RuntimeAudioObjectService;
   isAudioObject?: (objectType: string) => boolean;
   onAudioObjectDataChange?: (nodeId: string, updates: Record<string, unknown>) => void;
 }
@@ -23,31 +22,28 @@ export type RuntimeAudioObjectDescriptor = {
   id: string;
   objectType: string;
   params: unknown[];
-  edges: Edge[];
+};
+
+type RuntimeAudioObjectRecord = {
+  messageContext: MessageContext;
 };
 
 export class RuntimeAudioObjectAdapter {
-  private audioService?: RuntimeAudioObjectService;
+  private audioService: RuntimeAudioObjectService;
 
   private isAudioObject: (objectType: string) => boolean;
   private onAudioObjectDataChange?: (nodeId: string, updates: Record<string, unknown>) => void;
 
-  /** Node ids for audio objects created by this adapter, used for runtime-owned cleanup. */
-  private audioObjectIds = new Set<string>();
-
-  /** Last synced object type and params per node id, used to avoid unnecessary audio recreates. */
-  private audioObjectSyncKeys = new Map<string, string>();
-
-  /** Runtime-owned message contexts that keep audio object messages alive without a mounted view. */
-  private audioObjectMessageContexts = new Map<string, MessageContext>();
+  /** Runtime-owned audio objects and their message contexts. */
+  private audioObjects = new Map<string, RuntimeAudioObjectRecord>();
 
   /** Node ids whose next editor-state sync should be ignored because runtime messaging already applied it. */
   private suppressedAudioObjectSyncs = new Set<string>();
 
-  /** Runtime-managed dedicated UI audio node ids, tracked separately from generic object audio ids. */
-  private runtimeManagedAudioNodeIds = new Set<string>();
+  /** Reactive revision counter used by views that read runtime-derived audio node state. */
+  private audioObjectViewRevisions = new SvelteMap<string, number>();
 
-  constructor(options: RuntimeAudioObjectAdapterOptions = {}) {
+  constructor(options: RuntimeAudioObjectAdapterOptions) {
     this.audioService = options.audioService;
 
     this.isAudioObject =
@@ -60,142 +56,80 @@ export class RuntimeAudioObjectAdapter {
     return this.isAudioObject(objectType);
   }
 
-  syncAudioObject(descriptor: RuntimeAudioObjectDescriptor): boolean {
-    if (!this.isObjectInRegistry(descriptor.objectType)) {
-      // The same editor node may stop being an audio object after its text changes.
-      // If this adapter previously created audio runtime state for it, tear that down.
-      this.suppressedAudioObjectSyncs.delete(descriptor.id);
-      if (!this.audioObjectSyncKeys.has(descriptor.id)) return false;
-
-      this.destroyAudioObject(descriptor.id);
-
-      return true;
-    }
-
-    const syncKey = this.getAudioObjectSyncKey(descriptor);
-
-    if (this.audioObjectSyncKeys.get(descriptor.id) === syncKey) {
-      // The editor state still describes the same audio object. Usually this is a no-op,
-      // but delete/undo or graph cleanup can remove the AudioService node while leaving
-      // this adapter's sync cache warm. Recreate when the service node is missing.
-      if (!this.audioObjectIds.has(descriptor.id) || this.getAudioObject(descriptor.id)) {
-        return false;
-      }
-
-      this.upsertAudioObject(descriptor);
-
-      return true;
-    }
-
-    if (this.suppressedAudioObjectSyncs.delete(descriptor.id)) {
-      // Runtime-owned message contexts can update both the live audio node and editor
-      // node data. When that data change loops back through reconciliation, skip the
-      // recreate because the audio node already received the setting message.
-      if (this.audioObjectIds.has(descriptor.id)) {
-        this.audioObjectSyncKeys.set(descriptor.id, syncKey);
-      } else {
-        this.audioObjectSyncKeys.delete(descriptor.id);
-      }
-
-      return false;
-    }
-
-    this.upsertAudioObject(descriptor);
-
-    return true;
-  }
-
-  /**
-   * Syncs the full desired set of runtime-managed dedicated audio UI nodes.
-   * Any previously tracked runtime-managed node omitted from this set is destroyed.
-   */
-  syncRuntimeManagedAudioNodes(descriptors: Iterable<RuntimeAudioObjectDescriptor>): void {
-    const nextDescriptors = [...descriptors];
-    const nextIds = new Set(nextDescriptors.map((descriptor) => descriptor.id));
-
-    for (const nodeId of this.runtimeManagedAudioNodeIds) {
-      if (!nextIds.has(nodeId)) {
-        this.destroyAudioObject(nodeId);
-        this.runtimeManagedAudioNodeIds.delete(nodeId);
-      }
-    }
-
-    for (const descriptor of nextDescriptors) {
-      this.syncAudioObject(descriptor);
-      this.runtimeManagedAudioNodeIds.add(descriptor.id);
-    }
-  }
-
   suppressNextAudioObjectSync(nodeId: string): void {
     this.suppressedAudioObjectSyncs.add(nodeId);
   }
 
-  upsertAudioObject(descriptor: RuntimeAudioObjectDescriptor): void {
-    const audioService = this.getAudioService();
+  consumeSuppressedAudioObjectSync(nodeId: string): boolean {
+    const isSuppressed = this.suppressedAudioObjectSyncs.has(nodeId);
+    this.suppressedAudioObjectSyncs.delete(nodeId);
 
+    return isSuppressed;
+  }
+
+  upsertAudioObject(descriptor: RuntimeAudioObjectDescriptor): void {
     // cleanup existing nodes
     this.removeAudioObjectMessageContext(descriptor.id, false);
-    audioService.removeNodeById(descriptor.id);
+    this.audioService.removeNodeById(descriptor.id);
 
     // insert new nodes
-    audioService.createNode(descriptor.id, descriptor.objectType, descriptor.params);
-    this.createAudioObjectMessageContext(descriptor.id, descriptor.objectType);
-    audioService.updateEdges(descriptor.edges);
+    this.audioService.createNode(descriptor.id, descriptor.objectType, descriptor.params);
+    const messageContext = this.createAudioObjectMessageContext(
+      descriptor.id,
+      descriptor.objectType
+    );
 
-    // sync ids and keys
-    this.audioObjectIds.add(descriptor.id);
-    this.audioObjectSyncKeys.set(descriptor.id, this.getAudioObjectSyncKey(descriptor));
+    this.audioObjects.set(descriptor.id, { messageContext });
     this.suppressedAudioObjectSyncs.delete(descriptor.id);
+    this.bumpAudioObjectViewRevision(descriptor.id);
   }
 
   destroyAudioObject(nodeId: string): void {
     // cleanup existing nodes
-    this.getAudioService().removeNodeById(nodeId);
+    this.audioService.removeNodeById(nodeId);
     this.removeAudioObjectMessageContext(nodeId, true);
 
-    // sync ids and keys
-    this.audioObjectIds.delete(nodeId);
-    this.audioObjectSyncKeys.delete(nodeId);
     this.suppressedAudioObjectSyncs.delete(nodeId);
-    this.runtimeManagedAudioNodeIds.delete(nodeId);
+    this.bumpAudioObjectViewRevision(nodeId);
   }
 
   sendAudioObjectMessage(nodeId: string, key: string, message: unknown): void {
-    this.getAudioService().send(nodeId, key, message);
+    this.audioService.send(nodeId, key, message);
   }
 
   getAudioObject(nodeId: string): AudioNodeV2 | null {
-    return this.getAudioService().getNodeById(nodeId);
+    return this.audioService.getNodeById(nodeId);
+  }
+
+  subscribeAudioObjectMessages(nodeId: string, callback: MessageCallbackFn): (() => void) | null {
+    const messageContext = this.audioObjects.get(nodeId)?.messageContext;
+    if (!messageContext) return null;
+
+    messageContext.queue.addCallback(callback);
+
+    return () => {
+      messageContext.queue.removeCallback(callback);
+    };
+  }
+
+  trackAudioObjectViewRevision(nodeId: string): number {
+    return this.audioObjectViewRevisions.get(nodeId) ?? 0;
   }
 
   destroy(): void {
-    for (const nodeId of [...this.audioObjectIds]) {
+    for (const nodeId of [...this.audioObjects.keys()]) {
       this.destroyAudioObject(nodeId);
     }
   }
 
-  private getAudioService(): RuntimeAudioObjectService {
-    if (!this.audioService) {
-      throw new Error('RuntimeAudioObjectAdapter operations require an audioService');
-    }
-
-    return this.audioService;
-  }
-
-  private getAudioObjectSyncKey(
-    descriptor: Pick<RuntimeAudioObjectDescriptor, 'objectType' | 'params'>
-  ): string {
-    return hash([descriptor.objectType, descriptor.params]);
-  }
-
-  private createAudioObjectMessageContext(nodeId: string, objectType: string): void {
+  private createAudioObjectMessageContext(nodeId: string, objectType: string): MessageContext {
     const nodeClass = AudioRegistry.getInstance().get(objectType);
     const messageContext = new MessageContext(nodeId);
     const callback = this.createAudioObjectMessageCallback(nodeId, nodeClass);
 
     messageContext.queue.addCallback(callback);
 
-    this.audioObjectMessageContexts.set(nodeId, messageContext);
+    return messageContext;
   }
 
   private createAudioObjectMessageCallback(
@@ -219,19 +153,24 @@ export class RuntimeAudioObjectAdapter {
       const inlet = meta.inlet;
       if (inlet === undefined) return;
 
-      const inletName = nodeClass?.inlets?.[inlet]?.name;
-      if (!inletName) return;
+      const inletDefinition = nodeClass?.inlets?.[inlet];
+      if (!inletDefinition?.name) return;
+      if (!validateMessageToObject(message, inletDefinition)) return;
 
-      this.sendAudioObjectMessage(nodeId, inletName, message);
+      this.sendAudioObjectMessage(nodeId, inletDefinition.name, message);
     };
   }
 
   private removeAudioObjectMessageContext(nodeId: string, unregisterMessageNode: boolean): void {
-    const messageContext = this.audioObjectMessageContexts.get(nodeId);
+    const messageContext = this.audioObjects.get(nodeId)?.messageContext;
     if (!messageContext) return;
 
     messageContext.destroy({ unregisterNode: unregisterMessageNode });
 
-    this.audioObjectMessageContexts.delete(nodeId);
+    this.audioObjects.delete(nodeId);
+  }
+
+  private bumpAudioObjectViewRevision(nodeId: string): void {
+    this.audioObjectViewRevisions.set(nodeId, (this.audioObjectViewRevisions.get(nodeId) ?? 0) + 1);
   }
 }

--- a/ui/src/objects/object/ObjectNode.svelte
+++ b/ui/src/objects/object/ObjectNode.svelte
@@ -55,7 +55,7 @@
     selected: boolean;
   } = $props();
 
-  const { updateNodeData, deleteElements, updateNode, getEdges } = useSvelteFlow();
+  const { updateNodeData, deleteElements, updateNode } = useSvelteFlow();
 
   const edgesHelper = useEdges();
   const updateNodeInternals = useUpdateNodeInternals();
@@ -86,27 +86,8 @@
   // Track whether a negative value has been seen per inlet (for stable sign width)
   let stickyNegative = $state<Record<number, boolean>>({});
 
-  // Track object instance version to trigger re-evaluation of outlets
-  let objectInstanceVersion = $state(0);
-
   const eventBus = PatchiesEventBus.getInstance();
   const patchRuntime = getPatchRuntime();
-
-  function syncAudioObject(name: string, params: unknown[]) {
-    const didSync =
-      patchRuntime?.syncAudioObject({
-        id: nodeId,
-        objectType: name,
-        params,
-        edges: getEdges()
-      }) ?? false;
-
-    if (didSync) objectInstanceVersion++;
-  }
-
-  $effect(() => {
-    syncAudioObject(data.name, data.params);
-  });
 
   // Composable for searching disabled objects
   const { searchDisabledObject } = useDisabledObjectSuggestion(
@@ -124,7 +105,7 @@
   const objectPorts = useObjectPorts({
     nodeId,
     getObjectMeta: () => objectMeta,
-    trackObjectInstanceVersion: () => objectInstanceVersion
+    trackObjectInstanceVersion: () => patchRuntime?.trackObjectViewRevision(nodeId) ?? 0
   });
 
   const inlets = $derived(objectPorts.inlets);
@@ -361,8 +342,8 @@
         !inlet.type;
 
       if (matchesBaseType) {
-        // For audio objects, suppress the audio sync since the message is already
-        // being forwarded to the worklet directly via PatchRuntime below.
+        // For audio objects, suppress the next reconciler sync since the runtime-owned
+        // message context already forwards this message to the live audio node.
         if (isAudioObject) {
           patchRuntime?.suppressNextAudioObjectSync(nodeId);
         }
@@ -381,10 +362,7 @@
       isAutomated = { ...isAutomated, [meta.inlet]: true };
     }
 
-    // Route audio object messages to audio service
-    if (inlet.name && isAudioObject) {
-      patchRuntime?.sendAudioObjectMessage(nodeId, inlet.name, message);
-
+    if (isAudioObject) {
       return;
     }
   };
@@ -438,8 +416,6 @@
     updateNodeData(nodeId, { expr, name, params });
 
     if (!name || !getAudioObjectNames().includes(name)) return false;
-
-    syncAudioObject(name, params);
 
     return true;
   }
@@ -710,7 +686,7 @@
   const dynamicIconComponent = $derived.by(() => {
     // Re-evaluate when params change or when audio node is created
     void data.params;
-    void objectInstanceVersion;
+    patchRuntime?.trackObjectViewRevision(nodeId);
 
     const audioNode = patchRuntime?.getAudioObject(nodeId);
     if (!audioNode?.getIcon) return null;
@@ -724,7 +700,7 @@
   // Get the param index that the icon represents (to hide it from display)
   const iconParamIndex = $derived.by(() => {
     void data.params;
-    void objectInstanceVersion;
+    patchRuntime?.trackObjectViewRevision(nodeId);
 
     const audioNode = patchRuntime?.getAudioObject(nodeId);
     return audioNode?.getIconParamIndex?.() ?? null;


### PR DESCRIPTION
Cleanup how we reconciled audio objects with the main graph

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved runtime synchronization for audio objects, with explicit object/message/audio lifecycles and more reliable state reconciliation.
  * Audio updates are now handled through the runtime to avoid duplicate syncing of live audio nodes.
* **Bug Fixes**
  * Fixed audio view refresh so icons and node state update correctly after audio/message type changes.
  * Improved suppressed-audio-sync behavior by ensuring suppression markers are consumed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->