### PR TITLE
Adopt IBM Plex typography

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -130,7 +130,7 @@ but it must still feel authored rather than decorated from a generic template.
 
 The current startup, object-browser, settings, AI-settings, documentation, and
 Sparks surfaces are provisional redesign candidates. Their ornamental corner
-brackets and Instrument Serif plus Syne pairing are not design-system authority.
+brackets and the legacy serif plus Syne pairing are not design-system authority.
 The sidebar and command palette are usable evidence but remain open to
 refinement.
 
@@ -188,7 +188,7 @@ or creative action; never use it as continuous decoration across the editor.
 with a technical mono companion. It should feel engineered without becoming
 sterile. Expressive typography may be introduced for a redesigned onboarding
 experience, but it must be chosen intentionally for Patchies rather than
-inherited from the provisional Instrument Serif and Syne treatment.
+inherited from the provisional serif and Syne treatment.
 
 ### Hierarchy
 

--- a/docs/design-docs/specs/45-startup-modal.md
+++ b/docs/design-docs/specs/45-startup-modal.md
@@ -101,6 +101,13 @@ The startup modal is implemented as a modular component system in `/ui/src/lib/c
    - Defaults to enabled for first-time users
    - Orange toggle switch with smooth animation
 
+#### Typography
+
+- Use IBM Plex Sans for interface copy and IBM Plex Mono for shortcuts, commands, and technical
+  labels.
+- Use IBM Plex Serif for expressive editorial headings and italic display copy.
+- Do not use the former display serif. The startup modal should stay within the IBM Plex family.
+
 #### Example Patches JSON Format
 
 ```json

--- a/docs/design-docs/specs/62-improve-documentation-and-help.md
+++ b/docs/design-docs/specs/62-improve-documentation-and-help.md
@@ -320,7 +320,41 @@ Prose styles live in `ui/src/styles/prose.css` (imported in app.css):
 
 Don't duplicate these styles in components.
 
-### 5. Don't Forget Schema Registration
+### 5. Documentation Typography
+
+The `/docs` reading surface uses a **Plex System**:
+
+- **IBM Plex Sans** for page titles, prose, section headings, navigation, and interface labels
+- **IBM Plex Mono** for object names, code, signatures, paths, and other computational language
+- No legacy serif display face or Syne within `/docs`
+
+The typography should feel like a quiet, precise instrument. Hierarchy comes from scale, weight,
+spacing, contrast, and the existing Ember section marker rather than from an ornamental display
+face.
+
+The full documentation surface and compact in-app help share prose infrastructure, but their
+typography must remain independently tunable. A `/docs` typography change must not unintentionally
+change the denser in-app help, chat, or object-prompt variants.
+
+#### Hierarchy
+
+- Page titles are the strongest text on the page, set in Plex Sans with restrained weight and tight
+  tracking.
+- Section headings remain compact, uppercase wayfinding labels with an Ember left rule.
+- Subsection headings use sentence case and a modest increase in contrast over body copy.
+- Body copy prioritizes reading comfort with a stable measure and generous line height.
+- Technical content switches to Plex Mono without making ordinary navigation or prose feel like a
+  terminal.
+- Sidebar taxonomy and previous/next metadata use Plex Sans; object names remain Plex Mono.
+
+#### Performance and loading
+
+- Reuse the Plex families already loaded by the application.
+- Do not add a new font dependency for the documentation page.
+- IBM Plex Serif may serve expressive product surfaces, but `/docs` remains Sans and Mono only.
+- Remove Syne from the global font request only when no remaining product surface uses it.
+
+### 6. Don't Forget Schema Registration
 
 When migrating object docs, **always** complete these steps together:
 

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -1,5 +1,5 @@
 /* App fonts */
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&family=IBM+Plex+Sans:wght@400;500;600&family=Instrument+Serif:ital@0;1&family=Syne:wght@400;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Serif:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&family=Syne:wght@400;600;700;800&display=swap');
 
 /* Uiua array language font */
 @font-face {
@@ -92,7 +92,7 @@ body {
 
 @theme inline {
   --font-sans: 'IBM Plex Sans', ui-sans-serif, system-ui, sans-serif;
-  --font-serif: 'Instrument Serif', serif;
+  --font-serif: 'IBM Plex Serif', ui-serif, Georgia, serif;
   --font-mono:
     'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
     'Courier New', monospace;

--- a/ui/src/lib/components/docs/DocsNavigation.svelte
+++ b/ui/src/lib/components/docs/DocsNavigation.svelte
@@ -77,8 +77,7 @@
           class="group flex min-w-0 flex-1 flex-col rounded-lg border border-zinc-800/80 bg-zinc-900/30 p-4 transition-all hover:border-orange-500/30 hover:bg-zinc-900/60"
         >
           <span
-            class="mb-1.5 flex items-center gap-1 text-[10px] font-bold tracking-widest text-zinc-600 uppercase transition-colors group-hover:text-orange-500/70"
-            style="font-family: 'Syne', sans-serif;"
+            class="mb-1.5 flex items-center gap-1 font-sans text-[10px] font-semibold tracking-widest text-zinc-600 uppercase transition-colors group-hover:text-orange-500/70"
           >
             <ChevronLeft class="h-3 w-3" />
             Previous
@@ -103,8 +102,7 @@
           class="group flex min-w-0 flex-1 flex-col items-end rounded-lg border border-zinc-800/80 bg-zinc-900/30 p-4 text-right transition-all hover:border-orange-500/30 hover:bg-zinc-900/60 sm:items-end"
         >
           <span
-            class="mb-1.5 flex items-center gap-1 text-[10px] font-bold tracking-widest text-zinc-600 uppercase transition-colors group-hover:text-orange-500/70"
-            style="font-family: 'Syne', sans-serif;"
+            class="mb-1.5 flex items-center gap-1 font-sans text-[10px] font-semibold tracking-widest text-zinc-600 uppercase transition-colors group-hover:text-orange-500/70"
           >
             Next
             <ChevronRight class="h-3 w-3" />

--- a/ui/src/lib/components/docs/DocsSidebarDesktop.svelte
+++ b/ui/src/lib/components/docs/DocsSidebarDesktop.svelte
@@ -85,8 +85,7 @@
       <div class="mb-4 flex items-center justify-between">
         <a
           href="/"
-          class="inline-flex items-center gap-1.5 text-xs font-medium text-zinc-600 transition-colors hover:text-orange-400"
-          style="font-family: 'Syne', sans-serif; letter-spacing: 0.04em;"
+          class="inline-flex items-center gap-1.5 font-sans text-xs font-medium tracking-[0.04em] text-zinc-600 transition-colors hover:text-orange-400"
         >
           <ArrowLeft class="h-3.5 w-3.5" />
           Patchies
@@ -112,8 +111,7 @@
       <div class="mb-6">
         <button
           onclick={() => (guidesExpanded = !guidesExpanded)}
-          class="mb-2 flex w-full cursor-pointer items-center gap-1.5 text-[10px] font-bold tracking-widest text-amber-600/80 uppercase transition-colors hover:text-amber-500"
-          style="font-family: 'Syne', sans-serif;"
+          class="mb-2 flex w-full cursor-pointer items-center gap-1.5 font-sans text-[10px] font-semibold tracking-widest text-amber-600/80 uppercase transition-colors hover:text-amber-500"
         >
           {#if guidesExpanded}
             <ChevronDown class="h-3 w-3" />
@@ -132,8 +130,7 @@
               {#if categoryTopics && categoryTopics.length > 0}
                 <div>
                   <div
-                    class="mb-1 text-[9px] font-semibold tracking-widest text-zinc-600 uppercase"
-                    style="font-family: 'Syne', sans-serif;"
+                    class="mb-1 font-sans text-[9px] font-semibold tracking-widest text-zinc-600 uppercase"
                   >
                     {category}
                   </div>
@@ -168,8 +165,7 @@
       <div>
         <button
           onclick={() => (objectsExpanded = !objectsExpanded)}
-          class="mb-2 flex w-full cursor-pointer items-center gap-1.5 text-[10px] font-bold tracking-widest text-amber-600/80 uppercase transition-colors hover:text-amber-500"
-          style="font-family: 'Syne', sans-serif;"
+          class="mb-2 flex w-full cursor-pointer items-center gap-1.5 font-sans text-[10px] font-semibold tracking-widest text-amber-600/80 uppercase transition-colors hover:text-amber-500"
         >
           {#if objectsExpanded}
             <ChevronDown class="h-3 w-3" />

--- a/ui/src/lib/components/startup-modal/ShortcutsTab.svelte
+++ b/ui/src/lib/components/startup-modal/ShortcutsTab.svelte
@@ -143,7 +143,7 @@
   }
 
   .sc-headline {
-    font-family: 'Instrument Serif', serif;
+    font-family: 'IBM Plex Serif', ui-serif, Georgia, serif;
     font-style: italic;
     font-size: clamp(1.8rem, 5vw, 2.4rem);
     line-height: 1.12;

--- a/ui/src/lib/components/startup-modal/ThanksTab.svelte
+++ b/ui/src/lib/components/startup-modal/ThanksTab.svelte
@@ -350,7 +350,7 @@
   }
 
   .thanks-headline {
-    font-family: 'Instrument Serif', serif;
+    font-family: 'IBM Plex Serif', ui-serif, Georgia, serif;
     font-style: italic;
     font-size: clamp(1.8rem, 5vw, 2.6rem);
     line-height: 1.12;

--- a/ui/src/objects/title/TitleNode.svelte
+++ b/ui/src/objects/title/TitleNode.svelte
@@ -79,7 +79,7 @@
   const fontFamily = $derived(
     match(font)
       .with('mono', () => $editorFontFamily)
-      .with('serif', () => "'Instrument Serif', serif")
+      .with('serif', () => "'IBM Plex Serif', ui-serif, Georgia, serif")
       .with('syne', () => "'Syne', sans-serif")
       .with('custom', () => customFontFamily.trim() || $editorFontFamily)
       .otherwise(() => 'inherit')

--- a/ui/src/routes/docs/objects/[object]/+page.svelte
+++ b/ui/src/routes/docs/objects/[object]/+page.svelte
@@ -49,8 +49,7 @@
   {#if data.schema.inlets.length > 0}
     <section class="mb-6">
       <h2
-        class="mb-3 border-l-2 border-orange-500 pl-2 text-[10px] font-bold tracking-widest text-zinc-400 uppercase"
-        style="font-family: 'Syne', sans-serif;"
+        class="mb-3 border-l-2 border-orange-500 pl-2 font-sans text-[10px] font-semibold tracking-widest text-zinc-400 uppercase"
       >
         Inlets
       </h2>
@@ -66,8 +65,7 @@
   {#if data.schema.outlets.length > 0 && !data.schema.hasDynamicOutlets}
     <section class="mb-6">
       <h2
-        class="mb-3 border-l-2 border-orange-500 pl-2 text-[10px] font-bold tracking-widest text-zinc-400 uppercase"
-        style="font-family: 'Syne', sans-serif;"
+        class="mb-3 border-l-2 border-orange-500 pl-2 font-sans text-[10px] font-semibold tracking-widest text-zinc-400 uppercase"
       >
         Outlets
       </h2>
@@ -83,8 +81,7 @@
   {#if data.objectType === 'trigger'}
     <section class="mb-6">
       <h2
-        class="mb-3 border-l-2 border-orange-500 pl-2 text-[10px] font-bold tracking-widest text-zinc-400 uppercase"
-        style="font-family: 'Syne', sans-serif;"
+        class="mb-3 border-l-2 border-orange-500 pl-2 font-sans text-[10px] font-semibold tracking-widest text-zinc-400 uppercase"
       >
         Type Specifiers
       </h2>
@@ -130,8 +127,7 @@
 {#if data.schema?.tags && data.schema.tags.length > 0}
   <section class="mb-6">
     <h2
-      class="mb-3 border-l-2 border-orange-500 pl-2 text-[10px] font-bold tracking-widest text-zinc-400 uppercase"
-      style="font-family: 'Syne', sans-serif;"
+      class="mb-3 border-l-2 border-orange-500 pl-2 font-sans text-[10px] font-semibold tracking-widest text-zinc-400 uppercase"
     >
       Tags
     </h2>

--- a/ui/src/routes/sparks/SparkResults.svelte
+++ b/ui/src/routes/sparks/SparkResults.svelte
@@ -380,7 +380,7 @@
 
 <style>
   .serif-italic {
-    font-family: 'Instrument Serif', serif;
+    font-family: 'IBM Plex Serif', ui-serif, Georgia, serif;
     font-style: italic;
   }
   .syne {

--- a/ui/src/styles/prose.css
+++ b/ui/src/styles/prose.css
@@ -9,6 +9,7 @@
     --prose-h1: calc(1.5rem * var(--prose-scale));
     --prose-h2: calc(1.125rem * var(--prose-scale));
     --prose-h3: calc(0.9375rem * var(--prose-scale));
+    max-width: 70ch;
   }
 
   .prose-markdown:not(.promise-markdown-app) hr {
@@ -104,31 +105,44 @@
     --prose-h3: calc(0.9375rem * var(--prose-scale));
   }
 
-  .prose-markdown h1,
+  .prose-markdown h1 {
+    font-family: 'IBM Plex Sans', ui-sans-serif, sans-serif;
+    font-size: calc(2rem * var(--prose-scale));
+    font-weight: 600;
+    letter-spacing: -0.025em;
+    line-height: 1.2;
+  }
+
   .prose-markdown-app h1 {
     font-family: Syne, ui-sans-serif, sans-serif;
     font-size: calc(2rem * var(--prose-scale));
     font-weight: 700;
-    color: #fafafa;
     letter-spacing: -0.025em;
     line-height: 1.15;
+  }
+
+  .prose-markdown h1,
+  .prose-markdown-app h1 {
+    color: #fafafa;
     margin-bottom: 1.5rem;
     padding-bottom: 1.25rem;
     border-bottom: 1px solid #27272a;
   }
 
   .prose-markdown h2 {
-    font-family: 'Syne', sans-serif;
+    font-family: 'IBM Plex Sans', ui-sans-serif, sans-serif;
+    font-size: calc(0.75rem * var(--prose-scale));
+    font-weight: 600;
   }
 
   .prose-markdown-app h2 {
     font-family: 'IBM Plex Sans', ui-sans-serif, sans-serif;
+    font-size: calc(0.6875rem * var(--prose-scale));
+    font-weight: 700;
   }
 
   .prose-markdown h2,
   .prose-markdown-app h2 {
-    font-size: calc(0.6875rem * var(--prose-scale));
-    font-weight: 700;
     color: #a1a1aa;
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -139,19 +153,21 @@
   }
 
   .prose-markdown h3 {
-    font-family: 'Syne', sans-serif;
+    font-family: 'IBM Plex Sans', ui-sans-serif, sans-serif;
+    font-size: calc(1rem * var(--prose-scale));
+    letter-spacing: -0.01em;
   }
 
   .prose-markdown-app h3 {
     font-family: 'IBM Plex Sans', ui-sans-serif, sans-serif;
+    font-size: calc(0.875rem * var(--prose-scale));
+    letter-spacing: 0.02em;
   }
 
   .prose-markdown h3,
   .prose-markdown-app h3 {
-    font-size: calc(0.875rem * var(--prose-scale));
     font-weight: 600;
     color: #d4d4d8;
-    letter-spacing: 0.02em;
     margin-top: 1.75rem;
     margin-bottom: 0.625rem;
   }
@@ -195,9 +211,16 @@
     border: none;
   }
 
-  .prose-markdown code,
+  .prose-markdown code {
+    font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  }
+
   .prose-markdown-app code {
     font-family: ui-monospace, monospace;
+  }
+
+  .prose-markdown code,
+  .prose-markdown-app code {
     font-size: var(--prose-code);
     background: #27272a;
     padding: 0.125rem 0.375rem;


### PR DESCRIPTION
## Summary

- establish IBM Plex Sans and IBM Plex Mono as the documentation typography system
- replace Instrument Serif with IBM Plex Serif across expressive UI surfaces
- keep compact in-app help styling independent from the full documentation layout
- document the typography decisions in the relevant design specs

## Why

The previous Instrument Serif and Syne treatment felt generic and competed with user-created content. This consolidates the product around the IBM Plex family while keeping the editor quiet, precise, and readable.

## Validation

- [x] `bun run check` — 0 errors, 0 warnings
- [x] `bun run test` — 188 files, 1,199 tests passed
- [x] `bun run build`
- [x] desktop and mobile documentation visual inspection
- [x] no remaining `Instrument Serif` references
- [x] IBM Plex Google Fonts request returns HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated typography across the app, documentation, startup modal, and help content with IBM Plex Sans, Mono, and Serif fonts.
  * Improved heading hierarchy, spacing, font weights, and sidebar/navigation consistency.
  * Refined prose layout with a 70-character line width and clearer inline code styling.
  * Replaced legacy display-font styling with more consistent sans-serif and serif treatments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->