### PR TITLE
fix(renderer): hydra and shaderpark crashes on iOS

### DIFF
--- a/docs/design-docs/specs/145-ios-safari-render-worker-hardening.md
+++ b/docs/design-docs/specs/145-ios-safari-render-worker-hardening.md
@@ -10,6 +10,8 @@ On current iOS Safari, adding a `hydra` or `shaderpark` object can leave other w
 
 Safari/WebKit has known rough edges around worker `OffscreenCanvas` and WebGL context loss or blanking. The render worker should surface those failures instead of silently retaining the last frame.
 
+Production diagnostics identified a more specific failure mode. Loading a dynamic Hydra or ShaderPark worker chunk can re-evaluate the generated render-worker entry on iOS Safari. The second evaluation installs a new `self.onmessage` handler and creates a new `FBORenderer`, while the first renderer's animation loop continues posting frames. New control messages reach the second renderer, but visible frames still come from the first renderer's stale graph.
+
 ## Approach
 
 - Report render-worker global errors to the normal internal logger.
@@ -19,6 +21,22 @@ Safari/WebKit has known rough edges around worker `OffscreenCanvas` and WebGL co
 - On iOS Safari, refresh regl state after high-risk raw WebGL renderers.
 - On iOS Safari, flush after high-risk nodes (`hydra` and `shaderpark`) to reduce WebKit command-queue stalls.
 - Outside iOS Safari, keep the normal render path and avoid per-node `getError()` polling.
+- Keep worker-global installation in a small entry facade and the stateful renderer implementation in a neutral `render-core` chunk.
+- Install the render runtime synchronously behind a worker-global install-once guard. A repeated entry evaluation must not create another `FBORenderer`, message handler, or render loop.
+- Keep Hydra, ShaderPark, and other large renderer libraries lazy-loaded.
+- Prevent lazy renderer chunks from importing the side-effectful worker entry. Shared imports must target the neutral core chunk.
+
+## Worker Entry Invariant
+
+`GLSystem` constructs the small render-worker entry facade. The facade waits for its statically imported core module, then invokes the synchronous install-once guard. Only the guarded installation may create `FBORenderer`, install `self.onmessage`, and own render-loop lifecycle state.
+
+A production build is valid only when:
+
+- the entry remains a small facade;
+- the core implementation is a separate neutral chunk;
+- Hydra and ShaderPark remain dynamically imported;
+- no non-entry chunk imports the entry facade;
+- repeated entry installation against one worker global creates one runtime owner.
 
 ## Non-Goals
 

--- a/docs/reflections/2026-08-13-ios-safari-render-worker-chunking.md
+++ b/docs/reflections/2026-08-13-ios-safari-render-worker-chunking.md
@@ -1,0 +1,149 @@
+# iOS Safari Render Worker Chunking
+
+**Date:** 2026-08-13
+
+## Objective
+
+Fix a production-only rendering freeze on iOS Safari. Adding a `hydra` or `shaderpark` node froze the shared visual output and prevented later controls from taking effect. Development builds, macOS Safari, and visual nodes such as `glsl`, `regl`, and `three` did not reproduce the same failure.
+
+## What Made This Difficult
+
+The visible symptom suggested that the render worker had stopped, but the rendering profiler still reported draw calls. A `three` preview could also continue animating after the freeze while fullscreen and control changes stopped working. Those observations allowed several explanations:
+
+- Safari might have stopped delivering main-thread messages to a live worker.
+- `OffscreenCanvas`, WebGL, or `ImageBitmap` transfer might have stalled.
+- A renderer could have damaged shared WebGL state.
+- Production minification or tree-shaking could have changed runtime behavior.
+- The production worker module graph could have created two independent runtime owners.
+
+The iOS simulator was not a useful substitute because it did not reproduce the real device's worker rendering behavior. Safari Web Inspector was also initially unavailable until the physical device, cable connection, Web Inspector setting, and macOS inspection setting were all active. Even after inspection worked, manual production testing remained slow enough that each build needed to answer several questions at once.
+
+## Diagnostic Strategy
+
+The useful breakthrough was to instrument every boundary of the rendering pipeline and show it inside Patchies instead of depending on DevTools. The diagnostic panel recorded:
+
+- main-thread liveness;
+- every main-to-worker message with a sequence number;
+- worker acknowledgements and round-trip time;
+- worker timer heartbeats;
+- render-loop ticks;
+- output and preview bitmap creation;
+- worker-to-main frame posting;
+- main-thread frame receipt and presentation;
+- worker and main instance identities;
+- message errors, worker errors, and WebGL context loss.
+
+This separated “the worker is alive” from “the same worker runtime is receiving commands and producing the displayed frames.” That distinction was essential.
+
+Before the freeze, messages, acknowledgements, render ticks, and frame presentation advanced together. After adding Hydra, diagnostics revealed two worker runtime IDs inside one main-thread worker relationship:
+
+- the original runtime stopped acknowledging new control messages but continued rendering its stale graph and posting frames;
+- a second runtime acknowledged new messages but owned no active render graph and produced no frames.
+
+The browser was therefore not simply dropping messages. The displayed frames and the current message handler belonged to different runtime installations in the same worker global.
+
+## Generated Artifact Inspection
+
+The production artifact explained why development worked. Hydra and ShaderPark were emitted as dynamic worker chunks. Those chunks imported helpers back from the generated render-worker entry, which was wrapped by top-level-await transformation code. On iOS Safari, loading one of those chunks could re-evaluate the side-effectful entry:
+
+1. The first evaluation created `FBORenderer`, installed `self.onmessage`, and started the render loop.
+2. Loading Hydra or ShaderPark traversed a chunk edge back to the worker entry.
+3. A second evaluation created another `FBORenderer` and replaced `self.onmessage`.
+4. The first render loop survived and kept posting frames from its old graph.
+5. New messages reached the second renderer, so the visible output appeared frozen and controls no longer affected it.
+
+This topology existed only in the production worker bundle. Vite development served a different native module graph, which explains the production-only reproduction.
+
+## What Did Not Work
+
+### Treating the symptom as worker message starvation
+
+“The worker stopped handling inbound messages” described part of the observation, but it was not the root cause. Counters without runtime identity made two worker installations look like one worker that had become partially unresponsive.
+
+The better question was: which runtime received the message, and which runtime produced the frame?
+
+### Searching for a matching WebKit worker bug
+
+WebKit has related historical bugs involving `MessagePort`, worker lifetime, `OffscreenCanvas`, and WebGL. None exactly matched a worker that continued timers and outbound frame transfer while apparently losing only inbound commands. The research was useful for ruling out premature certainty, but it did not identify the Patchies failure.
+
+### Changing Terser settings
+
+Building without the custom Terser configuration did not fix the freeze. Minification was a production difference, but it was not the load-bearing difference.
+
+### Adding an idempotent asynchronous bootstrap
+
+An intermediate fix made the worker entry store a dynamic-import promise on the worker global before importing the render runtime. Its generated topology looked safer, but on the real iPhone the worker runtime did not start correctly: even a basic GLSL node rendered black with no preview or output.
+
+The bootstrap added another asynchronous module boundary before `self.onmessage` installation. Bundle inspection alone could not prove that the worker had actually initialized on iOS Safari. Restoring the direct worker entry fixed startup.
+
+This failed attempt reinforced an important rule: validate observable rendering, not only generated import structure.
+
+### Relying on the simulator or desktop Safari
+
+Neither environment reproduced the device-specific production behavior. The physical iPhone running the production build was the authoritative test target.
+
+## The Proven Fallback
+
+Setting `worker.rollupOptions.output.inlineDynamicImports` in Vite proved the diagnosis. The render worker remained the direct, side-effectful entry, but all internal renderer dependencies were emitted into one JavaScript module.
+
+The resulting production artifact has:
+
+- one `renderWorker-*.js` file;
+- no internal render-worker chunk directory;
+- no Hydra or ShaderPark module edge back to the worker entry;
+- one `FBORenderer`, one message handler, and one render-loop owner per worker global.
+
+On a physical iPhone running iOS Safari, GLSL, Hydra, and ShaderPark all rendered correctly. Diagnostics showed exactly one main instance and one worker runtime. Acknowledgements, heartbeats, render ticks, bitmap creation, frame receipt, and presentation all continued without errors or WebGL context loss. This established that the production chunk topology was the load-bearing cause.
+
+The tradeoff was too large for the final implementation: the unminified production render worker grew to approximately 11.8 MB and stopped lazy-loading every renderer dependency.
+
+## Preserving Lazy Loading
+
+The refined fix combines ownership protection with explicit chunk topology:
+
+1. `renderWorkerEntry.ts` is a small facade with no renderer state.
+2. `renderWorker.ts` exposes one deep interface, `installRenderWorkerRuntime()`, which owns `FBORenderer`, `self.onmessage`, services, build serialization, and render-loop state.
+3. `installRenderWorkerRuntimeOnce()` records installation on the worker global before calling the installer. Re-evaluating the entry cannot create a second runtime owner. Failed startup clears the flag so installation may be retried.
+4. Rollup assigns `renderWorker.ts` and its static dependencies to a neutral manual chunk. Lazy renderer chunks may import this core, but cannot import the side-effectful entry facade.
+5. The entry participates in the top-level-await dependency graph so the generated facade waits for the transformed core before calling its installer. This avoids the black-startup failure seen with the asynchronous dynamic-import bootstrap.
+
+The refined production artifact restores the original loading profile:
+
+- the entry facade is approximately 0.5 KB;
+- the initial neutral core is approximately 1.35 MB, close to the original split worker;
+- Hydra and ShaderPark remain separate lazy chunks;
+- 34 internal lazy chunks remain available;
+- no lazy chunk imports the entry facade;
+- lazy chunks that need shared helpers import the neutral core instead;
+- an automated ownership test verifies that two install attempts against the same worker global create one runtime.
+
+This architecture addresses the problem at two levels. The chunk graph removes the known entry cycle, while the worker-global guard preserves one runtime owner if a browser or future build transformation evaluates the facade again.
+
+The refined split-worker build was verified on a physical iPhone using the production preview. GLSL started normally, and adding Hydra and ShaderPark did not freeze previews, output, or controls. This confirmed that lazy loading could be preserved without reintroducing the duplicate-runtime failure.
+
+## Debugging Practices That Worked
+
+1. **Use the exact failing environment early.** Test the production artifact on the physical iPhone. Development, simulator, and desktop results were not interchangeable.
+2. **Instrument boundaries, not just activity.** A render counter proves that something rendered. It does not prove that the active message handler and visible frame producer share the same state.
+3. **Attach sequence and instance identities.** Message sequence numbers found the handoff point; main and worker IDs exposed duplicate ownership.
+4. **Make diagnostics visible in the product.** An on-screen panel made repeated device testing and log capture possible without depending on remote inspection.
+5. **Inspect generated code.** Source-level reasoning could not reveal the production chunk cycle. The emitted artifact was part of the program and needed direct inspection.
+6. **Change one build variable at a time.** Testing no-Terser, bootstrap, and single-file builds independently identified chunk topology as the load-bearing variable.
+7. **Verify both structure and behavior.** Artifact checks caught module topology; only a rendered GLSL/Hydra/ShaderPark test on the phone proved runtime correctness.
+8. **Treat browser-bug theories as hypotheses.** A platform-specific result can still be caused by application bundle structure that only triggers a browser-specific execution path.
+
+## What Could Be Better
+
+- Add an automated production smoke test that creates a render worker, builds a simple GLSL graph, and asserts that a non-empty preview frame is presented. Current unit tests mock worker construction and cannot detect worker startup failures.
+- Add a build-time artifact check for the render-worker invariant. This should inspect emitted Rollup metadata rather than assert source text.
+- Make worker runtime ownership explicit in architecture so global message handlers, render-loop state, and graph state cannot be installed independently.
+- Reduce the manual build-test cycle. A small production fixture containing GLSL, Hydra, and ShaderPark would make physical-device verification faster and more consistent.
+- Revisit worker size only with a topology-aware design and real iOS production validation.
+
+## Action Items
+
+- Keep the worker entry facade separate from the neutral renderer core.
+- Preserve the synchronous install-once guard; do not introduce a dynamic-import bootstrap before runtime installation.
+- Keep lazy renderer chunks from importing the entry facade.
+- Add a production render smoke-test seam when practical.
+- Require emitted-graph inspection and physical iOS testing for GLSL, Hydra, ShaderPark, controls, preview, and fullscreen output when worker chunking changes.

--- a/ui/src/lib/canvas/GLSystem.test.ts
+++ b/ui/src/lib/canvas/GLSystem.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-vi.mock('$workers/rendering/renderWorker?worker', () => ({
+vi.mock('$workers/rendering/renderWorkerEntry?worker', () => ({
   default: class RenderWorkerMock {
     addEventListener = vi.fn();
     postMessage = vi.fn();

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -4,6 +4,7 @@ import {
   type REdge,
   type RNode
 } from '$lib/rendering/graphUtils';
+
 import {
   isFBOCompatible,
   type FBOFormat,
@@ -11,8 +12,9 @@ import {
   type RenderNode,
   type RenderWorkerMessage
 } from '$lib/rendering/types';
+
 import type { ElementImageLike } from '$lib/html-in-canvas/html-canvas-video-output';
-import RenderWorker from '$workers/rendering/renderWorker?worker';
+import RenderWorker from '$workers/rendering/renderWorkerEntry?worker';
 import type { ProjMapSurface } from '$lib/projmap/types';
 
 import * as ohash from 'ohash';

--- a/ui/src/workers/rendering/renderWorker.ts
+++ b/ui/src/workers/rendering/renderWorker.ts
@@ -11,464 +11,405 @@ import { RenderWorkerLifecycle } from './RenderWorkerLifecycle';
 
 import type { RenderGraph } from '../../lib/rendering/types';
 
-const fboRenderer: FBORenderer = new FBORenderer();
+export function installRenderWorkerRuntime() {
+  const fboRenderer: FBORenderer = new FBORenderer();
 
-const mediaBunnyService = new MediaBunnyService({
-  setBitmap: (nodeId, bitmap) => fboRenderer.setBitmap(nodeId, bitmap),
-  postMessage: (message, transfer) => self.postMessage(message, { transfer: transfer ?? [] })
-});
+  const mediaBunnyService = new MediaBunnyService({
+    setBitmap: (nodeId, bitmap) => fboRenderer.setBitmap(nodeId, bitmap),
+    postMessage: (message, transfer) => self.postMessage(message, { transfer: transfer ?? [] })
+  });
 
-const lifecycle = new RenderWorkerLifecycle();
+  const lifecycle = new RenderWorkerLifecycle();
 
-/** Map of source worker nodeId → MessagePort for direct messaging */
-const workerRenderPorts = new Map<string, MessagePort>();
+  /** Map of source worker nodeId → MessagePort for direct messaging */
+  const workerRenderPorts = new Map<string, MessagePort>();
 
-self.onmessage = (event) => {
-  const { type, ...data } = event.data;
+  self.onmessage = (event) => {
+    const { type, ...data } = event.data;
 
-  // Route MediaBunny messages to dedicated service
-  if (mediaBunnyService.handleMessage(type, data)) {
-    return;
-  }
-
-  match(type)
-    .with('setPatchId', () => {
-      PatchStorageService.getInstance().setPatchId(data.patchId);
-    })
-    .with('buildRenderGraph', () =>
-      handleBuildRenderGraph(data.graph, new Set(data.connectedVideoOutputNodeIds ?? []))
-    )
-    .with('startAnimation', () => handleStartAnimation())
-    .with('stopAnimation', () => handleStopAnimation())
-    .with('setPreviewEnabled', () => handleSetPreviewEnabled(data.nodeId, data.enabled))
-    .with('setOutputEnabled', () => {
-      fboRenderer.isOutputEnabled = data.enabled;
-    })
-    .with('setUniformData', () =>
-      fboRenderer.setUniformData(data.nodeId, data.uniformName, data.uniformValue)
-    )
-    .with('setMouseData', () =>
-      fboRenderer.setMouseData(data.nodeId, data.x, data.y, data.z, data.w, data.buttons)
-    )
-    .with('zoomShaderParkOrbit', () => fboRenderer.zoomShaderParkOrbit(data.nodeId, data.deltaY))
-    .with('sendThreeWheelData', () =>
-      fboRenderer.sendThreeWheelData(data.nodeId, {
-        x: data.x,
-        y: data.y,
-        deltaX: data.deltaX,
-        deltaY: data.deltaY,
-        deltaMode: data.deltaMode
-      })
-    )
-    .with('resetThreeOrbitControls', () => fboRenderer.resetThreeOrbitControls(data.nodeId))
-    .with('setOutputSize', () => fboRenderer.setOutputSize(data.width, data.height))
-    .with('setBackgroundSize', () => fboRenderer.setBackgroundSize(data.width, data.height))
-    .with('setBitmap', () => fboRenderer.setBitmap(data.nodeId, data.bitmap))
-    .with('setElementImage', () =>
-      fboRenderer.setElementImage(data.nodeId, data.elementImage, data.width, data.height)
-    )
-    .with('setFloatTexture', () => {
-      const textureData = data.data;
-
-      if (!(textureData instanceof Float32Array)) {
-        console.warn('[renderWorker] Invalid setFloatTexture payload: data must be Float32Array');
-        return;
-      }
-
-      const buffer = textureData.buffer;
-      const textureFormat = data.textureFormat ?? 'rgba32f';
-
-      if (buffer instanceof SharedArrayBuffer) {
-        fboRenderer.setFloatTexture(
-          data.nodeId,
-          data.width,
-          data.height,
-          textureData,
-          textureFormat
-        );
-
-        return;
-      }
-
-      try {
-        fboRenderer.setFloatTexture(
-          data.nodeId,
-          data.width,
-          data.height,
-          textureData,
-          textureFormat
-        );
-      } finally {
-        self.postMessage(
-          {
-            type: 'floatTextureBufferReleased',
-            nodeId: data.nodeId,
-            buffer
-          },
-          { transfer: [buffer] }
-        );
-      }
-    })
-    .with('removeBitmap', () => fboRenderer.removeBitmap(data.nodeId))
-    .with('removeUniformData', () => fboRenderer.removeUniformData(data.nodeId))
-    .with('sendMessageToNode', () => fboRenderer.sendMessageToNode(data.nodeId, data.message))
-    .with('toggleNodePause', () => fboRenderer.toggleNodePause(data.nodeId))
-    .with('capturePreview', () =>
-      handleCapturePreview(data.nodeId, data.requestId, data.customSize)
-    )
-    .with('updateProjectionMap', () => fboRenderer.updateProjectionMap(data.nodeId, data.surfaces))
-    .with('setFFTData', () => handleSetFFTData(data))
-    .with('updateJSModule', () => fboRenderer.updateJSModule(data.moduleName, data.code))
-    .with('profilerEnable', () => fboRenderer.setProfilingEnabled(data.enabled))
-    .with('setRenderFpsCap', () => fboRenderer.setRenderFpsCap(data.fps))
-    .with('setCookStatsEnabled', () => fboRenderer.setCookStatsEnabled(data.enabled))
-    .with('setMaxPreviewsPerFrame', () => {
-      if (data.max !== undefined) {
-        fboRenderer.previewRenderer.maxPreviewsPerFrame = data.max;
-      }
-
-      if (data.maxNoOutput !== undefined) {
-        fboRenderer.previewRenderer.maxPreviewsPerFrameNoOutput = data.maxNoOutput;
-      }
-    })
-    .with('setVisibleNodes', () => {
-      fboRenderer.setVisibleNodes(new Set(data.nodeIds as string[]));
-    })
-    .with('setAllPreviewsDisabled', () => {
-      fboRenderer.setAllPreviewsDisabled(data.disabled as boolean);
-    })
-    .with('setPreviewScaleMultiplier', () => {
-      fboRenderer.setPreviewScaleMultiplier(data.multiplier as number);
-    })
-    .with('vfsUrlResolved', () => {
-      handleVfsUrlResolved(data);
-    })
-    .with('vfsTextResolved', () => {
-      handleVfsTextResolved(data);
-    })
-    .with('captureWorkerVideoFrames', () => {
-      handleCaptureWorkerVideoFrames(data.targetNodeId, data.sourceNodeIds, data.resolution);
-    })
-    .with('captureWorkerVideoFramesBatch', () => {
-      handleCaptureWorkerVideoFramesBatch(data.requests);
-    })
-    .with('captureMediaPipeVideoFramesBatch', () => {
-      handleCaptureMediaPipeVideoFramesBatch(data.requests);
-    })
-    .with('registerWorkerRenderPort', () => {
-      handleRegisterWorkerRenderPort(data.nodeId, event.ports[0]);
-    })
-    .with('unregisterWorkerRenderPort', () => {
-      handleUnregisterWorkerRenderPort(data.nodeId);
-    })
-    .with('syncTransportTime', () => {
-      fboRenderer.setTransportTime(data);
-    })
-    .with('setOverrideOutputNode', () => {
-      fboRenderer.setOverrideOutputNode(data.nodeId ?? null);
-    })
-    .with('channelMessage', () => {
-      fboRenderer.sendChannelMessageToNode(data.nodeId, data.channel, data.data, data.sourceNodeId);
-    })
-    .with('settingsValuesInit', () => {
-      fboRenderer.receiveSettingsValues(data.nodeId, data.requestId, data.values);
-    })
-    .with('settingsValueChanged', () => {
-      fboRenderer.receiveSettingsValueChanged(data.nodeId, data.key, data.value);
-    });
-};
-
-// Serializes buildFBOs calls: only one runs at a time, and if a new request
-// arrives while one is in-flight, the latest graph is queued and built after
-// the current build finishes. This prevents race conditions when setPortCount
-// messages trigger rebuilds during the initial build's async Phase 2.
-let buildInProgress = false;
-
-let pendingBuild: {
-  graph: RenderGraph;
-  connectedVideoOutputNodeIds: Set<string>;
-} | null = null;
-
-async function handleBuildRenderGraph(
-  graph: RenderGraph,
-  connectedVideoOutputNodeIds: Set<string> = new Set()
-) {
-  if (buildInProgress) {
-    // A build is running — queue the latest graph (drop any previously queued one)
-    pendingBuild = { graph, connectedVideoOutputNodeIds };
-    return;
-  }
-
-  buildInProgress = true;
-
-  try {
-    await fboRenderer.buildFBOs(graph, connectedVideoOutputNodeIds);
-
-    startRenderLoopIfReady();
-  } catch (error) {
-    if (error instanceof Error) {
-      self.postMessage({
-        type: 'error',
-        message: 'failed to build render graph: ' + error.message
-      });
-    }
-  } finally {
-    buildInProgress = false;
-
-    // If a new graph was queued while we were building, build it now
-    if (pendingBuild) {
-      const next = pendingBuild;
-
-      pendingBuild = null;
-      handleBuildRenderGraph(next.graph, next.connectedVideoOutputNodeIds);
-    }
-  }
-}
-
-function handleStartAnimation() {
-  lifecycle.requestStart();
-  startRenderLoopIfReady();
-}
-
-function startRenderLoopIfReady() {
-  if (!lifecycle.takeStart(Boolean(fboRenderer.renderGraph))) return;
-
-  fboRenderer.startRenderLoop(() => {
-    // do not render if there are no nodes and edges
-    if (
-      fboRenderer.renderGraph?.nodes?.length === 0 &&
-      fboRenderer.renderGraph?.edges?.length === 0
-    ) {
+    // Route MediaBunny messages to dedicated service
+    if (mediaBunnyService.handleMessage(type, data)) {
       return;
     }
 
-    if (fboRenderer.isOutputEnabled) {
-      // Profiler: forcibly forces gl sync to measure GL rendering time.
-      // Never do this outside of profiling, as it slows down rendering!
-      if (fboRenderer.isProfilingEnabled) {
-        fboRenderer.measureOp('finish', () => fboRenderer.gl.finish());
-      }
+    match(type)
+      .with('setPatchId', () => {
+        PatchStorageService.getInstance().setPatchId(data.patchId);
+      })
+      .with('buildRenderGraph', () =>
+        handleBuildRenderGraph(data.graph, new Set(data.connectedVideoOutputNodeIds ?? []))
+      )
+      .with('startAnimation', () => handleStartAnimation())
+      .with('stopAnimation', () => handleStopAnimation())
+      .with('setPreviewEnabled', () => handleSetPreviewEnabled(data.nodeId, data.enabled))
+      .with('setOutputEnabled', () => {
+        fboRenderer.isOutputEnabled = data.enabled;
+      })
+      .with('setUniformData', () =>
+        fboRenderer.setUniformData(data.nodeId, data.uniformName, data.uniformValue)
+      )
+      .with('setMouseData', () =>
+        fboRenderer.setMouseData(data.nodeId, data.x, data.y, data.z, data.w, data.buttons)
+      )
+      .with('zoomShaderParkOrbit', () => fboRenderer.zoomShaderParkOrbit(data.nodeId, data.deltaY))
+      .with('sendThreeWheelData', () =>
+        fboRenderer.sendThreeWheelData(data.nodeId, {
+          x: data.x,
+          y: data.y,
+          deltaX: data.deltaX,
+          deltaY: data.deltaY,
+          deltaMode: data.deltaMode
+        })
+      )
+      .with('resetThreeOrbitControls', () => fboRenderer.resetThreeOrbitControls(data.nodeId))
+      .with('setOutputSize', () => fboRenderer.setOutputSize(data.width, data.height))
+      .with('setBackgroundSize', () => fboRenderer.setBackgroundSize(data.width, data.height))
+      .with('setBitmap', () => fboRenderer.setBitmap(data.nodeId, data.bitmap))
+      .with('setElementImage', () =>
+        fboRenderer.setElementImage(data.nodeId, data.elementImage, data.width, data.height)
+      )
+      .with('setFloatTexture', () => {
+        const textureData = data.data;
 
-      const outputBitmap = fboRenderer.measureOp('transfer', () => fboRenderer.getOutputBitmap());
-
-      if (outputBitmap) {
-        self.postMessage({ type: 'animationFrame', outputBitmap }, { transfer: [outputBitmap] });
-      }
-    }
-
-    if (fboRenderer.shouldProcessPreviews) {
-      const previewBitmaps = fboRenderer.measureOp('preview', () =>
-        fboRenderer.renderPreviewBitmaps()
-      );
-
-      for (const [nodeId, bitmap] of previewBitmaps) {
-        self.postMessage({ type: 'previewFrame', nodeId, bitmap }, { transfer: [bitmap] });
-      }
-    }
-
-    // Harvest any completed async video frame captures
-    if (fboRenderer.hasPendingVideoFrames()) {
-      const completedBatches = fboRenderer.measureOp('video', () =>
-        fboRenderer.harvestVideoFrames()
-      );
-
-      if (completedBatches.length > 0) {
-        // Collect all bitmaps for transfer
-        const transferList: ImageBitmap[] = [];
-
-        for (const batch of completedBatches) {
-          for (const frame of batch.frames) {
-            if (frame) transferList.push(frame);
-          }
+        if (!(textureData instanceof Float32Array)) {
+          console.warn('[renderWorker] Invalid setFloatTexture payload: data must be Float32Array');
+          return;
         }
 
-        self.postMessage(
-          {
-            type: 'workerVideoFramesCapturedBatch',
-            results: completedBatches.map((b) => ({
-              targetNodeId: b.targetNodeId,
-              frames: b.frames
-            })),
-            timestamp: performance.now()
-          },
-          { transfer: transferList }
+        const buffer = textureData.buffer;
+        const textureFormat = data.textureFormat ?? 'rgba32f';
+
+        if (buffer instanceof SharedArrayBuffer) {
+          fboRenderer.setFloatTexture(
+            data.nodeId,
+            data.width,
+            data.height,
+            textureData,
+            textureFormat
+          );
+
+          return;
+        }
+
+        try {
+          fboRenderer.setFloatTexture(
+            data.nodeId,
+            data.width,
+            data.height,
+            textureData,
+            textureFormat
+          );
+        } finally {
+          self.postMessage(
+            {
+              type: 'floatTextureBufferReleased',
+              nodeId: data.nodeId,
+              buffer
+            },
+            { transfer: [buffer] }
+          );
+        }
+      })
+      .with('removeBitmap', () => fboRenderer.removeBitmap(data.nodeId))
+      .with('removeUniformData', () => fboRenderer.removeUniformData(data.nodeId))
+      .with('sendMessageToNode', () => fboRenderer.sendMessageToNode(data.nodeId, data.message))
+      .with('toggleNodePause', () => fboRenderer.toggleNodePause(data.nodeId))
+      .with('capturePreview', () =>
+        handleCapturePreview(data.nodeId, data.requestId, data.customSize)
+      )
+      .with('updateProjectionMap', () =>
+        fboRenderer.updateProjectionMap(data.nodeId, data.surfaces)
+      )
+      .with('setFFTData', () => handleSetFFTData(data))
+      .with('updateJSModule', () => fboRenderer.updateJSModule(data.moduleName, data.code))
+      .with('profilerEnable', () => fboRenderer.setProfilingEnabled(data.enabled))
+      .with('setRenderFpsCap', () => fboRenderer.setRenderFpsCap(data.fps))
+      .with('setCookStatsEnabled', () => fboRenderer.setCookStatsEnabled(data.enabled))
+      .with('setMaxPreviewsPerFrame', () => {
+        if (data.max !== undefined) {
+          fboRenderer.previewRenderer.maxPreviewsPerFrame = data.max;
+        }
+
+        if (data.maxNoOutput !== undefined) {
+          fboRenderer.previewRenderer.maxPreviewsPerFrameNoOutput = data.maxNoOutput;
+        }
+      })
+      .with('setVisibleNodes', () => {
+        fboRenderer.setVisibleNodes(new Set(data.nodeIds as string[]));
+      })
+      .with('setAllPreviewsDisabled', () => {
+        fboRenderer.setAllPreviewsDisabled(data.disabled as boolean);
+      })
+      .with('setPreviewScaleMultiplier', () => {
+        fboRenderer.setPreviewScaleMultiplier(data.multiplier as number);
+      })
+      .with('vfsUrlResolved', () => {
+        handleVfsUrlResolved(data);
+      })
+      .with('vfsTextResolved', () => {
+        handleVfsTextResolved(data);
+      })
+      .with('captureWorkerVideoFrames', () => {
+        handleCaptureWorkerVideoFrames(data.targetNodeId, data.sourceNodeIds, data.resolution);
+      })
+      .with('captureWorkerVideoFramesBatch', () => {
+        handleCaptureWorkerVideoFramesBatch(data.requests);
+      })
+      .with('captureMediaPipeVideoFramesBatch', () => {
+        handleCaptureMediaPipeVideoFramesBatch(data.requests);
+      })
+      .with('registerWorkerRenderPort', () => {
+        handleRegisterWorkerRenderPort(data.nodeId, event.ports[0]);
+      })
+      .with('unregisterWorkerRenderPort', () => {
+        handleUnregisterWorkerRenderPort(data.nodeId);
+      })
+      .with('syncTransportTime', () => {
+        fboRenderer.setTransportTime(data);
+      })
+      .with('setOverrideOutputNode', () => {
+        fboRenderer.setOverrideOutputNode(data.nodeId ?? null);
+      })
+      .with('channelMessage', () => {
+        fboRenderer.sendChannelMessageToNode(
+          data.nodeId,
+          data.channel,
+          data.data,
+          data.sourceNodeId
         );
+      })
+      .with('settingsValuesInit', () => {
+        fboRenderer.receiveSettingsValues(data.nodeId, data.requestId, data.values);
+      })
+      .with('settingsValueChanged', () => {
+        fboRenderer.receiveSettingsValueChanged(data.nodeId, data.key, data.value);
+      });
+  };
+
+  // Serializes buildFBOs calls: only one runs at a time, and if a new request
+  // arrives while one is in-flight, the latest graph is queued and built after
+  // the current build finishes. This prevents race conditions when setPortCount
+  // messages trigger rebuilds during the initial build's async Phase 2.
+  let buildInProgress = false;
+
+  let pendingBuild: {
+    graph: RenderGraph;
+    connectedVideoOutputNodeIds: Set<string>;
+  } | null = null;
+
+  async function handleBuildRenderGraph(
+    graph: RenderGraph,
+    connectedVideoOutputNodeIds: Set<string> = new Set()
+  ) {
+    if (buildInProgress) {
+      // A build is running — queue the latest graph (drop any previously queued one)
+      pendingBuild = { graph, connectedVideoOutputNodeIds };
+      return;
+    }
+
+    buildInProgress = true;
+
+    try {
+      await fboRenderer.buildFBOs(graph, connectedVideoOutputNodeIds);
+
+      startRenderLoopIfReady();
+    } catch (error) {
+      if (error instanceof Error) {
+        self.postMessage({
+          type: 'error',
+          message: 'failed to build render graph: ' + error.message
+        });
+      }
+    } finally {
+      buildInProgress = false;
+
+      // If a new graph was queued while we were building, build it now
+      if (pendingBuild) {
+        const next = pendingBuild;
+
+        pendingBuild = null;
+        handleBuildRenderGraph(next.graph, next.connectedVideoOutputNodeIds);
       }
     }
-
-    // Record frame timing for profiling
-    fboRenderer.recordFrameTime();
-  });
-}
-
-function handleStopAnimation() {
-  lifecycle.stop();
-  fboRenderer.stopRenderLoop();
-}
-
-function handleSetPreviewEnabled(nodeId: string, enabled: boolean) {
-  fboRenderer.setPreviewEnabled(nodeId, enabled);
-
-  self.postMessage({ type: 'previewToggled', nodeId, enabled });
-}
-
-function handleSetFFTData(payload: AudioAnalysisPayloadWithType) {
-  const { nodeType, nodeId } = payload;
-
-  match(nodeType)
-    .with('hydra', () => {
-      const hydraRenderer = fboRenderer.hydraByNode.get(nodeId);
-      if (!hydraRenderer) return;
-
-      hydraRenderer.setFFTData(payload);
-    })
-    .with('canvas', () => {
-      const canvasRenderer = fboRenderer.canvasByNode.get(nodeId);
-      if (!canvasRenderer) return;
-
-      canvasRenderer.setFFTData(payload);
-    })
-    .with('textmode', () => {
-      const textmodeRenderer = fboRenderer.textmodeByNode.get(nodeId);
-      if (!textmodeRenderer) return;
-
-      textmodeRenderer.setFFTData(payload);
-    })
-    .with('three', () => {
-      const threeRenderer = fboRenderer.threeByNode.get(nodeId);
-      if (!threeRenderer) return;
-
-      threeRenderer.setFFTData(payload);
-    })
-    .with('regl', () => {
-      const reglRenderer = fboRenderer.reglByNode.get(nodeId);
-      if (!reglRenderer) return;
-
-      reglRenderer.setFFTData(payload);
-    })
-    .with('swgl', () => {
-      const swglRenderer = fboRenderer.swglByNode.get(nodeId);
-      if (!swglRenderer) return;
-
-      swglRenderer.setFFTData(payload);
-    })
-    .with('glsl', () => {
-      fboRenderer.setFFTAsGlslUniforms(payload);
-    })
-    .exhaustive();
-}
-
-function handleCapturePreview(nodeId: string, requestId?: string, customSize?: [number, number]) {
-  const bitmap = fboRenderer.capturePreviewBitmap(nodeId, customSize);
-
-  if (bitmap) {
-    self.postMessage(
-      {
-        type: 'previewFrameCaptured',
-        success: true,
-        nodeId,
-        requestId,
-        bitmap
-      },
-      { transfer: [bitmap] }
-    );
-    return;
   }
 
-  self.postMessage({
-    type: 'previewFrameCaptured',
-    success: false,
-    nodeId,
-    requestId
-  });
-}
+  function handleStartAnimation() {
+    lifecycle.requestStart();
+    startRenderLoopIfReady();
+  }
 
-/**
- * Capture video frames from source nodes for a worker node.
- * This captures bitmaps from each connected source and sends them back to the main thread.
- */
-function handleCaptureWorkerVideoFrames(
-  targetNodeId: string,
-  sourceNodeIds: (string | null)[],
-  resolution?: [number, number]
-) {
-  const frames: (ImageBitmap | null)[] = [];
-  const transferList: ImageBitmap[] = [];
+  function startRenderLoopIfReady() {
+    if (!lifecycle.takeStart(Boolean(fboRenderer.renderGraph))) return;
 
-  for (const sourceNodeId of sourceNodeIds) {
-    if (!sourceNodeId) {
-      frames.push(null);
-      continue;
-    }
+    fboRenderer.startRenderLoop(() => {
+      // do not render if there are no nodes and edges
+      if (
+        fboRenderer.renderGraph?.nodes?.length === 0 &&
+        fboRenderer.renderGraph?.edges?.length === 0
+      ) {
+        return;
+      }
 
-    const bitmap = fboRenderer.capturePreviewBitmap(sourceNodeId, resolution);
-    frames.push(bitmap);
+      if (fboRenderer.isOutputEnabled) {
+        // Profiler: forcibly forces gl sync to measure GL rendering time.
+        // Never do this outside of profiling, as it slows down rendering!
+        if (fboRenderer.isProfilingEnabled) {
+          fboRenderer.measureOp('finish', () => fboRenderer.gl.finish());
+        }
+
+        const outputBitmap = fboRenderer.measureOp('transfer', () => fboRenderer.getOutputBitmap());
+
+        if (outputBitmap) {
+          self.postMessage({ type: 'animationFrame', outputBitmap }, { transfer: [outputBitmap] });
+        }
+      }
+
+      if (fboRenderer.shouldProcessPreviews) {
+        const previewBitmaps = fboRenderer.measureOp('preview', () =>
+          fboRenderer.renderPreviewBitmaps()
+        );
+
+        for (const [nodeId, bitmap] of previewBitmaps) {
+          self.postMessage({ type: 'previewFrame', nodeId, bitmap }, { transfer: [bitmap] });
+        }
+      }
+
+      // Harvest any completed async video frame captures
+      if (fboRenderer.hasPendingVideoFrames()) {
+        const completedBatches = fboRenderer.measureOp('video', () =>
+          fboRenderer.harvestVideoFrames()
+        );
+
+        if (completedBatches.length > 0) {
+          // Collect all bitmaps for transfer
+          const transferList: ImageBitmap[] = [];
+
+          for (const batch of completedBatches) {
+            for (const frame of batch.frames) {
+              if (frame) transferList.push(frame);
+            }
+          }
+
+          self.postMessage(
+            {
+              type: 'workerVideoFramesCapturedBatch',
+              results: completedBatches.map((b) => ({
+                targetNodeId: b.targetNodeId,
+                frames: b.frames
+              })),
+              timestamp: performance.now()
+            },
+            { transfer: transferList }
+          );
+        }
+      }
+
+      // Record frame timing for profiling
+      fboRenderer.recordFrameTime();
+    });
+  }
+
+  function handleStopAnimation() {
+    lifecycle.stop();
+    fboRenderer.stopRenderLoop();
+  }
+
+  function handleSetPreviewEnabled(nodeId: string, enabled: boolean) {
+    fboRenderer.setPreviewEnabled(nodeId, enabled);
+
+    self.postMessage({ type: 'previewToggled', nodeId, enabled });
+  }
+
+  function handleSetFFTData(payload: AudioAnalysisPayloadWithType) {
+    const { nodeType, nodeId } = payload;
+
+    match(nodeType)
+      .with('hydra', () => {
+        const hydraRenderer = fboRenderer.hydraByNode.get(nodeId);
+        if (!hydraRenderer) return;
+
+        hydraRenderer.setFFTData(payload);
+      })
+      .with('canvas', () => {
+        const canvasRenderer = fboRenderer.canvasByNode.get(nodeId);
+        if (!canvasRenderer) return;
+
+        canvasRenderer.setFFTData(payload);
+      })
+      .with('textmode', () => {
+        const textmodeRenderer = fboRenderer.textmodeByNode.get(nodeId);
+        if (!textmodeRenderer) return;
+
+        textmodeRenderer.setFFTData(payload);
+      })
+      .with('three', () => {
+        const threeRenderer = fboRenderer.threeByNode.get(nodeId);
+        if (!threeRenderer) return;
+
+        threeRenderer.setFFTData(payload);
+      })
+      .with('regl', () => {
+        const reglRenderer = fboRenderer.reglByNode.get(nodeId);
+        if (!reglRenderer) return;
+
+        reglRenderer.setFFTData(payload);
+      })
+      .with('swgl', () => {
+        const swglRenderer = fboRenderer.swglByNode.get(nodeId);
+        if (!swglRenderer) return;
+
+        swglRenderer.setFFTData(payload);
+      })
+      .with('glsl', () => {
+        fboRenderer.setFFTAsGlslUniforms(payload);
+      })
+      .exhaustive();
+  }
+
+  function handleCapturePreview(nodeId: string, requestId?: string, customSize?: [number, number]) {
+    const bitmap = fboRenderer.capturePreviewBitmap(nodeId, customSize);
 
     if (bitmap) {
-      transferList.push(bitmap);
+      self.postMessage(
+        {
+          type: 'previewFrameCaptured',
+          success: true,
+          nodeId,
+          requestId,
+          bitmap
+        },
+        { transfer: [bitmap] }
+      );
+      return;
     }
+
+    self.postMessage({
+      type: 'previewFrameCaptured',
+      success: false,
+      nodeId,
+      requestId
+    });
   }
 
-  self.postMessage(
-    {
-      type: 'workerVideoFramesCaptured',
-      targetNodeId,
-      frames,
-      timestamp: performance.now()
-    },
-    { transfer: transferList }
-  );
-}
-
-/**
- * Capture video frames for multiple worker nodes in a single batched request.
- * Uses async PBO reads to avoid blocking the GPU pipeline.
- *
- * Flow:
- * 1. Initiate async PBO reads for all unique source nodes
- * 2. Results are harvested in the render loop when GPU is done
- * 3. Completed frames are sent via workerVideoFramesCapturedBatch message
- */
-function handleCaptureWorkerVideoFramesBatch(
-  requests: Array<{
-    targetNodeId: string;
-    sourceNodeIds: (string | null)[];
-    resolution?: [number, number];
-  }>
-) {
-  // Initiate async captures - results will be harvested in the render loop
-  fboRenderer.initiateVideoFrameCaptureAsync(requests);
-}
-
-/**
- * Capture video frames for multiple MediaPipe nodes in a single batched request.
- * Uses synchronous bitmap capture (same as handleCaptureWorkerVideoFrames),
- * responds with mediaPipeVideoFramesCapturedBatch.
- */
-function handleCaptureMediaPipeVideoFramesBatch(
-  requests: Array<{
-    targetNodeId: string;
-    sourceNodeIds: (string | null)[];
-    resolution?: [number, number];
-  }>
-) {
-  const results: Array<{
-    targetNodeId: string;
-    frames: (ImageBitmap | null)[];
-  }> = [];
-
-  const transferList: ImageBitmap[] = [];
-
-  for (const request of requests) {
+  /**
+   * Capture video frames from source nodes for a worker node.
+   * This captures bitmaps from each connected source and sends them back to the main thread.
+   */
+  function handleCaptureWorkerVideoFrames(
+    targetNodeId: string,
+    sourceNodeIds: (string | null)[],
+    resolution?: [number, number]
+  ) {
     const frames: (ImageBitmap | null)[] = [];
+    const transferList: ImageBitmap[] = [];
 
-    for (const sourceNodeId of request.sourceNodeIds) {
+    for (const sourceNodeId of sourceNodeIds) {
       if (!sourceNodeId) {
         frames.push(null);
         continue;
       }
 
-      const bitmap = fboRenderer.capturePreviewBitmap(sourceNodeId, request.resolution);
+      const bitmap = fboRenderer.capturePreviewBitmap(sourceNodeId, resolution);
       frames.push(bitmap);
 
       if (bitmap) {
@@ -476,50 +417,118 @@ function handleCaptureMediaPipeVideoFramesBatch(
       }
     }
 
-    results.push({ targetNodeId: request.targetNodeId, frames });
+    self.postMessage(
+      {
+        type: 'workerVideoFramesCaptured',
+        targetNodeId,
+        frames,
+        timestamp: performance.now()
+      },
+      { transfer: transferList }
+    );
   }
 
-  self.postMessage(
-    {
-      type: 'mediaPipeVideoFramesCapturedBatch',
-      results,
-      timestamp: performance.now()
-    },
-    { transfer: transferList }
-  );
-}
-
-/**
- * Register a MessagePort from a worker node for direct messaging.
- * Messages received on this port are routed directly to FBORenderer.
- */
-function handleRegisterWorkerRenderPort(nodeId: string, port: MessagePort) {
-  workerRenderPorts.set(nodeId, port);
-
-  port.onmessage = (e) => {
-    const { targetNodeId, inlet, inletKey, data, fromNodeId } = e.data;
-
-    fboRenderer.sendMessageToNode(targetNodeId, {
-      data,
-      source: fromNodeId,
-      inlet,
-      inletKey
-    });
-  };
-
-  port.start();
-}
-
-/**
- * Unregister a worker's render port when the worker is destroyed.
- */
-function handleUnregisterWorkerRenderPort(nodeId: string) {
-  const port = workerRenderPorts.get(nodeId);
-
-  if (port) {
-    port.close();
-    workerRenderPorts.delete(nodeId);
+  /**
+   * Capture video frames for multiple worker nodes in a single batched request.
+   * Uses async PBO reads to avoid blocking the GPU pipeline.
+   *
+   * Flow:
+   * 1. Initiate async PBO reads for all unique source nodes
+   * 2. Results are harvested in the render loop when GPU is done
+   * 3. Completed frames are sent via workerVideoFramesCapturedBatch message
+   */
+  function handleCaptureWorkerVideoFramesBatch(
+    requests: Array<{
+      targetNodeId: string;
+      sourceNodeIds: (string | null)[];
+      resolution?: [number, number];
+    }>
+  ) {
+    // Initiate async captures - results will be harvested in the render loop
+    fboRenderer.initiateVideoFrameCaptureAsync(requests);
   }
-}
 
-console.log('[render worker] initialized');
+  /**
+   * Capture video frames for multiple MediaPipe nodes in a single batched request.
+   * Uses synchronous bitmap capture (same as handleCaptureWorkerVideoFrames),
+   * responds with mediaPipeVideoFramesCapturedBatch.
+   */
+  function handleCaptureMediaPipeVideoFramesBatch(
+    requests: Array<{
+      targetNodeId: string;
+      sourceNodeIds: (string | null)[];
+      resolution?: [number, number];
+    }>
+  ) {
+    const results: Array<{
+      targetNodeId: string;
+      frames: (ImageBitmap | null)[];
+    }> = [];
+
+    const transferList: ImageBitmap[] = [];
+
+    for (const request of requests) {
+      const frames: (ImageBitmap | null)[] = [];
+
+      for (const sourceNodeId of request.sourceNodeIds) {
+        if (!sourceNodeId) {
+          frames.push(null);
+          continue;
+        }
+
+        const bitmap = fboRenderer.capturePreviewBitmap(sourceNodeId, request.resolution);
+        frames.push(bitmap);
+
+        if (bitmap) {
+          transferList.push(bitmap);
+        }
+      }
+
+      results.push({ targetNodeId: request.targetNodeId, frames });
+    }
+
+    self.postMessage(
+      {
+        type: 'mediaPipeVideoFramesCapturedBatch',
+        results,
+        timestamp: performance.now()
+      },
+      { transfer: transferList }
+    );
+  }
+
+  /**
+   * Register a MessagePort from a worker node for direct messaging.
+   * Messages received on this port are routed directly to FBORenderer.
+   */
+  function handleRegisterWorkerRenderPort(nodeId: string, port: MessagePort) {
+    workerRenderPorts.set(nodeId, port);
+
+    port.onmessage = (e) => {
+      const { targetNodeId, inlet, inletKey, data, fromNodeId } = e.data;
+
+      fboRenderer.sendMessageToNode(targetNodeId, {
+        data,
+        source: fromNodeId,
+        inlet,
+        inletKey
+      });
+    };
+
+    port.start();
+  }
+
+  /**
+   * Unregister a worker's render port when the worker is destroyed.
+   */
+  function handleUnregisterWorkerRenderPort(nodeId: string) {
+    const port = workerRenderPorts.get(nodeId);
+
+    if (port) {
+      port.close();
+      workerRenderPorts.delete(nodeId);
+    }
+  }
+
+  console.log('[render worker] initialized');
+}

--- a/ui/src/workers/rendering/renderWorkerEntry.ts
+++ b/ui/src/workers/rendering/renderWorkerEntry.ts
@@ -1,0 +1,12 @@
+import { installRenderWorkerRuntime } from './renderWorker';
+
+import {
+  installRenderWorkerRuntimeOnce,
+  type RenderWorkerInstallScope
+} from './renderWorkerInstallOnce';
+
+// Keep this facade in the top-level-await dependency graph. The production
+// transformer then waits for the neutral render-core chunk before installation.
+await Promise.resolve();
+
+installRenderWorkerRuntimeOnce(self as RenderWorkerInstallScope, installRenderWorkerRuntime);

--- a/ui/src/workers/rendering/renderWorkerInstallOnce.test.ts
+++ b/ui/src/workers/rendering/renderWorkerInstallOnce.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  installRenderWorkerRuntimeOnce,
+  type RenderWorkerInstallScope
+} from './renderWorkerInstallOnce';
+
+describe('installRenderWorkerRuntimeOnce', () => {
+  it('installs one runtime for repeated evaluations of the same worker global', () => {
+    const scope: RenderWorkerInstallScope = {};
+    const install = vi.fn();
+
+    expect(installRenderWorkerRuntimeOnce(scope, install)).toBe(true);
+    expect(installRenderWorkerRuntimeOnce(scope, install)).toBe(false);
+    expect(install).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows startup to be retried after installation fails', () => {
+    const scope: RenderWorkerInstallScope = {};
+    const error = new Error('startup failed');
+
+    const install = vi.fn().mockImplementationOnce(() => {
+      throw error;
+    });
+
+    expect(() => installRenderWorkerRuntimeOnce(scope, install)).toThrow(error);
+    expect(installRenderWorkerRuntimeOnce(scope, install)).toBe(true);
+    expect(install).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/src/workers/rendering/renderWorkerInstallOnce.ts
+++ b/ui/src/workers/rendering/renderWorkerInstallOnce.ts
@@ -1,0 +1,27 @@
+export interface RenderWorkerInstallScope {
+  __patchiesRenderWorkerRuntimeInstalled__?: boolean;
+}
+
+/**
+ * Install the stateful render runtime at most once per worker global.
+ *
+ * The flag is set before installation so a new module
+ * evaluation cannot create a second renderer. Failed installation
+ * clears it so startup can be retried.
+ */
+export function installRenderWorkerRuntimeOnce(
+  scope: RenderWorkerInstallScope,
+  install: () => void
+): boolean {
+  if (scope.__patchiesRenderWorkerRuntimeInstalled__) return false;
+
+  scope.__patchiesRenderWorkerRuntimeInstalled__ = true;
+
+  try {
+    install();
+    return true;
+  } catch (error) {
+    delete scope.__patchiesRenderWorkerRuntimeInstalled__;
+    throw error;
+  }
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -164,6 +164,18 @@ export default defineConfig(() => ({
     format: 'es' as const,
     plugins: () => [wasm(), topLevelAwait(), minifyExceptShaderParkCore()],
     rollupOptions: {
+      output: {
+        manualChunks(id: string) {
+          const normalizedId = id.replaceAll('\\', '/');
+
+          // Keep worker-global installation in the tiny entry facade. Renderer
+          // chunks may share this neutral runtime chunk, but never import the
+          // side-effectful entry back into the worker global.
+          if (normalizedId.endsWith('/src/workers/rendering/renderWorker.ts')) {
+            return 'render-core';
+          }
+        }
+      },
       // Exclude heavy dependencies from worker bundle
       external: [
         '@csound/browser',


### PR DESCRIPTION
Fixes Hydra and ShaderPark crashes on iOS. Root cause was due to dynamic imports in the render worker ended up initializing the worker twice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering reliability on iOS Safari by preventing duplicate render-worker initialization and stale-frame freezes.
  * Preserved rendering behavior while making worker startup safe to retry after an initialization failure.

* **Tests**
  * Added coverage for one-time worker installation and successful retry after failure.

* **Documentation**
  * Added design and postmortem documentation covering the iOS Safari rendering issue, resolution, validation, and follow-up guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->