### PR TITLE
feat(sidebar): add object settings editor

### DIFF
--- a/docs/design-docs/specs/175-sidebar-object-settings-editor.md
+++ b/docs/design-docs/specs/175-sidebar-object-settings-editor.md
@@ -1,0 +1,53 @@
+# 175. Sidebar Object Settings Editor
+
+## Goal
+
+Give settings-schema-backed objects a persistent editor surface that does not
+require locating or panning to the node on the canvas. This complements the
+existing floating settings panel; it does not replace it.
+
+## Scope
+
+- Add a user-configurable `Settings` sidebar tab. It is hidden by default and
+  can be enabled with the existing sidebar tab picker.
+- The tab lists only nodes whose `data.settingsSchema` is a non-empty schema.
+  The sidebar renders settings only; it never exposes a node's code editor.
+- The active target follows a selected settings-capable canvas node. Selecting
+  a node with no settings preserves the most recently edited settings target.
+- Users can choose any eligible node from the tab without selecting or moving
+  that node on the canvas.
+- A single pin freezes the target against later canvas selection changes. A
+  deleted or ineligible pinned node clears the pin and falls back to the most
+  recent eligible target.
+- Reuse `ObjectSettings` so values, defaults, visibility rules, color pickers,
+  and undo/redo semantics stay identical to the existing floating panel.
+- Add an Editor preference, disabled by default, that opens a node's
+  schema-driven Settings action in the sidebar and enables the tab. Existing
+  floating settings behavior remains the default.
+
+## Interaction
+
+The Settings tab header contains an eligible-node selector and a pin toggle.
+The selector is the only way to change the sidebar target without changing the
+canvas selection. The settings form scrolls within the sidebar, keeping long
+schemas usable without affecting the canvas viewport.
+
+When the patch has no eligible nodes, the tab shows a concise empty state. If
+the current target disappears or loses its schema, the next available eligible
+node becomes the fallback target; otherwise the empty state is shown.
+
+## Boundaries
+
+This initial implementation covers the shared schema-driven settings system.
+It intentionally does not adapt bespoke settings panels (for example, complex
+object-specific panels) into a new shared contract.
+
+## Verification
+
+- The tab is hidden for new users and can be enabled from the sidebar menu.
+- Canvas selection follows into the tab unless its target is pinned.
+- The selector changes the edited node without changing canvas selection.
+- Pinning resists selection changes and clears safely when the node is gone.
+- A settings change updates the target's node data and remains undoable.
+- The preference routes schema-driven Settings actions to the sidebar only when
+  enabled; the default continues to open the floating panel.

--- a/docs/design-docs/specs/175-sidebar-object-settings-editor.md
+++ b/docs/design-docs/specs/175-sidebar-object-settings-editor.md
@@ -42,6 +42,14 @@ This initial implementation covers the shared schema-driven settings system.
 It intentionally does not adapt bespoke settings panels (for example, complex
 object-specific panels) into a new shared contract.
 
+## Architecture
+
+Schema-backed node layouts use a shared Svelte composable to register their
+live settings callbacks and route an action to the floating panel or sidebar,
+including the one-off Shift inversion. The sidebar owns a second composable for
+selection, pinning, and explicit node-target requests. Object layouts retain
+only their object-specific value and revert behavior.
+
 ## Verification
 
 - The tab is hidden for new users and can be enabled from the sidebar menu.

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -318,8 +318,8 @@
     showSettings = false;
   }
 
-  function openSettings() {
-    if (openObjectSettingsInSidebarIfPreferred()) {
+  function openSettings(event?: MouseEvent) {
+    if (nodeId && openObjectSettingsInSidebarIfPreferred(nodeId, event?.shiftKey)) {
       showSettings = false;
       return;
     }

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -319,7 +319,10 @@
   }
 
   function openSettings() {
-    if (openObjectSettingsInSidebarIfPreferred(showSettings)) return;
+    if (openObjectSettingsInSidebarIfPreferred()) {
+      showSettings = false;
+      return;
+    }
 
     showSettings = !showSettings;
     if (showSettings) showEditor = false;

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -31,10 +31,7 @@
     syncActiveCodeEditorTargetSettings
   } from '../../stores/code-editor-layout.store';
   import { defaultEditorLayout } from '../../stores/editor-layout-settings.store';
-  import {
-    openObjectSettingsInSidebarIfPreferred,
-    registerSettingsSidebarTarget
-  } from '../../stores/settings-sidebar.store';
+  import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
   import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { CanvasPreviewExpandController } from '$lib/canvas/CanvasPreviewExpandController';
@@ -318,27 +315,23 @@
     showSettings = false;
   }
 
-  function openSettings(event?: MouseEvent) {
-    if (nodeId && openObjectSettingsInSidebarIfPreferred(nodeId, event?.shiftKey)) {
-      showSettings = false;
-      return;
+  const settingsSidebarTarget = useSettingsSidebarTarget({
+    getTarget: () =>
+      nodeId && settingsSchema && settingsSchema.length > 0
+        ? {
+            id: nodeId,
+            label: title,
+            schema: settingsSchema,
+            values: settingsValues,
+            onValueChange: (key, value) => onSettingsValueChange?.(key, value),
+            onRevertAll: () => onSettingsRevertAll?.()
+          }
+        : null,
+    floating: {
+      isOpen: () => showSettings,
+      setOpen: (open) => (showSettings = open),
+      onOpenFloating: () => (showEditor = false)
     }
-
-    showSettings = !showSettings;
-    if (showSettings) showEditor = false;
-  }
-
-  $effect(() => {
-    if (!nodeId || !settingsSchema || settingsSchema.length === 0) return;
-
-    return registerSettingsSidebarTarget({
-      id: nodeId,
-      label: title,
-      schema: settingsSchema,
-      values: settingsValues,
-      onValueChange: (key, value) => onSettingsValueChange?.(key, value),
-      onRevertAll: () => onSettingsRevertAll?.()
-    });
   });
 
   function openSidebarCodeEditor() {
@@ -470,7 +463,7 @@
                 {canPin}
                 onPreviewToggle={onPreviewToggle ? handlePreviewToggle : undefined}
                 {previewVisible}
-                onSettingsToggle={openSettings}
+                onSettingsToggle={settingsSidebarTarget.toggle}
                 onCodeToggle={resolvedPrimary === 'code' ? undefined : handleCodeOpen}
                 onExpandToggle={canExpand ? handleExpandToggle : undefined}
                 {isExpanded}
@@ -501,7 +494,7 @@
                     <button
                       class="node-floating-button"
                       aria-label={showSettings ? 'Hide settings' : 'Settings'}
-                      onclick={openSettings}
+                      onclick={settingsSidebarTarget.toggle}
                     >
                       <SettingsIcon class="h-4 w-4 text-zinc-300" />
                     </button>
@@ -560,7 +553,7 @@
       {previewVisible}
       {settingsSchema}
       {showSettings}
-      onSettingsToggle={openSettings}
+      onSettingsToggle={settingsSidebarTarget.toggle}
       onCodeToggle={handleCodeOpen}
       onExpandToggle={canExpand ? handleExpandToggle : undefined}
       {isExpanded}

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -31,6 +31,10 @@
     syncActiveCodeEditorTargetSettings
   } from '../../stores/code-editor-layout.store';
   import { defaultEditorLayout } from '../../stores/editor-layout-settings.store';
+  import {
+    openObjectSettingsInSidebarIfPreferred,
+    registerSettingsSidebarTarget
+  } from '../../stores/settings-sidebar.store';
   import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { CanvasPreviewExpandController } from '$lib/canvas/CanvasPreviewExpandController';
@@ -314,6 +318,26 @@
     showSettings = false;
   }
 
+  function openSettings() {
+    if (openObjectSettingsInSidebarIfPreferred(showSettings)) return;
+
+    showSettings = !showSettings;
+    if (showSettings) showEditor = false;
+  }
+
+  $effect(() => {
+    if (!nodeId || !settingsSchema || settingsSchema.length === 0) return;
+
+    return registerSettingsSidebarTarget({
+      id: nodeId,
+      label: title,
+      schema: settingsSchema,
+      values: settingsValues,
+      onValueChange: (key, value) => onSettingsValueChange?.(key, value),
+      onRevertAll: () => onSettingsRevertAll?.()
+    });
+  });
+
   function openSidebarCodeEditor() {
     if (!nodeId) return;
 
@@ -443,10 +467,7 @@
                 {canPin}
                 onPreviewToggle={onPreviewToggle ? handlePreviewToggle : undefined}
                 {previewVisible}
-                onSettingsToggle={() => {
-                  showSettings = !showSettings;
-                  if (showSettings) showEditor = false;
-                }}
+                onSettingsToggle={openSettings}
                 onCodeToggle={resolvedPrimary === 'code' ? undefined : handleCodeOpen}
                 onExpandToggle={canExpand ? handleExpandToggle : undefined}
                 {isExpanded}
@@ -477,10 +498,7 @@
                     <button
                       class="node-floating-button"
                       aria-label={showSettings ? 'Hide settings' : 'Settings'}
-                      onclick={() => {
-                        showSettings = !showSettings;
-                        if (showSettings) showEditor = false;
-                      }}
+                      onclick={openSettings}
                     >
                       <SettingsIcon class="h-4 w-4 text-zinc-300" />
                     </button>
@@ -539,10 +557,7 @@
       {previewVisible}
       {settingsSchema}
       {showSettings}
-      onSettingsToggle={() => {
-        showSettings = !showSettings;
-        if (showSettings) showEditor = false;
-      }}
+      onSettingsToggle={openSettings}
       onCodeToggle={handleCodeOpen}
       onExpandToggle={canExpand ? handleExpandToggle : undefined}
       {isExpanded}

--- a/ui/src/lib/components/object-preview-menu-actions.ts
+++ b/ui/src/lib/components/object-preview-menu-actions.ts
@@ -35,7 +35,7 @@ export interface ObjectPreviewMenuProps {
   canPin?: boolean;
   onPreviewToggle?: () => void;
   previewVisible?: boolean;
-  onSettingsToggle?: () => void;
+  onSettingsToggle?: (event?: MouseEvent) => void;
   onCodeToggle?: (event: MouseEvent) => void;
   onExpandToggle?: () => void;
   isExpanded?: boolean;
@@ -106,7 +106,7 @@ export function getObjectPreviewMenuGroups({
       id: 'settings',
       label: showSettings ? 'Hide settings' : 'Settings',
       icon: Settings,
-      onclick: () => onSettingsToggle()
+      onclick: (event) => onSettingsToggle(event)
     });
   }
 

--- a/ui/src/lib/components/settings-modal/categories/EditorSettings.svelte
+++ b/ui/src/lib/components/settings-modal/categories/EditorSettings.svelte
@@ -5,9 +5,11 @@
   import {
     defaultEditorLayout,
     overlayEditorTransparency,
+    openObjectSettingsInSidebar,
     setDefaultEditorLayout,
     setOverlayEditorTransparency,
-    type EditorLayoutPreference
+    type EditorLayoutPreference,
+    setOpenObjectSettingsInSidebar
   } from '../../../../stores/editor-layout-settings.store';
   import {
     editorAutocompleteEnabled,
@@ -73,6 +75,17 @@
     options={editorLayoutOptions}
     onchange={handleLayoutChange}
     label="Default editor layout"
+  />
+</SettingRow>
+
+<SettingRow
+  title="Open object settings in sidebar"
+  description="Open schema-driven object settings in the Settings sidebar instead of beside the node."
+>
+  <SettingToggle
+    checked={$openObjectSettingsInSidebar}
+    onchange={setOpenObjectSettingsInSidebar}
+    label="Open object settings in sidebar"
   />
 </SettingRow>
 

--- a/ui/src/lib/components/settings/ObjectSettings.svelte
+++ b/ui/src/lib/components/settings/ObjectSettings.svelte
@@ -20,7 +20,8 @@
     onClose,
     settingsPrefix = 'settings',
     showCloseButton = true,
-    showRevertButton = true
+    showRevertButton = true,
+    variant = 'floating'
   }: {
     nodeId: string;
     schema: SettingsSchema;
@@ -34,6 +35,7 @@
     settingsPrefix?: string;
     showCloseButton?: boolean;
     showRevertButton?: boolean;
+    variant?: 'floating' | 'sidebar';
   } = $props();
 
   const createComboboxOpenState = (schema: SettingsSchema): Record<string, boolean> =>
@@ -184,7 +186,11 @@
 
 <!-- Close button bar -->
 {#if showCloseButton || (showRevertButton && isDirty)}
-  <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
+  <div
+    class={variant === 'floating'
+      ? 'absolute -top-7 left-0 flex w-full justify-end gap-x-1'
+      : 'mb-3 flex justify-end gap-x-1'}
+  >
     {#if showRevertButton && isDirty}
       <Tooltip.Root>
         <Tooltip.Trigger>
@@ -210,7 +216,11 @@
 {/if}
 
 <!-- Settings panel -->
-<div class="nodrag w-48 rounded-md border border-zinc-600 bg-zinc-900 p-4 shadow-xl">
+<div
+  class={variant === 'floating'
+    ? 'nodrag w-48 rounded-md border border-zinc-600 bg-zinc-900 p-4 shadow-xl'
+    : 'nodrag w-full'}
+>
   <div class="flex flex-col gap-3">
     {#each schema as field (field.key)}
       {#if isSettingsFieldVisible(schema, values, field)}

--- a/ui/src/lib/components/settings/ObjectSettings.svelte
+++ b/ui/src/lib/components/settings/ObjectSettings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Check, ChevronsUpDown, RotateCcw, X } from '@lucide/svelte/icons';
+  import { Check, ChevronDown, ChevronsUpDown, RotateCcw, X } from '@lucide/svelte/icons';
   import SettingsSlider from '$lib/components/SettingsSlider.svelte';
   import NativeColorPicker from '$lib/components/settings/NativeColorPicker.svelte';
   import * as Command from '$lib/components/ui/command';
@@ -65,6 +65,9 @@
   const tracker = useNodeDataTracker(getInitialNodeId());
   const comboboxOpen = $state(createInitialComboboxOpenState());
   const comboboxQuery = $state(createInitialComboboxQueryState());
+  let floatingPanelElement = $state<HTMLDivElement>();
+  let isFloatingScrollable = $state(false);
+  let hasMoreFloatingSettings = $state(false);
 
   function trackingKey(key: string): string {
     return settingsPrefix ? `${settingsPrefix}.${key}` : key;
@@ -112,6 +115,36 @@
     dismissActiveNativeColorPicker();
     onClose();
   }
+
+  function updateFloatingScrollIndicator() {
+    if (!floatingPanelElement || variant !== 'floating') {
+      isFloatingScrollable = false;
+      hasMoreFloatingSettings = false;
+      return;
+    }
+
+    isFloatingScrollable =
+      floatingPanelElement.scrollHeight > floatingPanelElement.clientHeight + 1;
+    hasMoreFloatingSettings =
+      isFloatingScrollable &&
+      floatingPanelElement.scrollTop + floatingPanelElement.clientHeight <
+        floatingPanelElement.scrollHeight - 1;
+  }
+
+  $effect(() => {
+    if (variant !== 'floating' || !floatingPanelElement) return;
+
+    const frame = requestAnimationFrame(updateFloatingScrollIndicator);
+    const observer = new ResizeObserver(updateFloatingScrollIndicator);
+    observer.observe(floatingPanelElement);
+    floatingPanelElement.firstElementChild &&
+      observer.observe(floatingPanelElement.firstElementChild);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  });
 
   function makeTracker(field: SettingsField) {
     if ((field.persistence ?? 'node') !== 'node') {
@@ -216,359 +249,380 @@
 {/if}
 
 <!-- Settings panel -->
-<div
-  class={variant === 'floating'
-    ? 'nodrag w-48 rounded-md border border-zinc-600 bg-zinc-900 p-4 shadow-xl'
-    : 'nodrag w-full'}
->
-  <div class="flex flex-col gap-3">
-    {#each schema as field (field.key)}
-      {#if isSettingsFieldVisible(schema, values, field)}
-        {#if field.type === 'slider'}
-          {@const sliderTracker = makeTracker(field)}
-          {@const rawValue = (getCurrentValue(field) as number) ?? field.min}
+<div class={variant === 'floating' ? 'relative w-48' : 'w-full'}>
+  <div
+    bind:this={floatingPanelElement}
+    onscroll={updateFloatingScrollIndicator}
+    class={variant === 'floating'
+      ? [
+          'nodrag max-h-[min(32rem,calc(100dvh-8rem))] overflow-y-auto overscroll-contain rounded-md border border-zinc-600 bg-zinc-900 p-4 shadow-xl',
+          isFloatingScrollable && 'nopan nowheel'
+        ]
+      : 'nodrag w-full'}
+  >
+    <div class="flex flex-col gap-3">
+      {#each schema as field (field.key)}
+        {#if isSettingsFieldVisible(schema, values, field)}
+          {#if field.type === 'slider'}
+            {@const sliderTracker = makeTracker(field)}
+            {@const rawValue = (getCurrentValue(field) as number) ?? field.min}
 
-          {@const decimals =
-            field.step != null && field.step < 1
-              ? Math.max(0, Math.ceil(-Math.log10(field.step)))
-              : 0}
+            {@const decimals =
+              field.step != null && field.step < 1
+                ? Math.max(0, Math.ceil(-Math.log10(field.step)))
+                : 0}
 
-          {@const displayValue = decimals > 0 ? rawValue.toFixed(decimals) : rawValue}
+            {@const displayValue = decimals > 0 ? rawValue.toFixed(decimals) : rawValue}
 
-          <div>
-            <div class="mb-1 flex items-start justify-between gap-2">
+            <div>
+              <div class="mb-1 flex items-start justify-between gap-2">
+                {#if field.description}
+                  <Tooltip.Root>
+                    <Tooltip.Trigger>
+                      <span class="cursor-default text-xs font-medium text-zinc-300"
+                        >{field.label}</span
+                      >
+                    </Tooltip.Trigger>
+                    <Tooltip.Content>{field.description}</Tooltip.Content>
+                  </Tooltip.Root>
+                {:else}
+                  <span class="text-xs font-medium text-zinc-300">{field.label}</span>
+                {/if}
+
+                <span class="shrink-0 text-xs text-zinc-500 tabular-nums">{displayValue}</span>
+              </div>
+
+              <SettingsSlider
+                min={field.min}
+                max={field.max}
+                step={field.step}
+                value={rawValue}
+                onchange={(v) => onValueChange(field.key, v)}
+                onpointerdown={sliderTracker.onFocus}
+                onpointerup={sliderTracker.onBlur}
+              />
+            </div>
+          {:else if field.type === 'number'}
+            {@const numTracker = makeTracker(field)}
+            <div>
               {#if field.description}
                 <Tooltip.Root>
                   <Tooltip.Trigger>
-                    <span class="cursor-default text-xs font-medium text-zinc-300"
+                    <label
+                      class="mb-1 block cursor-default text-xs font-medium text-zinc-300"
+                      for="setting-{field.key}">{field.label}</label
+                    >
+                  </Tooltip.Trigger>
+
+                  <Tooltip.Content>{field.description}</Tooltip.Content>
+                </Tooltip.Root>
+              {:else}
+                <label
+                  class="mb-1 block text-xs font-medium text-zinc-300"
+                  for="setting-{field.key}">{field.label}</label
+                >
+              {/if}
+              <input
+                id="setting-{field.key}"
+                type="number"
+                use:syncNumberValue={() => getCurrentValue(field) as number}
+                min={field.min}
+                max={field.max}
+                step={field.step}
+                class="nodrag w-full rounded border border-zinc-600 bg-zinc-800 px-2 py-1 text-xs text-zinc-100 outline-none focus:ring-1 focus:ring-zinc-500"
+                onfocus={numTracker.onFocus}
+                onblur={numTracker.onBlur}
+                oninput={(e) => {
+                  const raw = (e.target as HTMLInputElement).value;
+                  if (raw === '' || raw === '-') return;
+
+                  const parsed = parseFloat(raw);
+                  if (Number.isFinite(parsed)) onValueChange(field.key, parsed);
+                }}
+              />
+            </div>
+          {:else if field.type === 'string'}
+            {@const strTracker = makeTracker(field)}
+            <div>
+              {#if field.description}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <label
+                      class="mb-1 block cursor-default text-xs font-medium text-zinc-300"
+                      for="setting-{field.key}">{field.label}</label
+                    >
+                  </Tooltip.Trigger>
+
+                  <Tooltip.Content>{field.description}</Tooltip.Content>
+                </Tooltip.Root>
+              {:else}
+                <label
+                  class="mb-1 block text-xs font-medium text-zinc-300"
+                  for="setting-{field.key}">{field.label}</label
+                >
+              {/if}
+              <input
+                id="setting-{field.key}"
+                type="text"
+                value={(getCurrentValue(field) as string) ?? ''}
+                placeholder={field.placeholder}
+                class="nodrag w-full min-w-0 rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-xs text-zinc-300 outline-none focus:ring-1 focus:ring-zinc-500"
+                onfocus={strTracker.onFocus}
+                onblur={strTracker.onBlur}
+                oninput={(e) => onValueChange(field.key, (e.target as HTMLInputElement).value)}
+              />
+            </div>
+          {:else if field.type === 'boolean'}
+            {@const checked = !!(getCurrentValue(field) ?? false)}
+
+            <button
+              class="flex cursor-pointer items-center gap-1.5 transition-colors"
+              onclick={() => handleDiscreteChange(field, !getCurrentValue(field))}
+            >
+              <div
+                class={[
+                  'h-3 w-3 shrink-0 rounded-sm border transition-colors',
+                  checked ? 'border-zinc-500 bg-zinc-500' : 'border-zinc-600'
+                ]}
+              ></div>
+
+              {#if field.description}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <span class={['text-xs', checked ? 'text-zinc-400' : 'text-zinc-500']}
                       >{field.label}</span
                     >
                   </Tooltip.Trigger>
                   <Tooltip.Content>{field.description}</Tooltip.Content>
                 </Tooltip.Root>
               {:else}
-                <span class="text-xs font-medium text-zinc-300">{field.label}</span>
+                <span class={['text-xs', checked ? 'text-zinc-400' : 'text-zinc-500']}
+                  >{field.label}</span
+                >
+              {/if}
+            </button>
+          {:else if field.type === 'select'}
+            <div>
+              {#if field.description}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <span class="mb-2 block cursor-default text-xs font-medium text-zinc-300"
+                      >{field.label}</span
+                    >
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>{field.description}</Tooltip.Content>
+                </Tooltip.Root>
+              {:else}
+                <span class="mb-2 block text-xs font-medium text-zinc-300">{field.label}</span>
               {/if}
 
-              <span class="shrink-0 text-xs text-zinc-500 tabular-nums">{displayValue}</span>
-            </div>
+              <div class="flex flex-wrap gap-1">
+                {#each normalizeSettingsOptions(field.options) as option, index (index)}
+                  {@const isSelected = getCurrentValue(field) === option.value}
 
-            <SettingsSlider
-              min={field.min}
-              max={field.max}
-              step={field.step}
-              value={rawValue}
-              onchange={(v) => onValueChange(field.key, v)}
-              onpointerdown={sliderTracker.onFocus}
-              onpointerup={sliderTracker.onBlur}
-            />
-          </div>
-        {:else if field.type === 'number'}
-          {@const numTracker = makeTracker(field)}
-          <div>
-            {#if field.description}
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  <label
-                    class="mb-1 block cursor-default text-xs font-medium text-zinc-300"
-                    for="setting-{field.key}">{field.label}</label
-                  >
-                </Tooltip.Trigger>
-
-                <Tooltip.Content>{field.description}</Tooltip.Content>
-              </Tooltip.Root>
-            {:else}
-              <label class="mb-1 block text-xs font-medium text-zinc-300" for="setting-{field.key}"
-                >{field.label}</label
-              >
-            {/if}
-            <input
-              id="setting-{field.key}"
-              type="number"
-              use:syncNumberValue={() => getCurrentValue(field) as number}
-              min={field.min}
-              max={field.max}
-              step={field.step}
-              class="nodrag w-full rounded border border-zinc-600 bg-zinc-800 px-2 py-1 text-xs text-zinc-100 outline-none focus:ring-1 focus:ring-zinc-500"
-              onfocus={numTracker.onFocus}
-              onblur={numTracker.onBlur}
-              oninput={(e) => {
-                const raw = (e.target as HTMLInputElement).value;
-                if (raw === '' || raw === '-') return;
-
-                const parsed = parseFloat(raw);
-                if (Number.isFinite(parsed)) onValueChange(field.key, parsed);
-              }}
-            />
-          </div>
-        {:else if field.type === 'string'}
-          {@const strTracker = makeTracker(field)}
-          <div>
-            {#if field.description}
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  <label
-                    class="mb-1 block cursor-default text-xs font-medium text-zinc-300"
-                    for="setting-{field.key}">{field.label}</label
-                  >
-                </Tooltip.Trigger>
-
-                <Tooltip.Content>{field.description}</Tooltip.Content>
-              </Tooltip.Root>
-            {:else}
-              <label class="mb-1 block text-xs font-medium text-zinc-300" for="setting-{field.key}"
-                >{field.label}</label
-              >
-            {/if}
-            <input
-              id="setting-{field.key}"
-              type="text"
-              value={(getCurrentValue(field) as string) ?? ''}
-              placeholder={field.placeholder}
-              class="nodrag w-full min-w-0 rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-xs text-zinc-300 outline-none focus:ring-1 focus:ring-zinc-500"
-              onfocus={strTracker.onFocus}
-              onblur={strTracker.onBlur}
-              oninput={(e) => onValueChange(field.key, (e.target as HTMLInputElement).value)}
-            />
-          </div>
-        {:else if field.type === 'boolean'}
-          {@const checked = !!(getCurrentValue(field) ?? false)}
-
-          <button
-            class="flex cursor-pointer items-center gap-1.5 transition-colors"
-            onclick={() => handleDiscreteChange(field, !getCurrentValue(field))}
-          >
-            <div
-              class={[
-                'h-3 w-3 shrink-0 rounded-sm border transition-colors',
-                checked ? 'border-zinc-500 bg-zinc-500' : 'border-zinc-600'
-              ]}
-            ></div>
-
-            {#if field.description}
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  <span class={['text-xs', checked ? 'text-zinc-400' : 'text-zinc-500']}
-                    >{field.label}</span
-                  >
-                </Tooltip.Trigger>
-                <Tooltip.Content>{field.description}</Tooltip.Content>
-              </Tooltip.Root>
-            {:else}
-              <span class={['text-xs', checked ? 'text-zinc-400' : 'text-zinc-500']}
-                >{field.label}</span
-              >
-            {/if}
-          </button>
-        {:else if field.type === 'select'}
-          <div>
-            {#if field.description}
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  <span class="mb-2 block cursor-default text-xs font-medium text-zinc-300"
-                    >{field.label}</span
-                  >
-                </Tooltip.Trigger>
-                <Tooltip.Content>{field.description}</Tooltip.Content>
-              </Tooltip.Root>
-            {:else}
-              <span class="mb-2 block text-xs font-medium text-zinc-300">{field.label}</span>
-            {/if}
-
-            <div class="flex flex-wrap gap-1">
-              {#each normalizeSettingsOptions(field.options) as option, index (index)}
-                {@const isSelected = getCurrentValue(field) === option.value}
-
-                {#if option.description}
-                  <Tooltip.Root>
-                    <Tooltip.Trigger>
-                      <button
-                        onclick={() => handleDiscreteChange(field, option.value)}
-                        class={[
-                          'cursor-pointer rounded px-2 py-1 text-xs transition-colors',
-                          isSelected
-                            ? 'bg-zinc-600 text-white'
-                            : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700'
-                        ]}
-                      >
-                        {option.label}
-                      </button>
-                    </Tooltip.Trigger>
-                    <Tooltip.Content>{option.description}</Tooltip.Content>
-                  </Tooltip.Root>
-                {:else}
-                  <button
-                    onclick={() => handleDiscreteChange(field, option.value)}
-                    class={[
-                      'cursor-pointer rounded px-2 py-1 text-xs transition-colors',
-                      isSelected
-                        ? 'bg-zinc-600 text-white'
-                        : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700'
-                    ]}
-                  >
-                    {option.label}
-                  </button>
-                {/if}
-              {/each}
-            </div>
-          </div>
-        {:else if field.type === 'combobox'}
-          {@const comboboxOptions = normalizeSettingsOptions(field.options)}
-          {@const filteredOptions = filterSettingsOptions(
-            comboboxOptions,
-            comboboxQuery[field.key] ?? '',
-            field.maxVisibleOptions ?? 80
-          )}
-          <div>
-            {#if field.description}
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  <span class="mb-1 block cursor-default text-xs font-medium text-zinc-300"
-                    >{field.label}</span
-                  >
-                </Tooltip.Trigger>
-                <Tooltip.Content>{field.description}</Tooltip.Content>
-              </Tooltip.Root>
-            {:else}
-              <span class="mb-1 block text-xs font-medium text-zinc-300">{field.label}</span>
-            {/if}
-
-            <Popover.Root bind:open={comboboxOpen[field.key]}>
-              <Popover.Trigger
-                class="flex w-full cursor-pointer items-center justify-between gap-2 rounded border border-zinc-600 bg-zinc-800 px-2 py-1.5 text-left font-mono text-xs text-zinc-200 hover:bg-zinc-700"
-              >
-                <span class="min-w-0 truncate">{getSelectedOptionLabel(field)}</span>
-                <ChevronsUpDown class="h-3 w-3 shrink-0 text-zinc-500" />
-              </Popover.Trigger>
-
-              <Popover.Content class="w-72 p-0" align="start" sideOffset={6}>
-                <Command.Root shouldFilter={false}>
-                  <Command.Input
-                    placeholder={field.searchPlaceholder ??
-                      `Search ${field.label.toLowerCase()}...`}
-                    bind:value={comboboxQuery[field.key]}
-                  />
-                  <Command.List class="max-h-64">
-                    <Command.Empty>{field.emptyMessage ?? 'No options found.'}</Command.Empty>
-                    <Command.Group>
-                      {#each filteredOptions as option (option.value)}
-                        {@const isSelected = getCurrentValue(field) === option.value}
-                        <Command.Item
-                          value={`${option.label} ${option.value}`}
-                          onSelect={() => selectComboboxOption(field, option.value)}
-                          class="cursor-pointer"
+                  {#if option.description}
+                    <Tooltip.Root>
+                      <Tooltip.Trigger>
+                        <button
+                          onclick={() => handleDiscreteChange(field, option.value)}
+                          class={[
+                            'cursor-pointer rounded px-2 py-1 text-xs transition-colors',
+                            isSelected
+                              ? 'bg-zinc-600 text-white'
+                              : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700'
+                          ]}
                         >
-                          <Check class={['h-3 w-3', isSelected ? 'opacity-100' : 'opacity-0']} />
-                          <div class="min-w-0">
-                            <div class="truncate font-mono text-xs">{option.label}</div>
-                            {#if option.description}
-                              <div class="truncate text-[10px] text-zinc-500">
-                                {option.description}
-                              </div>
-                            {/if}
-                          </div>
-                        </Command.Item>
-                      {/each}
-                    </Command.Group>
-                  </Command.List>
-                </Command.Root>
-              </Popover.Content>
-            </Popover.Root>
-          </div>
-        {:else if field.type === 'color'}
-          <div>
-            {#if field.description}
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  <span class="mb-2 block cursor-default text-xs font-medium text-zinc-300"
-                    >{field.label}</span
-                  >
-                </Tooltip.Trigger>
-                <Tooltip.Content>{field.description}</Tooltip.Content>
-              </Tooltip.Root>
-            {:else}
-              <span class="mb-2 block text-xs font-medium text-zinc-300">{field.label}</span>
-            {/if}
-
-            {#if field.presets && field.presets.length > 0}
-              <div class="flex flex-wrap gap-2">
-                {#each field.presets as preset, index (index)}
-                  {@const isSelected = getCurrentValue(field) === preset}
-
-                  <button
-                    onclick={() => handleDiscreteChange(field, preset)}
-                    class={[
-                      'h-6 w-6 cursor-pointer rounded-full border-2 transition-all',
-                      isSelected
-                        ? 'scale-110 border-white shadow-md'
-                        : 'border-transparent hover:scale-105 hover:border-zinc-400'
-                    ]}
-                    style="background-color: {preset};"
-                    aria-label={preset}
-                  ></button>
+                          {option.label}
+                        </button>
+                      </Tooltip.Trigger>
+                      <Tooltip.Content>{option.description}</Tooltip.Content>
+                    </Tooltip.Root>
+                  {:else}
+                    <button
+                      onclick={() => handleDiscreteChange(field, option.value)}
+                      class={[
+                        'cursor-pointer rounded px-2 py-1 text-xs transition-colors',
+                        isSelected
+                          ? 'bg-zinc-600 text-white'
+                          : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700'
+                      ]}
+                    >
+                      {option.label}
+                    </button>
+                  {/if}
                 {/each}
               </div>
-            {:else}
-              <!-- Native color picker fallback -->
-              {@const colorTracker = makeTracker(field)}
-
-              {@const currentColor = (getCurrentValue(field) as string) ?? '#ffffff'}
-
-              <NativeColorPicker
-                value={currentColor}
-                ariaLabel={field.label}
-                showValue
-                onOpen={colorTracker.onFocus}
-                onInput={(value) => onValueChange(field.key, value)}
-                onChange={() => colorTracker.onBlur()}
-              />
-            {/if}
-          </div>
-        {:else if field.type === 'vec2'}
-          {@const vecTracker = makeTracker(field)}
-          {@const currentVec = toVec2(getCurrentValue(field), field.default ?? [0, 0])}
-          {@const minVec = toVec2(field.min, [-Infinity, -Infinity])}
-          {@const maxVec = toVec2(field.max, [Infinity, Infinity])}
-
-          <div>
-            {#if field.description}
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  <span class="mb-1 block cursor-default text-xs font-medium text-zinc-300"
-                    >{field.label}</span
-                  >
-                </Tooltip.Trigger>
-                <Tooltip.Content>{field.description}</Tooltip.Content>
-              </Tooltip.Root>
-            {:else}
-              <span class="mb-1 block text-xs font-medium text-zinc-300">{field.label}</span>
-            {/if}
-
-            <div class="grid grid-cols-2 gap-2">
-              {#each VECTOR_AXES as axisLabel, axis (axisLabel)}
-                <label class="min-w-0">
-                  <span class="mb-1 block text-[10px] font-medium text-zinc-500 uppercase"
-                    >{axisLabel}</span
-                  >
-                  <input
-                    id="setting-{field.key}-{axisLabel}"
-                    type="number"
-                    use:syncNumberValue={() => currentVec[axis]}
-                    min={Number.isFinite(minVec[axis]) ? minVec[axis] : undefined}
-                    max={Number.isFinite(maxVec[axis]) ? maxVec[axis] : undefined}
-                    step={field.step}
-                    class="nodrag w-full min-w-0 rounded border border-zinc-600 bg-zinc-800 px-2 py-1 text-xs text-zinc-100 outline-none focus:ring-1 focus:ring-zinc-500"
-                    onfocus={vecTracker.onFocus}
-                    onblur={vecTracker.onBlur}
-                    oninput={(e) =>
-                      handleVec2Input(field, axis, (e.target as HTMLInputElement).value)}
-                  />
-                </label>
-              {/each}
             </div>
-          </div>
+          {:else if field.type === 'combobox'}
+            {@const comboboxOptions = normalizeSettingsOptions(field.options)}
+            {@const filteredOptions = filterSettingsOptions(
+              comboboxOptions,
+              comboboxQuery[field.key] ?? '',
+              field.maxVisibleOptions ?? 80
+            )}
+            <div>
+              {#if field.description}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <span class="mb-1 block cursor-default text-xs font-medium text-zinc-300"
+                      >{field.label}</span
+                    >
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>{field.description}</Tooltip.Content>
+                </Tooltip.Root>
+              {:else}
+                <span class="mb-1 block text-xs font-medium text-zinc-300">{field.label}</span>
+              {/if}
+
+              <Popover.Root bind:open={comboboxOpen[field.key]}>
+                <Popover.Trigger
+                  class="flex w-full cursor-pointer items-center justify-between gap-2 rounded border border-zinc-600 bg-zinc-800 px-2 py-1.5 text-left font-mono text-xs text-zinc-200 hover:bg-zinc-700"
+                >
+                  <span class="min-w-0 truncate">{getSelectedOptionLabel(field)}</span>
+                  <ChevronsUpDown class="h-3 w-3 shrink-0 text-zinc-500" />
+                </Popover.Trigger>
+
+                <Popover.Content class="w-72 p-0" align="start" sideOffset={6}>
+                  <Command.Root shouldFilter={false}>
+                    <Command.Input
+                      placeholder={field.searchPlaceholder ??
+                        `Search ${field.label.toLowerCase()}...`}
+                      bind:value={comboboxQuery[field.key]}
+                    />
+                    <Command.List class="max-h-64">
+                      <Command.Empty>{field.emptyMessage ?? 'No options found.'}</Command.Empty>
+                      <Command.Group>
+                        {#each filteredOptions as option (option.value)}
+                          {@const isSelected = getCurrentValue(field) === option.value}
+                          <Command.Item
+                            value={`${option.label} ${option.value}`}
+                            onSelect={() => selectComboboxOption(field, option.value)}
+                            class="cursor-pointer"
+                          >
+                            <Check class={['h-3 w-3', isSelected ? 'opacity-100' : 'opacity-0']} />
+                            <div class="min-w-0">
+                              <div class="truncate font-mono text-xs">{option.label}</div>
+                              {#if option.description}
+                                <div class="truncate text-[10px] text-zinc-500">
+                                  {option.description}
+                                </div>
+                              {/if}
+                            </div>
+                          </Command.Item>
+                        {/each}
+                      </Command.Group>
+                    </Command.List>
+                  </Command.Root>
+                </Popover.Content>
+              </Popover.Root>
+            </div>
+          {:else if field.type === 'color'}
+            <div>
+              {#if field.description}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <span class="mb-2 block cursor-default text-xs font-medium text-zinc-300"
+                      >{field.label}</span
+                    >
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>{field.description}</Tooltip.Content>
+                </Tooltip.Root>
+              {:else}
+                <span class="mb-2 block text-xs font-medium text-zinc-300">{field.label}</span>
+              {/if}
+
+              {#if field.presets && field.presets.length > 0}
+                <div class="flex flex-wrap gap-2">
+                  {#each field.presets as preset, index (index)}
+                    {@const isSelected = getCurrentValue(field) === preset}
+
+                    <button
+                      onclick={() => handleDiscreteChange(field, preset)}
+                      class={[
+                        'h-6 w-6 cursor-pointer rounded-full border-2 transition-all',
+                        isSelected
+                          ? 'scale-110 border-white shadow-md'
+                          : 'border-transparent hover:scale-105 hover:border-zinc-400'
+                      ]}
+                      style="background-color: {preset};"
+                      aria-label={preset}
+                    ></button>
+                  {/each}
+                </div>
+              {:else}
+                <!-- Native color picker fallback -->
+                {@const colorTracker = makeTracker(field)}
+
+                {@const currentColor = (getCurrentValue(field) as string) ?? '#ffffff'}
+
+                <NativeColorPicker
+                  value={currentColor}
+                  ariaLabel={field.label}
+                  showValue
+                  onOpen={colorTracker.onFocus}
+                  onInput={(value) => onValueChange(field.key, value)}
+                  onChange={() => colorTracker.onBlur()}
+                />
+              {/if}
+            </div>
+          {:else if field.type === 'vec2'}
+            {@const vecTracker = makeTracker(field)}
+            {@const currentVec = toVec2(getCurrentValue(field), field.default ?? [0, 0])}
+            {@const minVec = toVec2(field.min, [-Infinity, -Infinity])}
+            {@const maxVec = toVec2(field.max, [Infinity, Infinity])}
+
+            <div>
+              {#if field.description}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <span class="mb-1 block cursor-default text-xs font-medium text-zinc-300"
+                      >{field.label}</span
+                    >
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>{field.description}</Tooltip.Content>
+                </Tooltip.Root>
+              {:else}
+                <span class="mb-1 block text-xs font-medium text-zinc-300">{field.label}</span>
+              {/if}
+
+              <div class="grid grid-cols-2 gap-2">
+                {#each VECTOR_AXES as axisLabel, axis (axisLabel)}
+                  <label class="min-w-0">
+                    <span class="mb-1 block text-[10px] font-medium text-zinc-500 uppercase"
+                      >{axisLabel}</span
+                    >
+                    <input
+                      id="setting-{field.key}-{axisLabel}"
+                      type="number"
+                      use:syncNumberValue={() => currentVec[axis]}
+                      min={Number.isFinite(minVec[axis]) ? minVec[axis] : undefined}
+                      max={Number.isFinite(maxVec[axis]) ? maxVec[axis] : undefined}
+                      step={field.step}
+                      class="nodrag w-full min-w-0 rounded border border-zinc-600 bg-zinc-800 px-2 py-1 text-xs text-zinc-100 outline-none focus:ring-1 focus:ring-zinc-500"
+                      onfocus={vecTracker.onFocus}
+                      onblur={vecTracker.onBlur}
+                      oninput={(e) =>
+                        handleVec2Input(field, axis, (e.target as HTMLInputElement).value)}
+                    />
+                  </label>
+                {/each}
+              </div>
+            </div>
+          {/if}
         {/if}
-      {/if}
-    {/each}
+      {/each}
+    </div>
   </div>
+
+  {#if variant === 'floating' && hasMoreFloatingSettings}
+    <div
+      class="pointer-events-none absolute right-px bottom-px left-px flex h-10 items-end justify-center rounded-b-md bg-gradient-to-t from-zinc-900 via-zinc-900/90 to-transparent pb-1 text-[10px] text-zinc-400"
+      aria-hidden="true"
+    >
+      <span class="flex items-center gap-1">
+        Scroll for more
+        <ChevronDown class="h-3 w-3" />
+      </span>
+    </div>
+  {/if}
 </div>

--- a/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
+++ b/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+  import { Pin, PinOff, RotateCcw, SlidersHorizontal } from '@lucide/svelte/icons';
+  import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
+  import * as Tooltip from '$lib/components/ui/tooltip';
+  import { selectedNodeInfo } from '../../../stores/ui.store';
+  import { settingsSidebarTargets } from '../../../stores/settings-sidebar.store';
+
+  let activeTargetId = $state<string | null>(null);
+  let pinnedTargetId = $state<string | null>(null);
+
+  let targets = $derived(
+    [...$settingsSidebarTargets.values()].sort((a, b) => a.label.localeCompare(b.label))
+  );
+  let activeTarget = $derived(
+    activeTargetId ? (targets.find((target) => target.id === activeTargetId) ?? null) : null
+  );
+
+  $effect(() => {
+    const pinnedTarget = pinnedTargetId
+      ? targets.find((target) => target.id === pinnedTargetId)
+      : undefined;
+
+    if (pinnedTarget) {
+      activeTargetId = pinnedTarget.id;
+      return;
+    }
+
+    if (pinnedTargetId) pinnedTargetId = null;
+
+    const selectedTarget = $selectedNodeInfo
+      ? targets.find((target) => target.id === $selectedNodeInfo?.id)
+      : undefined;
+
+    if (selectedTarget) {
+      activeTargetId = selectedTarget.id;
+    } else if (!activeTargetId || !targets.some((target) => target.id === activeTargetId)) {
+      activeTargetId = targets[0]?.id ?? null;
+    }
+  });
+
+  function handleTargetChange(event: Event) {
+    activeTargetId = (event.currentTarget as HTMLSelectElement).value || null;
+  }
+
+  function togglePin() {
+    pinnedTargetId = pinnedTargetId ? null : activeTargetId;
+  }
+
+  function settingsValueEquals(left: unknown, right: unknown): boolean {
+    if (Array.isArray(left) && Array.isArray(right)) {
+      return (
+        left.length === right.length &&
+        left.every((value, index) => settingsValueEquals(value, right[index]))
+      );
+    }
+
+    return left === right;
+  }
+
+  function hasDirtySettings(): boolean {
+    if (!activeTarget) return false;
+
+    return activeTarget.schema.some((field) => {
+      if (!('default' in field) || field.default === undefined) return false;
+
+      const value = activeTarget.values[field.key] ?? field.default;
+      return !settingsValueEquals(value, field.default);
+    });
+  }
+
+  let hasDirtySettingsValue = $derived(hasDirtySettings());
+</script>
+
+{#if targets.length === 0}
+  <div class="flex h-full flex-col items-center justify-center px-6 text-center">
+    <div
+      class="mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-zinc-800 bg-zinc-900 text-zinc-500"
+    >
+      <SlidersHorizontal class="h-5 w-5" />
+    </div>
+    <h2 class="text-sm font-medium text-zinc-300">No object settings</h2>
+    <p class="mt-1 max-w-56 text-xs leading-5 text-zinc-500">
+      Settings-capable objects will appear here when they are added to this patch.
+    </p>
+  </div>
+{:else if activeTarget}
+  <div class="flex min-h-full flex-col">
+    <div class="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950 px-5 py-4">
+      <div class="flex items-center gap-2">
+        <label class="sr-only" for="sidebar-settings-target">Object settings target</label>
+        <select
+          id="sidebar-settings-target"
+          value={activeTarget.id}
+          onchange={handleTargetChange}
+          class="h-8 min-w-0 flex-1 cursor-pointer rounded-md border border-zinc-700 bg-zinc-900 px-2 font-mono text-xs text-zinc-200 outline-none hover:border-zinc-600 focus-visible:border-orange-400 focus-visible:ring-2 focus-visible:ring-orange-400/20"
+        >
+          {#each targets as target (target.id)}
+            <option value={target.id}>{target.label}</option>
+          {/each}
+        </select>
+        {#if hasDirtySettingsValue}
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                class="flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-900 px-2 text-xs text-zinc-400 transition-colors hover:border-zinc-600 hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-orange-400/30 focus-visible:outline-none"
+                onclick={activeTarget.onRevertAll}
+                aria-label="Revert all settings to defaults"
+              >
+                <RotateCcw class="h-3.5 w-3.5" />
+                <span class="settings-revert-label">Revert</span>
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>Revert all to defaults</Tooltip.Content>
+          </Tooltip.Root>
+        {/if}
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button
+              class={[
+                'flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md border transition-colors focus-visible:ring-2 focus-visible:ring-orange-400/30 focus-visible:outline-none',
+                pinnedTargetId
+                  ? 'border-orange-500/50 bg-orange-500/15 text-orange-300 hover:bg-orange-500/25'
+                  : 'border-zinc-800 bg-zinc-900 text-zinc-500 hover:border-zinc-700 hover:text-zinc-300'
+              ]}
+              onclick={togglePin}
+              aria-label={pinnedTargetId ? 'Unpin settings target' : 'Pin settings target'}
+              aria-pressed={Boolean(pinnedTargetId)}
+            >
+              {#if pinnedTargetId}
+                <PinOff class="h-4 w-4" />
+              {:else}
+                <Pin class="h-4 w-4" />
+              {/if}
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>{pinnedTargetId ? 'Unpin target' : 'Pin target'}</Tooltip.Content>
+        </Tooltip.Root>
+      </div>
+      <p class="mt-2 truncate font-mono text-[11px] text-zinc-500">
+        {pinnedTargetId ? 'Pinned' : 'Following canvas selection'}
+      </p>
+    </div>
+
+    <div class="min-h-0 flex-1 px-5 py-5">
+      {#key activeTarget.id}
+        <ObjectSettings
+          nodeId={activeTarget.id}
+          schema={activeTarget.schema}
+          values={activeTarget.values}
+          onValueChange={activeTarget.onValueChange}
+          onRevertAll={activeTarget.onRevertAll}
+          onClose={() => {}}
+          showCloseButton={false}
+          showRevertButton={false}
+          variant="sidebar"
+        />
+      {/key}
+    </div>
+  </div>
+{/if}
+
+<style>
+  @container (max-width: 350px) {
+    .settings-revert-label {
+      display: none;
+    }
+  }
+</style>

--- a/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
+++ b/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
@@ -11,26 +11,16 @@
   import * as Command from '$lib/components/ui/command';
   import * as Popover from '$lib/components/ui/popover';
   import * as Tooltip from '$lib/components/ui/tooltip';
-  import { selectedNodeInfo } from '../../../stores/ui.store';
-  import {
-    requestSettingsSidebarTargetId,
-    settingsSidebarTargets
-  } from '../../../stores/settings-sidebar.store';
+  import { useSettingsSidebarTargetSelection } from '$lib/settings/use-settings-sidebar-target-selection.svelte';
 
   let { class: className = '' }: { class?: string } = $props();
 
-  let activeTargetId = $state<string | null>(null);
-  let pinnedTargetId = $state<string | null>(null);
-  let lastSelectedNodeId = $state<string | null>(null);
   let targetPickerOpen = $state(false);
   let targetQuery = $state('');
-
-  let targets = $derived(
-    [...$settingsSidebarTargets.values()].sort((a, b) => a.label.localeCompare(b.label))
-  );
-  let activeTarget = $derived(
-    activeTargetId ? (targets.find((target) => target.id === activeTargetId) ?? null) : null
-  );
+  const selection = useSettingsSidebarTargetSelection();
+  let targets = $derived(selection.targets);
+  let activeTarget = $derived(selection.activeTarget);
+  let pinnedTargetId = $derived(selection.pinnedTargetId);
   let filteredTargets = $derived(
     targets.filter((target) => {
       const query = targetQuery.trim().toLowerCase();
@@ -38,51 +28,10 @@
     })
   );
 
-  $effect(() => {
-    const requestedTargetId = $requestSettingsSidebarTargetId;
-    const requestedTarget = requestedTargetId
-      ? targets.find((target) => target.id === requestedTargetId)
-      : undefined;
-
-    if (requestedTarget) {
-      activeTargetId = requestedTarget.id;
-      requestSettingsSidebarTargetId.set(null);
-      return;
-    }
-
-    const pinnedTarget = pinnedTargetId
-      ? targets.find((target) => target.id === pinnedTargetId)
-      : undefined;
-
-    if (pinnedTarget) {
-      activeTargetId = pinnedTarget.id;
-      return;
-    }
-
-    if (pinnedTargetId) pinnedTargetId = null;
-
-    const selectedTarget = $selectedNodeInfo
-      ? targets.find((target) => target.id === $selectedNodeInfo?.id)
-      : undefined;
-
-    const selectedNodeId = $selectedNodeInfo?.id ?? null;
-    if (selectedTarget && selectedNodeId !== lastSelectedNodeId) {
-      activeTargetId = selectedTarget.id;
-    } else if (!activeTargetId || !targets.some((target) => target.id === activeTargetId)) {
-      activeTargetId = targets[0]?.id ?? null;
-    }
-
-    lastSelectedNodeId = selectedNodeId;
-  });
-
   function selectTarget(targetId: string) {
-    activeTargetId = targetId;
+    selection.selectTarget(targetId);
     targetPickerOpen = false;
     targetQuery = '';
-  }
-
-  function togglePin() {
-    pinnedTargetId = pinnedTargetId ? null : activeTargetId;
   }
 
   function settingsValueEquals(left: unknown, right: unknown): boolean {
@@ -185,7 +134,7 @@
                   ? 'border-orange-500/50 bg-orange-500/15 text-orange-300 hover:bg-orange-500/25'
                   : 'border-zinc-800 bg-zinc-900 text-zinc-500 hover:border-zinc-700 hover:text-zinc-300'
               ]}
-              onclick={togglePin}
+              onclick={selection.togglePin}
               aria-label={pinnedTargetId ? 'Unpin settings target' : 'Pin settings target'}
               aria-pressed={Boolean(pinnedTargetId)}
             >

--- a/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
+++ b/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
-  import { Pin, PinOff, RotateCcw, SlidersHorizontal } from '@lucide/svelte/icons';
+  import {
+    Check,
+    ChevronsUpDown,
+    Pin,
+    PinOff,
+    RotateCcw,
+    SlidersHorizontal
+  } from '@lucide/svelte/icons';
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
+  import * as Command from '$lib/components/ui/command';
+  import * as Popover from '$lib/components/ui/popover';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { selectedNodeInfo } from '../../../stores/ui.store';
   import { settingsSidebarTargets } from '../../../stores/settings-sidebar.store';
@@ -10,12 +19,20 @@
   let activeTargetId = $state<string | null>(null);
   let pinnedTargetId = $state<string | null>(null);
   let lastSelectedNodeId = $state<string | null>(null);
+  let targetPickerOpen = $state(false);
+  let targetQuery = $state('');
 
   let targets = $derived(
     [...$settingsSidebarTargets.values()].sort((a, b) => a.label.localeCompare(b.label))
   );
   let activeTarget = $derived(
     activeTargetId ? (targets.find((target) => target.id === activeTargetId) ?? null) : null
+  );
+  let filteredTargets = $derived(
+    targets.filter((target) => {
+      const query = targetQuery.trim().toLowerCase();
+      return !query || `${target.label} ${target.id}`.toLowerCase().includes(query);
+    })
   );
 
   $effect(() => {
@@ -44,8 +61,10 @@
     lastSelectedNodeId = selectedNodeId;
   });
 
-  function handleTargetChange(event: Event) {
-    activeTargetId = (event.currentTarget as HTMLSelectElement).value || null;
+  function selectTarget(targetId: string) {
+    activeTargetId = targetId;
+    targetPickerOpen = false;
+    targetQuery = '';
   }
 
   function togglePin() {
@@ -94,17 +113,40 @@
   <div class={['flex min-h-full flex-col', className]}>
     <div class="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950 px-5 py-4">
       <div class="flex items-center gap-2">
-        <label class="sr-only" for="sidebar-settings-target">Object settings target</label>
-        <select
-          id="sidebar-settings-target"
-          value={activeTarget.id}
-          onchange={handleTargetChange}
-          class="h-8 min-w-0 flex-1 cursor-pointer rounded-md border border-zinc-700 bg-zinc-900 px-2 font-mono text-xs text-zinc-200 outline-none hover:border-zinc-600 focus-visible:border-orange-400 focus-visible:ring-2 focus-visible:ring-orange-400/20"
-        >
-          {#each targets as target (target.id)}
-            <option value={target.id}>{target.label}</option>
-          {/each}
-        </select>
+        <Popover.Root bind:open={targetPickerOpen}>
+          <Popover.Trigger
+            class="flex h-8 min-w-0 flex-1 cursor-pointer items-center justify-between gap-2 rounded-md border border-zinc-700 bg-zinc-900 px-2 text-left font-mono text-xs text-zinc-200 outline-none hover:border-zinc-600 focus-visible:border-orange-400 focus-visible:ring-2 focus-visible:ring-orange-400/20"
+            aria-label="Select object settings target"
+          >
+            <span class="min-w-0 truncate">{activeTarget.label}</span>
+            <ChevronsUpDown class="h-3.5 w-3.5 shrink-0 text-zinc-500" />
+          </Popover.Trigger>
+          <Popover.Content class="w-[min(22rem,calc(100vw-2rem))] p-0" align="start" sideOffset={6}>
+            <Command.Root shouldFilter={false}>
+              <Command.Input placeholder="Search objects..." bind:value={targetQuery} />
+              <Command.List class="max-h-64">
+                <Command.Empty>No settings-capable object found.</Command.Empty>
+                <Command.Group>
+                  {#each filteredTargets as target (target.id)}
+                    <Command.Item
+                      value={`${target.label} ${target.id}`}
+                      onSelect={() => selectTarget(target.id)}
+                      class="cursor-pointer"
+                    >
+                      <Check
+                        class={[
+                          'h-3.5 w-3.5',
+                          target.id === activeTarget.id ? 'opacity-100' : 'opacity-0'
+                        ]}
+                      />
+                      <span class="min-w-0 truncate font-mono text-xs">{target.label}</span>
+                    </Command.Item>
+                  {/each}
+                </Command.Group>
+              </Command.List>
+            </Command.Root>
+          </Popover.Content>
+        </Popover.Root>
         {#if hasDirtySettingsValue}
           <Tooltip.Root>
             <Tooltip.Trigger>

--- a/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
+++ b/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
@@ -5,8 +5,11 @@
   import { selectedNodeInfo } from '../../../stores/ui.store';
   import { settingsSidebarTargets } from '../../../stores/settings-sidebar.store';
 
+  let { class: className = '' }: { class?: string } = $props();
+
   let activeTargetId = $state<string | null>(null);
   let pinnedTargetId = $state<string | null>(null);
+  let lastSelectedNodeId = $state<string | null>(null);
 
   let targets = $derived(
     [...$settingsSidebarTargets.values()].sort((a, b) => a.label.localeCompare(b.label))
@@ -31,11 +34,14 @@
       ? targets.find((target) => target.id === $selectedNodeInfo?.id)
       : undefined;
 
-    if (selectedTarget) {
+    const selectedNodeId = $selectedNodeInfo?.id ?? null;
+    if (selectedTarget && selectedNodeId !== lastSelectedNodeId) {
       activeTargetId = selectedTarget.id;
     } else if (!activeTargetId || !targets.some((target) => target.id === activeTargetId)) {
       activeTargetId = targets[0]?.id ?? null;
     }
+
+    lastSelectedNodeId = selectedNodeId;
   });
 
   function handleTargetChange(event: Event) {
@@ -63,7 +69,8 @@
     return activeTarget.schema.some((field) => {
       if (!('default' in field) || field.default === undefined) return false;
 
-      const value = activeTarget.values[field.key] ?? field.default;
+      const storedValue = activeTarget.values[field.key];
+      const value = storedValue !== undefined ? storedValue : field.default;
       return !settingsValueEquals(value, field.default);
     });
   }
@@ -72,7 +79,7 @@
 </script>
 
 {#if targets.length === 0}
-  <div class="flex h-full flex-col items-center justify-center px-6 text-center">
+  <div class={['flex h-full flex-col items-center justify-center px-6 text-center', className]}>
     <div
       class="mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-zinc-800 bg-zinc-900 text-zinc-500"
     >
@@ -84,7 +91,7 @@
     </p>
   </div>
 {:else if activeTarget}
-  <div class="flex min-h-full flex-col">
+  <div class={['flex min-h-full flex-col', className]}>
     <div class="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950 px-5 py-4">
       <div class="flex items-center gap-2">
         <label class="sr-only" for="sidebar-settings-target">Object settings target</label>

--- a/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
+++ b/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
@@ -12,7 +12,10 @@
   import * as Popover from '$lib/components/ui/popover';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { selectedNodeInfo } from '../../../stores/ui.store';
-  import { settingsSidebarTargets } from '../../../stores/settings-sidebar.store';
+  import {
+    requestSettingsSidebarTargetId,
+    settingsSidebarTargets
+  } from '../../../stores/settings-sidebar.store';
 
   let { class: className = '' }: { class?: string } = $props();
 
@@ -36,6 +39,17 @@
   );
 
   $effect(() => {
+    const requestedTargetId = $requestSettingsSidebarTargetId;
+    const requestedTarget = requestedTargetId
+      ? targets.find((target) => target.id === requestedTargetId)
+      : undefined;
+
+    if (requestedTarget) {
+      activeTargetId = requestedTarget.id;
+      requestSettingsSidebarTargetId.set(null);
+      return;
+    }
+
     const pinnedTarget = pinnedTargetId
       ? targets.find((target) => target.id === pinnedTargetId)
       : undefined;

--- a/ui/src/lib/components/sidebar/SidebarPanel.svelte
+++ b/ui/src/lib/components/sidebar/SidebarPanel.svelte
@@ -11,7 +11,8 @@
     Music,
     MessageSquare,
     Activity,
-    Code
+    Code,
+    Settings
   } from '@lucide/svelte/icons';
 
   import FileTreeView from './FileTreeView.svelte';
@@ -24,6 +25,7 @@
   import ChatSessionsPanel from './ChatSessionsPanel.svelte';
   import ProfilerView from './ProfilerView.svelte';
   import SidebarCodeEditorView from './SidebarCodeEditorView.svelte';
+  import SidebarObjectSettingsView from './SidebarObjectSettingsView.svelte';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import * as ContextMenu from '$lib/components/ui/context-menu';
   import * as Popover from '$lib/components/ui/popover';
@@ -91,7 +93,8 @@
     { id: 'chat', icon: MessageSquare, title: 'Chat', aiOnly: true },
     { id: 'preview', icon: AppWindow, title: 'Patch to App', aiOnly: true },
     { id: 'profiler', icon: Activity, title: 'Profiler' },
-    { id: 'code', icon: Code, title: 'Code' }
+    { id: 'code', icon: Code, title: 'Code' },
+    { id: 'settings', icon: Settings, title: 'Settings' }
   ];
 
   const AI_VIEWS: SidebarView[] = ['chat', 'preview'];
@@ -325,6 +328,8 @@
             title={codeEditorTitle}
             onrun={onRunCodeEditor}
           />
+        {:else if view === 'settings'}
+          <SidebarObjectSettingsView />
         {/if}
       </div>
     {/if}
@@ -343,3 +348,9 @@
     ></div>
   </div>
 {/if}
+
+<style>
+  [data-sidebar] {
+    container-type: inline-size;
+  }
+</style>

--- a/ui/src/lib/settings/use-settings-sidebar-target-selection.svelte.ts
+++ b/ui/src/lib/settings/use-settings-sidebar-target-selection.svelte.ts
@@ -1,0 +1,95 @@
+import { fromStore } from 'svelte/store';
+
+import { selectedNodeInfo } from '../../stores/ui.store';
+
+import {
+  requestSettingsSidebarTargetId,
+  settingsSidebarTargets,
+  type SettingsSidebarTarget
+} from '../../stores/settings-sidebar.store';
+
+export function useSettingsSidebarTargetSelection(): {
+  readonly targets: SettingsSidebarTarget[];
+  readonly activeTarget: SettingsSidebarTarget | null;
+  readonly pinnedTargetId: string | null;
+  selectTarget: (targetId: string) => void;
+  togglePin: () => void;
+} {
+  let activeTargetId = $state<string | null>(null);
+  let pinnedTargetId = $state<string | null>(null);
+  let lastSelectedNodeId = $state<string | null>(null);
+
+  const sidebarTargets = fromStore(settingsSidebarTargets);
+  const requestedTargetId = fromStore(requestSettingsSidebarTargetId);
+  const selectedNode = fromStore(selectedNodeInfo);
+
+  const targets = $derived(
+    [...sidebarTargets.current.values()].sort((a, b) => a.label.localeCompare(b.label))
+  );
+
+  const activeTarget = $derived(
+    activeTargetId ? (targets.find((target) => target.id === activeTargetId) ?? null) : null
+  );
+
+  $effect(() => {
+    const requestedId = requestedTargetId.current;
+
+    const requestedTarget = requestedId
+      ? targets.find((target) => target.id === requestedId)
+      : undefined;
+
+    if (requestedTarget) {
+      activeTargetId = requestedTarget.id;
+      requestSettingsSidebarTargetId.set(null);
+      return;
+    }
+
+    const pinnedTarget = pinnedTargetId
+      ? targets.find((target) => target.id === pinnedTargetId)
+      : undefined;
+
+    if (pinnedTarget) {
+      activeTargetId = pinnedTarget.id;
+      return;
+    }
+
+    if (pinnedTargetId) pinnedTargetId = null;
+
+    const selectedTarget = selectedNode.current
+      ? targets.find((target) => target.id === selectedNode.current?.id)
+      : undefined;
+
+    const selectedNodeId = selectedNode.current?.id ?? null;
+
+    if (selectedTarget && selectedNodeId !== lastSelectedNodeId) {
+      activeTargetId = selectedTarget.id;
+    } else if (!activeTargetId || !targets.some((target) => target.id === activeTargetId)) {
+      activeTargetId = targets[0]?.id ?? null;
+    }
+
+    lastSelectedNodeId = selectedNodeId;
+  });
+
+  function selectTarget(targetId: string): void {
+    activeTargetId = targetId;
+  }
+
+  function togglePin(): void {
+    pinnedTargetId = pinnedTargetId ? null : activeTargetId;
+  }
+
+  return {
+    selectTarget,
+    togglePin,
+
+    get targets() {
+      return targets;
+    },
+    get activeTarget() {
+      return activeTarget;
+    },
+    get pinnedTargetId() {
+      return pinnedTargetId;
+    }
+  };
+}

--- a/ui/src/lib/settings/use-settings-sidebar-target.svelte.ts
+++ b/ui/src/lib/settings/use-settings-sidebar-target.svelte.ts
@@ -1,0 +1,48 @@
+import type { SettingsSidebarTarget } from '../../stores/settings-sidebar.store';
+import {
+  openObjectSettingsInSidebarIfPreferred,
+  registerSettingsSidebarTarget
+} from '../../stores/settings-sidebar.store';
+
+export interface FloatingSettingsController {
+  isOpen: () => boolean;
+  setOpen: (open: boolean) => void;
+  onOpenFloating?: () => void;
+}
+
+export interface SettingsSidebarTargetOptions {
+  getTarget: () => SettingsSidebarTarget | null;
+  floating: FloatingSettingsController;
+}
+
+/**
+ * Registers a schema-backed node with the Settings sidebar and routes Settings
+ * actions to the preferred floating or sidebar surface.
+ */
+export function useSettingsSidebarTarget({ getTarget, floating }: SettingsSidebarTargetOptions): {
+  toggle: (event?: MouseEvent) => void;
+} {
+  $effect(() => {
+    const target = getTarget();
+    if (!target || target.schema.length === 0) return;
+
+    return registerSettingsSidebarTarget(target);
+  });
+
+  function toggle(event?: MouseEvent): void {
+    const target = getTarget();
+    if (!target) return;
+
+    if (openObjectSettingsInSidebarIfPreferred(target.id, event?.shiftKey)) {
+      floating.setOpen(false);
+      return;
+    }
+
+    const nextOpen = !floating.isOpen();
+    floating.setOpen(nextOpen);
+
+    if (nextOpen) floating.onOpenFloating?.();
+  }
+
+  return { toggle };
+}

--- a/ui/src/objects/audio-code/SimpleDspLayout.svelte
+++ b/ui/src/objects/audio-code/SimpleDspLayout.svelte
@@ -16,10 +16,7 @@
     syncActiveCodeEditorTargetSettings
   } from '../../stores/code-editor-layout.store';
   import { defaultEditorLayout } from '../../stores/editor-layout-settings.store';
-  import {
-    openObjectSettingsInSidebarIfPreferred,
-    registerSettingsSidebarTarget
-  } from '../../stores/settings-sidebar.store';
+  import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
   import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
   import { editorFontFamily } from '../../stores/editor.store';
 
@@ -116,19 +113,6 @@
     });
   });
 
-  $effect(() => {
-    if (!settingsSchema || settingsSchema.length === 0) return;
-
-    return registerSettingsSidebarTarget({
-      id: nodeId,
-      label: displayTitle,
-      schema: settingsSchema,
-      values: settingsValues,
-      onValueChange: (key, value) => onSettingsValueChange?.(key, value),
-      onRevertAll: () => onSettingsRevertAll?.()
-    });
-  });
-
   const containerClass = $derived.by(() => {
     const hasError = lineErrors !== undefined;
     if (hasError) return 'object-container-error';
@@ -209,15 +193,24 @@
     });
   }
 
-  function toggleSettings(event?: MouseEvent) {
-    if (openObjectSettingsInSidebarIfPreferred(nodeId, event?.shiftKey)) {
-      showSettings = false;
-      return;
+  const settingsSidebarTarget = useSettingsSidebarTarget({
+    getTarget: () =>
+      settingsSchema && settingsSchema.length > 0
+        ? {
+            id: nodeId,
+            label: displayTitle,
+            schema: settingsSchema,
+            values: settingsValues,
+            onValueChange: (key, value) => onSettingsValueChange?.(key, value),
+            onRevertAll: () => onSettingsRevertAll?.()
+          }
+        : null,
+    floating: {
+      isOpen: () => showSettings,
+      setOpen: (open) => (showSettings = open),
+      onOpenFloating: () => (showEditor = false)
     }
-
-    showSettings = !showSettings;
-    if (showSettings) showEditor = false;
-  }
+  });
 
   let minContainerWidth = $derived.by(() => {
     const baseWidth = 20;
@@ -244,7 +237,7 @@
                     e.preventDefault();
                     e.stopPropagation();
 
-                    toggleSettings(e);
+                    settingsSidebarTarget.toggle(e);
                   }}
                   aria-label="Settings"
                 >

--- a/ui/src/objects/audio-code/SimpleDspLayout.svelte
+++ b/ui/src/objects/audio-code/SimpleDspLayout.svelte
@@ -209,8 +209,8 @@
     });
   }
 
-  function toggleSettings() {
-    if (openObjectSettingsInSidebarIfPreferred()) {
+  function toggleSettings(event?: MouseEvent) {
+    if (openObjectSettingsInSidebarIfPreferred(nodeId, event?.shiftKey)) {
       showSettings = false;
       return;
     }
@@ -244,7 +244,7 @@
                     e.preventDefault();
                     e.stopPropagation();
 
-                    toggleSettings();
+                    toggleSettings(e);
                   }}
                   aria-label="Settings"
                 >

--- a/ui/src/objects/audio-code/SimpleDspLayout.svelte
+++ b/ui/src/objects/audio-code/SimpleDspLayout.svelte
@@ -16,6 +16,10 @@
     syncActiveCodeEditorTargetSettings
   } from '../../stores/code-editor-layout.store';
   import { defaultEditorLayout } from '../../stores/editor-layout-settings.store';
+  import {
+    openObjectSettingsInSidebarIfPreferred,
+    registerSettingsSidebarTarget
+  } from '../../stores/settings-sidebar.store';
   import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
   import { editorFontFamily } from '../../stores/editor.store';
 
@@ -112,6 +116,19 @@
     });
   });
 
+  $effect(() => {
+    if (!settingsSchema || settingsSchema.length === 0) return;
+
+    return registerSettingsSidebarTarget({
+      id: nodeId,
+      label: displayTitle,
+      schema: settingsSchema,
+      values: settingsValues,
+      onValueChange: (key, value) => onSettingsValueChange?.(key, value),
+      onRevertAll: () => onSettingsRevertAll?.()
+    });
+  });
+
   const containerClass = $derived.by(() => {
     const hasError = lineErrors !== undefined;
     if (hasError) return 'object-container-error';
@@ -193,6 +210,11 @@
   }
 
   function toggleSettings() {
+    if (openObjectSettingsInSidebarIfPreferred()) {
+      showSettings = false;
+      return;
+    }
+
     showSettings = !showSettings;
     if (showSettings) showEditor = false;
   }

--- a/ui/src/objects/code/CodeBlockBase.svelte
+++ b/ui/src/objects/code/CodeBlockBase.svelte
@@ -24,10 +24,7 @@
   } from '$lib/eventbus/events';
   import type { SupportedLanguage } from '$lib/codemirror/types';
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
-  import {
-    openObjectSettingsInSidebarIfPreferred,
-    registerSettingsSidebarTarget
-  } from '../../stores/settings-sidebar.store';
+  import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
   import type { SettingsSchema } from '$lib/settings';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import {
@@ -408,30 +405,23 @@
     setTimeout(() => updateContentWidth(), 10);
   }
 
-  function handleSettingsToggle(event?: MouseEvent) {
-    if (openObjectSettingsInSidebarIfPreferred(nodeId, event?.shiftKey)) {
-      showSettings = false;
-      return;
+  const settingsSidebarTarget = useSettingsSidebarTarget({
+    getTarget: () =>
+      settingsSchema && settingsSchema.length > 0
+        ? {
+            id: nodeId,
+            label: settingsSidebarLabel,
+            schema: settingsSchema,
+            values: settingsValues,
+            onValueChange: (key, value) => onSettingsValueChange?.(key, value),
+            onRevertAll: () => onSettingsRevertAll?.()
+          }
+        : null,
+    floating: {
+      isOpen: () => showSettings,
+      setOpen: (open) => (showSettings = open),
+      onOpenFloating: () => (showEditor = false)
     }
-
-    showSettings = !showSettings;
-
-    if (showSettings) {
-      showEditor = false;
-    }
-  }
-
-  $effect(() => {
-    if (!settingsSchema || settingsSchema.length === 0) return;
-
-    return registerSettingsSidebarTarget({
-      id: nodeId,
-      label: settingsSidebarLabel,
-      schema: settingsSchema,
-      values: settingsValues,
-      onValueChange: (key, value) => onSettingsValueChange?.(key, value),
-      onRevertAll: () => onSettingsRevertAll?.()
-    });
   });
 
   let minContainerWidth = $derived.by(() => {
@@ -494,7 +484,7 @@
                 {showSettings}
                 {settingsSchema}
                 onConsoleToggle={handleConsoleToggle}
-                onSettingsToggle={handleSettingsToggle}
+                onSettingsToggle={settingsSidebarTarget.toggle}
                 onCodeToggle={resolvedPrimary === 'code' ? undefined : toggleCode}
               />
             {:else}
@@ -518,7 +508,7 @@
               <Tooltip.Trigger>
                 <button
                   class="cursor-pointer rounded p-1 hover:bg-zinc-700"
-                  onclick={handleSettingsToggle}
+                  onclick={settingsSidebarTarget.toggle}
                   aria-label="Settings"
                 >
                   <SettingsIcon class="h-4 w-4 text-zinc-300" />

--- a/ui/src/objects/code/CodeBlockBase.svelte
+++ b/ui/src/objects/code/CodeBlockBase.svelte
@@ -408,8 +408,8 @@
     setTimeout(() => updateContentWidth(), 10);
   }
 
-  function handleSettingsToggle() {
-    if (openObjectSettingsInSidebarIfPreferred()) {
+  function handleSettingsToggle(event?: MouseEvent) {
+    if (openObjectSettingsInSidebarIfPreferred(nodeId, event?.shiftKey)) {
       showSettings = false;
       return;
     }

--- a/ui/src/objects/code/CodeBlockBase.svelte
+++ b/ui/src/objects/code/CodeBlockBase.svelte
@@ -24,6 +24,10 @@
   } from '$lib/eventbus/events';
   import type { SupportedLanguage } from '$lib/codemirror/types';
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
+  import {
+    openObjectSettingsInSidebarIfPreferred,
+    registerSettingsSidebarTarget
+  } from '../../stores/settings-sidebar.store';
   import type { SettingsSchema } from '$lib/settings';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import {
@@ -401,12 +405,27 @@
   }
 
   function handleSettingsToggle() {
+    if (openObjectSettingsInSidebarIfPreferred(showSettings)) return;
+
     showSettings = !showSettings;
 
     if (showSettings) {
       showEditor = false;
     }
   }
+
+  $effect(() => {
+    if (!settingsSchema || settingsSchema.length === 0) return;
+
+    return registerSettingsSidebarTarget({
+      id: nodeId,
+      label: nodeLabel,
+      schema: settingsSchema,
+      values: settingsValues,
+      onValueChange: (key, value) => onSettingsValueChange?.(key, value),
+      onRevertAll: () => onSettingsRevertAll?.()
+    });
+  });
 
   let minContainerWidth = $derived.by(() => {
     const baseWidth = 70;

--- a/ui/src/objects/code/CodeBlockBase.svelte
+++ b/ui/src/objects/code/CodeBlockBase.svelte
@@ -405,7 +405,10 @@
   }
 
   function handleSettingsToggle() {
-    if (openObjectSettingsInSidebarIfPreferred(showSettings)) return;
+    if (openObjectSettingsInSidebarIfPreferred()) {
+      showSettings = false;
+      return;
+    }
 
     showSettings = !showSettings;
 

--- a/ui/src/objects/code/CodeBlockBase.svelte
+++ b/ui/src/objects/code/CodeBlockBase.svelte
@@ -127,6 +127,10 @@
   let inletCount = $derived(data.inletCount ?? 1);
   let outletCount = $derived(data.outletCount ?? 1);
 
+  let settingsSidebarLabel = $derived(
+    (supportsLibraries && data.libraryName) || data.title || nodeLabel
+  );
+
   let showEditor = $state(false);
   let showSettings = $state(false);
   let contentWidth = $state(100);
@@ -422,7 +426,7 @@
 
     return registerSettingsSidebarTarget({
       id: nodeId,
-      label: nodeLabel,
+      label: settingsSidebarLabel,
       schema: settingsSchema,
       values: settingsValues,
       onValueChange: (key, value) => onSettingsValueChange?.(key, value),

--- a/ui/src/objects/code/CodeBlockOverflowMenu.svelte
+++ b/ui/src/objects/code/CodeBlockOverflowMenu.svelte
@@ -15,7 +15,7 @@
     showConsole: boolean;
     showSettings: boolean;
     onConsoleToggle: () => void;
-    onSettingsToggle: () => void;
+    onSettingsToggle: (event?: MouseEvent) => void;
     /** Provided when code editor is NOT the primary button — adds an "Edit code" entry. */
     onCodeToggle?: (event: MouseEvent) => void;
     settingsSchema: SettingsSchema;

--- a/ui/src/objects/mediapipe/components/MediaPipeNodeLayout.svelte
+++ b/ui/src/objects/mediapipe/components/MediaPipeNodeLayout.svelte
@@ -5,6 +5,10 @@
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings/types';
   import { useNodeSetPaused } from '$lib/canvas/use-node-set-paused.svelte';
+  import {
+    openObjectSettingsInSidebarIfPreferred,
+    registerSettingsSidebarTarget
+  } from '../../../stores/settings-sidebar.store';
 
   let {
     nodeId,
@@ -64,6 +68,28 @@
       .with('error', () => 'bg-red-500')
       .exhaustive()
   );
+
+  function toggleSettings() {
+    if (openObjectSettingsInSidebarIfPreferred()) {
+      showSettings = false;
+      return;
+    }
+
+    showSettings = !showSettings;
+  }
+
+  $effect(() => {
+    if (schema.length === 0) return;
+
+    return registerSettingsSidebarTarget({
+      id: nodeId,
+      label: title,
+      schema,
+      values: settingsData as Record<string, unknown>,
+      onValueChange: onSettingChange,
+      onRevertAll: onRevertSettings
+    });
+  });
 </script>
 
 <div class="relative flex gap-x-3">
@@ -92,7 +118,7 @@
         onclick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          showSettings = !showSettings;
+          toggleSettings();
         }}
       >
         <Settings class="h-4 w-4 text-zinc-300" />

--- a/ui/src/objects/mediapipe/components/MediaPipeNodeLayout.svelte
+++ b/ui/src/objects/mediapipe/components/MediaPipeNodeLayout.svelte
@@ -5,10 +5,7 @@
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings/types';
   import { useNodeSetPaused } from '$lib/canvas/use-node-set-paused.svelte';
-  import {
-    openObjectSettingsInSidebarIfPreferred,
-    registerSettingsSidebarTarget
-  } from '../../../stores/settings-sidebar.store';
+  import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
 
   let {
     nodeId,
@@ -69,26 +66,22 @@
       .exhaustive()
   );
 
-  function toggleSettings(event?: MouseEvent) {
-    if (openObjectSettingsInSidebarIfPreferred(nodeId, event?.shiftKey)) {
-      showSettings = false;
-      return;
+  const settingsSidebarTarget = useSettingsSidebarTarget({
+    getTarget: () =>
+      schema.length > 0
+        ? {
+            id: nodeId,
+            label: title,
+            schema,
+            values: settingsData as Record<string, unknown>,
+            onValueChange: onSettingChange,
+            onRevertAll: onRevertSettings
+          }
+        : null,
+    floating: {
+      isOpen: () => showSettings,
+      setOpen: (open) => (showSettings = open)
     }
-
-    showSettings = !showSettings;
-  }
-
-  $effect(() => {
-    if (schema.length === 0) return;
-
-    return registerSettingsSidebarTarget({
-      id: nodeId,
-      label: title,
-      schema,
-      values: settingsData as Record<string, unknown>,
-      onValueChange: onSettingChange,
-      onRevertAll: onRevertSettings
-    });
   });
 </script>
 
@@ -118,7 +111,7 @@
         onclick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          toggleSettings(e);
+          settingsSidebarTarget.toggle(e);
         }}
       >
         <Settings class="h-4 w-4 text-zinc-300" />

--- a/ui/src/objects/mediapipe/components/MediaPipeNodeLayout.svelte
+++ b/ui/src/objects/mediapipe/components/MediaPipeNodeLayout.svelte
@@ -69,8 +69,8 @@
       .exhaustive()
   );
 
-  function toggleSettings() {
-    if (openObjectSettingsInSidebarIfPreferred()) {
+  function toggleSettings(event?: MouseEvent) {
+    if (openObjectSettingsInSidebarIfPreferred(nodeId, event?.shiftKey)) {
       showSettings = false;
       return;
     }
@@ -118,7 +118,7 @@
         onclick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          toggleSettings();
+          toggleSettings(e);
         }}
       >
         <Settings class="h-4 w-4 text-zinc-300" />

--- a/ui/src/objects/smplr/GmNode.svelte
+++ b/ui/src/objects/smplr/GmNode.svelte
@@ -76,8 +76,8 @@
     await applySettings(GM_DEFAULT_SETTINGS);
   }
 
-  function toggleSettings() {
-    if (openObjectSettingsInSidebarIfPreferred()) {
+  function toggleSettings(event?: MouseEvent) {
+    if (openObjectSettingsInSidebarIfPreferred(node.id, event?.shiftKey)) {
       showSettings = false;
       return;
     }

--- a/ui/src/objects/smplr/GmNode.svelte
+++ b/ui/src/objects/smplr/GmNode.svelte
@@ -9,10 +9,7 @@
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { GM_DEFAULT_SETTINGS, GM_SETTINGS_SCHEMA } from './gm-settings';
   import { GmAudioNode, type GmMonitorSnapshot, type GmRuntimeStatus } from './GmAudioNode';
-  import {
-    openObjectSettingsInSidebarIfPreferred,
-    registerSettingsSidebarTarget
-  } from '../../stores/settings-sidebar.store';
+  import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
 
   type GmNodeData = {
     settings?: Record<string, unknown>;
@@ -76,24 +73,19 @@
     await applySettings(GM_DEFAULT_SETTINGS);
   }
 
-  function toggleSettings(event?: MouseEvent) {
-    if (openObjectSettingsInSidebarIfPreferred(node.id, event?.shiftKey)) {
-      showSettings = false;
-      return;
-    }
-
-    showSettings = !showSettings;
-  }
-
-  $effect(() => {
-    return registerSettingsSidebarTarget({
+  const settingsSidebarTarget = useSettingsSidebarTarget({
+    getTarget: () => ({
       id: node.id,
       label: 'gm~',
       schema: GM_SETTINGS_SCHEMA,
       values: settings,
       onValueChange: updateSetting,
       onRevertAll: revertSettings
-    });
+    }),
+    floating: {
+      isOpen: () => showSettings,
+      setOpen: (open) => (showSettings = open)
+    }
   });
 
   function createInitialMonitorChannels(): GmMonitorSnapshot['channels'] {
@@ -165,7 +157,7 @@
           type="button"
           class="node-floating-button !opacity-100"
           aria-label="Settings"
-          onclick={toggleSettings}
+          onclick={settingsSidebarTarget.toggle}
         >
           <Settings class="h-4 w-4 text-zinc-300" />
         </button>

--- a/ui/src/objects/smplr/GmNode.svelte
+++ b/ui/src/objects/smplr/GmNode.svelte
@@ -9,6 +9,10 @@
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { GM_DEFAULT_SETTINGS, GM_SETTINGS_SCHEMA } from './gm-settings';
   import { GmAudioNode, type GmMonitorSnapshot, type GmRuntimeStatus } from './GmAudioNode';
+  import {
+    openObjectSettingsInSidebarIfPreferred,
+    registerSettingsSidebarTarget
+  } from '../../stores/settings-sidebar.store';
 
   type GmNodeData = {
     settings?: Record<string, unknown>;
@@ -71,6 +75,26 @@
   async function revertSettings() {
     await applySettings(GM_DEFAULT_SETTINGS);
   }
+
+  function toggleSettings() {
+    if (openObjectSettingsInSidebarIfPreferred()) {
+      showSettings = false;
+      return;
+    }
+
+    showSettings = !showSettings;
+  }
+
+  $effect(() => {
+    return registerSettingsSidebarTarget({
+      id: node.id,
+      label: 'gm~',
+      schema: GM_SETTINGS_SCHEMA,
+      values: settings,
+      onValueChange: updateSetting,
+      onRevertAll: revertSettings
+    });
+  });
 
   function createInitialMonitorChannels(): GmMonitorSnapshot['channels'] {
     return Array.from({ length: 16 }, (_, index) => ({
@@ -141,7 +165,7 @@
           type="button"
           class="node-floating-button !opacity-100"
           aria-label="Settings"
-          onclick={() => (showSettings = !showSettings)}
+          onclick={toggleSettings}
         >
           <Settings class="h-4 w-4 text-zinc-300" />
         </button>

--- a/ui/src/objects/smplr/SmplrNodeLayout.svelte
+++ b/ui/src/objects/smplr/SmplrNodeLayout.svelte
@@ -99,8 +99,8 @@
     audioService.send(node.id, 'settings', descriptor.defaultSettings);
   }
 
-  function toggleSettings() {
-    if (openObjectSettingsInSidebarIfPreferred()) {
+  function toggleSettings(event?: MouseEvent) {
+    if (openObjectSettingsInSidebarIfPreferred(node.id, event?.shiftKey)) {
       showSettings = false;
       return;
     }

--- a/ui/src/objects/smplr/SmplrNodeLayout.svelte
+++ b/ui/src/objects/smplr/SmplrNodeLayout.svelte
@@ -8,10 +8,7 @@
   import { AudioService } from '$lib/audio/v2/AudioService';
   import { getPatchRuntimeViewRevisionTracker } from '$lib/runtime';
   import type { SettingsSchema } from '$lib/settings';
-  import {
-    openObjectSettingsInSidebarIfPreferred,
-    registerSettingsSidebarTarget
-  } from '../../stores/settings-sidebar.store';
+  import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
 
   import type { SmplrRuntimeStatus } from './SmplrInstrumentAudioNode';
   import type { GmRuntimeStatus } from './GmAudioNode';
@@ -99,26 +96,22 @@
     audioService.send(node.id, 'settings', descriptor.defaultSettings);
   }
 
-  function toggleSettings(event?: MouseEvent) {
-    if (openObjectSettingsInSidebarIfPreferred(node.id, event?.shiftKey)) {
-      showSettings = false;
-      return;
+  const settingsSidebarTarget = useSettingsSidebarTarget({
+    getTarget: () =>
+      settingsSchema.length > 0
+        ? {
+            id: node.id,
+            label: descriptor.title,
+            schema: settingsSchema,
+            values: settings,
+            onValueChange: updateSetting,
+            onRevertAll: revertSettings
+          }
+        : null,
+    floating: {
+      isOpen: () => showSettings,
+      setOpen: (open) => (showSettings = open)
     }
-
-    showSettings = !showSettings;
-  }
-
-  $effect(() => {
-    if (settingsSchema.length === 0) return;
-
-    return registerSettingsSidebarTarget({
-      id: node.id,
-      label: descriptor.title,
-      schema: settingsSchema,
-      values: settings,
-      onValueChange: updateSetting,
-      onRevertAll: revertSettings
-    });
   });
 
   function createSettingsSchema(
@@ -276,7 +269,7 @@
             type="button"
             class="cursor-pointer rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
             aria-label="Settings"
-            onclick={toggleSettings}
+            onclick={settingsSidebarTarget.toggle}
           >
             <Settings class="h-4 w-4" />
           </button>

--- a/ui/src/objects/smplr/SmplrNodeLayout.svelte
+++ b/ui/src/objects/smplr/SmplrNodeLayout.svelte
@@ -8,6 +8,10 @@
   import { AudioService } from '$lib/audio/v2/AudioService';
   import { getPatchRuntimeViewRevisionTracker } from '$lib/runtime';
   import type { SettingsSchema } from '$lib/settings';
+  import {
+    openObjectSettingsInSidebarIfPreferred,
+    registerSettingsSidebarTarget
+  } from '../../stores/settings-sidebar.store';
 
   import type { SmplrRuntimeStatus } from './SmplrInstrumentAudioNode';
   import type { GmRuntimeStatus } from './GmAudioNode';
@@ -94,6 +98,28 @@
 
     audioService.send(node.id, 'settings', descriptor.defaultSettings);
   }
+
+  function toggleSettings() {
+    if (openObjectSettingsInSidebarIfPreferred()) {
+      showSettings = false;
+      return;
+    }
+
+    showSettings = !showSettings;
+  }
+
+  $effect(() => {
+    if (settingsSchema.length === 0) return;
+
+    return registerSettingsSidebarTarget({
+      id: node.id,
+      label: descriptor.title,
+      schema: settingsSchema,
+      values: settings,
+      onValueChange: updateSetting,
+      onRevertAll: revertSettings
+    });
+  });
 
   function createSettingsSchema(
     descriptor: SmplrLayoutDescriptor,
@@ -250,7 +276,7 @@
             type="button"
             class="cursor-pointer rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
             aria-label="Settings"
-            onclick={() => (showSettings = !showSettings)}
+            onclick={toggleSettings}
           >
             <Settings class="h-4 w-4" />
           </button>

--- a/ui/src/stores/editor-layout-settings.store.ts
+++ b/ui/src/stores/editor-layout-settings.store.ts
@@ -6,12 +6,14 @@ export type EditorOpenLayout = 'inline' | 'overlay' | 'sidebar';
 
 const DEFAULT_EDITOR_LAYOUT_KEY = 'editor.defaultLayout';
 const OVERLAY_TRANSPARENCY_KEY = 'editor.overlayTransparency';
+const OPEN_OBJECT_SETTINGS_IN_SIDEBAR_KEY = 'editor.openObjectSettingsInSidebar';
 
 const DEFAULT_EDITOR_LAYOUT: EditorLayoutPreference = 'inline';
 const DEFAULT_OVERLAY_TRANSPARENCY = 0.72;
 
 export const defaultEditorLayout = writable<EditorLayoutPreference>(readDefaultEditorLayout());
 export const overlayEditorTransparency = writable<number>(readOverlayTransparency());
+export const openObjectSettingsInSidebar = writable<boolean>(readOpenObjectSettingsInSidebar());
 
 function readDefaultEditorLayout(): EditorLayoutPreference {
   if (typeof localStorage === 'undefined') return DEFAULT_EDITOR_LAYOUT;
@@ -38,6 +40,12 @@ function readOverlayTransparency(): number {
   return clampTransparency(Number(stored));
 }
 
+function readOpenObjectSettingsInSidebar(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+
+  return localStorage.getItem(OPEN_OBJECT_SETTINGS_IN_SIDEBAR_KEY) === 'true';
+}
+
 export function setDefaultEditorLayout(value: EditorLayoutPreference): void {
   defaultEditorLayout.set(value);
 
@@ -53,6 +61,14 @@ export function setOverlayEditorTransparency(value: number): void {
 
   if (typeof localStorage !== 'undefined') {
     localStorage.setItem(OVERLAY_TRANSPARENCY_KEY, String(next));
+  }
+}
+
+export function setOpenObjectSettingsInSidebar(value: boolean): void {
+  openObjectSettingsInSidebar.set(value);
+
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(OPEN_OBJECT_SETTINGS_IN_SIDEBAR_KEY, String(value));
   }
 }
 

--- a/ui/src/stores/settings-sidebar.store.ts
+++ b/ui/src/stores/settings-sidebar.store.ts
@@ -19,6 +19,9 @@ export interface SettingsSidebarTarget {
  */
 export const settingsSidebarTargets = writable<Map<string, SettingsSidebarTarget>>(new Map());
 
+/** Set when a node action explicitly opens its settings in the sidebar. */
+export const requestSettingsSidebarTargetId = writable<string | null>(null);
+
 export function registerSettingsSidebarTarget(target: SettingsSidebarTarget): () => void {
   settingsSidebarTargets.update((targets) => {
     const next = new Map(targets);
@@ -40,13 +43,15 @@ export function registerSettingsSidebarTarget(target: SettingsSidebarTarget): ()
 
 /**
  * Opens the Settings sidebar when the user has opted into that behavior.
+ * Holding Shift inverts the preferred destination for a one-off settings action.
  *
  * Returns whether the caller's settings action was handled by the sidebar.
  */
-export function openObjectSettingsInSidebarIfPreferred(): boolean {
-  if (!get(openObjectSettingsInSidebar)) return false;
+export function openObjectSettingsInSidebarIfPreferred(nodeId: string, shiftKey = false): boolean {
+  if (get(openObjectSettingsInSidebar) === shiftKey) return false;
 
   showSidebarTab('settings');
+  requestSettingsSidebarTargetId.set(nodeId);
   sidebarView.set('settings');
   isSidebarOpen.set(true);
 

--- a/ui/src/stores/settings-sidebar.store.ts
+++ b/ui/src/stores/settings-sidebar.store.ts
@@ -1,0 +1,54 @@
+import { get, writable } from 'svelte/store';
+import type { SettingsSchema } from '$lib/settings';
+import { isSidebarOpen, sidebarView } from './ui.store';
+import { showSidebarTab } from './sidebar-visibility.store';
+import { openObjectSettingsInSidebar } from './editor-layout-settings.store';
+
+export interface SettingsSidebarTarget {
+  id: string;
+  label: string;
+  schema: SettingsSchema;
+  values: Record<string, unknown>;
+  onValueChange: (key: string, value: unknown) => void;
+  onRevertAll: () => void;
+}
+
+/**
+ * Settings-schema views register their live callbacks here so the sidebar can
+ * edit a node without coupling to a particular object implementation.
+ */
+export const settingsSidebarTargets = writable<Map<string, SettingsSidebarTarget>>(new Map());
+
+export function registerSettingsSidebarTarget(target: SettingsSidebarTarget): () => void {
+  settingsSidebarTargets.update((targets) => {
+    const next = new Map(targets);
+    next.set(target.id, target);
+    return next;
+  });
+
+  return () => {
+    settingsSidebarTargets.update((targets) => {
+      const current = targets.get(target.id);
+      if (current !== target) return targets;
+
+      const next = new Map(targets);
+      next.delete(target.id);
+      return next;
+    });
+  };
+}
+
+/**
+ * Opens the Settings sidebar when the user has opted into that behavior.
+ *
+ * Returns whether the caller's settings action was handled by the sidebar.
+ */
+export function openObjectSettingsInSidebarIfPreferred(settingsAreOpen: boolean): boolean {
+  if (settingsAreOpen || !get(openObjectSettingsInSidebar)) return false;
+
+  showSidebarTab('settings');
+  sidebarView.set('settings');
+  isSidebarOpen.set(true);
+
+  return true;
+}

--- a/ui/src/stores/settings-sidebar.store.ts
+++ b/ui/src/stores/settings-sidebar.store.ts
@@ -43,8 +43,8 @@ export function registerSettingsSidebarTarget(target: SettingsSidebarTarget): ()
  *
  * Returns whether the caller's settings action was handled by the sidebar.
  */
-export function openObjectSettingsInSidebarIfPreferred(settingsAreOpen: boolean): boolean {
-  if (settingsAreOpen || !get(openObjectSettingsInSidebar)) return false;
+export function openObjectSettingsInSidebarIfPreferred(): boolean {
+  if (!get(openObjectSettingsInSidebar)) return false;
 
   showSidebarTab('settings');
   sidebarView.set('settings');

--- a/ui/src/stores/ui.store.ts
+++ b/ui/src/stores/ui.store.ts
@@ -90,7 +90,8 @@ export type SidebarView =
   | 'samples'
   | 'chat'
   | 'profiler'
-  | 'code';
+  | 'code'
+  | 'settings';
 
 const storedSidebarView =
   typeof localStorage !== 'undefined' ? localStorage.getItem('patchies-sidebar-view') : null;


### PR DESCRIPTION
## Summary

- add a hidden-by-default Settings sidebar tab for schema-driven object settings
- let the sidebar follow canvas selection, retain the last target, and pin one target
- add a preference to route object Settings actions to the sidebar, including the GLSL primary Settings action
- improve inspector padding and move Revert into the target controls with sidebar-width-aware compact behavior

## Why

Large parameter panels should be usable without panning the canvas or locating the node first.

## Validation

- `bun run check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings tab for editing node settings directly in the sidebar.
  * Settings can be selected, pinned, reverted, and automatically follow canvas selection.
  * Added empty states and fallback behavior when settings are unavailable.
  * Added an Editor preference to open schema-based settings in the sidebar or floating panel.
  * Settings remain available in the existing floating-panel layout by default.
  * Added scroll indicators for longer settings panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->