### PR TITLE
feat(tone~, sonic~, elem~): detach object lifecycle

### DIFF
--- a/docs/design-docs/specs/168-runtime-object-editor-representations.md
+++ b/docs/design-docs/specs/168-runtime-object-editor-representations.md
@@ -115,6 +115,9 @@ Important rules:
   must not receive or interpret dedicated editor data such as settings or a
   settings schema; the audio adapter binds that data directly to an audio class
   through its optional `bindRuntimeData` capability.
+- Runtime code editor changes remain an editor-only draft. Code reaches the
+  audio class only on runtime creation or an explicit run command from the Run
+  button, shortcut, or patch message.
 
 ## Data Ownership
 

--- a/docs/design-docs/specs/168-runtime-object-editor-representations.md
+++ b/docs/design-docs/specs/168-runtime-object-editor-representations.md
@@ -107,6 +107,10 @@ Important rules:
   the edge's numeric inlet index with the message, without learning the object
   name or its port grammar. The audio class translates that index into its
   dynamic runtime state. Its Svelte view owns only matching handle redraws.
+- A runtime-managed audio class that defines settings or dynamic editor metadata
+  owns the settings manager and publishes persisted-data updates through the
+  audio adapter. A mounted Svelte view uses that same manager; it must not
+  create a competing settings state.
 
 ## Data Ownership
 

--- a/docs/design-docs/specs/168-runtime-object-editor-representations.md
+++ b/docs/design-docs/specs/168-runtime-object-editor-representations.md
@@ -111,6 +111,10 @@ Important rules:
   owns the settings manager and publishes persisted-data updates through the
   audio adapter. A mounted Svelte view uses that same manager; it must not
   create a competing settings state.
+- `AudioService` receives audio params plus an optional pre-create callback. It
+  must not receive or interpret dedicated editor data such as settings or a
+  settings schema; the audio adapter passes that data directly to the audio
+  class through the callback.
 
 ## Data Ownership
 

--- a/docs/design-docs/specs/168-runtime-object-editor-representations.md
+++ b/docs/design-docs/specs/168-runtime-object-editor-representations.md
@@ -113,8 +113,8 @@ Important rules:
   create a competing settings state.
 - `AudioService` receives audio params plus an optional pre-create callback. It
   must not receive or interpret dedicated editor data such as settings or a
-  settings schema; the audio adapter passes that data directly to the audio
-  class through the callback.
+  settings schema; the audio adapter binds that data directly to an audio class
+  through its optional `bindRuntimeData` capability.
 
 ## Data Ownership
 

--- a/ui/src/lib/audio/index.ts
+++ b/ui/src/lib/audio/index.ts
@@ -1,6 +1,13 @@
 export { AudioService } from './v2/AudioService';
 
-export type { AudioNodeV2, AudioNodeClass, AudioNodeGroup } from './v2/interfaces/audio-nodes';
+export {
+  isRuntimeDataAwareAudioNode,
+  type AudioNodeV2,
+  type AudioNodeClass,
+  type AudioNodeGroup,
+  type RuntimeDataBinding,
+  type RuntimeDataAwareAudioNode
+} from './v2/interfaces/audio-nodes';
 
 export {
   AudioAnalysisSystem,

--- a/ui/src/lib/audio/v2/AudioService.test.ts
+++ b/ui/src/lib/audio/v2/AudioService.test.ts
@@ -1,11 +1,16 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('./nodes', () => ({
   registerAudioNodes: vi.fn()
 }));
 
 import { AudioService } from './AudioService';
-import type { AudioNodeV2 } from './interfaces/audio-nodes';
+import type { AudioNodeClass, AudioNodeV2 } from './interfaces/audio-nodes';
+import { logger } from '$lib/utils/logger';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function registerFakeNode(service: AudioService, node: AudioNodeV2): void {
   (
@@ -13,6 +18,10 @@ function registerFakeNode(service: AudioService, node: AudioNodeV2): void {
       nodesById: Map<string, AudioNodeV2>;
     }
   ).nodesById.set(node.nodeId, node);
+}
+
+function setFakeAudioContext(service: AudioService): void {
+  (service as unknown as { audioContext: AudioContext }).audioContext = {} as AudioContext;
 }
 
 describe('AudioService', () => {
@@ -46,5 +55,62 @@ describe('AudioService', () => {
     service.send(node.nodeId, 'gain', message);
 
     expect(node.send).toHaveBeenCalledWith('gain', message);
+  });
+
+  it('disposes a node superseded while beforeCreate is pending', async () => {
+    const service = new AudioService();
+    setFakeAudioContext(service);
+    const nodeId = 'superseded-node';
+    const replacement: AudioNodeV2 = { nodeId, audioNode: null };
+    const destroy = vi.fn();
+
+    class SupersededNode implements AudioNodeV2 {
+      static type = 'audio-service-superseded-test';
+      static group = 'processors' as const;
+      audioNode = null;
+      nodeId = nodeId;
+      destroy = destroy;
+    }
+
+    service.registry.register(SupersededNode as AudioNodeClass);
+    const connectPendingEdges = vi.spyOn(
+      service as unknown as { connectPendingEdges: (id: string) => void },
+      'connectPendingEdges'
+    );
+
+    const created = await service.createNode(nodeId, SupersededNode.type, [], async () => {
+      registerFakeNode(service, replacement);
+    });
+
+    expect(created).toBeNull();
+    expect(destroy).toHaveBeenCalledOnce();
+    expect(service.getNodeById(nodeId)).toBe(replacement);
+    expect(connectPendingEdges).not.toHaveBeenCalled();
+  });
+
+  it('disposes a node when initialization fails', async () => {
+    const service = new AudioService();
+    setFakeAudioContext(service);
+    const destroy = vi.fn();
+
+    class FailingNode implements AudioNodeV2 {
+      static type = 'audio-service-failing-test';
+      static group = 'processors' as const;
+      audioNode = null;
+      nodeId = 'failing-node';
+      destroy = destroy;
+      create = vi.fn(async () => {
+        throw new Error('create failed');
+      });
+    }
+
+    service.registry.register(FailingNode as AudioNodeClass);
+    const error = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+    await expect(service.createNode('failing-node', FailingNode.type)).resolves.toBeNull();
+
+    expect(error).toHaveBeenCalledWith(`cannot create node ${FailingNode.type}`, expect.any(Error));
+    expect(destroy).toHaveBeenCalledOnce();
+    expect(service.getNodeById('failing-node')).toBeNull();
   });
 });

--- a/ui/src/lib/audio/v2/AudioService.ts
+++ b/ui/src/lib/audio/v2/AudioService.ts
@@ -106,11 +106,7 @@ export class AudioService {
   removeNode(node?: AudioNodeV2 | null): void {
     if (!node) return;
 
-    if (node.destroy) {
-      node.destroy();
-    } else {
-      node.audioNode?.disconnect();
-    }
+    this.destroyNode(node);
 
     this.nodesById.delete(node.nodeId);
   }
@@ -349,9 +345,21 @@ export class AudioService {
 
     try {
       await beforeCreate?.(node);
+      if (!this.isCurrentNode(node)) {
+        this.discardNode(node);
+        return null;
+      }
+
       await node.create?.(params);
     } catch (error) {
       logger.error(`cannot create node ${nodeType}`, error);
+      this.discardNode(node);
+      return null;
+    }
+
+    if (!this.isCurrentNode(node)) {
+      this.discardNode(node);
+      return null;
     }
 
     // Connect destination nodes (out~) to output
@@ -370,6 +378,27 @@ export class AudioService {
     this.connectPendingEdges(nodeId);
 
     return node;
+  }
+
+  private isCurrentNode(node: AudioNodeV2): boolean {
+    return this.nodesById.get(node.nodeId) === node;
+  }
+
+  /** Dispose a creation that failed or was superseded without removing its replacement. */
+  private discardNode(node: AudioNodeV2): void {
+    this.destroyNode(node);
+
+    if (this.isCurrentNode(node)) {
+      this.nodesById.delete(node.nodeId);
+    }
+  }
+
+  private destroyNode(node: AudioNodeV2): void {
+    if (node.destroy) {
+      node.destroy();
+    } else {
+      node.audioNode?.disconnect();
+    }
   }
 
   /**

--- a/ui/src/lib/audio/v2/AudioService.ts
+++ b/ui/src/lib/audio/v2/AudioService.ts
@@ -324,13 +324,14 @@ export class AudioService {
    * @param nodeId - Unique identifier for the node
    * @param nodeType - The type of node to create
    * @param params - Array of parameters for the node
+   * @param beforeCreate - Optional node initialization run before audio creation
    * @returns The created node instance, or null if type not defined
    */
   async createNode(
     nodeId: string,
     nodeType: string,
     params: unknown[] = [],
-    runtimeData?: Record<string, unknown>
+    beforeCreate?: (node: AudioNodeV2) => void | Promise<void>
   ): Promise<AudioNodeV2 | null> {
     const NodeClass = this.registry.get(nodeType);
 
@@ -347,7 +348,7 @@ export class AudioService {
     this.nodesById.set(node.nodeId, node);
 
     try {
-      if (runtimeData) node.initializeRuntimeData?.(runtimeData);
+      await beforeCreate?.(node);
       await node.create?.(params);
     } catch (error) {
       logger.error(`cannot create node ${nodeType}`, error);

--- a/ui/src/lib/audio/v2/AudioService.ts
+++ b/ui/src/lib/audio/v2/AudioService.ts
@@ -329,7 +329,8 @@ export class AudioService {
   async createNode(
     nodeId: string,
     nodeType: string,
-    params: unknown[] = []
+    params: unknown[] = [],
+    runtimeData?: Record<string, unknown>
   ): Promise<AudioNodeV2 | null> {
     const NodeClass = this.registry.get(nodeType);
 
@@ -346,6 +347,7 @@ export class AudioService {
     this.nodesById.set(node.nodeId, node);
 
     try {
+      if (runtimeData) node.initializeRuntimeData?.(runtimeData);
       await node.create?.(params);
     } catch (error) {
       logger.error(`cannot create node ${nodeType}`, error);

--- a/ui/src/lib/audio/v2/interfaces/audio-nodes.ts
+++ b/ui/src/lib/audio/v2/interfaces/audio-nodes.ts
@@ -34,12 +34,6 @@ export type AudioNodeClass = {
   /** If true, dedicated UI nodes of this type are owned by PatchRuntime instead of the Svelte view. */
   runtimeManaged?: boolean;
 
-  /**
-   * If true, dedicated node data is initialized on the audio node before
-   * `create(params)` runs.
-   */
-  acceptsRuntimeData?: boolean;
-
   /** Aliases for the node type (e.g. 's~' for 'send~') */
   aliases?: string[];
 
@@ -51,6 +45,11 @@ export type AudioNodeClass = {
    * message handles whose indices are determined by the object runtime.
    */
   dynamicMessageTarget?: string;
+
+  /**
+   * Initialize runtime node data before `create(params)` runs.
+   */
+  acceptsRuntimeData?: boolean;
 } & ObjectMetadata &
   AudioNodeConstructor;
 

--- a/ui/src/lib/audio/v2/interfaces/audio-nodes.ts
+++ b/ui/src/lib/audio/v2/interfaces/audio-nodes.ts
@@ -1,4 +1,5 @@
 import type { ObjectMetadata } from '$lib/objects';
+import type { SettingsManager } from '$lib/settings';
 
 /**
  * Node group type for v2 audio nodes.
@@ -74,9 +75,6 @@ export interface AudioNodeV2 {
    */
   create?(params: unknown[]): void | Promise<void>;
 
-  /** Initialize dedicated-node data before audio creation. */
-  initializeRuntimeData?(data: Record<string, unknown>): void;
-
   /**
    * Handle incoming messages to the node.
    *
@@ -96,8 +94,6 @@ export interface AudioNodeV2 {
    * @returns The AudioParam or null if not found
    */
   getAudioParam?(name: string): AudioParam | null;
-
-  setRuntimeDataChangeListener?(listener: (updates: Record<string, unknown>) => void): void;
 
   /**
    * Connect this node to another node.
@@ -160,4 +156,25 @@ export interface AudioNodeV2 {
    * @returns The parameter index, or undefined if the icon doesn't replace a param
    */
   getIconParamIndex?(): number | undefined;
+
+  /** Returns runtime-owned settings for audio nodes that expose a settings UI. */
+  getSettingsManager?(): SettingsManager;
 }
+
+/**
+ * Editor data provided to runtime-managed audio nodes before they create their
+ * audio graph. Nodes use `update` to persist runtime-owned changes to editor.
+ */
+export interface RuntimeDataBinding {
+  initialData: Record<string, unknown>;
+  update: (updates: Record<string, unknown>) => void;
+}
+
+/** Capability for audio nodes that own dedicated editor data. */
+export interface RuntimeDataAwareAudioNode {
+  bindRuntimeData(binding: RuntimeDataBinding): void;
+}
+
+export const isRuntimeDataAwareAudioNode = (
+  node: AudioNodeV2
+): node is AudioNodeV2 & RuntimeDataAwareAudioNode => 'bindRuntimeData' in node;

--- a/ui/src/lib/audio/v2/interfaces/audio-nodes.ts
+++ b/ui/src/lib/audio/v2/interfaces/audio-nodes.ts
@@ -33,6 +33,12 @@ export type AudioNodeClass = {
   /** If true, dedicated UI nodes of this type are owned by PatchRuntime instead of the Svelte view. */
   runtimeManaged?: boolean;
 
+  /**
+   * If true, dedicated node data is initialized on the audio node before
+   * `create(params)` runs.
+   */
+  acceptsRuntimeData?: boolean;
+
   /** Aliases for the node type (e.g. 's~' for 'send~') */
   aliases?: string[];
 
@@ -68,6 +74,9 @@ export interface AudioNodeV2 {
    */
   create?(params: unknown[]): void | Promise<void>;
 
+  /** Initialize dedicated-node data before audio creation. */
+  initializeRuntimeData?(data: Record<string, unknown>): void;
+
   /**
    * Handle incoming messages to the node.
    *
@@ -87,6 +96,8 @@ export interface AudioNodeV2 {
    * @returns The AudioParam or null if not found
    */
   getAudioParam?(name: string): AudioParam | null;
+
+  setRuntimeDataChangeListener?(listener: (updates: Record<string, unknown>) => void): void;
 
   /**
    * Connect this node to another node.

--- a/ui/src/lib/audio/v2/interfaces/audio-nodes.ts
+++ b/ui/src/lib/audio/v2/interfaces/audio-nodes.ts
@@ -49,7 +49,7 @@ export type AudioNodeClass = {
   /**
    * Initialize runtime node data before `create(params)` runs.
    */
-  acceptsRuntimeData?: boolean;
+  hasRuntimeData?: boolean;
 } & ObjectMetadata &
   AudioNodeConstructor;
 

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -322,11 +322,7 @@ export class GLSystem {
     // Use match for early returns - most frequent messages first
     match(data)
       .with({ type: 'sendMessageFromNode' }, (data) => {
-        if (typeof data.options?.to === 'string') {
-          this.channelRegistry.broadcast(data.options.to, data.data, data.fromNodeId);
-        } else {
-          this.messageSystem.sendMessage(data.fromNodeId, data.data, data.options);
-        }
+        this.messageSystem.sendMessage(data.fromNodeId, data.data, data.options);
       })
       .with({ type: 'consoleOutput' }, (data) => {
         const args = data.args ?? [data.message];

--- a/ui/src/lib/messages/MessageContext.ts
+++ b/ui/src/lib/messages/MessageContext.ts
@@ -152,12 +152,7 @@ export class MessageContext {
   };
 
   send(data: unknown, options: SendMessageOptions = {}) {
-    // If `to` is a string, it's a channel name - broadcast via ChannelRegistry
-    if (typeof options.to === 'string') {
-      this.channelRegistry.broadcast(options.to, data, this.nodeId);
-    } else {
-      this.messageSystem.sendMessage(this.nodeId, data, options);
-    }
+    this.messageSystem.sendMessage(this.nodeId, data, options);
 
     this.onSend(data, options);
   }

--- a/ui/src/lib/messages/MessageSystem.test.ts
+++ b/ui/src/lib/messages/MessageSystem.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { MessageChannelRegistry } from './MessageChannelRegistry';
 import { MessageSystem } from './MessageSystem';
+
+const namedChannel = 'message-system-named-channel-test';
+const namedChannelReceiverId = 'message-system-named-channel-receiver';
+
+afterEach(() => {
+  MessageChannelRegistry.getInstance().unsubscribe(namedChannel, namedChannelReceiverId);
+});
 
 describe('MessageSystem patchbay edges', () => {
   it('routes messages across registered patchbay edges', () => {
@@ -29,6 +37,19 @@ describe('MessageSystem patchbay edges', () => {
 
     messageSystem.unregisterPatchbayEdge(routeId);
     messageSystem.unregisterNode(targetNodeId);
+  });
+});
+
+describe('MessageSystem named channels', () => {
+  it('broadcasts string targets through the named message channel', () => {
+    const receive = vi.fn();
+    MessageChannelRegistry.getInstance().subscribe(namedChannel, namedChannelReceiverId, receive);
+
+    MessageSystem.getInstance().sendMessage('message-system-named-channel-sender', 'hello', {
+      to: namedChannel
+    });
+
+    expect(receive).toHaveBeenCalledWith('hello', 'message-system-named-channel-sender');
   });
 });
 

--- a/ui/src/lib/messages/MessageSystem.ts
+++ b/ui/src/lib/messages/MessageSystem.ts
@@ -1,5 +1,6 @@
 import type { Edge } from '@xyflow/svelte';
 import type { SendMessageOptions } from './MessageContext';
+import { MessageChannelRegistry } from './MessageChannelRegistry';
 import { logger } from '$lib/utils/logger';
 import { profiler } from '$lib/profiler';
 
@@ -163,8 +164,9 @@ export class MessageSystem {
       return;
     }
 
-    // String `to` means channel-based routing - handled by ChannelRegistry, not edges
+    // String `to` means channel-based routing, not graph-edge routing.
     if (typeof options.to === 'string') {
+      MessageChannelRegistry.getInstance().broadcast(options.to, data, fromNodeId);
       return;
     }
 

--- a/ui/src/lib/runtime/adapters/AudioAdapter.ts
+++ b/ui/src/lib/runtime/adapters/AudioAdapter.ts
@@ -1,4 +1,9 @@
-import type { AudioService, AudioNodeClass, AudioNodeV2 } from '$lib/audio';
+import {
+  type AudioService,
+  type AudioNodeClass,
+  type AudioNodeV2,
+  isRuntimeDataAwareAudioNode
+} from '$lib/audio';
 
 import { MessageContext, type MessageCallbackFn } from '$lib/messages';
 
@@ -64,32 +69,31 @@ export class AudioAdapter {
     this.audioService.removeNodeById(descriptor.id);
 
     // insert new nodes
-    const beforeCreate = descriptor.runtimeData
-      ? (node: AudioNodeV2) => node.initializeRuntimeData?.(descriptor.runtimeData!)
+    const onBeforeAudioNodeCreate = descriptor.runtimeData
+      ? (node: AudioNodeV2) => {
+          if (!isRuntimeDataAwareAudioNode(node)) return;
+
+          node.bindRuntimeData({
+            initialData: descriptor.runtimeData!,
+            update: (updates) => {
+              if (this.audioService.getNodeById(descriptor.id) !== node) return;
+
+              this.suppressNextAudioObjectSync(descriptor.id);
+              this.onAudioObjectDataChange?.(descriptor.id, updates);
+              this.viewRevisions.bump(descriptor.id);
+            }
+          });
+        }
       : undefined;
 
     const nodePromise = this.audioService.createNode(
       descriptor.id,
       descriptor.objectType,
       descriptor.params,
-      beforeCreate
+      onBeforeAudioNodeCreate
     );
 
-    const attachRuntimeDataListener = (node: AudioNodeV2 | null) => {
-      node?.setRuntimeDataChangeListener?.((updates) => {
-        if (this.audioService.getNodeById(descriptor.id) !== node) return;
-
-        this.suppressNextAudioObjectSync(descriptor.id);
-        this.onAudioObjectDataChange?.(descriptor.id, updates);
-        this.viewRevisions.bump(descriptor.id);
-      });
-    };
-
-    if (typeof nodePromise.then === 'function') {
-      nodePromise.then(attachRuntimeDataListener).catch(() => undefined);
-    } else {
-      nodePromise.catch?.(() => undefined);
-    }
+    nodePromise.catch?.(() => undefined);
 
     const messageContext = this.createAudioObjectMessageContext(
       descriptor.id,

--- a/ui/src/lib/runtime/adapters/AudioAdapter.ts
+++ b/ui/src/lib/runtime/adapters/AudioAdapter.ts
@@ -1,4 +1,4 @@
-import type { AudioService, AudioNodeClass } from '$lib/audio';
+import type { AudioService, AudioNodeClass, AudioNodeV2 } from '$lib/audio';
 
 import { MessageContext, type MessageCallbackFn } from '$lib/messages';
 
@@ -64,17 +64,14 @@ export class AudioAdapter {
     this.audioService.removeNodeById(descriptor.id);
 
     // insert new nodes
-    const creation =
-      descriptor.runtimeData === undefined
-        ? this.audioService.createNode(descriptor.id, descriptor.objectType, descriptor.params)
-        : this.audioService.createNode(
-            descriptor.id,
-            descriptor.objectType,
-            descriptor.params,
-            descriptor.runtimeData
-          );
+    const nodePromise = this.audioService.createNode(
+      descriptor.id,
+      descriptor.objectType,
+      descriptor.params,
+      descriptor.runtimeData
+    );
 
-    const attachRuntimeDataListener = (node: Awaited<typeof creation>) => {
+    const attachRuntimeDataListener = (node: AudioNodeV2 | null) => {
       node?.setRuntimeDataChangeListener?.((updates) => {
         if (this.audioService.getNodeById(descriptor.id) !== node) return;
 
@@ -84,12 +81,10 @@ export class AudioAdapter {
       });
     };
 
-    if (typeof (creation as Promise<unknown>).then === 'function') {
-      (creation as Promise<Awaited<typeof creation>>)
-        .then(attachRuntimeDataListener)
-        .catch(() => undefined);
+    if (typeof nodePromise.then === 'function') {
+      nodePromise.then(attachRuntimeDataListener).catch(() => undefined);
     } else {
-      (creation as { catch?: (handler: () => void) => void }).catch?.(() => undefined);
+      nodePromise.catch?.(() => undefined);
     }
 
     const messageContext = this.createAudioObjectMessageContext(

--- a/ui/src/lib/runtime/adapters/AudioAdapter.ts
+++ b/ui/src/lib/runtime/adapters/AudioAdapter.ts
@@ -64,11 +64,15 @@ export class AudioAdapter {
     this.audioService.removeNodeById(descriptor.id);
 
     // insert new nodes
+    const beforeCreate = descriptor.runtimeData
+      ? (node: AudioNodeV2) => node.initializeRuntimeData?.(descriptor.runtimeData!)
+      : undefined;
+
     const nodePromise = this.audioService.createNode(
       descriptor.id,
       descriptor.objectType,
       descriptor.params,
-      descriptor.runtimeData
+      beforeCreate
     );
 
     const attachRuntimeDataListener = (node: AudioNodeV2 | null) => {

--- a/ui/src/lib/runtime/adapters/AudioAdapter.ts
+++ b/ui/src/lib/runtime/adapters/AudioAdapter.ts
@@ -64,9 +64,33 @@ export class AudioAdapter {
     this.audioService.removeNodeById(descriptor.id);
 
     // insert new nodes
-    this.audioService
-      .createNode(descriptor.id, descriptor.objectType, descriptor.params)
-      .catch(() => undefined);
+    const creation =
+      descriptor.runtimeData === undefined
+        ? this.audioService.createNode(descriptor.id, descriptor.objectType, descriptor.params)
+        : this.audioService.createNode(
+            descriptor.id,
+            descriptor.objectType,
+            descriptor.params,
+            descriptor.runtimeData
+          );
+
+    const attachRuntimeDataListener = (node: Awaited<typeof creation>) => {
+      node?.setRuntimeDataChangeListener?.((updates) => {
+        if (this.audioService.getNodeById(descriptor.id) !== node) return;
+
+        this.suppressNextAudioObjectSync(descriptor.id);
+        this.onAudioObjectDataChange?.(descriptor.id, updates);
+        this.viewRevisions.bump(descriptor.id);
+      });
+    };
+
+    if (typeof (creation as Promise<unknown>).then === 'function') {
+      (creation as Promise<Awaited<typeof creation>>)
+        .then(attachRuntimeDataListener)
+        .catch(() => undefined);
+    } else {
+      (creation as { catch?: (handler: () => void) => void }).catch?.(() => undefined);
+    }
 
     const messageContext = this.createAudioObjectMessageContext(
       descriptor.id,

--- a/ui/src/lib/runtime/services/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/services/PatchRuntime.test.ts
@@ -483,10 +483,9 @@ describe('AudioAdapter', () => {
     const node = {
       nodeId: 'runtime-audio-initial-data-test',
       audioNode: null,
-      initializeRuntimeData: vi.fn(),
-      setRuntimeDataChangeListener: (listener: (updates: Record<string, unknown>) => void) => {
-        listener({ messageInletCount: 1, messageOutletCount: 2 });
-      }
+      bindRuntimeData: vi.fn(({ update }) => {
+        update({ messageInletCount: 1, messageOutletCount: 2 });
+      })
     };
 
     audioService.audioNode = node;
@@ -504,7 +503,10 @@ describe('AudioAdapter', () => {
         messageOutletCount: 2
       });
     });
-    expect(node.initializeRuntimeData).toHaveBeenCalledWith({ settings: { gain: 0.5 } });
+    expect(node.bindRuntimeData).toHaveBeenCalledWith({
+      initialData: { settings: { gain: 0.5 } },
+      update: expect.any(Function)
+    });
 
     runtime.destroy();
   });

--- a/ui/src/lib/runtime/services/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/services/PatchRuntime.test.ts
@@ -17,6 +17,9 @@ import { MergeNode } from '$objects/audio-channel/MergeNode';
 import { SplitNode } from '$objects/audio-channel/SplitNode';
 import { ExprNode } from '$objects/expr~/ExprNode';
 import { FExprNode } from '$objects/expr~/FExprNode';
+import { ToneNode } from '$objects/tone~/ToneNode';
+import { SonicNode } from '$objects/sonic~/SonicNode';
+import { ElementaryNode } from '$objects/elem~/ElementaryNode';
 
 import { AudioAdapter } from '../adapters/AudioAdapter';
 import { MessageAdapter } from '../adapters/MessageAdapter';
@@ -63,6 +66,7 @@ const isPiano = (objectType: string) => objectType === 'piano~';
 const isAudioIo = (objectType: string) => objectType === 'out~' || objectType === 'mic~';
 const isAudioChannel = (objectType: string) => objectType === 'merge~' || objectType === 'split~';
 const isAudioExpression = (objectType: string) => objectType === 'expr~' || objectType === 'fexpr~';
+const isAudioCode = (objectType: string) => ['tone~', 'sonic~', 'elem~'].includes(objectType);
 const isOsc = (objectType: string) => objectType === 'osc~';
 const isTap = (objectType: string) => objectType === 'tap~';
 
@@ -470,6 +474,36 @@ describe('AudioAdapter', () => {
     expect(createPromise.catch).toHaveBeenCalledWith(expect.any(Function));
     expect(catchHandlers).toHaveLength(1);
     expect(() => catchHandlers[0](new Error('create failed'))).not.toThrow();
+  });
+
+  it('persists initial runtime-audio data emitted when a listener attaches', async () => {
+    const audioService = createFakeAudioService();
+    const onAudioObjectDataChange = vi.fn();
+    const runtime = new AudioAdapter({ audioService, onAudioObjectDataChange });
+    const node = {
+      nodeId: 'runtime-audio-initial-data-test',
+      audioNode: null,
+      setRuntimeDataChangeListener: (listener: (updates: Record<string, unknown>) => void) => {
+        listener({ messageInletCount: 1, messageOutletCount: 2 });
+      }
+    };
+
+    audioService.audioNode = node;
+
+    runtime.upsertAudioObject({
+      id: node.nodeId,
+      objectType: 'test~',
+      params: [],
+      runtimeData: {}
+    });
+    await Promise.resolve();
+
+    expect(onAudioObjectDataChange).toHaveBeenCalledWith(node.nodeId, {
+      messageInletCount: 1,
+      messageOutletCount: 2
+    });
+
+    runtime.destroy();
   });
 
   it('routes audio object command messages through runtime-owned message contexts', () => {
@@ -1400,6 +1434,61 @@ describe('EditorRuntimeReconciler', () => {
       null,
       '(x1 + x1[-1]) / 2'
     ]);
+
+    runtime.destroy();
+  });
+
+  it('syncs dedicated audio-code nodes with their persisted settings', async () => {
+    const audioService = createFakeAudioService();
+    const runtime = createTestPatchRuntime({
+      objectService: createFakeObjectService(),
+      audioService,
+      isAudioObject: isAudioCode
+    });
+
+    AudioRegistry.getInstance().register(ToneNode);
+    AudioRegistry.getInstance().register(SonicNode);
+    AudioRegistry.getInstance().register(ElementaryNode);
+
+    await setRuntimeGraphFromEditorGraph(runtime, [
+      {
+        id: 'tone-runtime-test',
+        type: 'tone~',
+        position: { x: 0, y: 0 },
+        data: { code: 'outputNode.gain.value = 0.5', settings: { gain: 0.5 }, settingsSchema: [] }
+      },
+      {
+        id: 'sonic-runtime-test',
+        type: 'sonic~',
+        position: { x: 0, y: 0 },
+        data: { code: 'Out.ar(outBus, SinOsc.ar(440))', settings: {}, settingsSchema: [] }
+      },
+      {
+        id: 'elem-runtime-test',
+        type: 'elem~',
+        position: { x: 0, y: 0 },
+        data: { code: 'el.cycle(440)', settings: {}, settingsSchema: [] }
+      }
+    ]);
+
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      'tone-runtime-test',
+      'tone~',
+      [null, 'outputNode.gain.value = 0.5'],
+      { code: 'outputNode.gain.value = 0.5', settings: { gain: 0.5 }, settingsSchema: [] }
+    );
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      'sonic-runtime-test',
+      'sonic~',
+      [null, 'Out.ar(outBus, SinOsc.ar(440))'],
+      { code: 'Out.ar(outBus, SinOsc.ar(440))', settings: {}, settingsSchema: [] }
+    );
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      'elem-runtime-test',
+      'elem~',
+      [null, 'el.cycle(440)'],
+      { code: 'el.cycle(440)', settings: {}, settingsSchema: [] }
+    );
 
     runtime.destroy();
   });

--- a/ui/src/lib/runtime/services/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/services/PatchRuntime.test.ts
@@ -483,6 +483,7 @@ describe('AudioAdapter', () => {
     const node = {
       nodeId: 'runtime-audio-initial-data-test',
       audioNode: null,
+      initializeRuntimeData: vi.fn(),
       setRuntimeDataChangeListener: (listener: (updates: Record<string, unknown>) => void) => {
         listener({ messageInletCount: 1, messageOutletCount: 2 });
       }
@@ -494,14 +495,16 @@ describe('AudioAdapter', () => {
       id: node.nodeId,
       objectType: 'test~',
       params: [],
-      runtimeData: {}
+      runtimeData: { settings: { gain: 0.5 } }
     });
-    await Promise.resolve();
 
-    expect(onAudioObjectDataChange).toHaveBeenCalledWith(node.nodeId, {
-      messageInletCount: 1,
-      messageOutletCount: 2
+    await vi.waitFor(() => {
+      expect(onAudioObjectDataChange).toHaveBeenCalledWith(node.nodeId, {
+        messageInletCount: 1,
+        messageOutletCount: 2
+      });
     });
+    expect(node.initializeRuntimeData).toHaveBeenCalledWith({ settings: { gain: 0.5 } });
 
     runtime.destroy();
   });
@@ -1476,19 +1479,19 @@ describe('EditorRuntimeReconciler', () => {
       'tone-runtime-test',
       'tone~',
       [null, 'outputNode.gain.value = 0.5'],
-      { code: 'outputNode.gain.value = 0.5', settings: { gain: 0.5 }, settingsSchema: [] }
+      expect.any(Function)
     );
     expect(audioService.createNode).toHaveBeenCalledWith(
       'sonic-runtime-test',
       'sonic~',
       [null, 'Out.ar(outBus, SinOsc.ar(440))'],
-      { code: 'Out.ar(outBus, SinOsc.ar(440))', settings: {}, settingsSchema: [] }
+      expect.any(Function)
     );
     expect(audioService.createNode).toHaveBeenCalledWith(
       'elem-runtime-test',
       'elem~',
       [null, 'el.cycle(440)'],
-      { code: 'el.cycle(440)', settings: {}, settingsSchema: [] }
+      expect.any(Function)
     );
 
     runtime.destroy();

--- a/ui/src/lib/runtime/services/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/services/PatchRuntime.test.ts
@@ -427,7 +427,7 @@ describe('AudioAdapter', () => {
     });
 
     expect(audioService.removeNodeById).toHaveBeenCalledWith(nodeId);
-    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'osc~', [440]);
+    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'osc~', [440], undefined);
 
     runtime.audioService.send(nodeId, 'frequency', 220);
     expect(audioService.send).toHaveBeenCalledWith(nodeId, 'frequency', 220);
@@ -943,7 +943,7 @@ describe('PatchRuntime', () => {
     });
 
     expect(objectService.getObjectById(nodeId)).toBeNull();
-    expect(audioService.createNode).toHaveBeenLastCalledWith(nodeId, 'osc~', []);
+    expect(audioService.createNode).toHaveBeenLastCalledWith(nodeId, 'osc~', [], undefined);
   });
 
   it('serializes overlapping object synchronization and retains the latest descriptor', async () => {
@@ -1095,7 +1095,7 @@ describe('PatchRuntime', () => {
     });
 
     expect(objectService.getObjectById(nodeId)).toBeInstanceOf(PatchRuntimeTestObject);
-    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'osc~', [440]);
+    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'osc~', [440], undefined);
 
     runtime.destroy();
 
@@ -1126,14 +1126,12 @@ describe('EditorRuntimeReconciler', () => {
       })
     ]);
 
-    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'tap~', [
-      null,
-      null,
-      1024,
-      'xy',
-      30,
-      false
-    ]);
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      nodeId,
+      'tap~',
+      [null, null, 1024, 'xy', 30, false],
+      undefined
+    );
 
     await setRuntimeGraphFromEditorGraph(runtime, []);
 
@@ -1166,14 +1164,12 @@ describe('EditorRuntimeReconciler', () => {
 
     expect(audioService.createNode).toHaveBeenCalledTimes(1);
 
-    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'tap~', [
-      null,
-      null,
-      1024,
-      'xy',
-      30,
-      false
-    ]);
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      nodeId,
+      'tap~',
+      [null, null, 1024, 'xy', 30, false],
+      undefined
+    );
 
     await setRuntimeGraphFromEditorGraph(runtime, []);
 
@@ -1234,14 +1230,12 @@ describe('EditorRuntimeReconciler', () => {
       }
     ]);
 
-    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'bytebeat~', [
-      null,
-      't * 3',
-      'floatbeat',
-      'function',
-      11025,
-      true
-    ]);
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      nodeId,
+      'bytebeat~',
+      [null, 't * 3', 'floatbeat', 'function', 11025, true],
+      undefined
+    );
 
     runtime.destroy();
   });
@@ -1274,16 +1268,12 @@ describe('EditorRuntimeReconciler', () => {
       }
     ]);
 
-    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'sampler~', [
-      null,
-      'user://samples/kick.wav',
-      0.25,
-      1.5,
-      0.8,
-      1.25,
-      -50,
-      'held'
-    ]);
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      nodeId,
+      'sampler~',
+      [null, 'user://samples/kick.wav', 0.25, 1.5, 0.8, 1.25, -50, 'held'],
+      undefined
+    );
 
     runtime.destroy();
   });
@@ -1308,10 +1298,12 @@ describe('EditorRuntimeReconciler', () => {
       }
     ]);
 
-    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'piano~', [
-      null,
-      { velocity: 88, volume: 72 }
-    ]);
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      nodeId,
+      'piano~',
+      [null, { velocity: 88, volume: 72 }],
+      undefined
+    );
 
     runtime.destroy();
   });
@@ -1347,17 +1339,18 @@ describe('EditorRuntimeReconciler', () => {
       }
     ]);
 
-    expect(audioService.createNode).toHaveBeenCalledWith('output-editor-runtime-test', 'out~', [
-      null,
-      'speakers-1'
-    ]);
-    expect(audioService.createNode).toHaveBeenCalledWith('mic-editor-runtime-test', 'mic~', [
-      null,
-      'microphone-1',
-      false,
-      false,
-      false
-    ]);
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      'output-editor-runtime-test',
+      'out~',
+      [null, 'speakers-1'],
+      undefined
+    );
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      'mic-editor-runtime-test',
+      'mic~',
+      [null, 'microphone-1', false, false, false],
+      undefined
+    );
 
     runtime.destroy();
   });
@@ -1388,14 +1381,18 @@ describe('EditorRuntimeReconciler', () => {
       }
     ]);
 
-    expect(audioService.createNode).toHaveBeenCalledWith('merge-editor-runtime-test', 'merge~', [
-      null,
-      4
-    ]);
-    expect(audioService.createNode).toHaveBeenCalledWith('split-editor-runtime-test', 'split~', [
-      null,
-      3
-    ]);
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      'merge-editor-runtime-test',
+      'merge~',
+      [null, 4],
+      undefined
+    );
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      'split-editor-runtime-test',
+      'split~',
+      [null, 3],
+      undefined
+    );
 
     runtime.destroy();
   });
@@ -1426,14 +1423,18 @@ describe('EditorRuntimeReconciler', () => {
       }
     ]);
 
-    expect(audioService.createNode).toHaveBeenCalledWith('expr-editor-runtime-test', 'expr~', [
-      null,
-      's * 0.5'
-    ]);
-    expect(audioService.createNode).toHaveBeenCalledWith('fexpr-editor-runtime-test', 'fexpr~', [
-      null,
-      '(x1 + x1[-1]) / 2'
-    ]);
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      'expr-editor-runtime-test',
+      'expr~',
+      [null, 's * 0.5'],
+      undefined
+    );
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      'fexpr-editor-runtime-test',
+      'fexpr~',
+      [null, '(x1 + x1[-1]) / 2'],
+      undefined
+    );
 
     runtime.destroy();
   });
@@ -1515,7 +1516,7 @@ describe('EditorRuntimeReconciler', () => {
       })
     ]);
 
-    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'osc~', [440]);
+    expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'osc~', [440], undefined);
     expect(createObject).not.toHaveBeenCalled();
 
     await setRuntimeGraphFromEditorGraph(runtime, []);

--- a/ui/src/lib/runtime/services/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/services/PatchRuntime.test.ts
@@ -1480,21 +1480,53 @@ describe('EditorRuntimeReconciler', () => {
     expect(audioService.createNode).toHaveBeenCalledWith(
       'tone-runtime-test',
       'tone~',
-      [null, 'outputNode.gain.value = 0.5'],
+      [null, null],
       expect.any(Function)
     );
     expect(audioService.createNode).toHaveBeenCalledWith(
       'sonic-runtime-test',
       'sonic~',
-      [null, 'Out.ar(outBus, SinOsc.ar(440))'],
+      [null, null],
       expect.any(Function)
     );
     expect(audioService.createNode).toHaveBeenCalledWith(
       'elem-runtime-test',
       'elem~',
-      [null, 'el.cycle(440)'],
+      [null, null],
       expect.any(Function)
     );
+
+    runtime.destroy();
+  });
+
+  it('does not recreate an audio-code node when its editor code changes', async () => {
+    const audioService = createFakeAudioService();
+    const runtime = createTestPatchRuntime({
+      objectService: createFakeObjectService(),
+      audioService,
+      isAudioObject: (objectType) => objectType === 'tone~'
+    });
+
+    AudioRegistry.getInstance().register(ToneNode);
+
+    await setRuntimeGraphFromEditorGraph(runtime, [
+      {
+        id: 'tone-code-edit-test',
+        type: 'tone~',
+        position: { x: 0, y: 0 },
+        data: { code: 'outputNode.gain.value = 0.5', settings: {}, settingsSchema: [] }
+      }
+    ]);
+    await setRuntimeGraphFromEditorGraph(runtime, [
+      {
+        id: 'tone-code-edit-test',
+        type: 'tone~',
+        position: { x: 0, y: 0 },
+        data: { code: 'outputNode.gain.value = 0.25', settings: {}, settingsSchema: [] }
+      }
+    ]);
+
+    expect(audioService.createNode).toHaveBeenCalledTimes(1);
 
     runtime.destroy();
   });

--- a/ui/src/lib/runtime/services/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/services/PatchRuntime.test.ts
@@ -5,6 +5,7 @@ import { MessageContext } from '$lib/messages/MessageContext';
 
 import { AudioRegistry } from '$lib/registry/AudioRegistry';
 import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+import { logger } from '$lib/utils/logger';
 
 import { ScopeAudioNode } from '$objects/scope~/ScopeAudioNode';
 import { TapNode } from '$objects/tap~/native-dsp/nodes/tap.node';
@@ -415,6 +416,30 @@ describe('MessageAdapter', () => {
 });
 
 describe('AudioAdapter', () => {
+  it.each([
+    [
+      'a synchronous throw',
+      () => {
+        throw new Error('beforeCreate failed');
+      }
+    ],
+    [
+      'an asynchronous rejection',
+      async () => {
+        throw new Error('beforeCreate failed');
+      }
+    ]
+  ])('keeps fake audio creation fire-and-forget after %s', async (_description, beforeCreate) => {
+    const audioService = createFakeAudioService();
+    const error = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+    await expect(audioService.createNode('node-id', 'test~', [], beforeCreate)).resolves.toBe(
+      audioService.audioNode
+    );
+
+    expect(error).toHaveBeenCalledWith('cannot create node test~', expect.any(Error));
+  });
+
   it('owns audio object service interactions', () => {
     const audioService = createFakeAudioService();
     const runtime = new AudioAdapter({ audioService });

--- a/ui/src/lib/runtime/services/RuntimeObjectResolver.ts
+++ b/ui/src/lib/runtime/services/RuntimeObjectResolver.ts
@@ -67,7 +67,9 @@ export class RuntimeObjectResolver {
       params: getAudioParamsFromData(nodeClass.inlets ?? [], object.data)
     };
 
-    if (nodeClass.acceptsRuntimeData) descriptor.runtimeData = object.data;
+    if (nodeClass.acceptsRuntimeData) {
+      descriptor.runtimeData = object.data;
+    }
 
     return descriptor;
   }

--- a/ui/src/lib/runtime/services/RuntimeObjectResolver.ts
+++ b/ui/src/lib/runtime/services/RuntimeObjectResolver.ts
@@ -61,10 +61,14 @@ export class RuntimeObjectResolver {
     const nodeClass = AudioRegistry.getInstance().get(object.type);
     if (!nodeClass?.runtimeManaged) return null;
 
-    return {
+    const descriptor: RuntimeAudioObjectDescriptor = {
       id: object.id,
       objectType: object.type,
       params: getAudioParamsFromData(nodeClass.inlets ?? [], object.data)
     };
+
+    if (nodeClass.acceptsRuntimeData) descriptor.runtimeData = object.data;
+
+    return descriptor;
   }
 }

--- a/ui/src/lib/runtime/services/RuntimeObjectResolver.ts
+++ b/ui/src/lib/runtime/services/RuntimeObjectResolver.ts
@@ -61,16 +61,12 @@ export class RuntimeObjectResolver {
     const nodeClass = AudioRegistry.getInstance().get(object.type);
     if (!nodeClass?.runtimeManaged) return null;
 
-    const descriptor: RuntimeAudioObjectDescriptor = {
+    return {
       id: object.id,
       objectType: object.type,
-      params: getAudioParamsFromData(nodeClass.inlets ?? [], object.data)
+      params: getAudioParamsFromData(nodeClass.inlets ?? [], object.data),
+
+      ...(nodeClass.hasRuntimeData && { runtimeData: object.data })
     };
-
-    if (nodeClass.acceptsRuntimeData) {
-      descriptor.runtimeData = object.data;
-    }
-
-    return descriptor;
   }
 }

--- a/ui/src/lib/runtime/services/RuntimeObjectResolver.ts
+++ b/ui/src/lib/runtime/services/RuntimeObjectResolver.ts
@@ -61,10 +61,15 @@ export class RuntimeObjectResolver {
     const nodeClass = AudioRegistry.getInstance().get(object.type);
     if (!nodeClass?.runtimeManaged) return null;
 
+    const params = getAudioParamsFromData(
+      nodeClass.inlets ?? [],
+      nodeClass.hasRuntimeData ? undefined : object.data
+    );
+
     return {
       id: object.id,
       objectType: object.type,
-      params: getAudioParamsFromData(nodeClass.inlets ?? [], object.data),
+      params,
 
       ...(nodeClass.hasRuntimeData && { runtimeData: object.data })
     };

--- a/ui/src/lib/runtime/types/audio-adapter.ts
+++ b/ui/src/lib/runtime/types/audio-adapter.ts
@@ -2,4 +2,5 @@ export type RuntimeAudioObjectDescriptor = {
   id: string;
   objectType: string;
   params: unknown[];
+  runtimeData?: Record<string, unknown>;
 };

--- a/ui/src/lib/runtime/utils/runtime-object-keys.ts
+++ b/ui/src/lib/runtime/utils/runtime-object-keys.ts
@@ -13,7 +13,7 @@ export const getRuntimeObjectDescriptorKey = (descriptor: RuntimeObjectDescripto
 
 export const getRuntimeAudioObjectDescriptorKey = (
   descriptor: RuntimeAudioObjectDescriptor
-): string => hash([descriptor.objectType, descriptor.params, descriptor.runtimeData]);
+): string => hash([descriptor.objectType, descriptor.params]);
 
 export const getRuntimeConnectionId = (connection: RuntimeConnectionSpec): string =>
   hash([connection.source, connection.outlet, connection.target, connection.inlet]);

--- a/ui/src/lib/runtime/utils/runtime-object-keys.ts
+++ b/ui/src/lib/runtime/utils/runtime-object-keys.ts
@@ -13,7 +13,7 @@ export const getRuntimeObjectDescriptorKey = (descriptor: RuntimeObjectDescripto
 
 export const getRuntimeAudioObjectDescriptorKey = (
   descriptor: RuntimeAudioObjectDescriptor
-): string => hash([descriptor.objectType, descriptor.params]);
+): string => hash([descriptor.objectType, descriptor.params, descriptor.runtimeData]);
 
 export const getRuntimeConnectionId = (connection: RuntimeConnectionSpec): string =>
   hash([connection.source, connection.outlet, connection.target, connection.inlet]);

--- a/ui/src/lib/runtime/utils/runtime-test-utils.ts
+++ b/ui/src/lib/runtime/utils/runtime-test-utils.ts
@@ -180,7 +180,11 @@ export const createFakeObjectService = () =>
 class FakeAudioService {
   audioNode: AudioNodeV2 = { nodeId: 'object-audio-runtime-test', audioNode: null };
   removeNodeById = vi.fn<AudioService['removeNodeById']>();
-  createNode = vi.fn<AudioService['createNode']>(() => Promise.resolve(this.audioNode));
+  createNode = vi.fn<AudioService['createNode']>((_nodeId, _nodeType, _params, beforeCreate) => {
+    const initialized = beforeCreate?.(this.audioNode);
+
+    return Promise.resolve(initialized).then(() => this.audioNode);
+  });
   send = vi.fn<AudioService['send']>();
   getNodeById = vi.fn<AudioService['getNodeById']>(() => this.audioNode);
   updateEdges = vi.fn<AudioService['updateEdges']>();

--- a/ui/src/lib/runtime/utils/runtime-test-utils.ts
+++ b/ui/src/lib/runtime/utils/runtime-test-utils.ts
@@ -3,6 +3,7 @@ import { vi } from 'vitest';
 
 import type { MessageContext } from '$lib/messages';
 import type { AudioService, AudioNodeV2 } from '$lib/audio';
+import { logger } from '$lib/utils/logger';
 
 import {
   type ObjectService,
@@ -180,11 +181,12 @@ export const createFakeObjectService = () =>
 class FakeAudioService {
   audioNode: AudioNodeV2 = { nodeId: 'object-audio-runtime-test', audioNode: null };
   removeNodeById = vi.fn<AudioService['removeNodeById']>();
-  createNode = vi.fn<AudioService['createNode']>((_nodeId, _nodeType, _params, beforeCreate) => {
-    const initialized = beforeCreate?.(this.audioNode);
-
-    return Promise.resolve(initialized).then(() => this.audioNode);
-  });
+  createNode = vi.fn<AudioService['createNode']>((_nodeId, nodeType, _params, beforeCreate) =>
+    Promise.resolve()
+      .then(() => beforeCreate?.(this.audioNode))
+      .catch((error) => logger.error(`cannot create node ${nodeType}`, error))
+      .then(() => this.audioNode)
+  );
   send = vi.fn<AudioService['send']>();
   getNodeById = vi.fn<AudioService['getNodeById']>(() => this.audioNode);
   updateEdges = vi.fn<AudioService['updateEdges']>();

--- a/ui/src/objects/audio-code/RuntimeAudioCodeState.test.ts
+++ b/ui/src/objects/audio-code/RuntimeAudioCodeState.test.ts
@@ -3,18 +3,22 @@ import { describe, expect, it } from 'vitest';
 import { RuntimeAudioCodeState } from './RuntimeAudioCodeState';
 
 describe('RuntimeAudioCodeState', () => {
-  it('replays code-derived editor metadata when the runtime listener attaches', () => {
+  it('replays persisted data when initialized with a runtime listener', () => {
     const state = new RuntimeAudioCodeState('runtime-audio-code-state-test');
     const updates: Record<string, unknown>[] = [];
 
     state.initialize({
-      code: 'setPortCount(1)',
-      settings: { gain: 0.5 },
-      settingsSchema: [],
-      showAudioInput: false
+      initialData: {
+        code: 'setPortCount(1)',
+        settings: { gain: 0.5 },
+        settingsSchema: [],
+        showAudioInput: false,
+        messageInletCount: 1,
+        messageOutletCount: 2,
+        title: 'synth'
+      },
+      update: (update) => updates.push(update)
     });
-    state.publish({ messageInletCount: 1, messageOutletCount: 2, title: 'synth' });
-    state.setListener((update) => updates.push(update));
 
     expect(updates).toEqual([
       {

--- a/ui/src/objects/audio-code/RuntimeAudioCodeState.test.ts
+++ b/ui/src/objects/audio-code/RuntimeAudioCodeState.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { RuntimeAudioCodeState } from './RuntimeAudioCodeState';
+
+describe('RuntimeAudioCodeState', () => {
+  it('replays code-derived editor metadata when the runtime listener attaches', () => {
+    const state = new RuntimeAudioCodeState('runtime-audio-code-state-test');
+    const updates: Record<string, unknown>[] = [];
+
+    state.initialize({
+      code: 'setPortCount(1)',
+      settings: { gain: 0.5 },
+      settingsSchema: [],
+      showAudioInput: false
+    });
+    state.publish({ messageInletCount: 1, messageOutletCount: 2, title: 'synth' });
+    state.setListener((update) => updates.push(update));
+
+    expect(updates).toEqual([
+      {
+        settings: { gain: 0.5 },
+        settingsSchema: [],
+        showAudioInput: false,
+        messageInletCount: 1,
+        messageOutletCount: 2,
+        title: 'synth'
+      }
+    ]);
+  });
+});

--- a/ui/src/objects/audio-code/RuntimeAudioCodeState.ts
+++ b/ui/src/objects/audio-code/RuntimeAudioCodeState.ts
@@ -1,6 +1,7 @@
 import type { SettingsSchema } from '$lib/settings';
 import { SettingsManager } from '$lib/settings';
 import { createKVStore } from '$lib/storage';
+import type { RuntimeDataBinding } from '$lib/audio';
 
 export class RuntimeAudioCodeState {
   private listener: (updates: Record<string, unknown>) => void = () => {};
@@ -30,25 +31,18 @@ export class RuntimeAudioCodeState {
     );
   }
 
-  initialize(data: Record<string, unknown>): void {
+  initialize(binding: RuntimeDataBinding): void {
+    const { initialData: data, update } = binding;
+
+    this.listener = update;
     this.code = typeof data.code === 'string' ? data.code : '';
     this.settings = isRecord(data.settings) ? data.settings : {};
+
     this.settingsSchema = Array.isArray(data.settingsSchema)
       ? (data.settingsSchema as SettingsSchema)
       : [];
+
     this.editorMetadata = pickEditorMetadata(data);
-  }
-
-  setCode(code: string): void {
-    this.code = code;
-  }
-
-  getCode(): string {
-    return this.code;
-  }
-
-  setListener(listener: (updates: Record<string, unknown>) => void): void {
-    this.listener = listener;
 
     this.publish({
       settings: this.settings,
@@ -60,6 +54,14 @@ export class RuntimeAudioCodeState {
   publish(updates: Record<string, unknown>): void {
     this.editorMetadata = { ...this.editorMetadata, ...pickEditorMetadata(updates) };
     this.listener(updates);
+  }
+
+  setCode(code: string): void {
+    this.code = code;
+  }
+
+  getCode(): string {
+    return this.code;
   }
 }
 

--- a/ui/src/objects/audio-code/RuntimeAudioCodeState.ts
+++ b/ui/src/objects/audio-code/RuntimeAudioCodeState.ts
@@ -1,0 +1,74 @@
+import type { SettingsSchema } from '$lib/settings';
+import { SettingsManager } from '$lib/settings';
+import { createKVStore } from '$lib/storage';
+
+export class RuntimeAudioCodeState {
+  private listener: (updates: Record<string, unknown>) => void = () => {};
+
+  private code = '';
+  private settings: Record<string, unknown> = {};
+  private settingsSchema: SettingsSchema = [];
+  private editorMetadata: Record<string, unknown> = {};
+
+  readonly settingsManager: SettingsManager;
+
+  constructor(nodeId: string) {
+    const updateNodeSettings = (
+      settings: Record<string, unknown>,
+      settingsSchema: SettingsSchema
+    ) => {
+      this.settings = settings;
+      this.settingsSchema = settingsSchema;
+
+      this.publish({ settings, settingsSchema });
+    };
+
+    this.settingsManager = new SettingsManager(
+      () => this.settings,
+      updateNodeSettings,
+      createKVStore(nodeId)
+    );
+  }
+
+  initialize(data: Record<string, unknown>): void {
+    this.code = typeof data.code === 'string' ? data.code : '';
+    this.settings = isRecord(data.settings) ? data.settings : {};
+    this.settingsSchema = Array.isArray(data.settingsSchema)
+      ? (data.settingsSchema as SettingsSchema)
+      : [];
+    this.editorMetadata = pickEditorMetadata(data);
+  }
+
+  setCode(code: string): void {
+    this.code = code;
+  }
+
+  getCode(): string {
+    return this.code;
+  }
+
+  setListener(listener: (updates: Record<string, unknown>) => void): void {
+    this.listener = listener;
+
+    this.publish({
+      settings: this.settings,
+      settingsSchema: this.settingsSchema,
+      ...this.editorMetadata
+    });
+  }
+
+  publish(updates: Record<string, unknown>): void {
+    this.editorMetadata = { ...this.editorMetadata, ...pickEditorMetadata(updates) };
+    this.listener(updates);
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const editorMetadataKeys = ['messageInletCount', 'messageOutletCount', 'showAudioInput', 'title'];
+
+const pickEditorMetadata = (data: Record<string, unknown>): Record<string, unknown> =>
+  Object.fromEntries(
+    editorMetadataKeys.filter((key) => key in data).map((key) => [key, data[key]])
+  );

--- a/ui/src/objects/audio-code/SimpleDspLayout.svelte
+++ b/ui/src/objects/audio-code/SimpleDspLayout.svelte
@@ -2,10 +2,8 @@
   import { Code, Expand, Play, Settings, Terminal, X } from '@lucide/svelte/icons';
   import { useUpdateNodeInternals } from '@xyflow/svelte';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
-  import { onMount, onDestroy, type Snippet } from 'svelte';
+  import { type Snippet } from 'svelte';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
-  import { MessageContext } from '$lib/messages/MessageContext';
-  import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings';
@@ -29,7 +27,6 @@
     selected,
     onCodeChange,
     onRun,
-    handleMessage,
     actionButtons,
     console: consoleSnippet,
     showConsole = false,
@@ -53,7 +50,6 @@
     selected: boolean;
     onCodeChange: (code: string) => void;
     onRun: () => void;
-    handleMessage: MessageCallbackFn;
     actionButtons?: Snippet;
     console?: Snippet;
     showConsole?: boolean;
@@ -69,7 +65,6 @@
   let showEditor = $state(false);
   let showSettings = $state(false);
   let contentWidth = $state(10);
-  let messageContext: MessageContext;
 
   const updateNodeInternals = useUpdateNodeInternals();
 
@@ -97,7 +92,7 @@
 
   // Update content width when title changes
   $effect(() => {
-    displayTitle;
+    void displayTitle;
     setTimeout(updateContentWidth, 0);
   });
 
@@ -134,18 +129,6 @@
       updateContentWidth();
     }, 10);
   }
-
-  onMount(() => {
-    messageContext = new MessageContext(nodeId);
-    messageContext.queue.addCallback(handleMessage);
-
-    updateContentWidth();
-  });
-
-  onDestroy(() => {
-    messageContext.queue.removeCallback(handleMessage);
-    messageContext.destroy();
-  });
 
   function updateContentWidth() {
     if (!contentContainer) return;
@@ -286,7 +269,7 @@
 
           <!-- Message inlets (only show if messageInletCount > 0) -->
           {#if messageInletCount > 0}
-            {#each Array.from({ length: messageInletCount }) as _, index (index)}
+            {#each Array.from({ length: messageInletCount }, (_, index) => index) as index (index)}
               <TypedHandle
                 port="inlet"
                 spec={{ handleType: 'message', handleId: index }}
@@ -329,7 +312,7 @@
 
           <!-- Message outlets (only show if messageOutletCount > 0) -->
           {#if messageOutletCount > 0}
-            {#each Array.from({ length: messageOutletCount }) as _, index (index)}
+            {#each Array.from({ length: messageOutletCount }, (_, index) => index) as index (index)}
               <TypedHandle
                 port="outlet"
                 spec={{ handleType: 'message', handleId: index }}

--- a/ui/src/objects/audio-code/runtime-audio-code-messages.ts
+++ b/ui/src/objects/audio-code/runtime-audio-code-messages.ts
@@ -1,0 +1,5 @@
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const isRunMessage = (value: unknown): boolean =>
+  isRecord(value) && isRecord(value.message) && value.message.type === 'run';

--- a/ui/src/objects/elem~/ElementaryAudioNode.svelte
+++ b/ui/src/objects/elem~/ElementaryAudioNode.svelte
@@ -1,22 +1,13 @@
 <script lang="ts">
   import { useSvelteFlow, useUpdateNodeInternals } from '@xyflow/svelte';
   import { onMount, onDestroy } from 'svelte';
-  import { match, P } from 'ts-pattern';
-  import { messages } from '$lib/objects/schemas';
   import { AudioService } from '$lib/audio/v2/AudioService';
-  import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import SimpleDspLayout from '$objects/audio-code/SimpleDspLayout.svelte';
   import type { ElementaryNode } from '$objects/elem~/ElementaryNode';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { ConsoleOutputEvent } from '$lib/eventbus/events';
-  import { SettingsManager } from '$lib/settings';
-  import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
-  import {
-    getInitialSimpleDspAudioInputVisibility,
-    hasAudioInputUsage
-  } from '$lib/audio/visible-audio-inputs';
 
   // Get node data from XY Flow - nodes receive their data as props
   let {
@@ -43,17 +34,7 @@
   const { updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
 
-  function getInitialNodeId() {
-    return nodeId;
-  }
-
   let audioService = AudioService.getInstance();
-
-  const settingsManager = new SettingsManager(
-    () => data.settings ?? {},
-    (settings, schema) => updateNodeData(nodeId, { settings, settingsSchema: schema }),
-    createKVStore(getInitialNodeId())
-  );
 
   let eventBus = PatchiesEventBus.getInstance();
   let previousExecuteCode = $state<number | undefined>(undefined);
@@ -78,50 +59,17 @@
     }
   });
 
-  const handleMessage: MessageCallbackFn = (message, meta) => {
-    match(message)
-      .with(messages.run, () => runElementary())
-      .with(P.any, () => {
-        if (meta?.inlet === undefined) return;
-
-        audioService.send(nodeId, 'messageInlet', {
-          inletIndex: meta.inlet,
-          message,
-          meta
-        });
-      });
-  };
+  $effect(() => {
+    void data.messageInletCount;
+    void data.messageOutletCount;
+    void data.showAudioInput;
+    updateNodeInternals(nodeId);
+  });
 
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
 
   function handleCodeChange(newCode: string) {
     updateNodeData(nodeId, { code: newCode });
-
-    setTimeout(() => {
-      const elemNode = audioService.getNodeById(nodeId) as ElementaryNode | undefined;
-
-      if (!elemNode) return;
-
-      elemNode.onSetPortCount = (inletCount: number, outletCount: number) => {
-        updateNodeData(nodeId, {
-          messageInletCount: inletCount,
-          messageOutletCount: outletCount
-        });
-
-        updateNodeInternals(nodeId);
-      };
-
-      elemNode.onSetTitle = (title: string) => {
-        updateNodeData(nodeId, { title });
-      };
-
-      elemNode.onSetAudioInputVisible = (showAudioInput: boolean) => {
-        updateNodeData(nodeId, { showAudioInput });
-        updateNodeInternals(nodeId);
-      };
-
-      updateNodeInternals(nodeId);
-    }, 10);
   }
 
   function runElementary() {
@@ -129,11 +77,6 @@
     consoleRef?.clearConsole();
     lineErrors = undefined;
 
-    updateNodeData(nodeId, {
-      showAudioInput: hasAudioInputUsage('elem~', data.code)
-    });
-
-    updateNodeInternals(nodeId);
     updateAudioCode(data.code);
   }
 
@@ -142,27 +85,10 @@
   }
 
   onMount(() => {
-    audioService.registerSettingsManager(nodeId, settingsManager);
-
-    updateNodeData(nodeId, {
-      showAudioInput: getInitialSimpleDspAudioInputVisibility(
-        'elem~',
-        data.showAudioInput,
-        data.code
-      )
-    });
-
-    audioService.createNode(nodeId, 'elem~', [null, data.code]);
-
-    handleCodeChange(data.code);
-
     eventBus.addEventListener('consoleOutput', handleConsoleOutput);
   });
 
   onDestroy(() => {
-    audioService.unregisterSettingsManager(nodeId);
-    audioService.removeNodeById(nodeId);
-
     eventBus.removeEventListener('consoleOutput', handleConsoleOutput);
   });
 </script>
@@ -175,14 +101,21 @@
   {selected}
   onCodeChange={handleCodeChange}
   onRun={runElementary}
-  {handleMessage}
   showConsole={data.showConsole}
   onToggleConsole={handleToggleConsole}
   {lineErrors}
   settingsSchema={data.settingsSchema}
   settingsValues={data.settings ?? {}}
-  onSettingsValueChange={(key, value) => settingsManager.setValue(key, value)}
-  onSettingsRevertAll={() => settingsManager.revertAll()}
+  onSettingsValueChange={(key, value) => {
+    const node = audioService.getNodeById(nodeId) as ElementaryNode | null;
+
+    node?.getSettingsManager().setValue(key, value);
+  }}
+  onSettingsRevertAll={() => {
+    const node = audioService.getNodeById(nodeId) as ElementaryNode | null;
+
+    node?.getSettingsManager().revertAll();
+  }}
 >
   {#snippet console()}
     <VirtualConsole

--- a/ui/src/objects/elem~/ElementaryAudioNode.svelte
+++ b/ui/src/objects/elem~/ElementaryAudioNode.svelte
@@ -65,7 +65,7 @@
     updateNodeInternals(nodeId);
   });
 
-  const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
+  const runAudioCode = (code: string) => audioService.send(nodeId, 'run', code);
   const getSettingsManager = () => audioService.getNodeById(nodeId)?.getSettingsManager?.();
 
   function handleCodeChange(newCode: string) {
@@ -77,7 +77,7 @@
     consoleRef?.clearConsole();
     lineErrors = undefined;
 
-    updateAudioCode(data.code);
+    runAudioCode(data.code);
   }
 
   function handleToggleConsole() {

--- a/ui/src/objects/elem~/ElementaryAudioNode.svelte
+++ b/ui/src/objects/elem~/ElementaryAudioNode.svelte
@@ -3,7 +3,6 @@
   import { onMount, onDestroy } from 'svelte';
   import { AudioService } from '$lib/audio/v2/AudioService';
   import SimpleDspLayout from '$objects/audio-code/SimpleDspLayout.svelte';
-  import type { ElementaryNode } from '$objects/elem~/ElementaryNode';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { ConsoleOutputEvent } from '$lib/eventbus/events';
@@ -67,6 +66,7 @@
   });
 
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
+  const getSettingsManager = () => audioService.getNodeById(nodeId)?.getSettingsManager?.();
 
   function handleCodeChange(newCode: string) {
     updateNodeData(nodeId, { code: newCode });
@@ -107,14 +107,10 @@
   settingsSchema={data.settingsSchema}
   settingsValues={data.settings ?? {}}
   onSettingsValueChange={(key, value) => {
-    const node = audioService.getNodeById(nodeId) as ElementaryNode | null;
-
-    node?.getSettingsManager().setValue(key, value);
+    getSettingsManager()?.setValue(key, value);
   }}
   onSettingsRevertAll={() => {
-    const node = audioService.getNodeById(nodeId) as ElementaryNode | null;
-
-    node?.getSettingsManager().revertAll();
+    getSettingsManager()?.revertAll();
   }}
 >
   {#snippet console()}

--- a/ui/src/objects/elem~/ElementaryNode.ts
+++ b/ui/src/objects/elem~/ElementaryNode.ts
@@ -26,8 +26,10 @@ type RecvCallback = (message: unknown, meta: unknown) => void;
 export class ElementaryNode implements AudioNodeV2 {
   static type = 'elem~';
   static group: AudioNodeGroup = 'processors';
+
   static runtimeManaged = true;
-  static acceptsRuntimeData = true;
+  static hasRuntimeData = true;
+
   static dynamicMessageTarget = 'messageInlet';
   static description = 'Elementary Audio DSP synthesis and processing node';
 

--- a/ui/src/objects/elem~/ElementaryNode.ts
+++ b/ui/src/objects/elem~/ElementaryNode.ts
@@ -4,17 +4,16 @@ import { logger } from '$lib/utils/logger';
 import { createCustomConsole } from '$lib/utils/createCustomConsole';
 import { handleCodeError } from '$lib/js-runner/handleCodeError';
 import { match, P } from 'ts-pattern';
-import { MessageContext } from '$lib/messages/MessageContext';
+import { MessageSystem } from '$lib/messages/MessageSystem';
 import { JSRunner } from '$lib/js-runner/JSRunner';
 import type WebRenderer from '@elemaudio/web-renderer';
 import { ELEM_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
-import { AudioService } from '$lib/audio/v2/AudioService';
 import { createSettingsAPI } from '$lib/settings/create-settings-api';
+import { hasAudioInputUsage } from '$lib/audio/visible-audio-inputs';
+import { RuntimeAudioCodeState } from '$objects/audio-code/RuntimeAudioCodeState';
+import { isRunMessage } from '$objects/audio-code/runtime-audio-code-messages';
 
 type RecvCallback = (message: unknown, meta: unknown) => void;
-type OnSetPortCount = (inletCount: number, outletCount: number) => void;
-type OnSetTitle = (title: string) => void;
-type OnSetAudioInputVisible = (visible: boolean) => void;
 
 /**
  * ElementaryNode implements the elem~ audio node.
@@ -23,6 +22,9 @@ type OnSetAudioInputVisible = (visible: boolean) => void;
 export class ElementaryNode implements AudioNodeV2 {
   static type = 'elem~';
   static group: AudioNodeGroup = 'processors';
+  static runtimeManaged = true;
+  static acceptsRuntimeData = true;
+  static dynamicMessageTarget = 'messageInlet';
   static description = 'Elementary Audio DSP synthesis and processing node';
 
   static inlets: ObjectInlet[] = [
@@ -47,7 +49,7 @@ export class ElementaryNode implements AudioNodeV2 {
 
   private inputNode: GainNode;
   private audioContext: AudioContext;
-  private messageContext: MessageContext;
+  private runtimeState: RuntimeAudioCodeState;
   private jsRunner: JSRunner;
 
   // Elementary Audio state
@@ -59,10 +61,6 @@ export class ElementaryNode implements AudioNodeV2 {
   // Dynamic port counts for UI
   private messageInletCount = 0;
   private messageOutletCount = 0;
-
-  public onSetPortCount: OnSetPortCount = () => {};
-  public onSetTitle: OnSetTitle = () => {};
-  public onSetAudioInputVisible: OnSetAudioInputVisible = () => {};
 
   // Custom console for routing output to VirtualConsole
   private customConsole;
@@ -79,7 +77,7 @@ export class ElementaryNode implements AudioNodeV2 {
     this.inputNode = audioContext.createGain();
     this.inputNode.gain.value = 1.0;
 
-    this.messageContext = new MessageContext(nodeId);
+    this.runtimeState = new RuntimeAudioCodeState(nodeId);
     this.jsRunner = JSRunner.getInstance();
   }
 
@@ -89,6 +87,16 @@ export class ElementaryNode implements AudioNodeV2 {
     if (code) {
       await this.setCode(code);
     }
+  }
+  initializeRuntimeData(data: Record<string, unknown>): void {
+    this.runtimeState.initialize(data);
+  }
+  setRuntimeDataChangeListener(listener: (updates: Record<string, unknown>) => void): void {
+    this.runtimeState.setListener(listener);
+  }
+
+  getSettingsManager() {
+    return this.runtimeState.settingsManager;
   }
 
   async send(key: string, msg: unknown): Promise<void> {
@@ -146,6 +154,8 @@ export class ElementaryNode implements AudioNodeV2 {
   }
 
   private async setCode(code: string): Promise<void> {
+    this.runtimeState.setCode(code);
+    this.runtimeState.publish({ showAudioInput: hasAudioInputUsage('elem~', code) });
     if (!code || code.trim() === '') {
       // render silence
       await this.core?.render();
@@ -168,8 +178,8 @@ export class ElementaryNode implements AudioNodeV2 {
       this.messageOutletCount = 0;
       this.recvCallback = null;
 
-      const settingsManager = AudioService.getInstance().getSettingsManager(this.nodeId);
-      settingsManager?.clearCallbacks();
+      const settingsManager = this.runtimeState.settingsManager;
+      settingsManager.clearCallbacks();
 
       // Create recv function for receiving messages
       const recv = (callback: (message: unknown, meta: unknown) => void) => {
@@ -178,7 +188,7 @@ export class ElementaryNode implements AudioNodeV2 {
 
       // Create send function for sending messages
       const send = (message: unknown, options?: { to?: number }) =>
-        this.messageContext.send(message, options);
+        MessageSystem.getInstance().sendMessage(this.nodeId, message, options);
 
       // Preprocess code using JSRunner
       const processedCode = await this.jsRunner.preprocessCode(code, { nodeId: this.nodeId });
@@ -193,10 +203,14 @@ export class ElementaryNode implements AudioNodeV2 {
         setPortCount: (inletCount: number = 0, outletCount: number = 0) => {
           this.messageInletCount = Math.max(0, inletCount);
           this.messageOutletCount = Math.max(0, outletCount);
-          this.onSetPortCount(this.messageInletCount, this.messageOutletCount);
+
+          this.runtimeState.publish({
+            messageInletCount: this.messageInletCount,
+            messageOutletCount: this.messageOutletCount
+          });
         },
         setTitle: (title: string) => {
-          this.onSetTitle(title);
+          this.runtimeState.publish({ title });
         },
         extraContext: {
           el: elementaryCore.el,
@@ -206,7 +220,7 @@ export class ElementaryNode implements AudioNodeV2 {
           outputNode: this.audioNode,
           recv,
           send,
-          showAudioInput: () => this.onSetAudioInputVisible(true),
+          showAudioInput: () => this.runtimeState.publish({ showAudioInput: true }),
           ...(settingsManager ? { settings: createSettingsAPI(settingsManager) } : {})
         }
       });
@@ -216,6 +230,11 @@ export class ElementaryNode implements AudioNodeV2 {
   }
 
   private handleMessageInlet(message: unknown): void {
+    if (isRunMessage(message)) {
+      this.setCode(this.runtimeState.getCode());
+      return;
+    }
+
     if (!this.recvCallback) return;
 
     const handleError = (error: unknown) => {
@@ -256,7 +275,6 @@ export class ElementaryNode implements AudioNodeV2 {
     this.cleanup();
     this.recvCallback = null;
 
-    this.messageContext.destroy();
     this.jsRunner.destroy(this.nodeId);
 
     // Disconnect audio nodes

--- a/ui/src/objects/elem~/ElementaryNode.ts
+++ b/ui/src/objects/elem~/ElementaryNode.ts
@@ -1,4 +1,8 @@
-import { type AudioNodeV2, type AudioNodeGroup } from '$lib/audio/v2/interfaces/audio-nodes';
+import {
+  type AudioNodeV2,
+  type AudioNodeGroup,
+  type RuntimeDataBinding
+} from '$lib/audio/v2/interfaces/audio-nodes';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 import { logger } from '$lib/utils/logger';
 import { createCustomConsole } from '$lib/utils/createCustomConsole';
@@ -87,18 +91,6 @@ export class ElementaryNode implements AudioNodeV2 {
     if (code) {
       await this.setCode(code);
     }
-  }
-
-  initializeRuntimeData(data: Record<string, unknown>): void {
-    this.runtimeState.initialize(data);
-  }
-
-  setRuntimeDataChangeListener(listener: (updates: Record<string, unknown>) => void): void {
-    this.runtimeState.setListener(listener);
-  }
-
-  getSettingsManager() {
-    return this.runtimeState.settingsManager;
   }
 
   async send(key: string, msg: unknown): Promise<void> {
@@ -264,6 +256,14 @@ export class ElementaryNode implements AudioNodeV2 {
     } catch (error) {
       handleError(error);
     }
+  }
+
+  bindRuntimeData(binding: RuntimeDataBinding): void {
+    this.runtimeState.initialize(binding);
+  }
+
+  getSettingsManager() {
+    return this.runtimeState.settingsManager;
   }
 
   private cleanup(): void {

--- a/ui/src/objects/elem~/ElementaryNode.ts
+++ b/ui/src/objects/elem~/ElementaryNode.ts
@@ -150,10 +150,13 @@ export class ElementaryNode implements AudioNodeV2 {
   private async setCode(code: string): Promise<void> {
     this.runtimeState.setCode(code);
     this.runtimeState.publish({ showAudioInput: hasAudioInputUsage('elem~', code) });
+    this.resetMessagePorts();
+
     if (!code || code.trim() === '') {
       // render silence
       await this.core?.render();
       this.cleanup();
+
       return;
     }
 
@@ -167,11 +170,6 @@ export class ElementaryNode implements AudioNodeV2 {
         throw new Error('Elementary Audio not initialized');
       }
 
-      // Reset message inlet count and recv callback for new code
-      this.messageInletCount = 0;
-      this.messageOutletCount = 0;
-      this.recvCallback = null;
-
       const settingsManager = this.runtimeState.settingsManager;
       settingsManager.clearCallbacks();
 
@@ -181,7 +179,7 @@ export class ElementaryNode implements AudioNodeV2 {
       };
 
       // Create send function for sending messages
-      const send = (message: unknown, options?: { to?: number }) =>
+      const send = (message: unknown, options?: { to?: number | string }) =>
         MessageSystem.getInstance().sendMessage(this.nodeId, message, options);
 
       // Preprocess code using JSRunner
@@ -256,6 +254,14 @@ export class ElementaryNode implements AudioNodeV2 {
     } catch (error) {
       handleError(error);
     }
+  }
+
+  private resetMessagePorts(): void {
+    this.messageInletCount = 0;
+    this.messageOutletCount = 0;
+    this.recvCallback = null;
+
+    this.runtimeState.publish({ messageInletCount: 0, messageOutletCount: 0 });
   }
 
   bindRuntimeData(binding: RuntimeDataBinding): void {

--- a/ui/src/objects/elem~/ElementaryNode.ts
+++ b/ui/src/objects/elem~/ElementaryNode.ts
@@ -87,8 +87,8 @@ export class ElementaryNode implements AudioNodeV2 {
     this.jsRunner = JSRunner.getInstance();
   }
 
-  async create(params: unknown[]): Promise<void> {
-    const [, code] = params as [unknown, string];
+  async create(): Promise<void> {
+    const code = this.runtimeState.getCode();
 
     if (code) {
       await this.setCode(code);
@@ -97,7 +97,7 @@ export class ElementaryNode implements AudioNodeV2 {
 
   async send(key: string, msg: unknown): Promise<void> {
     return match([key, msg])
-      .with(['code', P.string], ([, code]) => {
+      .with(['run', P.string], ([, code]) => {
         return this.setCode(code);
       })
       .with(['messageInlet', P.any], ([, messageData]) => {

--- a/ui/src/objects/elem~/ElementaryNode.ts
+++ b/ui/src/objects/elem~/ElementaryNode.ts
@@ -88,9 +88,11 @@ export class ElementaryNode implements AudioNodeV2 {
       await this.setCode(code);
     }
   }
+
   initializeRuntimeData(data: Record<string, unknown>): void {
     this.runtimeState.initialize(data);
   }
+
   setRuntimeDataChangeListener(listener: (updates: Record<string, unknown>) => void): void {
     this.runtimeState.setListener(listener);
   }

--- a/ui/src/objects/sonic~/SonicNode.svelte
+++ b/ui/src/objects/sonic~/SonicNode.svelte
@@ -3,7 +3,6 @@
   import { onMount, onDestroy } from 'svelte';
   import { AudioService } from '$lib/audio/v2/AudioService';
   import SimpleDspLayout from '$objects/audio-code/SimpleDspLayout.svelte';
-  import type { SonicNode } from '$objects/sonic~/SonicNode';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { ConsoleOutputEvent } from '$lib/eventbus/events';
@@ -65,6 +64,7 @@
   });
 
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
+  const getSettingsManager = () => audioService.getNodeById(nodeId)?.getSettingsManager?.();
 
   function handleCodeChange(newCode: string) {
     updateNodeData(nodeId, { code: newCode });
@@ -104,12 +104,12 @@
   {lineErrors}
   settingsSchema={data.settingsSchema}
   settingsValues={data.settings ?? {}}
-  onSettingsValueChange={(key, value) =>
-    (audioService.getNodeById(nodeId) as SonicNode | null)
-      ?.getSettingsManager()
-      .setValue(key, value)}
-  onSettingsRevertAll={() =>
-    (audioService.getNodeById(nodeId) as SonicNode | null)?.getSettingsManager().revertAll()}
+  onSettingsValueChange={(key, value) => {
+    getSettingsManager()?.setValue(key, value);
+  }}
+  onSettingsRevertAll={() => {
+    getSettingsManager()?.revertAll();
+  }}
 >
   {#snippet console()}
     <VirtualConsole

--- a/ui/src/objects/sonic~/SonicNode.svelte
+++ b/ui/src/objects/sonic~/SonicNode.svelte
@@ -63,7 +63,7 @@
     updateNodeInternals(nodeId);
   });
 
-  const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
+  const runAudioCode = (code: string) => audioService.send(nodeId, 'run', code);
   const getSettingsManager = () => audioService.getNodeById(nodeId)?.getSettingsManager?.();
 
   function handleCodeChange(newCode: string) {
@@ -75,7 +75,7 @@
     consoleRef?.clearConsole();
     lineErrors = undefined;
 
-    updateAudioCode(data.code);
+    runAudioCode(data.code);
   }
 
   function handleToggleConsole() {

--- a/ui/src/objects/sonic~/SonicNode.svelte
+++ b/ui/src/objects/sonic~/SonicNode.svelte
@@ -1,22 +1,13 @@
 <script lang="ts">
   import { useSvelteFlow, useUpdateNodeInternals } from '@xyflow/svelte';
   import { onMount, onDestroy } from 'svelte';
-  import { match, P } from 'ts-pattern';
-  import { messages } from '$lib/objects/schemas';
   import { AudioService } from '$lib/audio/v2/AudioService';
-  import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import SimpleDspLayout from '$objects/audio-code/SimpleDspLayout.svelte';
   import type { SonicNode } from '$objects/sonic~/SonicNode';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { ConsoleOutputEvent } from '$lib/eventbus/events';
-  import { SettingsManager } from '$lib/settings';
-  import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
-  import {
-    getInitialSimpleDspAudioInputVisibility,
-    hasAudioInputUsage
-  } from '$lib/audio/visible-audio-inputs';
 
   // Get node data from XY Flow - nodes receive their data as props
   let {
@@ -43,17 +34,7 @@
   const { updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
 
-  function getInitialNodeId() {
-    return nodeId;
-  }
-
   let audioService = AudioService.getInstance();
-
-  const settingsManager = new SettingsManager(
-    () => data.settings ?? {},
-    (settings, schema) => updateNodeData(nodeId, { settings, settingsSchema: schema }),
-    createKVStore(getInitialNodeId())
-  );
   let eventBus = PatchiesEventBus.getInstance();
   let previousExecuteCode = $state<number | undefined>(undefined);
   let consoleRef: VirtualConsole | null = $state(null);
@@ -76,50 +57,17 @@
     }
   });
 
-  const handleMessage: MessageCallbackFn = (message, meta) => {
-    match(message)
-      .with(messages.run, () => runSonic())
-      .with(P.any, () => {
-        if (meta?.inlet === undefined) return;
-
-        audioService.send(nodeId, 'messageInlet', {
-          inletIndex: meta.inlet,
-          message,
-          meta
-        });
-      });
-  };
+  $effect(() => {
+    void data.messageInletCount;
+    void data.messageOutletCount;
+    void data.showAudioInput;
+    updateNodeInternals(nodeId);
+  });
 
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
 
   function handleCodeChange(newCode: string) {
     updateNodeData(nodeId, { code: newCode });
-
-    setTimeout(() => {
-      const sonicNode = audioService.getNodeById(nodeId) as SonicNode | undefined;
-
-      if (!sonicNode) return;
-
-      sonicNode.onSetPortCount = (inletCount: number, outletCount: number) => {
-        updateNodeData(nodeId, {
-          messageInletCount: inletCount,
-          messageOutletCount: outletCount
-        });
-
-        updateNodeInternals(nodeId);
-      };
-
-      sonicNode.onSetTitle = (title: string) => {
-        updateNodeData(nodeId, { title });
-      };
-
-      sonicNode.onSetAudioInputVisible = (showAudioInput: boolean) => {
-        updateNodeData(nodeId, { showAudioInput });
-        updateNodeInternals(nodeId);
-      };
-
-      updateNodeInternals(nodeId);
-    }, 10);
   }
 
   function runSonic() {
@@ -127,11 +75,6 @@
     consoleRef?.clearConsole();
     lineErrors = undefined;
 
-    updateNodeData(nodeId, {
-      showAudioInput: hasAudioInputUsage('sonic~', data.code)
-    });
-
-    updateNodeInternals(nodeId);
     updateAudioCode(data.code);
   }
 
@@ -140,25 +83,10 @@
   }
 
   onMount(() => {
-    audioService.registerSettingsManager(nodeId, settingsManager);
-
-    updateNodeData(nodeId, {
-      showAudioInput: getInitialSimpleDspAudioInputVisibility(
-        'sonic~',
-        data.showAudioInput,
-        data.code
-      )
-    });
-
-    audioService.createNode(nodeId, 'sonic~', [null, data.code]);
-    handleCodeChange(data.code);
     eventBus.addEventListener('consoleOutput', handleConsoleOutput);
   });
 
   onDestroy(() => {
-    audioService.unregisterSettingsManager(nodeId);
-    audioService.removeNodeById(nodeId);
-
     eventBus.removeEventListener('consoleOutput', handleConsoleOutput);
   });
 </script>
@@ -171,14 +99,17 @@
   {selected}
   onCodeChange={handleCodeChange}
   onRun={runSonic}
-  {handleMessage}
   showConsole={data.showConsole}
   onToggleConsole={handleToggleConsole}
   {lineErrors}
   settingsSchema={data.settingsSchema}
   settingsValues={data.settings ?? {}}
-  onSettingsValueChange={(key, value) => settingsManager.setValue(key, value)}
-  onSettingsRevertAll={() => settingsManager.revertAll()}
+  onSettingsValueChange={(key, value) =>
+    (audioService.getNodeById(nodeId) as SonicNode | null)
+      ?.getSettingsManager()
+      .setValue(key, value)}
+  onSettingsRevertAll={() =>
+    (audioService.getNodeById(nodeId) as SonicNode | null)?.getSettingsManager().revertAll()}
 >
   {#snippet console()}
     <VirtualConsole

--- a/ui/src/objects/sonic~/SonicNode.test.ts
+++ b/ui/src/objects/sonic~/SonicNode.test.ts
@@ -45,6 +45,8 @@ describe('SonicNode', () => {
       update: (update) => updates.push(update)
     });
     await node.send('code', 'setPortCount(2, 1)');
+    await node.send('code', '');
+    await node.send('code', 'setPortCount(2, 1)');
     await node.send('code', 'outputNode.gain.value = 0.5');
 
     expect(updates).toContainEqual({ messageInletCount: 2, messageOutletCount: 1 });

--- a/ui/src/objects/sonic~/SonicNode.test.ts
+++ b/ui/src/objects/sonic~/SonicNode.test.ts
@@ -40,8 +40,10 @@ describe('SonicNode', () => {
     const node = new SonicNode('sonic-port-reset-test', audioContext);
     const updates: Record<string, unknown>[] = [];
 
-    node.initializeRuntimeData({ code: 'setPortCount(2, 1)' });
-    node.setRuntimeDataChangeListener((update) => updates.push(update));
+    node.bindRuntimeData({
+      initialData: { code: 'setPortCount(2, 1)' },
+      update: (update) => updates.push(update)
+    });
     await node.send('code', 'setPortCount(2, 1)');
     await node.send('code', 'outputNode.gain.value = 0.5');
 

--- a/ui/src/objects/sonic~/SonicNode.test.ts
+++ b/ui/src/objects/sonic~/SonicNode.test.ts
@@ -44,7 +44,7 @@ describe('SonicNode', () => {
       initialData: { code: 'setPortCount(2, 1)' },
       update: (update) => updates.push(update)
     });
-    await node.create([]);
+    await node.create();
     await node.send('run', 'outputNode.gain.value = 0.5');
     await node.send('run', '');
 

--- a/ui/src/objects/sonic~/SonicNode.test.ts
+++ b/ui/src/objects/sonic~/SonicNode.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { JSRunner } from '$lib/js-runner/JSRunner';
+import { SuperSonicManager } from '$lib/audio/SuperSonicManager';
+
+import { SonicNode } from './SonicNode';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('SonicNode', () => {
+  it('clears published message ports when replacement code omits setPortCount', async () => {
+    const gainNode = {
+      gain: { value: 0 },
+      connect: vi.fn(),
+      disconnect: vi.fn()
+    } as unknown as GainNode;
+    const audioContext = { createGain: () => gainNode } as unknown as AudioContext;
+    const executeJavaScript = vi.fn(async (_nodeId, _code, options) => {
+      if (executeJavaScript.mock.calls.length === 1) {
+        options.setPortCount(2, 1);
+      }
+    });
+
+    vi.spyOn(JSRunner, 'getInstance').mockReturnValue({
+      preprocessCode: vi.fn(async (code: string) => code),
+      executeJavaScript,
+      destroy: vi.fn()
+    } as unknown as JSRunner);
+    vi.spyOn(SuperSonicManager, 'getInstance').mockReturnValue({
+      ensureSuperSonic: vi.fn(async () => ({
+        sonic: { on: vi.fn(), node: gainNode },
+        SuperSonic: {},
+        sharedInputNode: gainNode
+      })),
+      allocateBusPair: vi.fn(() => ({ busIndex: 0, outputNode: gainNode }))
+    } as unknown as SuperSonicManager);
+
+    const node = new SonicNode('sonic-port-reset-test', audioContext);
+    const updates: Record<string, unknown>[] = [];
+
+    node.initializeRuntimeData({ code: 'setPortCount(2, 1)' });
+    node.setRuntimeDataChangeListener((update) => updates.push(update));
+    await node.send('code', 'setPortCount(2, 1)');
+    await node.send('code', 'outputNode.gain.value = 0.5');
+
+    expect(updates).toContainEqual({ messageInletCount: 2, messageOutletCount: 1 });
+    expect(updates).toContainEqual({ messageInletCount: 0, messageOutletCount: 0 });
+  });
+});

--- a/ui/src/objects/sonic~/SonicNode.test.ts
+++ b/ui/src/objects/sonic~/SonicNode.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
 });
 
 describe('SonicNode', () => {
-  it('clears published message ports when replacement code omits setPortCount', async () => {
+  it('clears message ports when explicit runs replace the active code', async () => {
     const gainNode = {
       gain: { value: 0 },
       connect: vi.fn(),
@@ -44,11 +44,11 @@ describe('SonicNode', () => {
       initialData: { code: 'setPortCount(2, 1)' },
       update: (update) => updates.push(update)
     });
-    await node.send('code', 'setPortCount(2, 1)');
-    await node.send('code', '');
-    await node.send('code', 'setPortCount(2, 1)');
-    await node.send('code', 'outputNode.gain.value = 0.5');
+    await node.create([]);
+    await node.send('run', 'outputNode.gain.value = 0.5');
+    await node.send('run', '');
 
+    expect(executeJavaScript).toHaveBeenCalledTimes(2);
     expect(updates).toContainEqual({ messageInletCount: 2, messageOutletCount: 1 });
     expect(updates).toContainEqual({ messageInletCount: 0, messageOutletCount: 0 });
   });

--- a/ui/src/objects/sonic~/SonicNode.ts
+++ b/ui/src/objects/sonic~/SonicNode.ts
@@ -118,6 +118,8 @@ export class SonicNode implements AudioNodeV2 {
   private async setCode(code: string): Promise<void> {
     this.runtimeState.setCode(code);
     this.runtimeState.publish({ showAudioInput: hasAudioInputUsage('sonic~', code) });
+    this.resetMessagePorts();
+
     if (!code || code.trim() === '') {
       return;
     }
@@ -145,15 +147,6 @@ export class SonicNode implements AudioNodeV2 {
         );
       }
 
-      // Reset message inlet count and recv callback for new code
-      this.messageInletCount = 0;
-      this.messageOutletCount = 0;
-      this.recvCallback = null;
-      this.runtimeState.publish({
-        messageInletCount: this.messageInletCount,
-        messageOutletCount: this.messageOutletCount
-      });
-
       const settingsManager = this.runtimeState.settingsManager;
       settingsManager.clearCallbacks();
 
@@ -163,7 +156,7 @@ export class SonicNode implements AudioNodeV2 {
       };
 
       // Create send function for sending messages
-      const send = (message: unknown, options?: { to?: number }) =>
+      const send = (message: unknown, options?: { to?: number | string }) =>
         MessageSystem.getInstance().sendMessage(this.nodeId, message, options);
 
       // Create event subscription function
@@ -243,6 +236,14 @@ export class SonicNode implements AudioNodeV2 {
     } catch (error) {
       handleError(error);
     }
+  }
+
+  private resetMessagePorts(): void {
+    this.messageInletCount = 0;
+    this.messageOutletCount = 0;
+    this.recvCallback = null;
+
+    this.runtimeState.publish({ messageInletCount: 0, messageOutletCount: 0 });
   }
 
   bindRuntimeData(binding: RuntimeDataBinding): void {

--- a/ui/src/objects/sonic~/SonicNode.ts
+++ b/ui/src/objects/sonic~/SonicNode.ts
@@ -29,8 +29,10 @@ type RecvCallback = (message: unknown, meta: unknown) => void;
 export class SonicNode implements AudioNodeV2 {
   static type = 'sonic~';
   static group: AudioNodeGroup = 'processors';
+
   static runtimeManaged = true;
-  static acceptsRuntimeData = true;
+  static hasRuntimeData = true;
+
   static dynamicMessageTarget = 'messageInlet';
   static description = 'Supersonic is SuperCollider engine for the web';
 

--- a/ui/src/objects/sonic~/SonicNode.ts
+++ b/ui/src/objects/sonic~/SonicNode.ts
@@ -89,8 +89,8 @@ export class SonicNode implements AudioNodeV2 {
     this.jsRunner = JSRunner.getInstance();
   }
 
-  async create(params: unknown[]): Promise<void> {
-    const [, code] = params as [unknown, string];
+  async create(): Promise<void> {
+    const code = this.runtimeState.getCode();
 
     if (code) {
       await this.setCode(code);
@@ -99,7 +99,7 @@ export class SonicNode implements AudioNodeV2 {
 
   async send(key: string, msg: unknown): Promise<void> {
     return match([key, msg])
-      .with(['code', P.string], ([, code]) => {
+      .with(['run', P.string], ([, code]) => {
         return this.setCode(code);
       })
       .with(['messageInlet', P.any], ([, messageData]) => {

--- a/ui/src/objects/sonic~/SonicNode.ts
+++ b/ui/src/objects/sonic~/SonicNode.ts
@@ -4,17 +4,16 @@ import { logger } from '$lib/utils/logger';
 import { createCustomConsole } from '$lib/utils/createCustomConsole';
 import { handleCodeError } from '$lib/js-runner/handleCodeError';
 import { match, P } from 'ts-pattern';
-import { MessageContext } from '$lib/messages/MessageContext';
+import { MessageSystem } from '$lib/messages/MessageSystem';
 import { JSRunner } from '$lib/js-runner/JSRunner';
 import { SuperSonicManager, type SonicBusAllocation } from '$lib/audio/SuperSonicManager';
 import { SONIC_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
-import { AudioService } from '$lib/audio/v2/AudioService';
 import { createSettingsAPI } from '$lib/settings/create-settings-api';
+import { hasAudioInputUsage } from '$lib/audio/visible-audio-inputs';
+import { RuntimeAudioCodeState } from '$objects/audio-code/RuntimeAudioCodeState';
+import { isRunMessage } from '$objects/audio-code/runtime-audio-code-messages';
 
 type RecvCallback = (message: unknown, meta: unknown) => void;
-type OnSetPortCount = (inletCount: number, outletCount: number) => void;
-type OnSetTitle = (title: string) => void;
-type OnSetAudioInputVisible = (visible: boolean) => void;
 
 /**
  * SonicNode implements the sonic~ audio node.
@@ -26,6 +25,9 @@ type OnSetAudioInputVisible = (visible: boolean) => void;
 export class SonicNode implements AudioNodeV2 {
   static type = 'sonic~';
   static group: AudioNodeGroup = 'processors';
+  static runtimeManaged = true;
+  static acceptsRuntimeData = true;
+  static dynamicMessageTarget = 'messageInlet';
   static description = 'Supersonic is SuperCollider engine for the web';
 
   static inlets: ObjectInlet[] = [
@@ -50,7 +52,7 @@ export class SonicNode implements AudioNodeV2 {
 
   private inputNode: GainNode;
   private audioContext: AudioContext;
-  private messageContext: MessageContext;
+  private runtimeState: RuntimeAudioCodeState;
   private jsRunner: JSRunner;
 
   // SuperSonic state
@@ -61,10 +63,6 @@ export class SonicNode implements AudioNodeV2 {
   // Dynamic port counts for UI
   private messageInletCount = 0;
   private messageOutletCount = 0;
-
-  public onSetPortCount: OnSetPortCount = () => {};
-  public onSetTitle: OnSetTitle = () => {};
-  public onSetAudioInputVisible: OnSetAudioInputVisible = () => {};
 
   // Custom console for routing output to VirtualConsole
   private customConsole;
@@ -81,7 +79,7 @@ export class SonicNode implements AudioNodeV2 {
     this.inputNode = audioContext.createGain();
     this.inputNode.gain.value = 1.0;
 
-    this.messageContext = new MessageContext(nodeId);
+    this.runtimeState = new RuntimeAudioCodeState(nodeId);
     this.jsRunner = JSRunner.getInstance();
   }
 
@@ -91,6 +89,16 @@ export class SonicNode implements AudioNodeV2 {
     if (code) {
       await this.setCode(code);
     }
+  }
+  initializeRuntimeData(data: Record<string, unknown>): void {
+    this.runtimeState.initialize(data);
+  }
+  setRuntimeDataChangeListener(listener: (updates: Record<string, unknown>) => void): void {
+    this.runtimeState.setListener(listener);
+  }
+
+  getSettingsManager() {
+    return this.runtimeState.settingsManager;
   }
 
   async send(key: string, msg: unknown): Promise<void> {
@@ -114,6 +122,8 @@ export class SonicNode implements AudioNodeV2 {
   }
 
   private async setCode(code: string): Promise<void> {
+    this.runtimeState.setCode(code);
+    this.runtimeState.publish({ showAudioInput: hasAudioInputUsage('sonic~', code) });
     if (!code || code.trim() === '') {
       return;
     }
@@ -146,8 +156,8 @@ export class SonicNode implements AudioNodeV2 {
       this.messageOutletCount = 0;
       this.recvCallback = null;
 
-      const settingsManager = AudioService.getInstance().getSettingsManager(this.nodeId);
-      settingsManager?.clearCallbacks();
+      const settingsManager = this.runtimeState.settingsManager;
+      settingsManager.clearCallbacks();
 
       // Create recv function for receiving messages
       const recv = (callback: (message: unknown, meta: unknown) => void) => {
@@ -156,7 +166,7 @@ export class SonicNode implements AudioNodeV2 {
 
       // Create send function for sending messages
       const send = (message: unknown, options?: { to?: number }) =>
-        this.messageContext.send(message, options);
+        MessageSystem.getInstance().sendMessage(this.nodeId, message, options);
 
       // Create event subscription function
       // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
@@ -175,10 +185,13 @@ export class SonicNode implements AudioNodeV2 {
         setPortCount: (inletCount: number = 0, outletCount: number = 0) => {
           this.messageInletCount = Math.max(0, inletCount);
           this.messageOutletCount = Math.max(0, outletCount);
-          this.onSetPortCount(this.messageInletCount, this.messageOutletCount);
+          this.runtimeState.publish({
+            messageInletCount: this.messageInletCount,
+            messageOutletCount: this.messageOutletCount
+          });
         },
         setTitle: (title: string) => {
-          this.onSetTitle(title);
+          this.runtimeState.publish({ title });
         },
         extraContext: {
           sonic,
@@ -190,7 +203,7 @@ export class SonicNode implements AudioNodeV2 {
           outBus: this.busAllocation?.busIndex ?? 0,
           recv,
           send,
-          showAudioInput: () => this.onSetAudioInputVisible(true),
+          showAudioInput: () => this.runtimeState.publish({ showAudioInput: true }),
           ...(settingsManager ? { settings: createSettingsAPI(settingsManager) } : {})
         }
       });
@@ -200,6 +213,11 @@ export class SonicNode implements AudioNodeV2 {
   }
 
   private handleMessageInlet(message: unknown): void {
+    if (isRunMessage(message)) {
+      this.setCode(this.runtimeState.getCode());
+      return;
+    }
+
     if (!this.recvCallback) return;
 
     const handleError = (error: unknown) => {
@@ -232,7 +250,6 @@ export class SonicNode implements AudioNodeV2 {
   destroy(): void {
     this.recvCallback = null;
 
-    this.messageContext.destroy();
     this.jsRunner.destroy(this.nodeId);
 
     // Release the bus pair back to the manager

--- a/ui/src/objects/sonic~/SonicNode.ts
+++ b/ui/src/objects/sonic~/SonicNode.ts
@@ -1,4 +1,8 @@
-import { type AudioNodeV2, type AudioNodeGroup } from '$lib/audio/v2/interfaces/audio-nodes';
+import {
+  type AudioNodeV2,
+  type AudioNodeGroup,
+  type RuntimeDataBinding
+} from '$lib/audio/v2/interfaces/audio-nodes';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 import { logger } from '$lib/utils/logger';
 import { createCustomConsole } from '$lib/utils/createCustomConsole';
@@ -89,18 +93,6 @@ export class SonicNode implements AudioNodeV2 {
     if (code) {
       await this.setCode(code);
     }
-  }
-
-  initializeRuntimeData(data: Record<string, unknown>): void {
-    this.runtimeState.initialize(data);
-  }
-
-  setRuntimeDataChangeListener(listener: (updates: Record<string, unknown>) => void): void {
-    this.runtimeState.setListener(listener);
-  }
-
-  getSettingsManager() {
-    return this.runtimeState.settingsManager;
   }
 
   async send(key: string, msg: unknown): Promise<void> {
@@ -251,6 +243,14 @@ export class SonicNode implements AudioNodeV2 {
     } catch (error) {
       handleError(error);
     }
+  }
+
+  bindRuntimeData(binding: RuntimeDataBinding): void {
+    this.runtimeState.initialize(binding);
+  }
+
+  getSettingsManager() {
+    return this.runtimeState.settingsManager;
   }
 
   destroy(): void {

--- a/ui/src/objects/sonic~/SonicNode.ts
+++ b/ui/src/objects/sonic~/SonicNode.ts
@@ -90,9 +90,11 @@ export class SonicNode implements AudioNodeV2 {
       await this.setCode(code);
     }
   }
+
   initializeRuntimeData(data: Record<string, unknown>): void {
     this.runtimeState.initialize(data);
   }
+
   setRuntimeDataChangeListener(listener: (updates: Record<string, unknown>) => void): void {
     this.runtimeState.setListener(listener);
   }

--- a/ui/src/objects/sonic~/SonicNode.ts
+++ b/ui/src/objects/sonic~/SonicNode.ts
@@ -155,6 +155,10 @@ export class SonicNode implements AudioNodeV2 {
       this.messageInletCount = 0;
       this.messageOutletCount = 0;
       this.recvCallback = null;
+      this.runtimeState.publish({
+        messageInletCount: this.messageInletCount,
+        messageOutletCount: this.messageOutletCount
+      });
 
       const settingsManager = this.runtimeState.settingsManager;
       settingsManager.clearCallbacks();

--- a/ui/src/objects/tone~/ToneNode.svelte
+++ b/ui/src/objects/tone~/ToneNode.svelte
@@ -65,16 +65,19 @@
     updateNodeInternals(nodeId);
   });
 
-  const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
+  const runAudioCode = (code: string) => audioService.send(nodeId, 'run', code);
   const getSettingsManager = () => audioService.getNodeById(nodeId)?.getSettingsManager?.();
-  const handleCodeChange = (newCode: string) => updateNodeData(nodeId, { code: newCode });
+
+  const handleCodeChange = (newCode: string) => {
+    updateNodeData(nodeId, { code: newCode });
+  };
 
   function runTone() {
     // Clear previous console output and error highlighting
     consoleRef?.clearConsole();
     lineErrors = undefined;
 
-    updateAudioCode(data.code);
+    runAudioCode(data.code);
   }
 
   function handleToggleConsole() {

--- a/ui/src/objects/tone~/ToneNode.svelte
+++ b/ui/src/objects/tone~/ToneNode.svelte
@@ -62,14 +62,12 @@
     void data.messageInletCount;
     void data.messageOutletCount;
     void data.showAudioInput;
+
     updateNodeInternals(nodeId);
   });
 
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
-
-  function handleCodeChange(newCode: string) {
-    updateNodeData(nodeId, { code: newCode });
-  }
+  const handleCodeChange = (newCode: string) => updateNodeData(nodeId, { code: newCode });
 
   function runTone() {
     // Clear previous console output and error highlighting
@@ -105,12 +103,16 @@
   {lineErrors}
   settingsSchema={data.settingsSchema}
   settingsValues={data.settings ?? {}}
-  onSettingsValueChange={(key, value) =>
-    (audioService.getNodeById(nodeId) as ToneNode | null)
-      ?.getSettingsManager()
-      .setValue(key, value)}
-  onSettingsRevertAll={() =>
-    (audioService.getNodeById(nodeId) as ToneNode | null)?.getSettingsManager().revertAll()}
+  onSettingsValueChange={(key, value) => {
+    const node = audioService.getNodeById(nodeId) as ToneNode | null;
+
+    node?.getSettingsManager().setValue(key, value);
+  }}
+  onSettingsRevertAll={() => {
+    const node = audioService.getNodeById(nodeId) as ToneNode | null;
+
+    node?.getSettingsManager().revertAll();
+  }}
 >
   {#snippet console()}
     <VirtualConsole

--- a/ui/src/objects/tone~/ToneNode.svelte
+++ b/ui/src/objects/tone~/ToneNode.svelte
@@ -3,7 +3,6 @@
   import { onMount, onDestroy } from 'svelte';
   import { AudioService } from '$lib/audio/v2/AudioService';
   import SimpleDspLayout from '$objects/audio-code/SimpleDspLayout.svelte';
-  import type { ToneNode } from '$objects/tone~/ToneNode';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { ConsoleOutputEvent } from '$lib/eventbus/events';
@@ -67,6 +66,7 @@
   });
 
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
+  const getSettingsManager = () => audioService.getNodeById(nodeId)?.getSettingsManager?.();
   const handleCodeChange = (newCode: string) => updateNodeData(nodeId, { code: newCode });
 
   function runTone() {
@@ -104,14 +104,10 @@
   settingsSchema={data.settingsSchema}
   settingsValues={data.settings ?? {}}
   onSettingsValueChange={(key, value) => {
-    const node = audioService.getNodeById(nodeId) as ToneNode | null;
-
-    node?.getSettingsManager().setValue(key, value);
+    getSettingsManager()?.setValue(key, value);
   }}
   onSettingsRevertAll={() => {
-    const node = audioService.getNodeById(nodeId) as ToneNode | null;
-
-    node?.getSettingsManager().revertAll();
+    getSettingsManager()?.revertAll();
   }}
 >
   {#snippet console()}

--- a/ui/src/objects/tone~/ToneNode.svelte
+++ b/ui/src/objects/tone~/ToneNode.svelte
@@ -1,22 +1,13 @@
 <script lang="ts">
   import { useSvelteFlow, useUpdateNodeInternals } from '@xyflow/svelte';
   import { onMount, onDestroy } from 'svelte';
-  import { match, P } from 'ts-pattern';
-  import { messages } from '$lib/objects/schemas';
   import { AudioService } from '$lib/audio/v2/AudioService';
-  import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import SimpleDspLayout from '$objects/audio-code/SimpleDspLayout.svelte';
   import type { ToneNode } from '$objects/tone~/ToneNode';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { ConsoleOutputEvent } from '$lib/eventbus/events';
-  import { SettingsManager } from '$lib/settings';
-  import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
-  import {
-    getInitialSimpleDspAudioInputVisibility,
-    hasAudioInputUsage
-  } from '$lib/audio/visible-audio-inputs';
 
   // Get node data from XY Flow - nodes receive their data as props
   let {
@@ -43,17 +34,7 @@
   const { updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
 
-  function getInitialNodeId() {
-    return nodeId;
-  }
-
   let audioService = AudioService.getInstance();
-
-  const settingsManager = new SettingsManager(
-    () => data.settings ?? {},
-    (settings, schema) => updateNodeData(nodeId, { settings, settingsSchema: schema }),
-    createKVStore(getInitialNodeId())
-  );
 
   let eventBus = PatchiesEventBus.getInstance();
   let previousExecuteCode = $state<number | undefined>(undefined);
@@ -77,50 +58,17 @@
     }
   });
 
-  const handleMessage: MessageCallbackFn = (message, meta) => {
-    match(message)
-      .with(messages.run, () => runTone())
-      .with(P.any, () => {
-        if (meta?.inlet === undefined) return;
-
-        audioService.send(nodeId, 'messageInlet', {
-          inletIndex: meta.inlet,
-          message,
-          meta
-        });
-      });
-  };
+  $effect(() => {
+    void data.messageInletCount;
+    void data.messageOutletCount;
+    void data.showAudioInput;
+    updateNodeInternals(nodeId);
+  });
 
   const updateAudioCode = (code: string) => audioService.send(nodeId, 'code', code);
 
   function handleCodeChange(newCode: string) {
     updateNodeData(nodeId, { code: newCode });
-
-    setTimeout(() => {
-      const toneNode = audioService.getNodeById(nodeId) as ToneNode | undefined;
-
-      if (!toneNode) return;
-
-      toneNode.onSetPortCount = (inletCount: number, outletCount: number) => {
-        updateNodeData(nodeId, {
-          messageInletCount: inletCount,
-          messageOutletCount: outletCount
-        });
-
-        updateNodeInternals(nodeId);
-      };
-
-      toneNode.onSetTitle = (title: string) => {
-        updateNodeData(nodeId, { title });
-      };
-
-      toneNode.onSetAudioInputVisible = (showAudioInput: boolean) => {
-        updateNodeData(nodeId, { showAudioInput });
-        updateNodeInternals(nodeId);
-      };
-
-      updateNodeInternals(nodeId);
-    }, 10);
   }
 
   function runTone() {
@@ -128,11 +76,6 @@
     consoleRef?.clearConsole();
     lineErrors = undefined;
 
-    updateNodeData(nodeId, {
-      showAudioInput: hasAudioInputUsage('tone~', data.code)
-    });
-
-    updateNodeInternals(nodeId);
     updateAudioCode(data.code);
   }
 
@@ -141,25 +84,10 @@
   }
 
   onMount(() => {
-    audioService.registerSettingsManager(nodeId, settingsManager);
-
-    updateNodeData(nodeId, {
-      showAudioInput: getInitialSimpleDspAudioInputVisibility(
-        'tone~',
-        data.showAudioInput,
-        data.code
-      )
-    });
-
-    audioService.createNode(nodeId, 'tone~', [null, data.code]);
-    handleCodeChange(data.code);
     eventBus.addEventListener('consoleOutput', handleConsoleOutput);
   });
 
   onDestroy(() => {
-    audioService.unregisterSettingsManager(nodeId);
-    audioService.removeNodeById(nodeId);
-
     eventBus.removeEventListener('consoleOutput', handleConsoleOutput);
   });
 </script>
@@ -172,14 +100,17 @@
   {selected}
   onCodeChange={handleCodeChange}
   onRun={runTone}
-  {handleMessage}
   showConsole={data.showConsole}
   onToggleConsole={handleToggleConsole}
   {lineErrors}
   settingsSchema={data.settingsSchema}
   settingsValues={data.settings ?? {}}
-  onSettingsValueChange={(key, value) => settingsManager.setValue(key, value)}
-  onSettingsRevertAll={() => settingsManager.revertAll()}
+  onSettingsValueChange={(key, value) =>
+    (audioService.getNodeById(nodeId) as ToneNode | null)
+      ?.getSettingsManager()
+      .setValue(key, value)}
+  onSettingsRevertAll={() =>
+    (audioService.getNodeById(nodeId) as ToneNode | null)?.getSettingsManager().revertAll()}
 >
   {#snippet console()}
     <VirtualConsole

--- a/ui/src/objects/tone~/ToneNode.ts
+++ b/ui/src/objects/tone~/ToneNode.ts
@@ -4,17 +4,14 @@ import { createCustomConsole } from '$lib/utils/createCustomConsole';
 import { handleCodeError } from '$lib/js-runner/handleCodeError';
 import { JSRunner } from '$lib/js-runner/JSRunner';
 import { match, P } from 'ts-pattern';
-import { MessageContext } from '$lib/messages/MessageContext';
 import { TONE_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
 import { extractToneVarNames, injectAutoDispose } from '$objects/tone~/tone-auto-dispose';
-import { AudioService } from '$lib/audio/v2/AudioService';
 import { createSettingsAPI } from '$lib/settings/create-settings-api';
+import { hasAudioInputUsage } from '$lib/audio/visible-audio-inputs';
+import { RuntimeAudioCodeState } from '$objects/audio-code/RuntimeAudioCodeState';
+import { isRunMessage } from '$objects/audio-code/runtime-audio-code-messages';
 
 type RecvCallback = (message: unknown, meta: unknown) => void;
-
-type OnSetPortCount = (inletCount: number, outletCount: number) => void;
-type OnSetTitle = (title: string) => void;
-type OnSetAudioInputVisible = (visible: boolean) => void;
 
 /**
  * ToneNode implements the tone~ audio node.
@@ -23,6 +20,9 @@ type OnSetAudioInputVisible = (visible: boolean) => void;
 export class ToneNode implements AudioNodeV2 {
   static type = 'tone~';
   static group: AudioNodeGroup = 'processors';
+  static runtimeManaged = true;
+  static acceptsRuntimeData = true;
+  static dynamicMessageTarget = 'messageInlet';
   static description = 'Tone.js synthesis and audio processing node';
 
   static inlets: ObjectInlet[] = [
@@ -47,7 +47,7 @@ export class ToneNode implements AudioNodeV2 {
 
   private inputNode: GainNode;
   private audioContext: AudioContext;
-  private messageContext: MessageContext;
+  private runtimeState: RuntimeAudioCodeState;
 
   private cleanupFn: (() => void) | null = null;
   private recvCallback: RecvCallback | null = null;
@@ -58,10 +58,6 @@ export class ToneNode implements AudioNodeV2 {
   // Dynamic port counts for UI
   private messageInletCount = 0;
   private messageOutletCount = 0;
-
-  public onSetPortCount: OnSetPortCount = () => {};
-  public onSetTitle: OnSetTitle = () => {};
-  public onSetAudioInputVisible: OnSetAudioInputVisible = () => {};
 
   // Custom console for routing output to VirtualConsole
   private customConsole;
@@ -78,7 +74,7 @@ export class ToneNode implements AudioNodeV2 {
     this.inputNode = audioContext.createGain();
     this.inputNode.gain.value = 1.0;
 
-    this.messageContext = new MessageContext(nodeId);
+    this.runtimeState = new RuntimeAudioCodeState(nodeId);
   }
 
   async create(params: unknown[]): Promise<void> {
@@ -87,6 +83,17 @@ export class ToneNode implements AudioNodeV2 {
     if (code) {
       await this.setCode(code);
     }
+  }
+  initializeRuntimeData(data: Record<string, unknown>): void {
+    this.runtimeState.initialize(data);
+  }
+
+  setRuntimeDataChangeListener(listener: (updates: Record<string, unknown>) => void): void {
+    this.runtimeState.setListener(listener);
+  }
+
+  getSettingsManager() {
+    return this.runtimeState.settingsManager;
   }
 
   async send(key: string, msg: unknown): Promise<void> {
@@ -164,6 +171,8 @@ export class ToneNode implements AudioNodeV2 {
   }
 
   private async setCode(code: string): Promise<void> {
+    this.runtimeState.setCode(code);
+    this.runtimeState.publish({ showAudioInput: hasAudioInputUsage('tone~', code) });
     const Tone = await this.ensureTone();
 
     if (!code || code.trim() === '') {
@@ -189,14 +198,14 @@ export class ToneNode implements AudioNodeV2 {
       const toneVarNames = extractToneVarNames(processedCode);
       const toneInstances: { dispose(): void }[] = [];
 
-      const settingsManager = AudioService.getInstance().getSettingsManager(this.nodeId);
-      settingsManager?.clearCallbacks();
+      const settingsManager = this.runtimeState.settingsManager;
+      settingsManager.clearCallbacks();
 
       const extraContext: Record<string, unknown> = {
         Tone,
         outputNode: this.audioNode,
         inputNode: this.inputNode,
-        showAudioInput: () => this.onSetAudioInputVisible(true),
+        showAudioInput: () => this.runtimeState.publish({ showAudioInput: true }),
         ...(settingsManager ? { settings: createSettingsAPI(settingsManager) } : {})
       };
 
@@ -214,10 +223,14 @@ export class ToneNode implements AudioNodeV2 {
         setPortCount: (inletCount: number = 0, outletCount: number = 0) => {
           this.messageInletCount = Math.max(0, inletCount);
           this.messageOutletCount = Math.max(0, outletCount);
-          this.onSetPortCount(this.messageInletCount, this.messageOutletCount);
+
+          this.runtimeState.publish({
+            messageInletCount: this.messageInletCount,
+            messageOutletCount: this.messageOutletCount
+          });
         },
         setTitle: (title: string) => {
-          this.onSetTitle(title);
+          this.runtimeState.publish({ title });
         }
       });
 
@@ -239,6 +252,11 @@ export class ToneNode implements AudioNodeV2 {
   }
 
   private handleMessageInlet(messageData: unknown): void {
+    if (isRunMessage(messageData)) {
+      this.setCode(this.runtimeState.getCode());
+      return;
+    }
+
     if (!this.recvCallback) return;
 
     const handleError = (error: unknown) => {
@@ -298,7 +316,6 @@ export class ToneNode implements AudioNodeV2 {
   destroy(): void {
     this.cleanup();
     this.recvCallback = null;
-    this.messageContext.destroy();
     this.audioNode.disconnect();
     this.inputNode.disconnect();
 

--- a/ui/src/objects/tone~/ToneNode.ts
+++ b/ui/src/objects/tone~/ToneNode.ts
@@ -1,4 +1,8 @@
-import { type AudioNodeV2, type AudioNodeGroup } from '$lib/audio/v2/interfaces/audio-nodes';
+import {
+  type AudioNodeV2,
+  type AudioNodeGroup,
+  type RuntimeDataBinding
+} from '$lib/audio/v2/interfaces/audio-nodes';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 import { createCustomConsole } from '$lib/utils/createCustomConsole';
 import { handleCodeError } from '$lib/js-runner/handleCodeError';
@@ -83,18 +87,6 @@ export class ToneNode implements AudioNodeV2 {
     if (code) {
       await this.setCode(code);
     }
-  }
-
-  initializeRuntimeData(data: Record<string, unknown>): void {
-    this.runtimeState.initialize(data);
-  }
-
-  setRuntimeDataChangeListener(listener: (updates: Record<string, unknown>) => void): void {
-    this.runtimeState.setListener(listener);
-  }
-
-  getSettingsManager() {
-    return this.runtimeState.settingsManager;
   }
 
   async send(key: string, msg: unknown): Promise<void> {
@@ -302,6 +294,7 @@ export class ToneNode implements AudioNodeV2 {
     if (this.toneInstances.length > 0) {
       this.customConsole.log(`auto-disposing ${this.toneInstances.length} objects`);
     }
+
     for (const instance of this.toneInstances) {
       try {
         instance.dispose();
@@ -312,6 +305,14 @@ export class ToneNode implements AudioNodeV2 {
 
     this.toneInstances = [];
     this.cleanupFn = null;
+  }
+
+  bindRuntimeData(binding: RuntimeDataBinding): void {
+    this.runtimeState.initialize(binding);
+  }
+
+  getSettingsManager() {
+    return this.runtimeState.settingsManager;
   }
 
   destroy(): void {

--- a/ui/src/objects/tone~/ToneNode.ts
+++ b/ui/src/objects/tone~/ToneNode.ts
@@ -83,8 +83,8 @@ export class ToneNode implements AudioNodeV2 {
     this.runtimeState = new RuntimeAudioCodeState(nodeId);
   }
 
-  async create(params: unknown[]): Promise<void> {
-    const [, code] = params as [unknown, string];
+  async create(): Promise<void> {
+    const code = this.runtimeState.getCode();
 
     if (code) {
       await this.setCode(code);
@@ -93,7 +93,7 @@ export class ToneNode implements AudioNodeV2 {
 
   async send(key: string, msg: unknown): Promise<void> {
     return match([key, msg])
-      .with(['code', P.string], ([, code]) => {
+      .with(['run', P.string], ([, code]) => {
         return this.setCode(code);
       })
       .with(['messageInlet', P.any], ([, messageData]) => {

--- a/ui/src/objects/tone~/ToneNode.ts
+++ b/ui/src/objects/tone~/ToneNode.ts
@@ -166,6 +166,7 @@ export class ToneNode implements AudioNodeV2 {
   private async setCode(code: string): Promise<void> {
     this.runtimeState.setCode(code);
     this.runtimeState.publish({ showAudioInput: hasAudioInputUsage('tone~', code) });
+    this.resetMessagePorts();
     const Tone = await this.ensureTone();
 
     if (!code || code.trim() === '') {
@@ -176,11 +177,6 @@ export class ToneNode implements AudioNodeV2 {
     try {
       // Clean up any existing objects
       this.cleanup();
-
-      // Reset message inlet count and recv callback for new code
-      this.messageInletCount = 0;
-      this.messageOutletCount = 0;
-      this.recvCallback = null;
 
       const jsRunner = JSRunner.getInstance();
 
@@ -277,6 +273,14 @@ export class ToneNode implements AudioNodeV2 {
     } catch (error) {
       handleError(error);
     }
+  }
+
+  private resetMessagePorts(): void {
+    this.messageInletCount = 0;
+    this.messageOutletCount = 0;
+    this.recvCallback = null;
+
+    this.runtimeState.publish({ messageInletCount: 0, messageOutletCount: 0 });
   }
 
   private cleanup() {

--- a/ui/src/objects/tone~/ToneNode.ts
+++ b/ui/src/objects/tone~/ToneNode.ts
@@ -24,8 +24,10 @@ type RecvCallback = (message: unknown, meta: unknown) => void;
 export class ToneNode implements AudioNodeV2 {
   static type = 'tone~';
   static group: AudioNodeGroup = 'processors';
+
   static runtimeManaged = true;
-  static acceptsRuntimeData = true;
+  static hasRuntimeData = true;
+
   static dynamicMessageTarget = 'messageInlet';
   static description = 'Tone.js synthesis and audio processing node';
 

--- a/ui/src/objects/tone~/ToneNode.ts
+++ b/ui/src/objects/tone~/ToneNode.ts
@@ -84,6 +84,7 @@ export class ToneNode implements AudioNodeV2 {
       await this.setCode(code);
     }
   }
+
   initializeRuntimeData(data: Record<string, unknown>): void {
     this.runtimeState.initialize(data);
   }


### PR DESCRIPTION
Detach the object lifecycle for `tone~`, `sonic~` and `elem~`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio-code nodes now preserve and restore runtime code, settings, editor metadata, dynamic ports, titles, and audio-input visibility.
  * Runtime changes synchronize automatically between audio nodes and the editor.
  * Runtime-triggered code execution is supported for Tone, Sonic, and Elementary audio nodes.
  * Mounted audio-code views now share the node’s settings and runtime state.
* **Bug Fixes**
  * Improved handling of asynchronous node creation and stale runtime updates.
  * Replacing runtime code now correctly resets previously published message port counts.
* **Documentation**
  * Clarified shared settings ownership and persisted-data updates for runtime audio objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->