### PR TITLE
feat(sequencer): make sequencer ui resizable

### DIFF
--- a/docs/design-docs/specs/88-seq-step-sequencer.md
+++ b/docs/design-docs/specs/88-seq-step-sequencer.md
@@ -97,6 +97,7 @@ Always a value — there's no bang-only mode. The value is always present.
 
 - **Track row**: label (left) + 16 step buttons
 - **Step button**: colored when on, dark when off; outlined when it's the current step
+- **Proportional resize**: **Resizable** in the Display settings section defaults to off. When it is enabled, selecting the node reveals XYFlow resize controls. The node cannot shrink below its natural grid size, and keeps its original aspect ratio so steps scale evenly in both directions.
 - **Visual cursor**: the current step column is highlighted across all rows simultaneously
 - **Outlets**: one per track, evenly spaced at the bottom; `useUpdateNodeInternals()` called after track count changes
 - **Settings panel** (gear icon → floating panel):

--- a/ui/src/lib/components/settings/SequencerSettings.svelte
+++ b/ui/src/lib/components/settings/SequencerSettings.svelte
@@ -19,6 +19,7 @@
     clockMode,
     showVelocity,
     showInTimeline,
+    resizable,
     tracks,
     swingTracker,
     onSetStepCount,
@@ -29,6 +30,7 @@
     onSetClockMode,
     onSetShowVelocity,
     onSetShowInTimeline,
+    onSetResizable,
     onAddTrack,
     onRemoveTrack,
     onUpdateTrackName,
@@ -42,6 +44,7 @@
     clockMode: 'auto' | 'manual';
     showVelocity: boolean;
     showInTimeline: boolean;
+    resizable: boolean;
     tracks: TrackData[];
     swingTracker: ContinuousTracker;
     onSetStepCount: (n: number) => void;
@@ -52,6 +55,7 @@
     onSetClockMode: (v: 'auto' | 'manual') => void;
     onSetShowVelocity: (v: boolean) => void;
     onSetShowInTimeline: (v: boolean) => void;
+    onSetResizable: (v: boolean) => void;
     onAddTrack: () => void;
     onRemoveTrack: (idx: number) => void;
     onUpdateTrackName: (idx: number, name: string) => void;
@@ -220,6 +224,21 @@
     <div>
       <span class="mb-2 block text-xs font-medium text-zinc-300">Display</span>
       <div class="flex flex-col gap-1">
+        <button
+          class="flex cursor-pointer items-center gap-1.5 transition-colors"
+          onclick={() => onSetResizable(!resizable)}
+        >
+          <div
+            class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
+            class:border-zinc-500={resizable}
+            class:bg-zinc-500={resizable}
+            class:border-zinc-600={!resizable}
+          ></div>
+          <span class="text-xs" class:text-zinc-400={resizable} class:text-zinc-500={!resizable}>
+            Resizable
+          </span>
+        </button>
+
         <button
           class="flex cursor-pointer items-center gap-1.5 transition-colors"
           onclick={() => onSetShowVelocity(!showVelocity)}

--- a/ui/src/objects/default-node-data.ts
+++ b/ui/src/objects/default-node-data.ts
@@ -339,7 +339,8 @@ export function getDefaultNodeData(nodeType: string): NodeData {
       swing: 0,
       outputMode: 'bang',
       showVelocity: false,
-      showInTimeline: true
+      showInTimeline: true,
+      resizable: false
     }))
     .with('curve', () => CURVE_DEFAULT_OBJECT_DATA)
     .with('pads~', () => DEFAULT_PADS_NODE_DATA)

--- a/ui/src/objects/sequencer/SequencerNode.svelte
+++ b/ui/src/objects/sequencer/SequencerNode.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { useSvelteFlow, useUpdateNodeInternals, useStore, type NodeProps } from '@xyflow/svelte';
+  import {
+    NodeResizer,
+    useSvelteFlow,
+    useUpdateNodeInternals,
+    useStore,
+    type NodeProps
+  } from '@xyflow/svelte';
   import type { OutletMode, SequencerOutputMode } from './sequencer-output';
   import { getSequencerVisualStep } from './sequencer-scheduler';
   import { type TrackData, DEFAULT_TRACKS, TRACK_COLORS } from '$lib/nodes/sequencer-constants';
@@ -14,7 +20,9 @@
   let {
     id: nodeId,
     data,
-    selected
+    selected,
+    width: persistedWidth,
+    height: persistedHeight
   }: NodeProps & {
     data: SequencerData;
   } = $props();
@@ -44,10 +52,22 @@
 
   const showVelocity = $derived(data.showVelocity ?? false);
   const showInTimeline = $derived(data.showInTimeline ?? true);
+  const resizable = $derived(data.resizable ?? false);
   const muted = $derived(data.muted ?? false);
   const trackCount = $derived(tracks.length);
   const stepsPerRow = $derived(Math.min(steps, 16));
   const rowCount = $derived(Math.ceil(steps / 16));
+
+  const defaultGridHeight = $derived(
+    showVelocity ? rowCount * 70 + (rowCount - 1) * 2 : rowCount * 24 + (rowCount - 1) * 2
+  );
+
+  const defaultNodeWidth = $derived(58 + stepsPerRow * 20);
+  const defaultNodeHeight = $derived(14 + trackCount * (4 + defaultGridHeight));
+
+  const nodeWidth = $derived(persistedWidth ?? defaultNodeWidth);
+  const nodeHeight = $derived(persistedHeight ?? defaultNodeHeight);
+  const scale = $derived(nodeWidth / defaultNodeWidth);
 
   function setNodeData<T extends keyof SequencerData>(key: T, value: SequencerData[T]): void {
     updateNodeData(nodeId, { ...data, [key]: value });
@@ -150,9 +170,16 @@
   }
 </script>
 
-<div class="relative">
+<div class="relative h-full" style:width="{nodeWidth}px" style:height="{nodeHeight}px">
+  <NodeResizer
+    isVisible={selected && resizable}
+    minWidth={defaultNodeWidth}
+    minHeight={defaultNodeHeight}
+    keepAspectRatio
+  />
+
   <!-- Main sequencer body -->
-  <div class="group relative">
+  <div class="group relative h-full">
     <!-- Header buttons (visible on hover, mute always visible when active) -->
     {#if store.nodesDraggable}
       <div class="absolute -top-7 right-0 z-10 flex items-center">
@@ -188,99 +215,114 @@
 
     <div
       class={[
-        'rounded-md border bg-zinc-900 p-1.5 transition-opacity',
+        'flex h-full flex-col rounded-md border bg-zinc-900 transition-opacity',
         selected ? 'border-zinc-600' : 'border-zinc-800',
         muted ? 'opacity-40' : 'opacity-100'
       ]}
+      style:padding="{6 * scale}px"
     >
       {#each tracks as track, trackIdx (trackIdx)}
-        <div class="flex items-center gap-1.5 py-0.5">
+        <div
+          class="flex min-h-0 w-full flex-1 items-center"
+          style:gap="{6 * scale}px"
+          style:padding-top="{2 * scale}px"
+          style:padding-bottom="{2 * scale}px"
+        >
           <!-- Track label -->
           <div
-            class="w-10 shrink-0 overflow-hidden text-right font-mono text-[9px] leading-none tracking-widest uppercase"
+            class="shrink-0 overflow-hidden text-right font-mono leading-none tracking-widest uppercase"
             style:color={track.color}
             style:opacity="0.8"
+            style:width="{40 * scale}px"
+            style:font-size="{9 * scale}px"
           >
             {track.name}
           </div>
 
           <!-- Step grid: up to 16 per row, wrap for 24/32 -->
-          <div class="flex flex-col gap-0.5">
+          <div class="flex h-full min-w-0 flex-1 flex-col" style:gap="{2 * scale}px">
             {#each Array.from({ length: rowCount }) as _, rowIdx (rowIdx)}
-              <div class="nodrag flex gap-0.5">
-                {#each Array.from({ length: stepsPerRow }) as _, colIdx (colIdx)}
-                  {@const stepIdx = rowIdx * 16 + colIdx}
-
-                  {#if track && stepIdx < steps}
-                    {@const isOn = track.stepOn?.[stepIdx] ?? false}
-                    {@const isCurrent = stepIdx === currentVisualStep}
-
-                    <button
-                      class={[
-                        'w-[18px] cursor-pointer rounded-sm transition-all duration-75',
-                        showVelocity ? 'h-[20px]' : 'h-[24px]'
-                      ]}
-                      class:ring-1={isCurrent}
-                      class:ring-white={isCurrent}
-                      class:ring-offset-0={isCurrent}
-                      style:background-color={isOn ? track.color : '#3f3f46'}
-                      style:opacity={isCurrent && !isOn ? '0.45' : '1'}
-                      onclick={() => toggleStep(trackIdx, stepIdx)}
-                      aria-label="Track {track.name} step {stepIdx + 1}"
-                    ></button>
-                  {/if}
-                {/each}
-              </div>
-
-              {#if showVelocity}
-                <div class="flex gap-0.5">
+              <div class="flex min-h-0 flex-1 flex-col" style:gap="{2 * scale}px">
+                <div class="nodrag flex min-h-0 flex-[5]" style:gap="{2 * scale}px">
                   {#each Array.from({ length: stepsPerRow }) as _, colIdx (colIdx)}
                     {@const stepIdx = rowIdx * 16 + colIdx}
 
                     {#if track && stepIdx < steps}
-                      {@const barValue = track.stepValues?.[stepIdx] ?? 1.0}
-                      {@const isStepOn = track.stepOn?.[stepIdx] ?? false}
+                      {@const isOn = track.stepOn?.[stepIdx] ?? false}
+                      {@const isCurrent = stepIdx === currentVisualStep}
 
-                      <div
-                        role="slider"
-                        aria-valuenow={barValue}
-                        aria-valuemin={0}
-                        aria-valuemax={1}
-                        tabindex="-1"
-                        class="nodrag relative h-[48px] w-[18px] cursor-ns-resize overflow-hidden rounded-sm bg-zinc-800"
-                        onpointerdown={(e) => {
-                          e.stopPropagation();
-                          (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-                          velocityDragOldTracks = tracks;
-                          const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-                          setStepValue(trackIdx, stepIdx, 1 - (e.clientY - rect.top) / rect.height);
-                        }}
-                        onpointermove={(e) => {
-                          if (!velocityDragOldTracks) return;
-                          const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-                          setStepValue(trackIdx, stepIdx, 1 - (e.clientY - rect.top) / rect.height);
-                        }}
-                        onpointerup={() => {
-                          if (!velocityDragOldTracks) return;
-                          tracker.commit(
-                            'tracks',
-                            velocityDragOldTracks,
-                            (data.tracks ?? DEFAULT_TRACKS) as TrackData[]
-                          );
-                          velocityDragOldTracks = null;
-                        }}
-                      >
-                        <div
-                          class="absolute right-0 bottom-0 left-0 rounded-sm"
-                          style:background-color={track.color}
-                          style:opacity={isStepOn ? '0.85' : '0.2'}
-                          style:height="{barValue * 100}%"
-                        ></div>
-                      </div>
+                      <button
+                        class="h-full min-w-0 flex-1 cursor-pointer rounded-sm transition-all duration-75"
+                        class:ring-1={isCurrent}
+                        class:ring-white={isCurrent}
+                        class:ring-offset-0={isCurrent}
+                        style:background-color={isOn ? track.color : '#3f3f46'}
+                        style:opacity={isCurrent && !isOn ? '0.45' : '1'}
+                        onclick={() => toggleStep(trackIdx, stepIdx)}
+                        aria-label="Track {track.name} step {stepIdx + 1}"
+                      ></button>
                     {/if}
                   {/each}
                 </div>
-              {/if}
+
+                {#if showVelocity}
+                  <div class="flex min-h-0 flex-[12]" style:gap="{2 * scale}px">
+                    {#each Array.from({ length: stepsPerRow }) as _, colIdx (colIdx)}
+                      {@const stepIdx = rowIdx * 16 + colIdx}
+
+                      {#if track && stepIdx < steps}
+                        {@const barValue = track.stepValues?.[stepIdx] ?? 1.0}
+                        {@const isStepOn = track.stepOn?.[stepIdx] ?? false}
+
+                        <div
+                          role="slider"
+                          aria-valuenow={barValue}
+                          aria-valuemin={0}
+                          aria-valuemax={1}
+                          tabindex="-1"
+                          class="nodrag relative h-full min-w-0 flex-1 cursor-ns-resize overflow-hidden rounded-sm bg-zinc-800"
+                          onpointerdown={(e) => {
+                            e.stopPropagation();
+                            (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+                            velocityDragOldTracks = tracks;
+                            const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                            setStepValue(
+                              trackIdx,
+                              stepIdx,
+                              1 - (e.clientY - rect.top) / rect.height
+                            );
+                          }}
+                          onpointermove={(e) => {
+                            if (!velocityDragOldTracks) return;
+                            const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                            setStepValue(
+                              trackIdx,
+                              stepIdx,
+                              1 - (e.clientY - rect.top) / rect.height
+                            );
+                          }}
+                          onpointerup={() => {
+                            if (!velocityDragOldTracks) return;
+                            tracker.commit(
+                              'tracks',
+                              velocityDragOldTracks,
+                              (data.tracks ?? DEFAULT_TRACKS) as TrackData[]
+                            );
+                            velocityDragOldTracks = null;
+                          }}
+                        >
+                          <div
+                            class="absolute right-0 bottom-0 left-0 rounded-sm"
+                            style:background-color={track.color}
+                            style:opacity={isStepOn ? '0.85' : '0.2'}
+                            style:height="{barValue * 100}%"
+                          ></div>
+                        </div>
+                      {/if}
+                    {/each}
+                  </div>
+                {/if}
+              </div>
             {/each}
           </div>
         </div>
@@ -341,6 +383,7 @@
         {clockMode}
         {showVelocity}
         {showInTimeline}
+        {resizable}
         {tracks}
         {swingTracker}
         onSetStepCount={setStepCount}
@@ -358,6 +401,7 @@
         onSetClockMode={(v) => setNodeData('clockMode', v)}
         onSetShowVelocity={(v) => setNodeData('showVelocity', v)}
         onSetShowInTimeline={(v) => setNodeData('showInTimeline', v)}
+        onSetResizable={(v) => setNodeData('resizable', v)}
         onAddTrack={addTrack}
         onRemoveTrack={removeTrack}
         onUpdateTrackName={updateTrackName}

--- a/ui/src/objects/sequencer/sequencer-state.test.ts
+++ b/ui/src/objects/sequencer/sequencer-state.test.ts
@@ -24,4 +24,9 @@ describe('sequencer state', () => {
     expect(getSequencerData({ outletMode: 'multi', outputMode: 'value' }).outputMode).toBe('value');
     expect(getSequencerData({ outletMode: 'multi', outputMode: 'midi' }).outputMode).toBe('bang');
   });
+
+  it('keeps resizing disabled unless explicitly enabled', () => {
+    expect(getSequencerData({}).resizable).toBe(false);
+    expect(getSequencerData({ resizable: true }).resizable).toBe(true);
+  });
 });

--- a/ui/src/objects/sequencer/sequencer-state.ts
+++ b/ui/src/objects/sequencer/sequencer-state.ts
@@ -21,6 +21,7 @@ export type SequencerData = {
   clockMode?: 'auto' | 'manual';
   showVelocity?: boolean;
   showInTimeline?: boolean;
+  resizable?: boolean;
   muted?: boolean;
   manualStep?: number;
   currentStep?: number;
@@ -46,6 +47,7 @@ export function getSequencerData(data: SequencerData): ResolvedSequencerData {
     clockMode: data.clockMode === 'manual' ? 'manual' : 'auto',
     showVelocity: data.showVelocity === true,
     showInTimeline: data.showInTimeline !== false,
+    resizable: data.resizable === true,
     muted: data.muted === true,
     manualStep: typeof data.manualStep === 'number' ? Math.floor(data.manualStep) : 0,
     currentStep: typeof data.currentStep === 'number' ? Math.floor(data.currentStep) : -1

--- a/ui/static/content/objects/sequencer.md
+++ b/ui/static/content/objects/sequencer.md
@@ -16,6 +16,13 @@ lasts one tempo beat, so changing the number of steps changes the pattern
 length, not its speed. In a 5/4 transport, an 8-step pattern continues across
 the bar boundary instead of squeezing all eight steps into five beats.
 
+## Resize
+
+Enable **Resizable** under **Display** in the settings panel, then select the
+sequencer and drag a resize handle to scale it. The node keeps its original
+proportions, so the step grid grows evenly in both directions instead of
+stretching its cells wider.
+
 ## Clock Modes
 
 Set via **Clock** in the settings panel:


### PR DESCRIPTION
Makes the sequencer ui resizable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Resizable setting for sequencer nodes.
  * Resizable sequencers preserve their original proportions while scaling.
  * Resizing controls appear when the setting is enabled.
  * Sequencer layout elements adjust dynamically to the node size.

* **Documentation**
  * Added guidance for enabling and using sequencer resizing.

* **Bug Fixes**
  * Resizing is disabled by default unless explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->