### PR TITLE
chore(runtime): unify text object with visual object shape

### DIFF
--- a/docs/design-docs/specs/168-runtime-object-editor-representations.md
+++ b/docs/design-docs/specs/168-runtime-object-editor-representations.md
@@ -53,9 +53,11 @@ runtime.disconnect(connectionId);
 runtime.send(id, message);
 ```
 
-All message-object changes use `RuntimeObjectSpec`, including the internal
-message reconciliation and adapter boundary. Raw expression parameters are
-derived from `data.expr` only where object creation needs them. Message, audio,
+All object changes use `RuntimeObjectSpec`, including the internal message and
+audio adapter boundaries. Raw expression parameters are derived from `data.expr`
+only where text-object creation needs them. Audio resolution adds derived params
+to the object-owned data, making `data.params` the AudioService contract while
+keeping runtime-managed code and settings flat beside it. Message, audio,
 rendering, and editor compatibility stay behind this API. The editor reconciler
 is one adapter from XYFlow state. Internal helpers can store objects,
 connections, snapshots, and object keys, but callers use `PatchRuntime`.

--- a/docs/design-docs/specs/168-runtime-object-editor-representations.md
+++ b/docs/design-docs/specs/168-runtime-object-editor-representations.md
@@ -53,11 +53,12 @@ runtime.disconnect(connectionId);
 runtime.send(id, message);
 ```
 
-All public object changes use `RuntimeObjectSpec`. Parsed message descriptors and
-raw parameters are internal resolver details. Message, audio, rendering, and
-editor compatibility stay behind this API. The editor reconciler is one adapter
-from XYFlow state. Internal helpers can store objects, connections, snapshots,
-and descriptor keys, but callers use `PatchRuntime`.
+All message-object changes use `RuntimeObjectSpec`, including the internal
+message reconciliation and adapter boundary. Raw expression parameters are
+derived from `data.expr` only where object creation needs them. Message, audio,
+rendering, and editor compatibility stay behind this API. The editor reconciler
+is one adapter from XYFlow state. Internal helpers can store objects,
+connections, snapshots, and object keys, but callers use `PatchRuntime`.
 
 Runtime objects implement a common lifecycle and message interface:
 

--- a/ui/packages/csound-browser/.prettierrc.json
+++ b/ui/packages/csound-browser/.prettierrc.json
@@ -3,5 +3,6 @@
   "printWidth": 100,
   "tabWidth": 2,
   "singleQuote": false,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "jsxBracketSameLine": false
 }

--- a/ui/packages/csound-browser/.prettierrc.json
+++ b/ui/packages/csound-browser/.prettierrc.json
@@ -3,6 +3,5 @@
   "printWidth": 100,
   "tabWidth": 2,
   "singleQuote": false,
-  "trailingComma": "all",
-  "jsxBracketSameLine": false
+  "trailingComma": "all"
 }

--- a/ui/src/lib/runtime/adapters/AudioAdapter.ts
+++ b/ui/src/lib/runtime/adapters/AudioAdapter.ts
@@ -12,9 +12,11 @@ import { validateMessageToObject } from '$lib/objects/validate-object-message';
 
 import { RuntimeViewRevisionTracker } from '../services/RuntimeViewRevisionTracker';
 
-import type { RuntimeAudioObjectDescriptor } from '../types/audio-adapter';
-
-import type { RuntimeObjectViewRevisionListener } from '../types/runtime-object';
+import type {
+  RuntimeAudioObjectData,
+  RuntimeObjectSpec,
+  RuntimeObjectViewRevisionListener
+} from '../types/runtime-object';
 
 interface AudioAdapterOptions {
   audioService: AudioService;
@@ -66,50 +68,48 @@ export class AudioAdapter {
     return isSuppressed;
   }
 
-  upsertAudioObject(descriptor: RuntimeAudioObjectDescriptor): void {
+  upsertAudioObject(object: RuntimeObjectSpec<RuntimeAudioObjectData>): void {
     // cleanup existing nodes
-    this.removeAudioObjectMessageContext(descriptor.id, false);
-    this.audioService.removeNodeById(descriptor.id);
+    this.removeAudioObjectMessageContext(object.id, false);
+    this.audioService.removeNodeById(object.id);
 
     // insert new nodes
-    const onBeforeAudioNodeCreate = descriptor.runtimeData
+    const nodeClass = AudioRegistry.getInstance().get(object.type);
+    const onBeforeAudioNodeCreate = nodeClass?.hasRuntimeData
       ? (node: AudioNodeV2) => {
           if (!isRuntimeDataAwareAudioNode(node)) return;
 
           node.bindRuntimeData({
-            initialData: descriptor.runtimeData!,
+            initialData: object.data,
             update: (updates) => {
-              if (this.audioService.getNodeById(descriptor.id) !== node) return;
+              if (this.audioService.getNodeById(object.id) !== node) return;
 
-              this.suppressNextAudioObjectSync(descriptor.id);
-              this.onAudioObjectDataChange?.(descriptor.id, updates);
-              this.viewRevisions.bump(descriptor.id);
+              this.suppressNextAudioObjectSync(object.id);
+              this.onAudioObjectDataChange?.(object.id, updates);
+              this.viewRevisions.bump(object.id);
             }
           });
         }
       : undefined;
 
     const nodePromise = this.audioService.createNode(
-      descriptor.id,
-      descriptor.objectType,
-      descriptor.params,
+      object.id,
+      object.type,
+      object.data.params,
       onBeforeAudioNodeCreate
     );
 
     nodePromise.catch?.(() => undefined);
 
-    const messageContext = this.createAudioObjectMessageContext(
-      descriptor.id,
-      descriptor.objectType
-    );
+    const messageContext = this.createAudioObjectMessageContext(object.id, object.type);
 
-    this.audioObjects.set(descriptor.id, {
+    this.audioObjects.set(object.id, {
       messageContext,
-      params: [...descriptor.params]
+      params: [...object.data.params]
     });
 
-    this.suppressedAudioObjectSyncs.delete(descriptor.id);
-    this.viewRevisions.bump(descriptor.id);
+    this.suppressedAudioObjectSyncs.delete(object.id);
+    this.viewRevisions.bump(object.id);
   }
 
   destroyAudioObject(nodeId: string): void {

--- a/ui/src/lib/runtime/adapters/MessageAdapter.ts
+++ b/ui/src/lib/runtime/adapters/MessageAdapter.ts
@@ -8,12 +8,13 @@ import { MessageContext, type MessageCallbackFn, type MessageSystem } from '$lib
 import { RuntimeViewRevisionTracker } from '../services/RuntimeViewRevisionTracker';
 
 import type {
-  RuntimeObjectDescriptor,
+  RuntimeObjectSpec,
   RuntimeObjectPorts,
   RuntimeObjectViewRevisionListener
 } from '../types/runtime-object';
 
 import { getObjectLifecycleKey } from '../utils/runtime-object-keys';
+import { getRawObjectParamsFromExpr } from '../utils/runtime-object-data';
 import { diffNodeData, hasParamChanges } from '../utils/runtime-diff-utils';
 
 type ObjectParamsChangedEvent = {
@@ -68,74 +69,74 @@ export class MessageAdapter {
     this.eventBus.addEventListener('objectDataChanged', this.handleObjectDataChanged);
   }
 
-  async createObject(descriptor: RuntimeObjectDescriptor): Promise<void> {
-    this.removeObject(descriptor.id, {
+  async createObject(spec: RuntimeObjectSpec): Promise<void> {
+    this.removeObject(spec.id, {
       bumpRevision: false,
       unregisterNodeFromMessageSystem: false
     });
 
-    const messageContext = new MessageContext(descriptor.id);
+    const messageContext = new MessageContext(spec.id);
 
-    const lifecycleToken = this.nextObjectLifecycleToken(descriptor.id);
-    const lifecycleKey = getObjectLifecycleKey(descriptor);
+    const lifecycleToken = this.nextObjectLifecycleToken(spec.id);
+    const lifecycleKey = getObjectLifecycleKey(spec);
 
-    this.objects.set(descriptor.id, {
-      objectType: descriptor.objectType,
+    this.objects.set(spec.id, {
+      objectType: spec.type,
       lifecycleKey,
       messageContext,
       lifecycleToken
     });
 
+    const rawParams = getRawObjectParamsFromExpr(spec.data.expr);
+
     const object = await this.objectService.createObject(
-      descriptor.id,
-      descriptor.objectType,
+      spec.id,
+      spec.type,
       messageContext,
-      descriptor.data,
-      descriptor.rawParams
+      spec.data,
+      rawParams
     );
 
-    if (!this.isCurrentObjectLifecycleToken(descriptor.id, lifecycleToken)) {
+    if (!this.isCurrentObjectLifecycleToken(spec.id, lifecycleToken)) {
       return;
     }
 
     if (!object) {
-      this.viewRevisions.bump(descriptor.id);
+      this.viewRevisions.bump(spec.id);
       return;
     }
 
     const params = object.context.getParams();
     const data = object.context.getData();
 
-    if (Array.isArray(descriptor.data.params) && hasParamChanges(descriptor.data.params, params)) {
-      this.onObjectParamsChange?.(descriptor.id, params);
+    if (Array.isArray(spec.data.params) && hasParamChanges(spec.data.params, params)) {
+      this.onObjectParamsChange?.(spec.id, params);
     }
 
-    const dataDiffs = diffNodeData(descriptor.data, data);
+    const dataDiffs = diffNodeData(spec.data, data);
 
     if (Object.keys(dataDiffs).length > 0) {
-      this.onObjectDataChange?.(descriptor.id, dataDiffs);
+      this.onObjectDataChange?.(spec.id, dataDiffs);
     }
 
-    this.viewRevisions.bump(descriptor.id);
+    this.viewRevisions.bump(spec.id);
   }
 
-  async updateObject(nodeId: string, descriptor: RuntimeObjectDescriptor): Promise<void> {
+  async updateObject(nodeId: string, spec: RuntimeObjectSpec): Promise<void> {
     const existing = this.objects.get(nodeId);
-    const lifecycleKey = getObjectLifecycleKey(descriptor);
+    const lifecycleKey = getObjectLifecycleKey(spec);
 
     const canSkipUpdate =
-      existing &&
-      existing.objectType === descriptor.objectType &&
-      existing.lifecycleKey === lifecycleKey;
+      existing && existing.objectType === spec.type && existing.lifecycleKey === lifecycleKey;
 
     if (canSkipUpdate) {
       const object = this.objectService.getObjectById(nodeId);
 
-      object?.context.setData(descriptor.data);
-      object?.update?.(descriptor.data);
+      object?.context.setData(spec.data);
+      object?.update?.(spec.data);
 
       if (object) {
-        const dataDiffs = diffNodeData(descriptor.data, object.context.getData());
+        const dataDiffs = diffNodeData(spec.data, object.context.getData());
 
         if (Object.keys(dataDiffs).length > 0) {
           this.onObjectDataChange?.(nodeId, dataDiffs);
@@ -147,7 +148,7 @@ export class MessageAdapter {
       return;
     }
 
-    await this.createObject(descriptor);
+    await this.createObject(spec);
   }
 
   destroyObject(nodeId: string): void {

--- a/ui/src/lib/runtime/index.ts
+++ b/ui/src/lib/runtime/index.ts
@@ -1,8 +1,7 @@
-export type { RuntimeAudioObjectDescriptor } from './types/audio-adapter';
-
 export type {
   RuntimeConnectionSpec,
   RuntimeGraphSpec,
+  RuntimeAudioObjectData,
   RuntimeObjectSpec
 } from './types/runtime-object';
 

--- a/ui/src/lib/runtime/index.ts
+++ b/ui/src/lib/runtime/index.ts
@@ -3,7 +3,6 @@ export type { RuntimeAudioObjectDescriptor } from './types/audio-adapter';
 export type {
   RuntimeConnectionSpec,
   RuntimeGraphSpec,
-  RuntimeObjectDescriptor,
   RuntimeObjectSpec
 } from './types/runtime-object';
 

--- a/ui/src/lib/runtime/services/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/services/PatchRuntime.test.ts
@@ -1484,6 +1484,60 @@ describe('EditorRuntimeReconciler', () => {
     runtime.destroy();
   });
 
+  it('keeps explicit audio params alongside runtime code and settings', async () => {
+    const nodeId = 'tone-runtime-data-and-params-test';
+    const params = [null, 'initial code param'];
+    const audioService = createFakeAudioService();
+    const runtimeNode = {
+      nodeId,
+      audioNode: null,
+      bindRuntimeData: vi.fn()
+    };
+
+    audioService.audioNode = runtimeNode;
+
+    const runtime = createTestPatchRuntime({
+      objectService: createFakeObjectService(),
+      audioService,
+      isAudioObject: (objectType) => objectType === 'tone~'
+    });
+
+    AudioRegistry.getInstance().register(ToneNode);
+
+    await setRuntimeGraphFromEditorGraph(runtime, [
+      {
+        id: nodeId,
+        type: 'tone~',
+        position: { x: 0, y: 0 },
+        data: {
+          params,
+          code: 'outputNode.gain.value = 0.5',
+          settings: { gain: 0.5 },
+          settingsSchema: []
+        }
+      }
+    ]);
+
+    expect(audioService.createNode).toHaveBeenCalledWith(
+      nodeId,
+      'tone~',
+      params,
+      expect.any(Function)
+    );
+
+    expect(runtimeNode.bindRuntimeData).toHaveBeenCalledWith({
+      initialData: {
+        params,
+        code: 'outputNode.gain.value = 0.5',
+        settings: { gain: 0.5 },
+        settingsSchema: []
+      },
+      update: expect.any(Function)
+    });
+
+    runtime.destroy();
+  });
+
   it('does not recreate an audio-code node when its editor code changes', async () => {
     const audioService = createFakeAudioService();
     const runtime = createTestPatchRuntime({

--- a/ui/src/lib/runtime/services/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/services/PatchRuntime.test.ts
@@ -85,6 +85,12 @@ const createTestMessageAdapter = (options: TestMessageAdapterOptions) =>
     messageSystem: options.messageSystem ?? MessageSystem.getInstance()
   });
 
+const messageObjectSpec = (id: string, params: unknown[], data: Record<string, unknown> = {}) => ({
+  id,
+  type: TEST_OBJECT_TYPE,
+  data: { name: TEST_OBJECT_TYPE, expr: `${TEST_OBJECT_TYPE} ${params.join(' ')}`, params, ...data }
+});
+
 describe('MessageAdapter', () => {
   it('owns V2 text object lifecycle independent of editor graph reconciliation', async () => {
     const objectService = createFakeObjectService();
@@ -92,12 +98,7 @@ describe('MessageAdapter', () => {
     const runtime = createTestMessageAdapter({ objectService, eventBus });
     const nodeId = 'object-patch-runtime-test';
 
-    await runtime.createObject({
-      id: nodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['initial'] },
-      rawParams: ['initial']
-    });
+    await runtime.createObject(messageObjectSpec(nodeId, ['initial']));
 
     const createdObject = objectService.getObjectById(nodeId);
     expect(createdObject).toBeInstanceOf(PatchRuntimeTestObject);
@@ -105,12 +106,10 @@ describe('MessageAdapter', () => {
 
     expect(PatchRuntimeTestObject.createdRawParams).toEqual([['initial']]);
 
-    await runtime.updateObject(nodeId, {
-      id: nodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['display-only update'] },
-      rawParams: ['initial']
-    });
+    await runtime.updateObject(
+      nodeId,
+      messageObjectSpec(nodeId, ['initial'], { params: ['display-only update'] })
+    );
 
     expect(objectService.getObjectById(nodeId)).toBe(createdObject);
     expect(PatchRuntimeTestObject.destroyedNodeIds).toEqual([]);
@@ -134,12 +133,7 @@ describe('MessageAdapter', () => {
     const targetQueue = messageSystem.registerNode(targetNodeId);
     targetQueue.addCallback(onMessage);
 
-    await runtime.createObject({
-      id: sourceNodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['initial'] },
-      rawParams: ['initial']
-    });
+    await runtime.createObject(messageObjectSpec(sourceNodeId, ['initial']));
 
     messageSystem.updateEdges([
       {
@@ -158,12 +152,7 @@ describe('MessageAdapter', () => {
       expect.objectContaining({ source: sourceNodeId })
     );
 
-    await runtime.updateObject(sourceNodeId, {
-      id: sourceNodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['next'] },
-      rawParams: ['next']
-    });
+    await runtime.updateObject(sourceNodeId, messageObjectSpec(sourceNodeId, ['next']));
 
     runtime.getObjectMessageContext(sourceNodeId)?.send('after replace');
     expect(onMessage).toHaveBeenCalledWith(
@@ -196,12 +185,7 @@ describe('MessageAdapter', () => {
 
     const nodeId = 'object-patch-runtime-async-test';
 
-    const createPromise = runtime.createObject({
-      id: nodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['initial'] },
-      rawParams: ['initial']
-    });
+    const createPromise = runtime.createObject(messageObjectSpec(nodeId, ['initial']));
 
     runtime.destroyObject(nodeId);
     releaseCreate();
@@ -251,12 +235,7 @@ describe('MessageAdapter', () => {
     PatchRuntimeTestObject.dynamicInlets = [{ name: 'dynamic-in', type: 'float' }];
     PatchRuntimeTestObject.dynamicOutlets = [{ name: 'dynamic-out', type: 'string' }];
 
-    await runtime.createObject({
-      id: nodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['initial'] },
-      rawParams: ['initial']
-    });
+    await runtime.createObject(messageObjectSpec(nodeId, ['initial']));
 
     expect(
       runtime.getObjectPorts(nodeId, {
@@ -277,12 +256,7 @@ describe('MessageAdapter', () => {
     const eventBus = PatchiesEventBus.getInstance();
     const runtime = createTestMessageAdapter({ objectService, eventBus });
 
-    await runtime.createObject({
-      id: nodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['initial'] },
-      rawParams: ['initial']
-    });
+    await runtime.createObject(messageObjectSpec(nodeId, ['initial']));
 
     const onMessage = vi.fn();
     const unsubscribe = runtime.subscribeObjectMessages(nodeId, onMessage);
@@ -315,21 +289,11 @@ describe('MessageAdapter', () => {
       eventBus: PatchiesEventBus.getInstance()
     });
 
-    await runtime.createObject({
-      id: nodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['initial'] },
-      rawParams: ['initial']
-    });
+    await runtime.createObject(messageObjectSpec(nodeId, ['initial']));
 
     const revisionAfterCreate = runtime.trackObjectViewRevision(nodeId);
 
-    await runtime.updateObject(nodeId, {
-      id: nodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['next'] },
-      rawParams: ['next']
-    });
+    await runtime.updateObject(nodeId, messageObjectSpec(nodeId, ['next']));
 
     expect(runtime.trackObjectViewRevision(nodeId)).toBe(revisionAfterCreate + 1);
   });
@@ -346,23 +310,16 @@ describe('MessageAdapter', () => {
       onObjectDataChange: (nodeId, updates) => dataUpdates.push({ nodeId, updates })
     });
 
-    await runtime.createObject({
-      id: nodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['stable'], value: 'initial' },
-      rawParams: ['stable']
-    });
+    await runtime.createObject(messageObjectSpec(nodeId, ['stable'], { value: 'initial' }));
 
     const revisionAfterCreate = runtime.trackObjectViewRevision(nodeId);
     dataUpdates.length = 0;
     PatchRuntimeTestObject.normalizeDataOnUpdate = true;
 
-    await runtime.updateObject(nodeId, {
-      id: nodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['stable'], value: 'incoming' },
-      rawParams: ['stable']
-    });
+    await runtime.updateObject(
+      nodeId,
+      messageObjectSpec(nodeId, ['stable'], { value: 'incoming' })
+    );
 
     expect(dataUpdates).toEqual([
       {
@@ -385,32 +342,17 @@ describe('MessageAdapter', () => {
 
     const revisionUpdates: string[] = [];
 
-    await runtime.createObject({
-      id: nodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['initial'] },
-      rawParams: ['initial']
-    });
+    await runtime.createObject(messageObjectSpec(nodeId, ['initial']));
 
     const unsubscribe = runtime.subscribeObjectViewRevisions((changedNodeId) => {
       revisionUpdates.push(changedNodeId);
     });
 
-    await runtime.updateObject(nodeId, {
-      id: nodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['next'] },
-      rawParams: ['next']
-    });
+    await runtime.updateObject(nodeId, messageObjectSpec(nodeId, ['next']));
 
     unsubscribe();
 
-    await runtime.updateObject(nodeId, {
-      id: nodeId,
-      objectType: TEST_OBJECT_TYPE,
-      data: { params: ['final'] },
-      rawParams: ['final']
-    });
+    await runtime.updateObject(nodeId, messageObjectSpec(nodeId, ['final']));
 
     expect(revisionUpdates).toEqual([nodeId]);
   });

--- a/ui/src/lib/runtime/services/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/services/PatchRuntime.test.ts
@@ -91,6 +91,12 @@ const messageObjectSpec = (id: string, params: unknown[], data: Record<string, u
   data: { name: TEST_OBJECT_TYPE, expr: `${TEST_OBJECT_TYPE} ${params.join(' ')}`, params, ...data }
 });
 
+const audioObjectSpec = (id: string, type: string, params: unknown[], data = {}) => ({
+  id,
+  type,
+  data: { params, ...data }
+});
+
 describe('MessageAdapter', () => {
   it('owns V2 text object lifecycle independent of editor graph reconciliation', async () => {
     const objectService = createFakeObjectService();
@@ -388,11 +394,7 @@ describe('AudioAdapter', () => {
     const runtime = new AudioAdapter({ audioService });
     const nodeId = 'object-audio-runtime-test';
 
-    runtime.upsertAudioObject({
-      id: nodeId,
-      objectType: 'osc~',
-      params: [440]
-    });
+    runtime.upsertAudioObject(audioObjectSpec(nodeId, 'osc~', [440]));
 
     expect(audioService.removeNodeById).toHaveBeenCalledWith(nodeId);
     expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'osc~', [440], undefined);
@@ -426,7 +428,7 @@ describe('AudioAdapter', () => {
       }
     ]);
 
-    runtime.upsertAudioObject({ id: nodeId, objectType: 'gain~', params: [null, 1] });
+    runtime.upsertAudioObject(audioObjectSpec(nodeId, 'gain~', [null, 1]));
     messageSystem.sendMessage(sourceNodeId, 0.5);
 
     expect(audioService.send).toHaveBeenCalledWith(nodeId, 'gain', 0.5);
@@ -464,11 +466,7 @@ describe('AudioAdapter', () => {
 
     audioService.createNode.mockReturnValueOnce(createPromise);
 
-    runtime.upsertAudioObject({
-      id: nodeId,
-      objectType: 'osc~',
-      params: [440]
-    });
+    runtime.upsertAudioObject(audioObjectSpec(nodeId, 'osc~', [440]));
 
     expect(createPromise.catch).toHaveBeenCalledWith(expect.any(Function));
     expect(catchHandlers).toHaveLength(1);
@@ -488,13 +486,11 @@ describe('AudioAdapter', () => {
     };
 
     audioService.audioNode = node;
+    AudioRegistry.getInstance().register(ToneNode);
 
-    runtime.upsertAudioObject({
-      id: node.nodeId,
-      objectType: 'test~',
-      params: [],
-      runtimeData: { settings: { gain: 0.5 } }
-    });
+    runtime.upsertAudioObject(
+      audioObjectSpec(node.nodeId, 'tone~', [], { settings: { gain: 0.5 } })
+    );
 
     await vi.waitFor(() => {
       expect(onAudioObjectDataChange).toHaveBeenCalledWith(node.nodeId, {
@@ -503,7 +499,7 @@ describe('AudioAdapter', () => {
       });
     });
     expect(node.bindRuntimeData).toHaveBeenCalledWith({
-      initialData: { settings: { gain: 0.5 } },
+      initialData: { params: [], settings: { gain: 0.5 } },
       update: expect.any(Function)
     });
 
@@ -538,11 +534,9 @@ describe('AudioAdapter', () => {
       }
     ]);
 
-    runtime.upsertAudioObject({
-      id: tapNodeId,
-      objectType: 'tap~',
-      params: [null, null, 512, 'wave', 0, true]
-    });
+    runtime.upsertAudioObject(
+      audioObjectSpec(tapNodeId, 'tap~', [null, null, 512, 'wave', 0, true])
+    );
 
     messageSystem.sendMessage(sourceNodeId, { type: 'setSamples', value: 1024 });
 
@@ -573,7 +567,7 @@ describe('AudioAdapter', () => {
       }
     ]);
 
-    runtime.upsertAudioObject({ id: nodeId, objectType: 'bytebeat~', params: [] });
+    runtime.upsertAudioObject(audioObjectSpec(nodeId, 'bytebeat~', []));
     messageSystem.sendMessage(sourceNodeId, { type: 'play' });
 
     expect(audioService.send).toHaveBeenCalledWith(nodeId, 'control', { type: 'play' });
@@ -602,7 +596,7 @@ describe('AudioAdapter', () => {
       }
     ]);
 
-    runtime.upsertAudioObject({ id: nodeId, objectType: 'expr~', params: [null, 's + $3'] });
+    runtime.upsertAudioObject(audioObjectSpec(nodeId, 'expr~', [null, 's + $3']));
     messageSystem.sendMessage(sourceNodeId, 0.75);
 
     expect(audioService.send).toHaveBeenCalledWith(nodeId, 'messageInlet', {
@@ -950,7 +944,7 @@ describe('PatchRuntime', () => {
     expect(audioService.createNode).toHaveBeenLastCalledWith(nodeId, 'osc~', [], undefined);
   });
 
-  it('serializes overlapping object synchronization and retains the latest descriptor', async () => {
+  it('serializes overlapping object synchronization and retains the latest object', async () => {
     let releaseCreate!: () => void;
     PatchRuntimeTestObject.createGate = new Promise((resolve) => {
       releaseCreate = resolve;
@@ -1029,11 +1023,7 @@ describe('PatchRuntime', () => {
 
     expect(runtime.isObjectInRegistry('osc~')).toBe(true);
 
-    runtime.upsertAudioObject({
-      id: audioNodeId,
-      objectType: 'osc~',
-      params: [440]
-    });
+    runtime.upsertAudioObject(audioObjectSpec(audioNodeId, 'osc~', [440]));
 
     const unsubscribe = runtime.subscribeObjectMessages(audioNodeId, callback);
     expect(unsubscribe).toEqual(expect.any(Function));
@@ -1092,11 +1082,7 @@ describe('PatchRuntime', () => {
 
     expect(PatchRuntimeTestObject.createdRawParams).toContainEqual(['initial']);
 
-    runtime.upsertAudioObject({
-      id: nodeId,
-      objectType: 'osc~',
-      params: [440]
-    });
+    runtime.upsertAudioObject(audioObjectSpec(nodeId, 'osc~', [440]));
 
     expect(objectService.getObjectById(nodeId)).toBeInstanceOf(PatchRuntimeTestObject);
     expect(audioService.createNode).toHaveBeenCalledWith(nodeId, 'osc~', [440], undefined);

--- a/ui/src/lib/runtime/services/PatchRuntime.ts
+++ b/ui/src/lib/runtime/services/PatchRuntime.ts
@@ -13,10 +13,9 @@ import { RuntimeObjectResolver } from './RuntimeObjectResolver';
 import { RuntimeObjectReconciler } from './RuntimeObjectReconciler';
 import { createSerialQueue } from '../utils/serial-queue';
 
-import type { RuntimeAudioObjectDescriptor } from '../types/audio-adapter';
-
 import type {
   RuntimeConnectionSpec,
+  RuntimeAudioObjectData,
   RuntimeGraphSpec,
   RuntimeObjectPorts,
   RuntimeObjectSpec,
@@ -70,7 +69,7 @@ export class PatchRuntime {
       createMessageObject: (descriptor) => this.message.createObject(descriptor),
       updateMessageObject: (nodeId, descriptor) => this.message.updateObject(nodeId, descriptor),
       destroyMessageObject: (nodeId) => this.message.destroyObject(nodeId),
-      upsertAudioObject: (descriptor) => this.upsertAudioObject(descriptor),
+      upsertAudioObject: (object) => this.upsertAudioObject(object),
       destroyAudioObject: (nodeId) => this.destroyAudioObject(nodeId),
       getAudioObject: (nodeId) => this.getAudioObject(nodeId),
       consumeSuppressedAudioObjectSync: (nodeId) => this.consumeSuppressedAudioObjectSync(nodeId)
@@ -226,8 +225,8 @@ export class PatchRuntime {
     return this.audio.consumeSuppressedAudioObjectSync(nodeId);
   }
 
-  upsertAudioObject(descriptor: RuntimeAudioObjectDescriptor): void {
-    this.audio.upsertAudioObject(descriptor);
+  upsertAudioObject(object: RuntimeObjectSpec<RuntimeAudioObjectData>): void {
+    this.audio.upsertAudioObject(object);
   }
 
   destroyAudioObject(nodeId: string): void {

--- a/ui/src/lib/runtime/services/RuntimeObjectReconciler.ts
+++ b/ui/src/lib/runtime/services/RuntimeObjectReconciler.ts
@@ -1,25 +1,22 @@
 import { logger } from '$lib/utils/logger';
 
 import { RuntimeObjectResolver } from './RuntimeObjectResolver';
-import {
-  getRuntimeAudioObjectDescriptorKey,
-  getRuntimeObjectDescriptorKey
-} from '../utils/runtime-object-keys';
+import { getRuntimeAudioObjectDescriptorKey, getObjectKey } from '../utils/runtime-object-keys';
 import { createSerialQueue } from '../utils/serial-queue';
 
 import type { RuntimeAudioObjectDescriptor } from '../types/audio-adapter';
-import type { RuntimeObjectDescriptor, RuntimeObjectSpec } from '../types/runtime-object';
+import type { RuntimeObjectSpec } from '../types/runtime-object';
 
 interface RuntimeObjectSnapshot {
   ids: Set<string>;
-  descriptorKeys: Map<string, string>;
+  objectKeys: Map<string, string>;
 }
 
 type NextRuntimeObjectSnapshot = RuntimeObjectSnapshot & { pendingIds: Set<string> };
 
 export interface RuntimeObjectReconcilerRuntime {
-  createMessageObject(descriptor: RuntimeObjectDescriptor): Promise<void>;
-  updateMessageObject(nodeId: string, descriptor: RuntimeObjectDescriptor): Promise<void>;
+  createMessageObject(object: RuntimeObjectSpec): Promise<void>;
+  updateMessageObject(nodeId: string, object: RuntimeObjectSpec): Promise<void>;
   destroyMessageObject(nodeId: string): void;
   upsertAudioObject(descriptor: RuntimeAudioObjectDescriptor): void;
   destroyAudioObject(nodeId: string): void;
@@ -32,17 +29,17 @@ export class RuntimeObjectReconciler {
 
   private current: RuntimeObjectSnapshot = {
     ids: new Set(),
-    descriptorKeys: new Map()
+    objectKeys: new Map()
   };
 
   private currentAudio: RuntimeObjectSnapshot = {
     ids: new Set(),
-    descriptorKeys: new Map()
+    objectKeys: new Map()
   };
 
   private next: NextRuntimeObjectSnapshot = {
     ids: new Set(),
-    descriptorKeys: new Map(),
+    objectKeys: new Map(),
     pendingIds: new Set()
   };
 
@@ -64,7 +61,7 @@ export class RuntimeObjectReconciler {
   }
 
   private async reconcileObjects(objects: RuntimeObjectSpec[]): Promise<void> {
-    const nextObjectDescriptors = new Map<string, RuntimeObjectDescriptor>();
+    const nextMessageObjects = new Map<string, RuntimeObjectSpec>();
     const nextAudioDescriptors = new Map<string, RuntimeAudioObjectDescriptor>();
 
     const pendingRuntimeUpdates: Promise<void>[] = [];
@@ -78,26 +75,23 @@ export class RuntimeObjectReconciler {
       }
 
       if (resolved.kind === 'message') {
-        nextObjectDescriptors.set(resolved.descriptor.id, resolved.descriptor);
+        nextMessageObjects.set(resolved.object.id, resolved.object);
       }
     }
 
-    this.next.ids = new Set(nextObjectDescriptors.keys());
+    this.next.ids = new Set(nextMessageObjects.keys());
 
-    this.next.descriptorKeys = new Map(
-      Array.from(nextObjectDescriptors).map(([nodeId, descriptor]) => [
-        nodeId,
-        getRuntimeObjectDescriptorKey(descriptor)
-      ])
+    this.next.objectKeys = new Map(
+      Array.from(nextMessageObjects).map(([nodeId, object]) => [nodeId, getObjectKey(object)])
     );
 
     const trackedRuntimeObjectIds = new Set([...this.current.ids, ...this.next.pendingIds]);
 
     for (const nodeId of trackedRuntimeObjectIds) {
-      if (!nextObjectDescriptors.has(nodeId)) {
+      if (!nextMessageObjects.has(nodeId)) {
         this.runtime.destroyMessageObject(nodeId);
         this.current.ids.delete(nodeId);
-        this.current.descriptorKeys.delete(nodeId);
+        this.current.objectKeys.delete(nodeId);
 
         this.next.pendingIds.delete(nodeId);
       }
@@ -105,21 +99,21 @@ export class RuntimeObjectReconciler {
 
     this.syncAudioObjects(nextAudioDescriptors);
 
-    for (const descriptor of nextObjectDescriptors.values()) {
-      if (this.next.pendingIds.has(descriptor.id)) continue;
+    for (const object of nextMessageObjects.values()) {
+      if (this.next.pendingIds.has(object.id)) continue;
 
-      const descriptorKey = getRuntimeObjectDescriptorKey(descriptor);
-      const hasCommittedObject = this.current.ids.has(descriptor.id);
-      const lastSyncedDescriptorKey = this.current.descriptorKeys.get(descriptor.id);
+      const objectKey = getObjectKey(object);
+      const hasCommittedObject = this.current.ids.has(object.id);
+      const lastSyncedObjectKey = this.current.objectKeys.get(object.id);
 
-      if (hasCommittedObject && lastSyncedDescriptorKey === descriptorKey) continue;
+      if (hasCommittedObject && lastSyncedObjectKey === objectKey) continue;
 
       const operation = () =>
         hasCommittedObject
-          ? this.runtime.updateMessageObject(descriptor.id, descriptor)
-          : this.runtime.createMessageObject(descriptor);
+          ? this.runtime.updateMessageObject(object.id, object)
+          : this.runtime.createMessageObject(object);
 
-      pendingRuntimeUpdates.push(this.syncRuntimeObject(descriptor, descriptorKey, operation));
+      pendingRuntimeUpdates.push(this.syncRuntimeObject(object, objectKey, operation));
     }
 
     await Promise.all(pendingRuntimeUpdates);
@@ -130,14 +124,14 @@ export class RuntimeObjectReconciler {
       if (!nextAudioDescriptors.has(nodeId)) {
         this.runtime.destroyAudioObject(nodeId);
         this.currentAudio.ids.delete(nodeId);
-        this.currentAudio.descriptorKeys.delete(nodeId);
+        this.currentAudio.objectKeys.delete(nodeId);
       }
     }
 
     for (const descriptor of nextAudioDescriptors.values()) {
       const descriptorKey = getRuntimeAudioObjectDescriptorKey(descriptor);
       const hasCommittedAudioObject = this.currentAudio.ids.has(descriptor.id);
-      const lastSyncedDescriptorKey = this.currentAudio.descriptorKeys.get(descriptor.id);
+      const lastSyncedDescriptorKey = this.currentAudio.objectKeys.get(descriptor.id);
 
       if (
         hasCommittedAudioObject &&
@@ -149,9 +143,9 @@ export class RuntimeObjectReconciler {
 
       if (this.runtime.consumeSuppressedAudioObjectSync(descriptor.id)) {
         if (hasCommittedAudioObject) {
-          this.currentAudio.descriptorKeys.set(descriptor.id, descriptorKey);
+          this.currentAudio.objectKeys.set(descriptor.id, descriptorKey);
         } else {
-          this.currentAudio.descriptorKeys.delete(descriptor.id);
+          this.currentAudio.objectKeys.delete(descriptor.id);
         }
 
         continue;
@@ -159,28 +153,28 @@ export class RuntimeObjectReconciler {
 
       this.runtime.upsertAudioObject(descriptor);
       this.currentAudio.ids.add(descriptor.id);
-      this.currentAudio.descriptorKeys.set(descriptor.id, descriptorKey);
+      this.currentAudio.objectKeys.set(descriptor.id, descriptorKey);
     }
   }
 
   private async syncRuntimeObject(
-    descriptor: RuntimeObjectDescriptor,
-    descriptorKey: string,
+    spec: RuntimeObjectSpec,
+    objectKey: string,
     operation: () => Promise<void>
   ): Promise<void> {
-    this.next.pendingIds.add(descriptor.id);
+    this.next.pendingIds.add(spec.id);
 
     try {
       await operation();
 
-      if (this.next.descriptorKeys.get(descriptor.id) !== descriptorKey) return;
+      if (this.next.objectKeys.get(spec.id) !== objectKey) return;
 
-      this.current.ids.add(descriptor.id);
-      this.current.descriptorKeys.set(descriptor.id, descriptorKey);
+      this.current.ids.add(spec.id);
+      this.current.objectKeys.set(spec.id, objectKey);
     } catch (error) {
-      logger.warn(`failed to sync runtime object "${descriptor.id}"`, error);
+      logger.warn(`failed to sync runtime object "${spec.id}"`, error);
     } finally {
-      this.next.pendingIds.delete(descriptor.id);
+      this.next.pendingIds.delete(spec.id);
     }
   }
 }

--- a/ui/src/lib/runtime/services/RuntimeObjectReconciler.ts
+++ b/ui/src/lib/runtime/services/RuntimeObjectReconciler.ts
@@ -1,11 +1,10 @@
 import { logger } from '$lib/utils/logger';
 
 import { RuntimeObjectResolver } from './RuntimeObjectResolver';
-import { getRuntimeAudioObjectDescriptorKey, getObjectKey } from '../utils/runtime-object-keys';
+import { getRuntimeAudioObjectKey, getObjectKey } from '../utils/runtime-object-keys';
 import { createSerialQueue } from '../utils/serial-queue';
 
-import type { RuntimeAudioObjectDescriptor } from '../types/audio-adapter';
-import type { RuntimeObjectSpec } from '../types/runtime-object';
+import type { RuntimeAudioObjectData, RuntimeObjectSpec } from '../types/runtime-object';
 
 interface RuntimeObjectSnapshot {
   ids: Set<string>;
@@ -18,7 +17,7 @@ export interface RuntimeObjectReconcilerRuntime {
   createMessageObject(object: RuntimeObjectSpec): Promise<void>;
   updateMessageObject(nodeId: string, object: RuntimeObjectSpec): Promise<void>;
   destroyMessageObject(nodeId: string): void;
-  upsertAudioObject(descriptor: RuntimeAudioObjectDescriptor): void;
+  upsertAudioObject(object: RuntimeObjectSpec<RuntimeAudioObjectData>): void;
   destroyAudioObject(nodeId: string): void;
   getAudioObject(nodeId: string): unknown | null;
   consumeSuppressedAudioObjectSync(nodeId: string): boolean;
@@ -62,7 +61,7 @@ export class RuntimeObjectReconciler {
 
   private async reconcileObjects(objects: RuntimeObjectSpec[]): Promise<void> {
     const nextMessageObjects = new Map<string, RuntimeObjectSpec>();
-    const nextAudioDescriptors = new Map<string, RuntimeAudioObjectDescriptor>();
+    const nextAudioObjects = new Map<string, RuntimeObjectSpec<RuntimeAudioObjectData>>();
 
     const pendingRuntimeUpdates: Promise<void>[] = [];
 
@@ -70,7 +69,7 @@ export class RuntimeObjectReconciler {
       const resolved = this.resolver.resolve(object);
 
       if (resolved.kind === 'audio') {
-        nextAudioDescriptors.set(resolved.descriptor.id, resolved.descriptor);
+        nextAudioObjects.set(resolved.object.id, resolved.object);
         continue;
       }
 
@@ -97,7 +96,7 @@ export class RuntimeObjectReconciler {
       }
     }
 
-    this.syncAudioObjects(nextAudioDescriptors);
+    this.syncAudioObjects(nextAudioObjects);
 
     for (const object of nextMessageObjects.values()) {
       if (this.next.pendingIds.has(object.id)) continue;
@@ -119,41 +118,43 @@ export class RuntimeObjectReconciler {
     await Promise.all(pendingRuntimeUpdates);
   }
 
-  private syncAudioObjects(nextAudioDescriptors: Map<string, RuntimeAudioObjectDescriptor>): void {
+  private syncAudioObjects(
+    nextAudioObjects: Map<string, RuntimeObjectSpec<RuntimeAudioObjectData>>
+  ): void {
     for (const nodeId of this.currentAudio.ids) {
-      if (!nextAudioDescriptors.has(nodeId)) {
+      if (!nextAudioObjects.has(nodeId)) {
         this.runtime.destroyAudioObject(nodeId);
         this.currentAudio.ids.delete(nodeId);
         this.currentAudio.objectKeys.delete(nodeId);
       }
     }
 
-    for (const descriptor of nextAudioDescriptors.values()) {
-      const descriptorKey = getRuntimeAudioObjectDescriptorKey(descriptor);
-      const hasCommittedAudioObject = this.currentAudio.ids.has(descriptor.id);
-      const lastSyncedDescriptorKey = this.currentAudio.objectKeys.get(descriptor.id);
+    for (const object of nextAudioObjects.values()) {
+      const objectKey = getRuntimeAudioObjectKey(object);
+      const hasCommittedAudioObject = this.currentAudio.ids.has(object.id);
+      const lastSyncedObjectKey = this.currentAudio.objectKeys.get(object.id);
 
       if (
         hasCommittedAudioObject &&
-        lastSyncedDescriptorKey === descriptorKey &&
-        this.runtime.getAudioObject(descriptor.id)
+        lastSyncedObjectKey === objectKey &&
+        this.runtime.getAudioObject(object.id)
       ) {
         continue;
       }
 
-      if (this.runtime.consumeSuppressedAudioObjectSync(descriptor.id)) {
+      if (this.runtime.consumeSuppressedAudioObjectSync(object.id)) {
         if (hasCommittedAudioObject) {
-          this.currentAudio.objectKeys.set(descriptor.id, descriptorKey);
+          this.currentAudio.objectKeys.set(object.id, objectKey);
         } else {
-          this.currentAudio.objectKeys.delete(descriptor.id);
+          this.currentAudio.objectKeys.delete(object.id);
         }
 
         continue;
       }
 
-      this.runtime.upsertAudioObject(descriptor);
-      this.currentAudio.ids.add(descriptor.id);
-      this.currentAudio.objectKeys.set(descriptor.id, descriptorKey);
+      this.runtime.upsertAudioObject(object);
+      this.currentAudio.ids.add(object.id);
+      this.currentAudio.objectKeys.set(object.id, objectKey);
     }
   }
 

--- a/ui/src/lib/runtime/services/RuntimeObjectResolver.ts
+++ b/ui/src/lib/runtime/services/RuntimeObjectResolver.ts
@@ -1,15 +1,15 @@
+import type { AudioNodeClass } from '$lib/audio';
 import { AudioRegistry } from '$lib/registry/AudioRegistry';
 
 import {
+  isObjectBoxData,
+  getTextObjectData,
   getAudioParamsFromData,
   getRawObjectParamsFromExpr,
-  getRuntimeObjectParamsFromData,
-  getTextObjectData,
-  isObjectBoxData
+  getRuntimeObjectParamsFromData
 } from '../utils/runtime-object-data';
 
-import type { RuntimeAudioObjectDescriptor } from '../types/audio-adapter';
-import type { RuntimeObjectSpec } from '../types/runtime-object';
+import type { RuntimeAudioObjectData, RuntimeObjectSpec } from '../types/runtime-object';
 
 type RuntimeObjectResolverOptions = {
   isMessageObject: (objectType: string) => boolean;
@@ -18,15 +18,15 @@ type RuntimeObjectResolverOptions = {
 
 export type ResolvedRuntimeObject =
   | { kind: 'message'; object: RuntimeObjectSpec }
-  | { kind: 'audio'; descriptor: RuntimeAudioObjectDescriptor }
+  | { kind: 'audio'; object: RuntimeObjectSpec<RuntimeAudioObjectData> }
   | { kind: 'ignored' };
 
 export class RuntimeObjectResolver {
   constructor(private options: RuntimeObjectResolverOptions) {}
 
   resolve(object: RuntimeObjectSpec): ResolvedRuntimeObject {
-    const audioDescriptor = this.getAudioObjectDescriptor(object);
-    if (audioDescriptor) return { kind: 'audio', descriptor: audioDescriptor };
+    const audioObject = this.getAudioObjectSpec(object);
+    if (audioObject) return { kind: 'audio', object: audioObject };
 
     const messageObject = this.getMessageObjectSpec(object);
     if (messageObject) return { kind: 'message', object: messageObject };
@@ -47,31 +47,34 @@ export class RuntimeObjectResolver {
     return { ...object, data: runtimeData };
   }
 
-  private getAudioObjectDescriptor(object: RuntimeObjectSpec): RuntimeAudioObjectDescriptor | null {
+  private getAudioObjectSpec(
+    object: RuntimeObjectSpec
+  ): RuntimeObjectSpec<RuntimeAudioObjectData> | null {
     if (!this.options.isAudioObject(object.type)) return null;
 
     if (isObjectBoxData(object.type, object.data)) {
       return {
-        id: object.id,
-        objectType: object.type,
-        params: getRuntimeObjectParamsFromData(object.type, object.data)
+        ...object,
+        data: { params: getRuntimeObjectParamsFromData(object.type, object.data) }
       };
     }
 
     const nodeClass = AudioRegistry.getInstance().get(object.type);
     if (!nodeClass?.runtimeManaged) return null;
 
-    const params = getAudioParamsFromData(
-      nodeClass.inlets ?? [],
-      nodeClass.hasRuntimeData ? undefined : object.data
-    );
+    const params = getAudioObjectParams(object, nodeClass);
 
-    return {
-      id: object.id,
-      objectType: object.type,
-      params,
-
-      ...(nodeClass.hasRuntimeData && { runtimeData: object.data })
-    };
+    return { ...object, data: { ...object.data, params } };
   }
+}
+
+function getAudioObjectParams(object: RuntimeObjectSpec, nodeClass: AudioNodeClass) {
+  if (Array.isArray(object.data.params)) {
+    return object.data.params;
+  }
+
+  return getAudioParamsFromData(
+    nodeClass.inlets ?? [],
+    nodeClass.hasRuntimeData ? undefined : object.data
+  );
 }

--- a/ui/src/lib/runtime/services/RuntimeObjectResolver.ts
+++ b/ui/src/lib/runtime/services/RuntimeObjectResolver.ts
@@ -9,7 +9,7 @@ import {
 } from '../utils/runtime-object-data';
 
 import type { RuntimeAudioObjectDescriptor } from '../types/audio-adapter';
-import type { RuntimeObjectDescriptor, RuntimeObjectSpec } from '../types/runtime-object';
+import type { RuntimeObjectSpec } from '../types/runtime-object';
 
 type RuntimeObjectResolverOptions = {
   isMessageObject: (objectType: string) => boolean;
@@ -17,7 +17,7 @@ type RuntimeObjectResolverOptions = {
 };
 
 export type ResolvedRuntimeObject =
-  | { kind: 'message'; descriptor: RuntimeObjectDescriptor }
+  | { kind: 'message'; object: RuntimeObjectSpec }
   | { kind: 'audio'; descriptor: RuntimeAudioObjectDescriptor }
   | { kind: 'ignored' };
 
@@ -28,13 +28,13 @@ export class RuntimeObjectResolver {
     const audioDescriptor = this.getAudioObjectDescriptor(object);
     if (audioDescriptor) return { kind: 'audio', descriptor: audioDescriptor };
 
-    const messageDescriptor = this.getMessageObjectDescriptor(object);
-    if (messageDescriptor) return { kind: 'message', descriptor: messageDescriptor };
+    const messageObject = this.getMessageObjectSpec(object);
+    if (messageObject) return { kind: 'message', object: messageObject };
 
     return { kind: 'ignored' };
   }
 
-  private getMessageObjectDescriptor(object: RuntimeObjectSpec): RuntimeObjectDescriptor | null {
+  private getMessageObjectSpec(object: RuntimeObjectSpec): RuntimeObjectSpec | null {
     if (!this.options.isMessageObject(object.type)) return null;
 
     const data = object.data;
@@ -44,7 +44,7 @@ export class RuntimeObjectResolver {
       ? getTextObjectData(object.type, data, rawParams)
       : { ...data };
 
-    return { id: object.id, objectType: object.type, data: runtimeData, rawParams };
+    return { ...object, data: runtimeData };
   }
 
   private getAudioObjectDescriptor(object: RuntimeObjectSpec): RuntimeAudioObjectDescriptor | null {

--- a/ui/src/lib/runtime/types/audio-adapter.ts
+++ b/ui/src/lib/runtime/types/audio-adapter.ts
@@ -1,6 +1,0 @@
-export type RuntimeAudioObjectDescriptor = {
-  id: string;
-  objectType: string;
-  params: unknown[];
-  runtimeData?: Record<string, unknown>;
-};

--- a/ui/src/lib/runtime/types/runtime-object.ts
+++ b/ui/src/lib/runtime/types/runtime-object.ts
@@ -6,13 +6,6 @@ export interface RuntimeObjectSpec<TData = Record<string, unknown>> {
   data: TData;
 }
 
-export interface RuntimeObjectDescriptor {
-  id: string;
-  objectType: string;
-  data: Record<string, unknown>;
-  rawParams: string[];
-}
-
 export interface RuntimeConnectionSpec {
   id?: string;
 

--- a/ui/src/lib/runtime/types/runtime-object.ts
+++ b/ui/src/lib/runtime/types/runtime-object.ts
@@ -28,3 +28,7 @@ export interface RuntimeObjectPorts {
 }
 
 export type RuntimeObjectViewRevisionListener = (nodeId: string) => void;
+
+export type RuntimeAudioObjectData = {
+  params: unknown[];
+} & Record<string, unknown>;

--- a/ui/src/lib/runtime/utils/runtime-object-data.ts
+++ b/ui/src/lib/runtime/utils/runtime-object-data.ts
@@ -1,3 +1,4 @@
+import type { ObjectNodeData } from '$objects/object/types';
 import type { ObjectInlet } from '$lib/objects/v2/object-metadata';
 import { parseObjectParamFromString } from '$lib/objects/parse-object-param';
 
@@ -8,13 +9,13 @@ export function getTextObjectData(
   objectType: string,
   data: Record<string, unknown>,
   rawParams: string[]
-): Record<string, unknown> {
+): ObjectNodeData {
   const params = getRuntimeObjectParamsFromData(objectType, data, rawParams);
 
   return {
-    expr: typeof data.expr === 'string' ? data.expr : '',
     name: objectType,
-    params
+    params,
+    expr: typeof data.expr === 'string' ? data.expr : ''
   };
 }
 

--- a/ui/src/lib/runtime/utils/runtime-object-keys.ts
+++ b/ui/src/lib/runtime/utils/runtime-object-keys.ts
@@ -1,15 +1,10 @@
 import { hash } from 'ohash';
 
+import { getRawObjectParamsFromExpr } from './runtime-object-data';
+
 import type { RuntimeAudioObjectDescriptor } from '../types/audio-adapter';
 
-import type {
-  RuntimeConnectionSpec,
-  RuntimeObjectDescriptor,
-  RuntimeObjectSpec
-} from '../types/runtime-object';
-
-export const getRuntimeObjectDescriptorKey = (descriptor: RuntimeObjectDescriptor): string =>
-  hash([descriptor.objectType, descriptor.data, descriptor.rawParams]);
+import type { RuntimeConnectionSpec, RuntimeObjectSpec } from '../types/runtime-object';
 
 export const getRuntimeAudioObjectDescriptorKey = (
   descriptor: RuntimeAudioObjectDescriptor
@@ -18,8 +13,8 @@ export const getRuntimeAudioObjectDescriptorKey = (
 export const getRuntimeConnectionId = (connection: RuntimeConnectionSpec): string =>
   hash([connection.source, connection.outlet, connection.target, connection.inlet]);
 
-export const getObjectLifecycleKey = (descriptor: RuntimeObjectDescriptor): string =>
-  hash([descriptor.objectType, descriptor.rawParams]);
+export const getObjectLifecycleKey = (object: RuntimeObjectSpec): string =>
+  hash([object.type, getRawObjectParamsFromExpr(object.data.expr)]);
 
 export const getConnectionKey = (connection: RuntimeConnectionSpec & { id: string }): string =>
   `${connection.id}:${getRuntimeConnectionId(connection)}`;

--- a/ui/src/lib/runtime/utils/runtime-object-keys.ts
+++ b/ui/src/lib/runtime/utils/runtime-object-keys.ts
@@ -2,13 +2,15 @@ import { hash } from 'ohash';
 
 import { getRawObjectParamsFromExpr } from './runtime-object-data';
 
-import type { RuntimeAudioObjectDescriptor } from '../types/audio-adapter';
+import type {
+  RuntimeAudioObjectData,
+  RuntimeConnectionSpec,
+  RuntimeObjectSpec
+} from '../types/runtime-object';
 
-import type { RuntimeConnectionSpec, RuntimeObjectSpec } from '../types/runtime-object';
-
-export const getRuntimeAudioObjectDescriptorKey = (
-  descriptor: RuntimeAudioObjectDescriptor
-): string => hash([descriptor.objectType, descriptor.params]);
+export const getRuntimeAudioObjectKey = (
+  object: RuntimeObjectSpec<RuntimeAudioObjectData>
+): string => hash([object.type, object.data.params]);
 
 export const getRuntimeConnectionId = (connection: RuntimeConnectionSpec): string =>
   hash([connection.source, connection.outlet, connection.target, connection.inlet]);

--- a/ui/src/objects/object/ObjectNode.svelte
+++ b/ui/src/objects/object/ObjectNode.svelte
@@ -44,6 +44,7 @@
   import { getPatchRuntime, getPatchRuntimeViewRevisionTracker } from '$lib/runtime';
   import { useObjectPorts } from '$objects/object/useObjectPorts.svelte';
   import { useObjectRuntimeView } from '$objects/object/useObjectRuntimeView.svelte';
+  import type { ObjectNodeData } from './types';
 
   let {
     id: nodeId,
@@ -51,7 +52,7 @@
     selected
   }: {
     id: string;
-    data: { expr: string; name: string; params: unknown[] };
+    data: ObjectNodeData;
     selected: boolean;
   } = $props();
 

--- a/ui/src/objects/object/types.ts
+++ b/ui/src/objects/object/types.ts
@@ -1,0 +1,5 @@
+export type ObjectNodeData = {
+  name: string;
+  expr: string;
+  params: unknown[];
+};


### PR DESCRIPTION
Use the same `{id, type, data}` shape for text objects as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized runtime object handling for more consistent creation, updates, synchronization, and lifecycle tracking.
  * Improved audio object processing while preserving parameters, runtime code, and settings together.
  * Refined object identity handling to support reliable updates and synchronization.
* **Documentation**
  * Clarified runtime object representations and integration boundaries.
* **Tests**
  * Expanded coverage for runtime lifecycle, synchronization, updates, and audio parameter preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->