### PR TITLE
feat(fft~, send, recv): send/recv forwards fft analysis results

### DIFF
--- a/docs/design-docs/specs/23-fft.md
+++ b/docs/design-docs/specs/23-fft.md
@@ -23,6 +23,8 @@ We want to create a system for audio analysis, for two reasons:
     - We should not always require the user provide the `id` of the analysis object though, as that would be cumbersome.
     - We need to instead track what is the nodeId of the analysis object that the P5.js sketch is connected to. Then, we can use that id to route the audio data correctly.
     - If the `id` is specified, then we still use that object id instead.
+    - Named channels may forward this analysis marker through one `send` / `recv` hop. The runtime resolves `fft~ → send <channel> → recv <channel> → P5` to the original analyzer; it does not forward FFT sample arrays as messages.
+    - GLSL sampler routing still requires a direct `fft~` analysis edge and does not use this named-channel resolution.
   - Luckily, the `ArrayBuffer` is a transferable object, so you can postMessage with `{transfer: [buffer]}` to transfer the ownership of the buffer to the worker.
   - For Hydra and GLSL, the key challenge is that it's running in a web worker context, so we need to transfer the audio data between the main thread and the worker.
   - For Hydra, the `fft` function will work differently than P5.js as they are in a web worker context.

--- a/ui/src/lib/audio/AudioAnalysisSystem.test.ts
+++ b/ui/src/lib/audio/AudioAnalysisSystem.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/browser/BrowserFocusService', () => ({
+  BrowserFocusService: {
+    getInstance: () => ({
+      isWindowFocused: true,
+      isDocumentVisible: true,
+      onFocusChange: () => () => {}
+    })
+  }
+}));
+
+import { MessageChannelRegistry } from '$lib/messages/MessageChannelRegistry';
+import { MessageSystem } from '$lib/messages/MessageSystem';
+
+import { AudioAnalysisSystem } from './AudioAnalysisSystem';
+
+const channel = 'fft-analysis-channel-test';
+const fftNodeId = 'object-fft-analysis-source';
+const sendNodeId = 'object-fft-analysis-send';
+const recvNodeId = 'object-fft-analysis-recv';
+const consumerNodeId = 'p5-fft-analysis-consumer';
+
+class FakeFFTNode {
+  static type = 'fft~';
+
+  audioNode = {
+    fftSize: 4,
+    getByteTimeDomainData: (array: Uint8Array) => array.set([11, 22, 33, 44]),
+    getFloatTimeDomainData: () => {},
+    getByteFrequencyData: () => {},
+    getFloatFrequencyData: () => {}
+  };
+}
+
+afterEach(() => {
+  const registry = MessageChannelRegistry.getInstance();
+  registry.unregisterSender(channel, sendNodeId);
+  registry.unsubscribe(channel, recvNodeId);
+
+  MessageSystem.getInstance().updateEdges([]);
+});
+
+interface MockAnalysisSystem {
+  audioService: { getNodeById: (nodeId: string) => unknown };
+}
+
+function createAnalysisSystem(): AudioAnalysisSystem {
+  const system = new AudioAnalysisSystem();
+  const fftNode = new FakeFFTNode();
+
+  (system as unknown as MockAnalysisSystem).audioService = {
+    getNodeById: (nodeId) => (nodeId === fftNodeId ? fftNode : null)
+  };
+
+  return system;
+}
+
+function connectFFTThroughChannel(): void {
+  const registry = MessageChannelRegistry.getInstance();
+  registry.registerSender(channel, sendNodeId);
+  registry.subscribe(channel, recvNodeId, () => {});
+
+  connectFFTChannelEdges();
+}
+
+function connectFFTChannelEdges(): void {
+  MessageSystem.getInstance().updateEdges([
+    {
+      id: 'fft-to-send',
+      source: fftNodeId,
+      sourceHandle: 'analysis-out-0',
+      target: sendNodeId,
+      targetHandle: 'message-in-0'
+    },
+    {
+      id: 'recv-to-consumer',
+      source: recvNodeId,
+      sourceHandle: 'message-out-0',
+      target: consumerNodeId,
+      targetHandle: 'message-in-0'
+    }
+  ]);
+}
+
+describe('AudioAnalysisSystem', () => {
+  it('resolves fft analysis through a send and recv channel', () => {
+    connectFFTThroughChannel();
+
+    const analysis = createAnalysisSystem().getAnalysisForNode(consumerNodeId);
+    expect(analysis).toEqual(new Uint8Array([11, 22, 33, 44]));
+  });
+
+  it('resolves a channel after its sender and receiver register', () => {
+    connectFFTChannelEdges();
+
+    const system = createAnalysisSystem();
+    expect(system.getAnalysisForNode(consumerNodeId)).toBeNull();
+
+    const registry = MessageChannelRegistry.getInstance();
+    registry.registerSender(channel, sendNodeId);
+    registry.subscribe(channel, recvNodeId, () => {});
+
+    expect(system.getAnalysisForNode(consumerNodeId)).toEqual(new Uint8Array([11, 22, 33, 44]));
+  });
+});

--- a/ui/src/lib/audio/AudioAnalysisSystem.ts
+++ b/ui/src/lib/audio/AudioAnalysisSystem.ts
@@ -10,6 +10,7 @@ import {
 } from './v2/constants/fft';
 import { getObjectType } from '$lib/objects/get-type';
 import { BrowserFocusService } from '$lib/browser/BrowserFocusService';
+import { MessageChannelRegistry } from '$lib/messages/MessageChannelRegistry';
 
 export type AudioAnalysisType = 'wave' | 'freq';
 export type AudioAnalysisFormat = 'int' | 'float';
@@ -66,6 +67,7 @@ export class AudioAnalysisSystem {
   private static instance: AudioAnalysisSystem;
   private audioService = AudioService.getInstance();
   private messageSystem = MessageSystem.getInstance();
+  private messageChannelRegistry = MessageChannelRegistry.getInstance();
   private browserFocus = BrowserFocusService.getInstance();
 
   // Cache for FFT node connections: nodeId -> fftNodeId
@@ -91,6 +93,12 @@ export class AudioAnalysisSystem {
 
   /** Unsubscribe function for focus listener */
   private unsubscribeFocus: (() => void) | null = null;
+
+  constructor() {
+    this.messageChannelRegistry.onChannelsChange(() => {
+      this.fftConnectionCache.clear();
+    });
+  }
 
   private getPooledArray(
     analyzerNodeId: string,
@@ -241,22 +249,45 @@ export class AudioAnalysisSystem {
     }
 
     const connectedSourceIds = this.messageSystem.getConnectedSourceNodes(nodeId);
+    const directFftNodeId = this.findFFTNodeId(connectedSourceIds);
+
+    if (directFftNodeId) {
+      this.fftConnectionCache.set(nodeId, directFftNodeId);
+
+      return directFftNodeId;
+    }
+
     let fftNodeId: string | null = null;
 
-    for (const sourceId of connectedSourceIds) {
-      if (sourceId.startsWith('object-')) {
-        const node = this.audioService.getNodeById(sourceId);
+    for (const receiverNodeId of connectedSourceIds) {
+      const senderNodeIds = this.messageChannelRegistry.getSenderNodeIdsForReceiver(receiverNodeId);
 
-        if (node && getObjectType(node) === 'fft~') {
-          fftNodeId = sourceId;
-          break;
-        }
-      }
+      fftNodeId = this.findFFTNodeId(
+        senderNodeIds.flatMap((senderNodeId) =>
+          this.messageSystem.getConnectedSourceNodes(senderNodeId)
+        )
+      );
+
+      if (fftNodeId) break;
     }
 
     this.fftConnectionCache.set(nodeId, fftNodeId);
 
     return fftNodeId;
+  }
+
+  private findFFTNodeId(nodeIds: string[]): string | null {
+    for (const nodeId of nodeIds) {
+      if (!nodeId.startsWith('object-')) continue;
+
+      const node = this.audioService.getNodeById(nodeId);
+
+      if (node && getObjectType(node) === 'fft~') {
+        return nodeId;
+      }
+    }
+
+    return null;
   }
 
   /** Enable FFT for a node */

--- a/ui/src/lib/messages/MessageChannelRegistry.ts
+++ b/ui/src/lib/messages/MessageChannelRegistry.ts
@@ -147,6 +147,25 @@ export class MessageChannelRegistry {
   }
 
   /**
+   * Get send object node IDs that broadcast to channels received by a node.
+   *
+   * This lets systems that route metadata alongside messages follow a named-channel hop.
+   */
+  getSenderNodeIdsForReceiver(receiverNodeId: string): string[] {
+    const senderNodeIds = new Set<string>();
+
+    for (const channelData of this.channels.values()) {
+      if (!channelData.receivers.has(receiverNodeId)) continue;
+
+      for (const senderNodeId of channelData.senders) {
+        senderNodeIds.add(senderNodeId);
+      }
+    }
+
+    return Array.from(senderNodeIds);
+  }
+
+  /**
    * Get real node IDs associated with a channel.
    * Synthetic patchbay subscriber IDs are excluded because they are not canvas nodes.
    */


### PR DESCRIPTION
Use send and recv to forward `fft~` analysis results.

Does not work on GLSL video output. Only works with textual inlets/outlets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FFT audio analysis can now resolve through named message channels across one sender/receiver hop.
  * Added explicit FFT selection with `fft({ id })` when multiple senders share a channel.
* **Bug Fixes**
  * Improved FFT analyzer discovery when audio sources are connected through channel routing.
* **Documentation**
  * Updated the FFT specification to describe channel forwarding, ambiguity handling, and direct-only GLSL routing.
* **Tests**
  * Added coverage for channel-based FFT discovery, setup, cleanup, and initial analysis states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->