### PR TITLE
fix(audio): audio param should show parameter automation label

### DIFF
--- a/ui/src/lib/runtime/adapters/AudioAdapter.ts
+++ b/ui/src/lib/runtime/adapters/AudioAdapter.ts
@@ -39,6 +39,9 @@ export class AudioAdapter {
   /** Runtime-owned audio objects and their message contexts. */
   private audioObjects = new Map<string, RuntimeAudioObjectEntry>();
 
+  /** View callbacks retained while the runtime creates or replaces an audio object. */
+  private messageSubscribers = new Map<string, Set<MessageCallbackFn>>();
+
   /** Node ids whose next editor-state sync should be ignored because runtime messaging already applied it. */
   private suppressedAudioObjectSyncs = new Set<string>();
 
@@ -117,6 +120,10 @@ export class AudioAdapter {
       params: [...object.data.params]
     });
 
+    for (const callback of this.messageSubscribers.get(object.id) ?? []) {
+      messageContext.queue.addCallback(callback);
+    }
+
     this.suppressedAudioObjectSyncs.delete(object.id);
     this.viewRevisions.bump(object.id);
   }
@@ -131,13 +138,25 @@ export class AudioAdapter {
   }
 
   subscribeAudioObjectMessages(nodeId: string, callback: MessageCallbackFn): (() => void) | null {
-    const messageContext = this.audioObjects.get(nodeId)?.messageContext;
-    if (!messageContext) return null;
+    let subscribers = this.messageSubscribers.get(nodeId);
 
-    messageContext.queue.addCallback(callback);
+    if (!subscribers) {
+      subscribers = new Set();
+      this.messageSubscribers.set(nodeId, subscribers);
+    }
+
+    subscribers.add(callback);
+
+    const messageContext = this.audioObjects.get(nodeId)?.messageContext;
+    messageContext?.queue.addCallback(callback);
 
     return () => {
-      messageContext.queue.removeCallback(callback);
+      this.messageSubscribers.get(nodeId)?.delete(callback);
+      this.audioObjects.get(nodeId)?.messageContext.queue.removeCallback(callback);
+
+      if (this.messageSubscribers.get(nodeId)?.size === 0) {
+        this.messageSubscribers.delete(nodeId);
+      }
     };
   }
 
@@ -153,6 +172,8 @@ export class AudioAdapter {
     for (const nodeId of this.audioObjects.keys()) {
       this.destroyAudioObject(nodeId);
     }
+
+    this.messageSubscribers.clear();
   }
 
   private createAudioObjectMessageContext(nodeId: string, objectType: string): MessageContext {

--- a/ui/src/lib/runtime/services/PatchRuntime.test.ts
+++ b/ui/src/lib/runtime/services/PatchRuntime.test.ts
@@ -1070,6 +1070,51 @@ describe('PatchRuntime', () => {
     messageSystem.updateEdges([]);
   });
 
+  it('keeps view message subscriptions made before an audio object is created', () => {
+    const audioNodeId = 'late-audio-target';
+    const sourceNodeId = 'late-audio-source';
+
+    const audioService = createFakeAudioService();
+
+    const runtime = createTestPatchRuntime({
+      objectService: createFakeObjectService(),
+      audioService,
+      isAudioObject: isOsc
+    });
+
+    const callback = vi.fn();
+    const messageSystem = MessageSystem.getInstance();
+
+    const unsubscribe = runtime.subscribeObjectMessages(audioNodeId, callback);
+    expect(unsubscribe).toEqual(expect.any(Function));
+
+    runtime.upsertAudioObject(audioObjectSpec(audioNodeId, 'osc~', [440]));
+    messageSystem.registerNode(sourceNodeId);
+
+    messageSystem.updateEdges([
+      {
+        id: 'late-source-to-audio',
+        source: sourceNodeId,
+        target: audioNodeId,
+        sourceHandle: 'message-out',
+        targetHandle: 'message-in-0'
+      }
+    ]);
+
+    messageSystem.sendMessage(sourceNodeId, { type: 'set', value: 220, time: 1 });
+
+    expect(callback).toHaveBeenCalledWith(
+      { type: 'set', value: 220, time: 1 },
+      expect.objectContaining({ inlet: 0 })
+    );
+
+    unsubscribe?.();
+    runtime.destroy();
+
+    messageSystem.unregisterNode(sourceNodeId);
+    messageSystem.updateEdges([]);
+  });
+
   it('creates message objects from public runtime graph specs', async () => {
     const nodeId = 'object-patch-runtime-facade-test';
 


### PR DESCRIPTION
Audio params should show parameter automation label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed audio message subscriptions so they remain active when audio objects are created or recreated.
  - Ensured subscriptions continue working even when no corresponding audio object currently exists.
  - Properly removed subscriptions when they are unsubscribed or the runtime is destroyed.

- **Tests**
  - Added regression coverage for messages sent to newly created audio objects, including payload and inlet information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->