### PR TITLE
feat(js): re-run library and dependents

### DIFF
--- a/docs/design-docs/specs/121-vfs-js-modules.md
+++ b/docs/design-docs/specs/121-vfs-js-modules.md
@@ -90,7 +90,9 @@ This reuses the existing module sync infrastructure entirely — no new message 
 
 ### Re-Execution on Change
 
-When a VFS JS file changes, all nodes that import from it should re-execute — same as how `// @lib` changes trigger re-execution of importers. JSRunner needs to track VFS file → importer node dependencies.
+When a library is explicitly re-run, all canvas nodes that import it re-execute. This includes transitive library dependencies: if `render-utils` imports `math-utils`, re-running `math-utils` first refreshes `render-utils`, then every node importing either library re-executes. A `// @lib` node exposes this re-run button in its editor and supports Shift+Enter for the same action.
+
+When a VFS JS file changes, all nodes that import from it should use the same dependent re-execution flow. JSRunner needs to track VFS file → importer node dependencies.
 
 ### Snippet Preset Integration
 

--- a/ui/src/lib/js-runner/JSRunner.ts
+++ b/ui/src/lib/js-runner/JSRunner.ts
@@ -235,7 +235,7 @@ export class JSRunner {
       const libName = getLibName(code);
 
       if (libName) {
-        this.setLibraryCode(nodeId, code);
+        await this.setLibraryCode(nodeId, code, { syncImmediately: true });
         setLibraryName?.(libName);
 
         return null;
@@ -560,7 +560,11 @@ export class JSRunner {
     return userFunction(...functionArgs);
   }
 
-  async setLibraryCode(nodeId: string, code: string) {
+  async setLibraryCode(
+    nodeId: string,
+    code: string,
+    { syncImmediately = false }: { syncImmediately?: boolean } = {}
+  ) {
     const libName = getLibName(code);
     if (!libName) return;
 
@@ -569,7 +573,11 @@ export class JSRunner {
 
     await this.ensureRenderWorker();
 
-    this.sendToRenderWorkerSlow?.(libName, code);
+    if (syncImmediately) {
+      this.sendToRenderWorker?.(libName, code);
+    } else {
+      this.sendToRenderWorkerSlow?.(libName, code);
+    }
   }
 
   private setModuleAndSync(moduleName: string, code: string | null) {

--- a/ui/src/lib/js-runner/js-module-utils.test.ts
+++ b/ui/src/lib/js-runner/js-module-utils.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { isSnippetModule, getLibName } from './js-module-utils';
+import {
+  getImportedModuleNames,
+  getLibraryDependentNodeIds,
+  isSnippetModule,
+  getLibName
+} from './js-module-utils';
 
 describe('js module utils', () => {
   const ism = isSnippetModule;
@@ -20,5 +25,33 @@ describe('js module utils', () => {
     expect(getLibName('const a = 1')).toBe(null);
     expect(getLibName('// some other comment\nconst a = 1')).toBe(null);
     expect(getLibName('//   @lib   three   \nconst scene = new THREE.Scene()')).toBe('three');
+  });
+
+  it('should extract static import module names', () => {
+    expect(
+      getImportedModuleNames(
+        "import { add } from 'math'\nimport helpers from \"helpers\"\nimport 'setup'\n// import 'ignored'"
+      )
+    ).toEqual(new Set(['math', 'helpers', 'setup']));
+  });
+
+  it('should find direct and transitive library dependents', () => {
+    expect(
+      getLibraryDependentNodeIds(
+        [
+          { id: 'math', data: { code: '// @lib math\nexport const add = () => {}' } },
+          {
+            id: 'render-utils',
+            data: {
+              code: "// @lib render-utils\nimport { add } from 'math'\nexport const draw = () => add()"
+            }
+          },
+          { id: 'canvas', data: { code: "import { draw } from 'render-utils'\ndraw()" } },
+          { id: 'unrelated', data: { code: "import { x } from 'other'" } }
+        ],
+        'math',
+        'math'
+      )
+    ).toEqual(['render-utils', 'canvas']);
   });
 });

--- a/ui/src/lib/js-runner/js-module-utils.ts
+++ b/ui/src/lib/js-runner/js-module-utils.ts
@@ -1,3 +1,5 @@
+import { stripJavaScriptComments } from '$lib/utils/javascript-comments';
+
 export const getModuleNameByNode = (nodeId: string) => `node-${nodeId}.js`;
 
 export const isSnippetModule = (code: string): boolean => {
@@ -15,6 +17,64 @@ export const getLibName = (code: string): string | null => {
   const match = code.match(/\/\/\s*@lib\s+(\S+)/);
 
   return match ? match[1] : null;
+};
+
+/** Return the module specifiers imported by a JavaScript module. */
+export const getImportedModuleNames = (code: string): Set<string> => {
+  const importRegex = /import\s+(?:[\w\s{},*]+\s+from\s+)?['"]([^'"]+)['"]/g;
+  const moduleNames = new Set<string>();
+  const codeWithoutComments = stripJavaScriptComments(code);
+  let match: RegExpExecArray | null;
+
+  while ((match = importRegex.exec(codeWithoutComments)) !== null) {
+    moduleNames.add(match[1]);
+  }
+
+  return moduleNames;
+};
+
+type ModuleNode = {
+  id: string;
+  data: Record<string, unknown>;
+};
+
+/**
+ * Find every node that needs to run after a named canvas library is refreshed.
+ * Library importers are included so that their own dependents can be discovered.
+ */
+export const getLibraryDependentNodeIds = (
+  nodes: ModuleNode[],
+  libraryName: string,
+  sourceNodeId: string
+): string[] => {
+  const moduleNames = [libraryName];
+  const dependentNodeIds: string[] = [];
+
+  let foundNewLibrary: boolean;
+
+  do {
+    foundNewLibrary = false;
+
+    for (const node of nodes) {
+      const nodeCode = typeof node.data.code === 'string' ? node.data.code : null;
+      if (!nodeCode || node.id === sourceNodeId || dependentNodeIds.includes(node.id)) continue;
+
+      const importedModuleNames = getImportedModuleNames(nodeCode);
+      if (!moduleNames.some((moduleName) => importedModuleNames.has(moduleName))) continue;
+
+      dependentNodeIds.push(node.id);
+
+      const dependentLibraryName =
+        typeof node.data.libraryName === 'string' ? node.data.libraryName : getLibName(nodeCode);
+
+      if (dependentLibraryName && !moduleNames.includes(dependentLibraryName)) {
+        moduleNames.push(dependentLibraryName);
+        foundNewLibrary = true;
+      }
+    }
+  } while (foundNewLibrary);
+
+  return dependentNodeIds;
 };
 
 export function deleteAfterComment(s: string, delimiter: string) {

--- a/ui/src/objects/code/CodeBlockBase.svelte
+++ b/ui/src/objects/code/CodeBlockBase.svelte
@@ -350,7 +350,7 @@
 
   function handleCodeOpen(event?: MouseEvent) {
     if (supportsLibraries && data.libraryName) {
-      openInlineEditor();
+      toggleInlineEditor();
       return;
     }
 
@@ -372,6 +372,15 @@
     }
   }
 
+  function handleRunButtonClick() {
+    if (supportsLibraries && data.libraryName) {
+      toggleInlineEditor();
+      return;
+    }
+
+    runOrStop();
+  }
+
   export function flash() {
     isFlashing = true;
     setTimeout(() => {
@@ -384,12 +393,6 @@
     overlayConsoleRef?.clearConsole();
     lineErrors = undefined;
     hasError = false;
-  }
-
-  function handleDoubleClickOnRun() {
-    if (supportsLibraries && data.libraryName) {
-      toggleInlineEditor();
-    }
   }
 
   function handleConsoleToggle() {
@@ -582,15 +585,13 @@
                   : 'hover:shadow-glow-sm bg-zinc-900'
             ]}
             style={`min-width: ${minContainerWidth}px`}
-            onclick={runOrStop}
-            ondblclick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-
-              handleDoubleClickOnRun();
-            }}
+            onclick={handleRunButtonClick}
             aria-disabled={showRunningIndicator && isRunning && !isLongRunningTaskActive}
-            aria-label={isLongRunningTaskActive ? 'Stop' : 'Run code'}
+            aria-label={supportsLibraries && data.libraryName
+              ? 'Edit shared code'
+              : isLongRunningTaskActive
+                ? 'Stop'
+                : 'Run code'}
           >
             <div
               class={[
@@ -611,7 +612,7 @@
           >
             {#if supportsLibraries && data.libraryName}
               {#if !showEditor}
-                <div>double click to edit shared code</div>
+                <div>click to edit shared code</div>
               {/if}
             {:else}
               <div>click to run</div>
@@ -652,6 +653,22 @@
             </Tooltip.Trigger>
 
             <Tooltip.Content>Open Expanded Editor</Tooltip.Content>
+          </Tooltip.Root>
+        {/if}
+
+        {#if supportsLibraries && data.libraryName}
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                onclick={executeCode}
+                class="cursor-pointer rounded p-1 hover:bg-zinc-700"
+                aria-label="Re-run dependent code"
+              >
+                <Play class="h-4 w-4 text-zinc-300" />
+              </button>
+            </Tooltip.Trigger>
+
+            <Tooltip.Content>Re-run dependent code</Tooltip.Content>
           </Tooltip.Root>
         {/if}
 

--- a/ui/src/objects/js/JSBlockNode.svelte
+++ b/ui/src/objects/js/JSBlockNode.svelte
@@ -17,6 +17,7 @@
   import { overrideOutputNodeId } from '../../stores/renderer.store';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { useNodeSetPaused } from '$lib/canvas/use-node-set-paused.svelte';
+  import { getLibName, getLibraryDependentNodeIds } from '$lib/js-runner/js-module-utils';
 
   // Get node data from XY Flow - nodes receive their data as props
   let {
@@ -47,7 +48,7 @@
   }
 
   // Get flow utilities to update node data
-  const { updateNodeData } = useSvelteFlow();
+  const { getNodes, updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
 
   const jsRunner = JSRunner.getInstance();
@@ -234,6 +235,21 @@
     }
   }
 
+  async function rerunLibraryAndDependents() {
+    await executeCode();
+
+    const libraryName = getLibName(code);
+    if (!libraryName) return;
+
+    const dependents = getLibraryDependentNodeIds(getNodes(), libraryName, nodeId);
+
+    for (const dependentNodeId of dependents) {
+      updateNodeData(dependentNodeId, {
+        executeCode: Date.now()
+      });
+    }
+  }
+
   function handleCodeChange(newCode: string) {
     if (data.libraryName) {
       jsRunner.setLibraryCode(nodeId, newCode);
@@ -246,7 +262,7 @@
   id={nodeId}
   {data}
   {selected}
-  onExecute={executeCode}
+  onExecute={rerunLibraryAndDependents}
   onCleanup={cleanupRunningTasks}
   onCodeChange={handleCodeChange}
   {isRunning}


### PR DESCRIPTION
## Summary

- Add an editor-side re-run action for `// @lib` JavaScript nodes.
- Re-run direct and transitive importers after a library refresh.
- Keep package-node clicks focused on opening or closing the editor.

## Why

Editing a shared canvas JavaScript library previously left nodes that import it running stale code.

## Validation

- `bun run test -- js-module-utils.test.ts`
- `bun run lint`
- `bun run check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Re-running a shared library now automatically refreshes code that depends on it, including transitive dependencies.
  - Added an option to manually re-run dependent code from the inline editor.
  - Shared-library blocks can now be opened or closed with a single click.
  - VFS file updates follow the same dependent re-execution behavior.

- **Bug Fixes**
  - Improved import detection, including imports within commented code, for more reliable dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->