### PR TITLE
fix(soundfile~): preserve sampler conversion

### DIFF
--- a/ui/src/lib/runtime/adapters/AudioAdapter.ts
+++ b/ui/src/lib/runtime/adapters/AudioAdapter.ts
@@ -99,6 +99,15 @@ export class AudioAdapter {
       onBeforeAudioNodeCreate
     );
 
+    // Node creation can asynchronously load runtime state (for example a sampler
+    // decoding its VFS file). Notify views again once that state is available.
+    const completion = nodePromise.then?.((node) => {
+      if (node && this.audioService.getNodeById(object.id) === node) {
+        this.viewRevisions.bump(object.id);
+      }
+    });
+
+    completion?.catch?.(() => undefined);
     nodePromise.catch?.(() => undefined);
 
     const messageContext = this.createAudioObjectMessageContext(object.id, object.type);

--- a/ui/src/lib/runtime/services/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/services/PatchRuntime.test.ts
@@ -408,6 +408,18 @@ describe('AudioAdapter', () => {
     expect(audioService.removeNodeById).toHaveBeenLastCalledWith(nodeId);
   });
 
+  it('notifies views again after asynchronous audio node creation completes', async () => {
+    const audioService = createFakeAudioService();
+    const runtime = new AudioAdapter({ audioService });
+    const nodeId = 'async-audio-view-test';
+
+    runtime.upsertAudioObject(audioObjectSpec(nodeId, 'sampler~', []));
+
+    expect(runtime.trackAudioObjectViewRevision(nodeId)).toBe(1);
+
+    await vi.waitFor(() => expect(runtime.trackAudioObjectViewRevision(nodeId)).toBe(2));
+  });
+
   it('persists numeric messages sent to audio parameters for the object display', () => {
     const nodeId = 'gain-parameter-target';
     const sourceNodeId = 'gain-parameter-source';

--- a/ui/src/lib/services/NodeOperationsService.test.ts
+++ b/ui/src/lib/services/NodeOperationsService.test.ts
@@ -51,13 +51,15 @@ function createContext() {
       historyManager: { execute: vi.fn() },
       canvasAccessors: {}
     },
-    getNodes: () => nodes
+    getNodes: () => nodes,
+    getEdges: () => edges
   };
 }
 
 describe('NodeOperationsService', () => {
   test('creates gm~ as a dedicated visual node type', () => {
     const { ctx } = createContext();
+
     const service = new NodeOperationsService(
       ctx as unknown as ConstructorParameters<typeof NodeOperationsService>[0]
     );
@@ -79,6 +81,7 @@ describe('NodeOperationsService', () => {
 
   test('creates new group nodes with explicit top-level dimensions', () => {
     const { ctx, getNodes } = createContext();
+
     const service = new NodeOperationsService(
       ctx as unknown as ConstructorParameters<typeof NodeOperationsService>[0]
     );
@@ -95,6 +98,7 @@ describe('NodeOperationsService', () => {
 
   test('replaces nodes with group nodes that have explicit top-level dimensions', () => {
     const { ctx, getNodes } = createContext();
+
     ctx.nodes = [{ id: 'old-1', type: 'js', position: { x: 10, y: 20 }, data: {} }];
     const service = new NodeOperationsService(
       ctx as unknown as ConstructorParameters<typeof NodeOperationsService>[0]
@@ -116,5 +120,43 @@ describe('NodeOperationsService', () => {
       height: DEFAULT_GROUP_HEIGHT,
       data: {}
     });
+  });
+
+  test('remaps soundfile handles to the sampler handles that exist today', () => {
+    const { ctx, getEdges } = createContext();
+    ctx.nodes = [{ id: 'soundfile~-1', type: 'soundfile~', position: { x: 10, y: 20 }, data: {} }];
+    ctx.edges = [
+      {
+        id: 'sampler-to-out',
+        source: 'soundfile~-1',
+        sourceHandle: 'audio-out-0',
+        target: 'out~-1',
+        targetHandle: 'audio-in'
+      },
+      {
+        id: 'message-to-sampler',
+        source: 'message-1',
+        sourceHandle: 'message-out',
+        target: 'soundfile~-1',
+        targetHandle: 'message-in'
+      }
+    ];
+
+    const service = new NodeOperationsService(
+      ctx as unknown as ConstructorParameters<typeof NodeOperationsService>[0]
+    );
+
+    service.replaceNode({
+      type: 'nodeReplace',
+      nodeId: 'soundfile~-1',
+      newType: 'sampler~',
+      newData: { hasRecording: true },
+      handleMapping: { 'audio-out-0': 'audio-out' }
+    });
+
+    expect(getEdges()).toEqual([
+      expect.objectContaining({ source: 'sampler~-1', sourceHandle: 'audio-out' }),
+      expect.objectContaining({ target: 'sampler~-1', targetHandle: 'message-in' })
+    ]);
   });
 });

--- a/ui/src/objects/sampler~/SamplerNode.svelte
+++ b/ui/src/objects/sampler~/SamplerNode.svelte
@@ -151,10 +151,6 @@
   const detune = $derived(node.data.detune || 0);
   const noteOffMode = $derived(node.data.noteOffMode ?? 'one-shot');
 
-  // Derive isPlaying from active voice count
-  const activeVoiceCount = $derived(activePlaybackVoices.size);
-  const isPlaying = $derived(activeVoiceCount > 0);
-
   // Use node dimensions if available, otherwise use defaults
   const width = $derived(node.width || 190);
   const height = $derived(node.height || 35);

--- a/ui/src/objects/sampler~/SamplerNode.svelte
+++ b/ui/src/objects/sampler~/SamplerNode.svelte
@@ -170,7 +170,11 @@
 
     const runtimeNode = audioService.getNodeById(node.id);
     const samplerNode = runtimeNode instanceof SamplerNodeV2 ? runtimeNode : null;
-    if (samplerNode === v2Node) return;
+
+    if (samplerNode === v2Node) {
+      audioBuffer = samplerNode?.audioBuffer ?? null;
+      return;
+    }
 
     if (v2Node) {
       v2Node.onPlaybackStart = undefined;

--- a/ui/src/objects/soundfile~/SoundFile.svelte
+++ b/ui/src/objects/soundfile~/SoundFile.svelte
@@ -241,8 +241,7 @@
           vfsPath: node.data.vfsPath
         },
         handleMapping: {
-          'audio-out-0': 'audio-out-audio-out',
-          'message-in': 'message-in-message-in'
+          'audio-out-0': 'audio-out'
         }
       });
     } catch (err) {


### PR DESCRIPTION
## Summary

- Preserve valid audio and message edge handles when converting `soundfile~` to `sampler~`.
- Notify sampler views after their asynchronous VFS audio buffer has finished loading.
- Add regression coverage for converted edges and async audio-view updates.

## Root cause

The conversion used retired sampler handle IDs, so the editor rendered cables against nonexistent handles. Separately, asynchronous sampler loading completed without a second view-revision notification, leaving the UI in its empty state.

## Validation

- `bun run test -- NodeOperationsService.test.ts PatchRuntime.test.ts`
- `bun run check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio node updates after asynchronous creation completes.
  * Fixed sampler audio buffer refreshes when the underlying node remains unchanged.
  * Improved conversion from soundfile playback to sampler nodes, preserving connections and correctly remapping audio output.
* **Tests**
  * Added coverage for asynchronous audio updates and node conversion connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->