### PR TITLE
fix(sequencer~): time signature sequencer fixes

### DIFF
--- a/docs/design-docs/specs/88-seq-step-sequencer.md
+++ b/docs/design-docs/specs/88-seq-step-sequencer.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-A DAW-style multi-track step sequencer (drum machine) driven by the global transport clock. Multiple instrument tracks share a step grid. Each track has its own outlet, so output can be wired directly to sounds without needing a `route` node.
+A DAW-style multi-track step sequencer (drum machine) driven by the global transport clock. Multiple instrument tracks share a step grid. Each track has its own outlet, so output can be wired directly to sounds without needing a `route` node. A pattern keeps its 4/4 duration when the transport meter changes, so meter changes affect bar boundaries rather than step speed.
 
 ## Concept
 
-N tracks, each with 16 (configurable) steps. All tracks share the same clock — one bar divided into `steps` equal parts. When step `s` fires, every track with `stepOn[s] = true` sends a message on its own outlet. Supports swing, audio-rate scheduling, and per-step values (velocity).
+N tracks, each with 16 (configurable) steps. All tracks share the same clock — a 4/4-length pattern divided into `steps` equal parts. When step `s` fires, every track with `stepOn[s] = true` sends a message on its own outlet. Supports swing, audio-rate scheduling, and per-step values (velocity). In other meters, patterns can continue across bar boundaries.
 
 ## Node Data
 
@@ -58,20 +58,20 @@ When a step is off, no message is sent on that outlet for that step.
 
 One `LookaheadClockScheduler` drives all tracks:
 
-1. Subscribe: `scheduler.every("0:${beatsPerBar/steps}:0", callback, { audio: true })`
+1. Schedule a 4-quarter-note pattern and chain the next pattern boundary.
 2. In each callback, compute step index from transport time (stateless):
 
    ```
-   stepInterval = (60/bpm) * (beatsPerBar/numSteps)
-   barDuration  = (60/bpm) * beatsPerBar
-   posInBar     = time % barDuration
-   stepIndex    = floor(posInBar / stepInterval) % numSteps
+   stepInterval   = (60/bpm) * (4/numSteps)
+   patternDuration = (60/bpm) * 4
+   posInPattern   = time % patternDuration
+   stepIndex       = floor(posInPattern / stepInterval) % numSteps
    ```
 
 3. Apply swing for odd steps: one-shot `schedule(time + swingOffset)` where
    `swingOffset = (swing/100) * 0.5 * stepInterval`
 4. At fire time, iterate tracks: for each track `t`, if `stepOn[stepIndex]` fire outlet `t`
-5. Re-subscribe when `steps` count or time signature (`beatsPerBar`) changes
+5. Re-schedule when the `steps` count changes. Time-signature changes do not change the pattern duration or step interval.
 6. Visual cursor: poll `Transport.ticks` at 30fps
 
 ## Output Format

--- a/ui/src/objects/sequencer/sequencer-scheduler.test.ts
+++ b/ui/src/objects/sequencer/sequencer-scheduler.test.ts
@@ -67,6 +67,45 @@ describe('SequencerScheduler', () => {
     expect(getSequencerVisualStep(-4)).toBe(-1);
   });
 
+  it('keeps 8-step patterns at their 4/4 speed across a 5/4 bar', () => {
+    transportState.isPlaying = true;
+    transportState.beatsPerBar = 5;
+
+    // At 120 BPM an eight-step pattern advances every eighth note (96 ticks),
+    // independent of how many beats the current bar contains.
+    transportState.ticks = 192;
+    expect(getSequencerVisualStep(8)).toBe(2);
+
+    // The pattern completes after four quarter-note beats and continues into
+    // the next 5/4 bar rather than being squeezed into that bar.
+    transportState.ticks = 4 * transportState.ppq;
+    expect(getSequencerVisualStep(8)).toBe(0);
+  });
+
+  it('fires 8-step patterns every eighth note in 5/4', () => {
+    vi.useFakeTimers();
+    transportState.isPlaying = true;
+    transportState.beatsPerBar = 5;
+
+    const onFire = vi.fn();
+    const scheduler = new SequencerScheduler(
+      'seq-1',
+      () => ({ clockMode: 'auto', audioRate: true, steps: 8, swing: 0 }),
+      onFire
+    );
+
+    scheduler.start();
+    vi.advanceTimersByTime(25);
+
+    transportState.seconds = 0.2;
+    transportState.phase = 0.4;
+    vi.advanceTimersByTime(25);
+    scheduler.dispose();
+
+    expect(onFire).toHaveBeenNthCalledWith(1, 0, 0);
+    expect(onFire).toHaveBeenNthCalledWith(2, 1, 0.25);
+  });
+
   it('schedules the first bar when transport starts in audio lookahead mode', () => {
     vi.useFakeTimers();
 

--- a/ui/src/objects/sequencer/sequencer-scheduler.ts
+++ b/ui/src/objects/sequencer/sequencer-scheduler.ts
@@ -12,12 +12,13 @@ export interface SequencerConfig {
 export function getSequencerVisualStep(numSteps: number): number {
   if (!Transport.isPlaying || numSteps <= 0) return -1;
 
-  const ticksPerBeat = Transport.ppq * (4 / Transport.denominator);
-  const ticksPerBar = ticksPerBeat * Transport.beatsPerBar;
-  const ticksPerStep = ticksPerBar / numSteps;
-  const ticksInBar = Transport.ticks % ticksPerBar;
+  // A pattern keeps the duration it has in 4/4: changing the meter changes
+  // bar boundaries, not the tempo or the sequencer's step rate.
+  const ticksPerPattern = Transport.ppq * 4;
+  const ticksPerStep = ticksPerPattern / numSteps;
+  const ticksInPattern = Transport.ticks % ticksPerPattern;
 
-  return Math.floor(ticksInBar / ticksPerStep) % numSteps;
+  return Math.floor(ticksInPattern / ticksPerStep) % numSteps;
 }
 
 /**
@@ -26,7 +27,7 @@ export function getSequencerVisualStep(numSteps: number): number {
  */
 export class SequencerScheduler {
   private scheduler: LookaheadClockScheduler;
-  private barSubId: string | null = null;
+  private patternSubId: string | null = null;
   private playStateSubId: string | null = null;
   private stepScheduleIds: string[] = [];
   private stepMarkerIds: string[] = [];
@@ -53,27 +54,32 @@ export class SequencerScheduler {
     this.scheduler.setTimelineStyle({ visible: false });
   }
 
-  private scheduleBar(barTime: number): void {
+  private schedulePattern(patternTime: number): void {
     const { steps, swing, audioRate } = this.getConfig();
 
-    // Cancel any leftover step schedules and markers from the previous bar
+    if (this.patternSubId) {
+      this.scheduler.cancel(this.patternSubId);
+      this.patternSubId = null;
+    }
+
+    // Cancel any leftover step schedules and markers from the previous pattern.
     for (const id of this.stepScheduleIds) this.scheduler.cancel(id);
     this.stepScheduleIds = [];
 
     this.clearMarkers();
 
-    const beatDuration = (60 / Transport.bpm) * (4 / Transport.denominator);
-    const stepInterval = (beatDuration * Transport.beatsPerBar) / steps;
+    const beatDuration = 60 / Transport.bpm;
+    const stepInterval = (beatDuration * 4) / steps;
 
     // Swing operates at the 8th-note level: the off-beat 8th note in each beat pair is delayed.
-    const stepsPerBeat = steps / Transport.beatsPerBar;
+    const stepsPerBeat = steps / 4;
     const halfBeat = Math.max(1, Math.round(stepsPerBeat / 2));
     const eighthInterval = stepInterval * halfBeat;
 
     for (let i = 0; i < steps; i++) {
       const isSwung = swing > 0 && i % (halfBeat * 2) === halfBeat;
       const swingOffset = isSwung ? (swing / 100) * 0.5 * eighthInterval : 0;
-      const stepTime = barTime + i * stepInterval + swingOffset;
+      const stepTime = patternTime + i * stepInterval + swingOffset;
 
       const id = this.scheduler.schedule(stepTime, (t) => this.onFire(i, t), {
         audio: audioRate
@@ -85,23 +91,29 @@ export class SequencerScheduler {
         this.stepMarkerIds.push(this.scheduler.addMarker(stepTime, color));
       }
     }
+
+    const patternDuration = stepInterval * steps;
+    this.patternSubId = this.scheduler.schedule(
+      patternTime + patternDuration,
+      (nextPatternTime) => this.schedulePattern(nextPatternTime),
+      { audio: audioRate }
+    );
   }
 
-  private scheduleCurrentBar(): void {
-    const beatDuration = (60 / Transport.bpm) * (4 / Transport.denominator);
-    const barDuration = beatDuration * Transport.beatsPerBar;
-    const barTime = Math.floor(Transport.seconds / barDuration) * barDuration;
+  private scheduleCurrentPattern(): void {
+    const patternDuration = (60 / Transport.bpm) * 4;
+    const patternTime = Math.floor(Transport.seconds / patternDuration) * patternDuration;
 
-    this.scheduleBar(barTime);
+    this.schedulePattern(patternTime);
   }
 
-  /** Re-subscribe to the bar clock, respecting current clockMode. */
+  /** Re-subscribe to the pattern clock, respecting current clockMode. */
   setup(): void {
     const { clockMode, audioRate } = this.getConfig();
 
-    if (this.barSubId) {
-      this.scheduler.cancel(this.barSubId);
-      this.barSubId = null;
+    if (this.patternSubId) {
+      this.scheduler.cancel(this.patternSubId);
+      this.patternSubId = null;
     }
 
     if (this.playStateSubId) {
@@ -118,16 +130,12 @@ export class SequencerScheduler {
 
     this.playStateSubId = this.scheduler.onPlayStateChange((state) => {
       if (state === 'playing') {
-        this.scheduleCurrentBar();
+        this.scheduleCurrentPattern();
       }
     });
 
-    this.barSubId = this.scheduler.onBeat(0, (barTime) => this.scheduleBar(barTime), {
-      audio: audioRate
-    });
-
     if (Transport.isPlaying) {
-      this.scheduleCurrentBar();
+      this.scheduleCurrentPattern();
     }
   }
 

--- a/ui/static/content/objects/sequencer.md
+++ b/ui/static/content/objects/sequencer.md
@@ -11,8 +11,11 @@ Click any step button to toggle it on or off.
 
 ## Steps
 
-Choose 4, 8, 12, 16, 24, or 32 steps per bar from the settings panel. Steps
-always fill exactly one bar regardless of time signature.
+Choose 4, 8, 12, 16, 24, or 32 steps from the settings panel. A pattern keeps
+the same duration it has in 4/4, so changing the time signature changes bar
+boundaries without changing the step speed. In a 5/4 transport, for example,
+an 8-step pattern continues across the bar boundary instead of squeezing all
+eight steps into five beats.
 
 ## Clock Modes
 


### PR DESCRIPTION
Fix time signature in `sequencer~` object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sequencer patterns now consistently span four quarter notes, regardless of the transport time signature.
  - Step timing remains steady in meters such as 5/4, preventing visual compression and incorrect audio scheduling.
  - Pattern playback continues smoothly across bar boundaries when the time signature changes.

- **Documentation**
  - Updated sequencer guidance to explain fixed 4/4 pattern duration and cross-bar playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->