### PR TITLE
feat(sidebar): follow selected code nodes

### DIFF
--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -142,6 +142,12 @@ Sidebar mode is useful for focused editing without covering the background
 output. Unlike overlay mode, opening the sidebar editor should not create a
 temporary background output override.
 
+The Code sidebar follows the single selected code-capable node. Its header can
+pin the current target, which prevents subsequent canvas selections from
+changing the editor until unpinned. Explicit Code actions still select their
+own target. Nodes without an applicable code accessor leave the pinned or last
+available target unchanged.
+
 ## Settings
 
 Add editor layout preferences to `SettingsModal.svelte`.

--- a/ui/src/lib/code-editor/use-code-sidebar-target.svelte.ts
+++ b/ui/src/lib/code-editor/use-code-sidebar-target.svelte.ts
@@ -1,0 +1,116 @@
+import { fromStore } from 'svelte/store';
+
+import { selectedNodeInfo } from '../../stores/ui.store';
+import { activateCodeEditorSidebarTarget } from '../../stores/code-editor-layout.store';
+
+import {
+  codeSidebarTargets,
+  registerCodeSidebarTarget,
+  requestCodeSidebarTargetId,
+  type CodeSidebarTarget
+} from '../../stores/code-sidebar.store';
+
+/** Registers a code accessor so the Code sidebar can follow canvas selection. */
+export function useCodeSidebarTarget(getTarget: () => CodeSidebarTarget | null): void {
+  $effect(() => {
+    const target = getTarget();
+    if (!target) return;
+
+    return registerCodeSidebarTarget(target);
+  });
+}
+
+export function useCodeSidebarTargetSelection(): {
+  readonly targets: CodeSidebarTarget[];
+  readonly activeTarget: CodeSidebarTarget | null;
+  readonly pinnedTargetId: string | null;
+  selectTarget: (targetId: string) => void;
+  togglePin: () => void;
+} {
+  const targetsSource = fromStore(codeSidebarTargets);
+  const requestedTargetId = fromStore(requestCodeSidebarTargetId);
+  const selectedNode = fromStore(selectedNodeInfo);
+
+  let activeTargetId = $state<string | null>(null);
+  let pinnedTargetId = $state<string | null>(null);
+  let lastSelectedNodeId = $state<string | null>(null);
+
+  const targets = $derived(
+    [...targetsSource.current.values()].sort((a, b) => a.label.localeCompare(b.label))
+  );
+
+  const activeTarget = $derived(
+    activeTargetId ? (targets.find((target) => target.nodeId === activeTargetId) ?? null) : null
+  );
+
+  $effect(() => {
+    const requestedId = requestedTargetId.current;
+
+    const requestedTarget = requestedId
+      ? targets.find((target) => target.nodeId === requestedId)
+      : undefined;
+
+    if (requestedTarget) {
+      activeTargetId = requestedTarget.nodeId;
+      activateCodeEditorSidebarTarget(requestedTarget);
+      requestCodeSidebarTargetId.set(null);
+
+      return;
+    }
+
+    const pinnedTarget = pinnedTargetId
+      ? targets.find((target) => target.nodeId === pinnedTargetId)
+      : undefined;
+
+    if (pinnedTarget) {
+      activeTargetId = pinnedTarget.nodeId;
+      activateCodeEditorSidebarTarget(pinnedTarget);
+
+      return;
+    }
+
+    if (pinnedTargetId) {
+      pinnedTargetId = null;
+    }
+
+    const selectedId = selectedNode.current?.id ?? null;
+
+    const selectedTarget = selectedId
+      ? targets.find((target) => target.nodeId === selectedId)
+      : undefined;
+
+    if (selectedTarget && selectedId !== lastSelectedNodeId) {
+      activeTargetId = selectedTarget.nodeId;
+      activateCodeEditorSidebarTarget(selectedTarget);
+    } else if (!activeTargetId || !targets.some((target) => target.nodeId === activeTargetId)) {
+      activeTargetId = targets[0]?.nodeId ?? null;
+
+      if (targets[0]) {
+        activateCodeEditorSidebarTarget(targets[0]);
+      }
+    }
+
+    lastSelectedNodeId = selectedId;
+  });
+
+  return {
+    selectTarget: (targetId) => {
+      activeTargetId = targetId;
+
+      const target = targets.find((candidate) => candidate.nodeId === targetId);
+      if (target) activateCodeEditorSidebarTarget(target);
+    },
+    togglePin: () => {
+      pinnedTargetId = pinnedTargetId ? null : activeTargetId;
+    },
+    get targets() {
+      return targets;
+    },
+    get activeTarget() {
+      return activeTarget;
+    },
+    get pinnedTargetId() {
+      return pinnedTargetId;
+    }
+  };
+}

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -33,6 +33,7 @@
   import { defaultEditorLayout } from '../../stores/editor-layout-settings.store';
   import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
   import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
+  import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { CanvasPreviewExpandController } from '$lib/canvas/CanvasPreviewExpandController';
   import { SurfaceListeners } from '$lib/canvas/SurfaceListeners';
@@ -332,6 +333,26 @@
       setOpen: (open) => (showSettings = open),
       onOpenFloating: () => (showEditor = false)
     }
+  });
+
+  useCodeSidebarTarget(() => {
+    if (!nodeId || !onCodeChange) return null;
+
+    const value = getNode(nodeId)?.data?.[codeDataKey];
+
+    return {
+      nodeId,
+      dataKey: codeDataKey,
+      language: codeLanguage,
+      nodeType: objectType,
+      label: title,
+      title,
+      placeholder: codePlaceholder,
+      value: typeof value === 'string' ? value : '',
+      onchange: onCodeChange,
+      onrun: onrun ? handleRun : undefined,
+      settings: detachedSettings
+    };
   });
 
   function openSidebarCodeEditor() {

--- a/ui/src/lib/components/sidebar/SidebarCodeEditorView.svelte
+++ b/ui/src/lib/components/sidebar/SidebarCodeEditorView.svelte
@@ -1,62 +1,138 @@
 <script lang="ts">
-  import { PanelLeftOpen, Play } from '@lucide/svelte/icons';
+  import { Check, ChevronsUpDown, PanelLeftOpen, Pin, PinOff, Play } from '@lucide/svelte/icons';
   import * as Tooltip from '$lib/components/ui/tooltip';
+  import * as Command from '$lib/components/ui/command';
+  import * as Popover from '$lib/components/ui/popover';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
-  import type { CodeEditorTarget } from '../../../stores/code-editor-layout.store';
+  import { useCodeSidebarTargetSelection } from '$lib/code-editor/use-code-sidebar-target.svelte';
   import {
     defaultEditorLayout,
     setDefaultEditorLayout
   } from '../../../stores/editor-layout-settings.store';
 
-  let {
-    target,
-    value = '',
-    onchange,
-    title,
-    onrun
-  }: {
-    target?: CodeEditorTarget;
-    value?: string;
-    onchange?: (value: string) => void;
-    title?: string;
-    onrun?: (code?: string) => void;
-  } = $props();
+  const selection = useCodeSidebarTargetSelection();
+
+  let targets = $derived(selection.targets);
+  let target = $derived(selection.activeTarget);
+  let pinnedTargetId = $derived(selection.pinnedTargetId);
+  let targetPickerOpen = $state(false);
+  let targetQuery = $state('');
+
+  let filteredTargets = $derived(
+    targets.filter((candidate) => {
+      const query = targetQuery.trim().toLowerCase();
+
+      return !query || `${candidate.label} ${candidate.nodeId}`.toLowerCase().includes(query);
+    })
+  );
 
   function useSidebarByDefault() {
     setDefaultEditorLayout('sidebar');
   }
+
+  function selectTarget(targetId: string) {
+    selection.selectTarget(targetId);
+    targetPickerOpen = false;
+    targetQuery = '';
+  }
 </script>
 
 <div class="flex h-full min-h-0 flex-col">
-  <div class="flex shrink-0 items-center justify-between gap-3 border-b border-zinc-800 px-3 py-2">
-    <div class="min-w-0">
-      <div class="truncate text-sm font-medium text-zinc-200">{title ?? 'Code'}</div>
-    </div>
-
-    <div class="flex shrink-0 items-center gap-1">
-      {#if onrun}
-        <Tooltip.Root>
-          <Tooltip.Trigger>
-            <button
-              class="cursor-pointer rounded p-1.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
-              onclick={() => onrun()}
-              aria-label="Run code"
-            >
-              <Play class="h-4 w-4" />
-            </button>
-          </Tooltip.Trigger>
-
-          <Tooltip.Content>Run Code</Tooltip.Content>
-        </Tooltip.Root>
+  <div class="shrink-0 border-b border-zinc-800 bg-zinc-950 px-3 py-2">
+    <div class="flex items-center gap-2">
+      {#if target}
+        <Popover.Root bind:open={targetPickerOpen}>
+          <Popover.Trigger
+            class="flex h-8 min-w-0 flex-1 cursor-pointer items-center justify-between gap-2 rounded-md border border-zinc-700 bg-zinc-900 px-2 text-left font-mono text-xs text-zinc-200 outline-none hover:border-zinc-600 focus-visible:border-orange-400 focus-visible:ring-2 focus-visible:ring-orange-400/20"
+            aria-label="Select code target"
+          >
+            <span class="min-w-0 truncate">{target.label}</span>
+            <ChevronsUpDown class="h-3.5 w-3.5 shrink-0 text-zinc-500" />
+          </Popover.Trigger>
+          <Popover.Content class="w-[min(22rem,calc(100vw-2rem))] p-0" align="start" sideOffset={6}>
+            <Command.Root shouldFilter={false}>
+              <Command.Input placeholder="Search objects..." bind:value={targetQuery} />
+              <Command.List class="max-h-64">
+                <Command.Empty>No code-capable object found.</Command.Empty>
+                <Command.Group>
+                  {#each filteredTargets as candidate (candidate.nodeId)}
+                    <Command.Item
+                      value={`${candidate.label} ${candidate.nodeId}`}
+                      onSelect={() => selectTarget(candidate.nodeId)}
+                      class="cursor-pointer"
+                    >
+                      <Check
+                        class={[
+                          'h-3.5 w-3.5',
+                          candidate.nodeId === target.nodeId ? 'opacity-100' : 'opacity-0'
+                        ]}
+                      />
+                      <span class="min-w-0 truncate font-mono text-xs">{candidate.label}</span>
+                    </Command.Item>
+                  {/each}
+                </Command.Group>
+              </Command.List>
+            </Command.Root>
+          </Popover.Content>
+        </Popover.Root>
+      {:else}
+        <div class="min-w-0">
+          <div class="truncate text-sm font-medium text-zinc-200">Code</div>
+        </div>
       {/if}
+
+      <div class="flex shrink-0 items-center gap-1">
+        {#if target?.onrun}
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-md border border-zinc-800 bg-zinc-900 text-zinc-500 transition-colors hover:border-zinc-700 hover:text-zinc-300 focus-visible:ring-2 focus-visible:ring-orange-400/30 focus-visible:outline-none"
+                onclick={() => target?.onrun?.()}
+                aria-label="Run code"
+              >
+                <Play class="h-4 w-4" />
+              </button>
+            </Tooltip.Trigger>
+
+            <Tooltip.Content>Run Code</Tooltip.Content>
+          </Tooltip.Root>
+        {/if}
+        {#if target}
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                class={[
+                  'flex h-8 w-8 cursor-pointer items-center justify-center rounded-md border transition-colors focus-visible:ring-2 focus-visible:ring-orange-400/30 focus-visible:outline-none',
+                  pinnedTargetId
+                    ? 'border-orange-500/50 bg-orange-500/15 text-orange-300 hover:bg-orange-500/25'
+                    : 'border-zinc-800 bg-zinc-900 text-zinc-500 hover:border-zinc-700 hover:text-zinc-300'
+                ]}
+                onclick={selection.togglePin}
+                aria-label={pinnedTargetId ? 'Unpin code target' : 'Pin code target'}
+                aria-pressed={Boolean(pinnedTargetId)}
+              >
+                {#if pinnedTargetId}<PinOff class="h-3.5 w-3.5" />{:else}<Pin
+                    class="h-3.5 w-3.5"
+                  />{/if}
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>{pinnedTargetId ? 'Unpin target' : 'Pin target'}</Tooltip.Content>
+          </Tooltip.Root>
+        {/if}
+      </div>
     </div>
+    {#if target}
+      <p class="mt-1.5 truncate font-mono text-[11px] text-zinc-500">
+        {pinnedTargetId ? 'Pinned' : 'Following canvas selection'}
+      </p>
+    {/if}
   </div>
 
   <div class="sidebar-code-editor min-h-0 flex-1 overflow-hidden">
     {#if target}
       <CodeEditor
-        {value}
-        onchange={onchange ?? (() => {})}
+        value={target.value}
+        onchange={target.onchange ?? (() => {})}
         language={target.language}
         nodeType={target.nodeType}
         placeholder={target.placeholder ?? ''}
@@ -69,7 +145,7 @@
       <div class="flex h-full items-center justify-center px-4 text-center">
         <div class="flex max-w-[220px] flex-col items-center gap-3">
           <div class="text-sm leading-5 text-zinc-500">
-            Open editors here by default when using visual code nodes.
+            Select a code-capable object to edit it here.
           </div>
 
           <button

--- a/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
+++ b/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
@@ -17,13 +17,17 @@
 
   let targetPickerOpen = $state(false);
   let targetQuery = $state('');
+
   const selection = useSettingsSidebarTargetSelection();
+
   let targets = $derived(selection.targets);
   let activeTarget = $derived(selection.activeTarget);
   let pinnedTargetId = $derived(selection.pinnedTargetId);
+
   let filteredTargets = $derived(
     targets.filter((target) => {
       const query = targetQuery.trim().toLowerCase();
+
       return !query || `${target.label} ${target.id}`.toLowerCase().includes(query);
     })
   );
@@ -74,7 +78,7 @@
   </div>
 {:else if activeTarget}
   <div class={['flex min-h-full flex-col', className]}>
-    <div class="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950 px-5 py-4">
+    <div class="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950 px-3 py-2">
       <div class="flex items-center gap-2">
         <Popover.Root bind:open={targetPickerOpen}>
           <Popover.Trigger
@@ -148,12 +152,12 @@
           <Tooltip.Content>{pinnedTargetId ? 'Unpin target' : 'Pin target'}</Tooltip.Content>
         </Tooltip.Root>
       </div>
-      <p class="mt-2 truncate font-mono text-[11px] text-zinc-500">
+      <p class="mt-1.5 truncate font-mono text-[11px] text-zinc-500">
         {pinnedTargetId ? 'Pinned' : 'Following canvas selection'}
       </p>
     </div>
 
-    <div class="min-h-0 flex-1 px-5 py-5">
+    <div class="min-h-0 flex-1 px-3 py-3">
       {#key activeTarget.id}
         <ObjectSettings
           nodeId={activeTarget.id}

--- a/ui/src/lib/components/sidebar/SidebarPanel.svelte
+++ b/ui/src/lib/components/sidebar/SidebarPanel.svelte
@@ -321,13 +321,7 @@
         {:else if view === 'preview'}
           <AppPreviewView {onRequestApiKey} {onOpenPatchToApp} />
         {:else if view === 'code'}
-          <SidebarCodeEditorView
-            target={codeEditorTarget}
-            value={codeEditorValue ?? ''}
-            onchange={onCodeEditorChange}
-            title={codeEditorTitle}
-            onrun={onRunCodeEditor}
-          />
+          <SidebarCodeEditorView />
         {:else if view === 'settings'}
           <SidebarObjectSettingsView />
         {/if}

--- a/ui/src/objects/audio-code/SimpleDspLayout.svelte
+++ b/ui/src/objects/audio-code/SimpleDspLayout.svelte
@@ -18,6 +18,7 @@
   import { defaultEditorLayout } from '../../stores/editor-layout-settings.store';
   import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
   import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
+  import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
   import { editorFontFamily } from '../../stores/editor.store';
 
   let {
@@ -91,6 +92,20 @@
       : undefined
   );
 
+  useCodeSidebarTarget(() => ({
+    nodeId,
+    dataKey: 'code',
+    language: 'javascript',
+    nodeType,
+    label: displayTitle,
+    title: displayTitle,
+    value: code,
+    onchange: handleCodeChangeInternal,
+    onrun: onRun,
+    lineErrors,
+    settings: detachedSettings
+  }));
+
   // Update content width when title changes
   $effect(() => {
     void displayTitle;
@@ -157,6 +172,7 @@
       language: 'javascript',
       nodeType,
       title: displayTitle,
+      onchange: handleCodeChangeInternal,
       onrun: onRun,
       lineErrors,
       settings: detachedSettings
@@ -173,6 +189,7 @@
       language: 'javascript',
       nodeType,
       title: displayTitle,
+      onchange: handleCodeChangeInternal,
       onrun: onRun,
       lineErrors,
       settings: detachedSettings

--- a/ui/src/objects/code/CodeBlockBase.svelte
+++ b/ui/src/objects/code/CodeBlockBase.svelte
@@ -37,6 +37,7 @@
   } from '../../stores/code-editor-layout.store';
   import { defaultEditorLayout } from '../../stores/editor-layout-settings.store';
   import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
+  import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
 
   let contentContainer: HTMLDivElement | null = null;
   let inlineConsoleRef: VirtualConsole | null = $state(null);
@@ -423,6 +424,22 @@
       onOpenFloating: () => (showEditor = false)
     }
   });
+
+  useCodeSidebarTarget(() => ({
+    nodeId,
+    dataKey: 'code',
+    language,
+    nodeType,
+    label: (supportsLibraries && data.libraryName) || data.title || nodeLabel,
+    title: (supportsLibraries && data.libraryName) || data.title || nodeLabel,
+    placeholder: editorPlaceholder,
+    value: code,
+    onchange: onCodeChange,
+    onrun: executeCode,
+    lineErrors,
+    settings: detachedSettings,
+    console: detachedConsole
+  }));
 
   let minContainerWidth = $derived.by(() => {
     const baseWidth = 70;

--- a/ui/src/objects/expression/CommonExprLayout.svelte
+++ b/ui/src/objects/expression/CommonExprLayout.svelte
@@ -14,6 +14,7 @@
     openCodeEditorOverlay
   } from '../../stores/code-editor-layout.store';
   import { createCommonExprEditorTarget } from '$lib/code-editor/common-expr-editor-target';
+  import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
   import { editorFontFamily } from '../../stores/editor.store';
 
   import 'highlight.js/styles/tokyo-night-dark.css';
@@ -211,6 +212,22 @@
     updateNodeData(nodeId, { expr: value });
     onExpressionChange(value);
   }
+
+  useCodeSidebarTarget(() => ({
+    nodeId,
+    dataKey,
+    language,
+    nodeType,
+    label: detachedEditorTitle ?? displayPrefix ?? nodeType,
+    title: detachedEditorTitle,
+    placeholder,
+    value: expr,
+    onchange: handleExpressionUpdate,
+    onrun: onRun,
+    customActions: detachedActions,
+    customSettings: detachedSettings,
+    lineWrap
+  }));
 
   const containerClass = $derived.by(() => {
     const base = hasError

--- a/ui/src/objects/patchbay/PatchbayNode.svelte
+++ b/ui/src/objects/patchbay/PatchbayNode.svelte
@@ -34,6 +34,7 @@
   import { MessageChannelRegistry } from '$lib/messages/MessageChannelRegistry';
   import { getPatchbayObjectPorts } from '$objects/patchbay/patchbay-object-ports';
   import { requestFitView } from '../../stores/ui.store';
+  import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
 
   import type { ObjectContext } from '$lib/objects/v2/ObjectContext';
   import type { PatchbayDiagnostic } from '$lib/patchbay/patchbay-parser';
@@ -175,6 +176,24 @@
   function handleCodeChange(nextCode: string) {
     updateNodeData(nodeId, { code: nextCode });
   }
+
+  useCodeSidebarTarget(() => ({
+    nodeId,
+    dataKey: 'code',
+    language: 'patchbay',
+    nodeType: 'patchbay',
+    label: 'patchbay',
+    title: 'patchbay',
+    placeholder: '[Message]\nchan Logger\nClock -> Logger',
+    value: code,
+    onchange: handleCodeChange,
+    onrun: applyPatchbayCode,
+    lineErrors,
+    inlineDecorations,
+    extraExtensions: patchbayCompletionExtensions,
+    onAltDecorationClick: focusPatchbayReference,
+    lineWrap: true
+  }));
 
   function handleRunOnEditChange(nextRunOnEdit: boolean) {
     const oldRunOnEdit = runOnEdit;

--- a/ui/src/stores/code-editor-layout.store.ts
+++ b/ui/src/stores/code-editor-layout.store.ts
@@ -6,6 +6,7 @@ import type { SupportedLanguage } from '$lib/codemirror/types';
 import type { SettingsSchema } from '$lib/settings';
 import { isSidebarOpen, sidebarView } from './ui.store';
 import { showSidebarTab } from './sidebar-visibility.store';
+import { requestCodeSidebarTargetId } from './code-sidebar.store';
 
 export interface CodeEditorTargetSettings {
   schema: SettingsSchema;
@@ -48,9 +49,14 @@ export function openCodeEditorOverlay(target: OpenCodeEditorOverlayTarget): void
 
 export function openCodeEditorSidebar(target: OpenCodeEditorSidebarTarget): void {
   activeCodeEditorTarget.set({ ...target, mode: 'sidebar' });
+  requestCodeSidebarTargetId.set(target.nodeId);
   showSidebarTab('code');
   sidebarView.set('code');
   isSidebarOpen.set(true);
+}
+
+export function activateCodeEditorSidebarTarget(target: OpenCodeEditorSidebarTarget): void {
+  activeCodeEditorTarget.set({ ...target, mode: 'sidebar' });
 }
 
 export function closeCodeEditorOverlay(): void {

--- a/ui/src/stores/code-sidebar.store.test.ts
+++ b/ui/src/stores/code-sidebar.store.test.ts
@@ -1,0 +1,34 @@
+import { get } from 'svelte/store';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  codeSidebarTargets,
+  registerCodeSidebarTarget,
+  requestCodeSidebarTargetId
+} from './code-sidebar.store';
+
+afterEach(() => {
+  codeSidebarTargets.set(new Map());
+  requestCodeSidebarTargetId.set(null);
+});
+
+describe('code sidebar targets', () => {
+  it('keeps the current accessor when an older registration is cleaned up', () => {
+    const first = {
+      nodeId: 'node-1',
+      dataKey: 'code',
+      language: 'javascript' as const,
+      label: 'First',
+      value: 'first'
+    };
+    const second = { ...first, label: 'Second', value: 'second' };
+
+    const unregisterFirst = registerCodeSidebarTarget(first);
+    const unregisterSecond = registerCodeSidebarTarget(second);
+    unregisterFirst();
+
+    expect(get(codeSidebarTargets).get('node-1')).toBe(second);
+
+    unregisterSecond();
+    expect(get(codeSidebarTargets).size).toBe(0);
+  });
+});

--- a/ui/src/stores/code-sidebar.store.ts
+++ b/ui/src/stores/code-sidebar.store.ts
@@ -1,0 +1,33 @@
+import { writable } from 'svelte/store';
+import type { CodeEditorTarget } from './code-editor-layout.store';
+
+export interface CodeSidebarTarget extends Omit<CodeEditorTarget, 'mode'> {
+  label: string;
+  value: string;
+}
+
+/** Live code-editor accessors registered by code-capable nodes. */
+export const codeSidebarTargets = writable<Map<string, CodeSidebarTarget>>(new Map());
+
+/** Set when an explicit Code action opens a node in the sidebar. */
+export const requestCodeSidebarTargetId = writable<string | null>(null);
+
+export function registerCodeSidebarTarget(target: CodeSidebarTarget): () => void {
+  codeSidebarTargets.update((targets) => {
+    const next = new Map(targets);
+    next.set(target.nodeId, target);
+
+    return next;
+  });
+
+  return () => {
+    codeSidebarTargets.update((targets) => {
+      if (targets.get(target.nodeId) !== target) return targets;
+
+      const next = new Map(targets);
+      next.delete(target.nodeId);
+
+      return next;
+    });
+  };
+}

--- a/ui/src/stores/settings-sidebar.store.ts
+++ b/ui/src/stores/settings-sidebar.store.ts
@@ -26,6 +26,7 @@ export function registerSettingsSidebarTarget(target: SettingsSidebarTarget): ()
   settingsSidebarTargets.update((targets) => {
     const next = new Map(targets);
     next.set(target.id, target);
+
     return next;
   });
 
@@ -36,6 +37,7 @@ export function registerSettingsSidebarTarget(target: SettingsSidebarTarget): ()
 
       const next = new Map(targets);
       next.delete(target.id);
+
       return next;
     });
   };


### PR DESCRIPTION
## Summary
- make the Code sidebar follow selected code-capable nodes with a pin control
- align Code and Settings sidebar headers with compact searchable target pickers
- preserve the sidebar default editor layout behavior

## Verification
- bun run check
- bun run test -- src/stores/code-sidebar.store.test.ts