### PR TITLE
fix(numeric-operators): recompute on bang

### DIFF
--- a/docs/design-docs/specs/160-numeric-operator-objects.md
+++ b/docs/design-docs/specs/160-numeric-operator-objects.md
@@ -15,7 +15,9 @@ compact text objects without requiring a full expression.
 - `* n` multiplies incoming numbers by `n`.
 - `/ n` divides incoming numbers by `n`.
 - With no argument, the right operand defaults to `0`, matching the audio operator default.
-- Inlet 0 is hot: a number is transformed and emitted immediately.
+- Inlet 0 is hot: a number is stored as the left operand, transformed, and emitted immediately.
+- A `bang` sent to inlet 0 recomputes and emits using the stored left operand and the current
+  right operand. Before a number has been received, the stored left operand defaults to `0`.
 - Inlet 1 is cold: a number updates the right operand without output.
 - `/ 0` emits `0` instead of `Infinity` or `NaN`.
 

--- a/ui/src/lib/generated/object-schemas.generated.ts
+++ b/ui/src/lib/generated/object-schemas.generated.ts
@@ -18,7 +18,13 @@ export const generatedObjectSchemas: ObjectSchemaRegistry = {
         id: 'value',
         type: 'message',
         description: 'Number to transform',
-        messages: [{ schema: Type.Number(), description: 'Apply the operator to this number' }],
+        messages: [
+          { schema: Type.Number(), description: 'Apply the operator to this number' },
+          {
+            schema: Type.Object({ type: Type.Literal('bang') }),
+            description: 'Recompute using the previous value'
+          }
+        ],
         handle: { handleType: 'message', handleId: 0 }
       },
       {
@@ -145,7 +151,13 @@ export const generatedObjectSchemas: ObjectSchemaRegistry = {
         id: 'value',
         type: 'message',
         description: 'Number to transform',
-        messages: [{ schema: Type.Number(), description: 'Apply the operator to this number' }],
+        messages: [
+          { schema: Type.Number(), description: 'Apply the operator to this number' },
+          {
+            schema: Type.Object({ type: Type.Literal('bang') }),
+            description: 'Recompute using the previous value'
+          }
+        ],
         handle: { handleType: 'message', handleId: 0 }
       },
       {
@@ -205,7 +217,13 @@ export const generatedObjectSchemas: ObjectSchemaRegistry = {
         id: 'value',
         type: 'message',
         description: 'Number to transform',
-        messages: [{ schema: Type.Number(), description: 'Apply the operator to this number' }],
+        messages: [
+          { schema: Type.Number(), description: 'Apply the operator to this number' },
+          {
+            schema: Type.Object({ type: Type.Literal('bang') }),
+            description: 'Recompute using the previous value'
+          }
+        ],
         handle: { handleType: 'message', handleId: 0 }
       },
       {
@@ -302,7 +320,13 @@ export const generatedObjectSchemas: ObjectSchemaRegistry = {
         id: 'value',
         type: 'message',
         description: 'Number to transform',
-        messages: [{ schema: Type.Number(), description: 'Apply the operator to this number' }],
+        messages: [
+          { schema: Type.Number(), description: 'Apply the operator to this number' },
+          {
+            schema: Type.Object({ type: Type.Literal('bang') }),
+            description: 'Recompute using the previous value'
+          }
+        ],
         handle: { handleType: 'message', handleId: 0 }
       },
       {

--- a/ui/src/objects/numeric-operators/NumericOperatorObject.test.ts
+++ b/ui/src/objects/numeric-operators/NumericOperatorObject.test.ts
@@ -7,6 +7,9 @@ import {
   SubtractObject
 } from '$objects/numeric-operators/NumericOperatorObject';
 
+import { validateMessageToObject } from '$lib/objects/validate-object-message';
+import { Bang } from '$lib/objects/schemas/common';
+
 import type { ObjectContext } from '$lib/objects/v2/ObjectContext';
 import type { MessageMeta, TextObjectV2 } from '$lib/objects/v2/interfaces/text-objects';
 
@@ -69,6 +72,28 @@ describe('NumericOperatorObject', () => {
     expect(values.operand).toBe(3);
     expect(sent).toEqual([{ data: 15, options: undefined }]);
   });
+
+  it.each([
+    [AddObject, 2, 5, 7],
+    [SubtractObject, 2, 5, 3],
+    [MultiplyObject, 2, 5, 10],
+    [DivideObject, 2, 5, 2.5]
+  ])(
+    'recomputes the stored value when the hot inlet receives bang',
+    (ObjectClass, operand, value, result) => {
+      const { object, sent } = createNumericOperator(ObjectClass, [operand]);
+
+      object.onMessage?.(value, meta('value'));
+      object.onMessage?.({ type: 'bang' }, meta('value'));
+
+      expect(ObjectClass.inlets[0].messages?.some(({ schema }) => schema === Bang)).toBe(true);
+      expect(validateMessageToObject({ type: 'bang' }, ObjectClass.inlets[0])).toBe(true);
+      expect(sent).toEqual([
+        { data: result, options: undefined },
+        { data: result, options: undefined }
+      ]);
+    }
+  );
 
   it('outputs zero when dividing by zero', () => {
     const { object, sent } = createNumericOperator(DivideObject, [0]);

--- a/ui/src/objects/numeric-operators/NumericOperatorObject.ts
+++ b/ui/src/objects/numeric-operators/NumericOperatorObject.ts
@@ -4,6 +4,7 @@ import { match } from 'ts-pattern';
 import type { ObjectContext } from '$lib/objects/v2/ObjectContext';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 import type { MessageMeta, TextObjectV2 } from '$lib/objects/v2/interfaces/text-objects';
+import { Bang, messages } from '$lib/objects/schemas/common';
 import { schema } from '$lib/objects/schemas/types';
 
 type NumericOperation = (value: number, operand: number) => number;
@@ -19,7 +20,10 @@ const numericOperatorInlets: ObjectInlet[] = [
     description: 'Number to transform',
     hot: true,
     hideTextParam: true,
-    messages: [{ schema: Type.Number(), description: 'Apply the operator to this number' }]
+    messages: [
+      { schema: Type.Number(), description: 'Apply the operator to this number' },
+      { schema: Bang, description: 'Recompute using the previous value' }
+    ]
   },
   {
     name: 'operand',
@@ -55,7 +59,11 @@ abstract class NumericOperatorObject implements TextObjectV2 {
 
   onMessage(data: unknown, meta: MessageMeta): void {
     match([meta.inletName, data])
+      .with(['value', messages.bang], () => {
+        this.context.send(this.operate(this.getValue(), this.getOperand()));
+      })
       .with(['value', numericOperatorMessages.number], ([, value]) => {
+        this.context.setParam('value', value, { notifyUI: true });
         this.context.send(this.operate(value, this.getOperand()));
       })
       .with(['operand', numericOperatorMessages.number], ([, value]) => {
@@ -76,6 +84,12 @@ abstract class NumericOperatorObject implements TextObjectV2 {
     const operand = this.context.getParam('operand');
 
     return typeof operand === 'number' && Number.isFinite(operand) ? operand : 0;
+  }
+
+  private getValue(): number {
+    const value = this.context.getParam('value');
+
+    return typeof value === 'number' && Number.isFinite(value) ? value : 0;
   }
 }
 

--- a/ui/static/content/objects/add.md
+++ b/ui/static/content/objects/add.md
@@ -8,7 +8,7 @@ Add a number to incoming values.
 ```
 
 The argument sets the right operand. A number sent to the hot inlet is added to that operand
-and emitted immediately.
+and emitted immediately. Send a bang to repeat the calculation with the previous value.
 
 ## Inlets
 

--- a/ui/static/content/objects/div.md
+++ b/ui/static/content/objects/div.md
@@ -8,7 +8,8 @@ Divide incoming values by a number.
 ```
 
 The argument sets the right operand. A number sent to the hot inlet is divided by that operand
-and emitted immediately. Dividing by `0` outputs `0`.
+and emitted immediately. Send a bang to repeat the calculation with the previous value. Dividing
+by `0` outputs `0`.
 
 ## Inlets
 

--- a/ui/static/content/objects/mul.md
+++ b/ui/static/content/objects/mul.md
@@ -8,7 +8,7 @@ Multiply incoming values by a number.
 ```
 
 The argument sets the right operand. A number sent to the hot inlet is multiplied by that
-operand and emitted immediately.
+operand and emitted immediately. Send a bang to repeat the calculation with the previous value.
 
 ## Inlets
 

--- a/ui/static/content/objects/sub.md
+++ b/ui/static/content/objects/sub.md
@@ -8,7 +8,8 @@ Subtract a number from incoming values.
 ```
 
 The argument sets the right operand. A number sent to the hot inlet has that operand
-subtracted from it and is emitted immediately.
+subtracted from it and is emitted immediately. Send a bang to repeat the calculation with the
+previous value.
 
 ## Inlets
 


### PR DESCRIPTION
# Summary

- Store each numeric operator's most recent hot-inlet value.
- Accept a bang on `+`, `-`, `*`, and `/` to recompute using that stored value and the current right operand.
- Document the behavior and cover it with regression tests.

# Root cause

Numeric operators accepted only number messages on their hot inlet, so they neither retained the left operand nor declared bang as a valid input.

# Validation

- `bun run check`
- `bun run lint`
- `bun run test -- NumericOperatorObject.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Numeric operators now accept a bang on the value inlet to repeat the calculation using the most recently received value.
  * Bang-triggered calculations use the stored value and current operand, with a default of `0` before a value is received.
  * Division by zero outputs `0`.

* **Documentation**
  * Updated addition, subtraction, multiplication, and division documentation to describe bang-triggered recalculation behavior and division-by-zero handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->