### PR TITLE
feat(sequencer): show on settings sidebar and resize on track change

### DIFF
--- a/docs/design-docs/specs/175-sidebar-object-settings-editor.md
+++ b/docs/design-docs/specs/175-sidebar-object-settings-editor.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Give settings-schema-backed objects a persistent editor surface that does not
+Give settings-capable objects a persistent editor surface that does not
 require locating or panning to the node on the canvas. This complements the
 existing floating settings panel; it does not replace it.
 
@@ -10,8 +10,9 @@ existing floating settings panel; it does not replace it.
 
 - Add a user-configurable `Settings` sidebar tab. It is hidden by default and
   can be enabled with the existing sidebar tab picker.
-- The tab lists only nodes whose `data.settingsSchema` is a non-empty schema.
-  The sidebar renders settings only; it never exposes a node's code editor.
+- The tab lists schema-backed nodes and object-specific panels that register a
+  sidebar settings view. The sidebar renders settings only; it never exposes a
+  node's code editor.
 - The active target follows a selected settings-capable canvas node. Selecting
   a node with no settings preserves the most recently edited settings target.
 - Users can choose any eligible node from the tab without selecting or moving
@@ -21,9 +22,9 @@ existing floating settings panel; it does not replace it.
   recent eligible target.
 - Reuse `ObjectSettings` so values, defaults, visibility rules, color pickers,
   and undo/redo semantics stay identical to the existing floating panel.
-- Add an Editor preference, disabled by default, that opens a node's
-  schema-driven Settings action in the sidebar and enables the tab. Existing
-  floating settings behavior remains the default.
+- Add an Editor preference, disabled by default, that opens a node's Settings
+  action in the sidebar and enables the tab. Existing floating settings
+  behavior remains the default.
 
 ## Interaction
 
@@ -38,17 +39,17 @@ node becomes the fallback target; otherwise the empty state is shown.
 
 ## Boundaries
 
-This initial implementation covers the shared schema-driven settings system.
-It intentionally does not adapt bespoke settings panels (for example, complex
-object-specific panels) into a new shared contract.
+Schema-driven settings remain the default integration. Bespoke settings panels
+can also register a live, object-specific Svelte settings view when a schema
+cannot express their controls; the sequencer is the initial example.
 
 ## Architecture
 
-Schema-backed node layouts use a shared Svelte composable to register their
-live settings callbacks and route an action to the floating panel or sidebar,
-including the one-off Shift inversion. The sidebar owns a second composable for
-selection, pinning, and explicit node-target requests. Object layouts retain
-only their object-specific value and revert behavior.
+Node layouts use a shared Svelte composable to register either a schema with
+live callbacks or a bespoke settings view, then route an action to the floating
+panel or sidebar, including the one-off Shift inversion. The sidebar owns a
+second composable for selection, pinning, and explicit node-target requests.
+Object layouts retain their object-specific value and revert behavior.
 
 ## Verification
 
@@ -57,5 +58,7 @@ only their object-specific value and revert behavior.
 - The selector changes the edited node without changing canvas selection.
 - Pinning resists selection changes and clears safely when the node is gone.
 - A settings change updates the target's node data and remains undoable.
-- The preference routes schema-driven Settings actions to the sidebar only when
-  enabled; the default continues to open the floating panel.
+- The preference routes Settings actions to the sidebar only when enabled; the
+  default continues to open the floating panel.
+- Selecting a sequencer shows its existing settings controls in the sidebar,
+  and changes retain the existing node-data and undo/redo behavior.

--- a/docs/design-docs/specs/88-seq-step-sequencer.md
+++ b/docs/design-docs/specs/88-seq-step-sequencer.md
@@ -101,6 +101,9 @@ Always a value — there's no bang-only mode. The value is always present.
 - **Visual cursor**: the current step column is highlighted across all rows simultaneously
 - **Outlets**: one per track, evenly spaced at the bottom; `useUpdateNodeInternals()` called after track count changes
 - **Settings panel** (gear icon → floating panel):
+  - The panel caps its height to the viewport and scrolls internally when its
+    controls overflow. A bottom fade says **Scroll for more** until the user
+    reaches the end.
   - Step count: segmented buttons `4 / 8 / 12 / 16 / 24 / 32`
   - Swing: slider 0–100%
   - Audio Rate: toggle

--- a/ui/src/lib/components/settings/ObjectSettings.svelte
+++ b/ui/src/lib/components/settings/ObjectSettings.svelte
@@ -133,10 +133,13 @@
     if (variant !== 'floating' || !floatingPanelElement) return;
 
     const frame = requestAnimationFrame(updateFloatingScrollIndicator);
+
     const observer = new ResizeObserver(updateFloatingScrollIndicator);
     observer.observe(floatingPanelElement);
-    floatingPanelElement.firstElementChild &&
+
+    if (floatingPanelElement.firstElementChild) {
       observer.observe(floatingPanelElement.firstElementChild);
+    }
 
     return () => {
       cancelAnimationFrame(frame);
@@ -179,6 +182,7 @@
 
     const next = toVec2(getCurrentValue(field));
     next[axis] = parsed;
+
     onValueChange(field.key, next);
   }
 

--- a/ui/src/lib/components/settings/ObjectSettings.svelte
+++ b/ui/src/lib/components/settings/ObjectSettings.svelte
@@ -9,6 +9,7 @@
   import type { SettingsField, SettingsSchema } from '$lib/settings/types';
   import { filterSettingsOptions, normalizeSettingsOptions } from '$lib/settings/options';
   import { isSettingsFieldVisible } from '$lib/settings/visibility';
+  import { useFloatingSettingsScroll } from './use-floating-settings-scroll.svelte';
 
   let {
     nodeId,
@@ -64,9 +65,7 @@
   const tracker = useNodeDataTracker(getInitialNodeId());
   const comboboxOpen = $state(createInitialComboboxOpenState());
   const comboboxQuery = $state(createInitialComboboxQueryState());
-  let floatingPanelElement = $state<HTMLDivElement>();
-  let isFloatingScrollable = $state(false);
-  let hasMoreFloatingSettings = $state(false);
+  const floatingScroll = useFloatingSettingsScroll(() => variant === 'floating');
 
   function trackingKey(key: string): string {
     return settingsPrefix ? `${settingsPrefix}.${key}` : key;
@@ -113,39 +112,6 @@
   function handleClose() {
     onClose();
   }
-
-  function updateFloatingScrollIndicator() {
-    if (!floatingPanelElement || variant !== 'floating') {
-      isFloatingScrollable = false;
-      hasMoreFloatingSettings = false;
-      return;
-    }
-
-    isFloatingScrollable =
-      floatingPanelElement.scrollHeight > floatingPanelElement.clientHeight + 1;
-    hasMoreFloatingSettings =
-      isFloatingScrollable &&
-      floatingPanelElement.scrollTop + floatingPanelElement.clientHeight <
-        floatingPanelElement.scrollHeight - 1;
-  }
-
-  $effect(() => {
-    if (variant !== 'floating' || !floatingPanelElement) return;
-
-    const frame = requestAnimationFrame(updateFloatingScrollIndicator);
-
-    const observer = new ResizeObserver(updateFloatingScrollIndicator);
-    observer.observe(floatingPanelElement);
-
-    if (floatingPanelElement.firstElementChild) {
-      observer.observe(floatingPanelElement.firstElementChild);
-    }
-
-    return () => {
-      cancelAnimationFrame(frame);
-      observer.disconnect();
-    };
-  });
 
   function makeTracker(field: SettingsField) {
     if ((field.persistence ?? 'node') !== 'node') {
@@ -253,12 +219,12 @@
 <!-- Settings panel -->
 <div class={variant === 'floating' ? 'relative w-48' : 'w-full'}>
   <div
-    bind:this={floatingPanelElement}
-    onscroll={updateFloatingScrollIndicator}
+    bind:this={floatingScroll.element}
+    onscroll={floatingScroll.onScroll}
     class={variant === 'floating'
       ? [
-          'nodrag max-h-[min(32rem,calc(100dvh-8rem))] overflow-y-auto overscroll-contain rounded-md border border-zinc-600 bg-zinc-900 p-4 shadow-xl',
-          isFloatingScrollable && 'nopan nowheel'
+          'nodrag max-h-[min(25rem,calc(100dvh-8rem))] overflow-y-auto overscroll-contain rounded-md border border-zinc-600 bg-zinc-900 p-4 shadow-xl',
+          floatingScroll.isScrollable && 'nopan nowheel'
         ]
       : 'nodrag w-full'}
   >
@@ -616,7 +582,7 @@
     </div>
   </div>
 
-  {#if variant === 'floating' && hasMoreFloatingSettings}
+  {#if variant === 'floating' && floatingScroll.hasMore}
     <div
       class="pointer-events-none absolute right-px bottom-px left-px flex h-10 items-end justify-center rounded-b-md bg-gradient-to-t from-zinc-900 via-zinc-900/90 to-transparent pb-1 text-[10px] text-zinc-400"
       aria-hidden="true"

--- a/ui/src/lib/components/settings/SequencerSettings.svelte
+++ b/ui/src/lib/components/settings/SequencerSettings.svelte
@@ -3,7 +3,7 @@
   import * as Tooltip from '$lib/components/ui/tooltip';
   import SettingsSlider from '$lib/components/SettingsSlider.svelte';
   import NativeColorPicker from '$lib/components/settings/NativeColorPicker.svelte';
-  import { Plus, Trash2 } from '@lucide/svelte/icons';
+  import { ChevronDown, Plus, Trash2 } from '@lucide/svelte/icons';
   import type { TrackData } from '$lib/nodes/sequencer-constants';
 
   const STEP_COUNTS = [4, 8, 12, 16, 24, 32] as const;
@@ -74,6 +74,43 @@
       : 'Unchecked sends bang; checked sends velocity value'
   );
 
+  let floatingPanelElement = $state<HTMLDivElement>();
+  let isFloatingScrollable = $state(false);
+  let hasMoreFloatingSettings = $state(false);
+
+  function updateFloatingScrollIndicator(): void {
+    if (!floatingPanelElement || variant !== 'floating') {
+      isFloatingScrollable = false;
+      hasMoreFloatingSettings = false;
+      return;
+    }
+
+    isFloatingScrollable =
+      floatingPanelElement.scrollHeight > floatingPanelElement.clientHeight + 1;
+
+    hasMoreFloatingSettings =
+      isFloatingScrollable &&
+      floatingPanelElement.scrollTop + floatingPanelElement.clientHeight <
+        floatingPanelElement.scrollHeight - 1;
+  }
+
+  $effect(() => {
+    if (variant !== 'floating' || !floatingPanelElement) return;
+
+    const frame = requestAnimationFrame(updateFloatingScrollIndicator);
+    const observer = new ResizeObserver(updateFloatingScrollIndicator);
+    observer.observe(floatingPanelElement);
+
+    if (floatingPanelElement.firstElementChild) {
+      observer.observe(floatingPanelElement.firstElementChild);
+    }
+
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  });
+
   function toggleOutputMode(): void {
     if (outletMode === 'single') {
       onSetOutputMode(outputValueMode ? 'index' : 'midi');
@@ -84,283 +121,299 @@
   }
 </script>
 
-<div
-  class={[
-    'nodrag',
-    variant === 'floating'
-      ? 'w-56 rounded-md border border-zinc-600 bg-zinc-900 p-4 shadow-xl'
-      : 'w-full'
-  ]}
->
-  <div class="flex flex-col gap-3">
-    <!-- Steps -->
-    <div>
-      <span class="mb-2 block text-xs font-medium text-zinc-300">Steps</span>
-      <div class="flex flex-wrap gap-1">
-        {#each STEP_COUNTS as count}
-          <button
-            onclick={() => onSetStepCount(count)}
-            class="cursor-pointer rounded px-2 py-1 text-xs transition-colors"
-            class:bg-zinc-600={steps === count}
-            class:text-white={steps === count}
-            class:bg-zinc-800={steps !== count}
-            class:text-zinc-300={steps !== count}
-            class:hover:bg-zinc-700={steps !== count}
-          >
-            {count}
-          </button>
-        {/each}
-      </div>
-    </div>
-
-    <!-- Output -->
-    <div>
-      <span class="mb-2 block text-xs font-medium text-zinc-300">Output</span>
-
-      <div class="flex flex-col gap-1">
-        <Tooltip.Root>
-          <Tooltip.Trigger>
+<div class={variant === 'floating' ? 'relative w-56' : 'w-full'}>
+  <div
+    bind:this={floatingPanelElement}
+    onscroll={updateFloatingScrollIndicator}
+    class={variant === 'floating'
+      ? [
+          'nodrag max-h-[min(25rem,calc(100dvh-8rem))] overflow-y-auto overscroll-contain rounded-md border border-zinc-600 bg-zinc-900 p-4 shadow-xl',
+          isFloatingScrollable && 'nopan nowheel'
+        ]
+      : 'nodrag w-full'}
+  >
+    <div class="flex flex-col gap-3">
+      <!-- Steps -->
+      <div>
+        <span class="mb-2 block text-xs font-medium text-zinc-300">Steps</span>
+        <div class="flex flex-wrap gap-1">
+          {#each STEP_COUNTS as count (count)}
             <button
-              class="flex cursor-pointer items-center gap-1.5 transition-colors"
-              onclick={() => onSetOutletMode(outletMode === 'single' ? 'multi' : 'single')}
+              onclick={() => onSetStepCount(count)}
+              class="cursor-pointer rounded px-2 py-1 text-xs transition-colors"
+              class:bg-zinc-600={steps === count}
+              class:text-white={steps === count}
+              class:bg-zinc-800={steps !== count}
+              class:text-zinc-300={steps !== count}
+              class:hover:bg-zinc-700={steps !== count}
             >
-              <div
-                class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
-                class:border-zinc-500={outletMode === 'single'}
-                class:bg-zinc-500={outletMode === 'single'}
-                class:border-zinc-600={outletMode !== 'single'}
-              ></div>
+              {count}
+            </button>
+          {/each}
+        </div>
+      </div>
 
-              <span
-                class="text-xs"
-                class:text-zinc-400={outletMode === 'single'}
-                class:text-zinc-500={outletMode !== 'single'}
+      <!-- Output -->
+      <div>
+        <span class="mb-2 block text-xs font-medium text-zinc-300">Output</span>
+
+        <div class="flex flex-col gap-1">
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                class="flex cursor-pointer items-center gap-1.5 transition-colors"
+                onclick={() => onSetOutletMode(outletMode === 'single' ? 'multi' : 'single')}
               >
-                Single outlet
-              </span>
-            </button>
-          </Tooltip.Trigger>
+                <div
+                  class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
+                  class:border-zinc-500={outletMode === 'single'}
+                  class:bg-zinc-500={outletMode === 'single'}
+                  class:border-zinc-600={outletMode !== 'single'}
+                ></div>
 
-          <Tooltip.Content>One merged outlet instead of one per track</Tooltip.Content>
-        </Tooltip.Root>
-
-        <Tooltip.Root>
-          <Tooltip.Trigger>
-            <button
-              class="flex cursor-pointer items-center gap-1.5 transition-colors"
-              onclick={toggleOutputMode}
-            >
-              <div
-                class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
-                class:border-zinc-500={outputValueMode}
-                class:bg-zinc-500={outputValueMode}
-                class:border-zinc-600={!outputValueMode}
-              ></div>
-
-              <span
-                class="text-xs"
-                class:text-zinc-400={outputValueMode}
-                class:text-zinc-500={!outputValueMode}
-              >
-                {outputValueLabel}
-              </span>
-            </button>
-          </Tooltip.Trigger>
-
-          <Tooltip.Content>{outputValueTip}</Tooltip.Content>
-        </Tooltip.Root>
-
-        <Tooltip.Root>
-          <Tooltip.Trigger>
-            <button
-              class="flex cursor-pointer items-center gap-1.5 transition-colors"
-              onclick={() => onSetAudioRate(!audioRate)}
-            >
-              <div
-                class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
-                class:border-zinc-500={audioRate}
-                class:bg-zinc-500={audioRate}
-                class:border-zinc-600={!audioRate}
-              ></div>
-              <span
-                class="text-xs"
-                class:text-zinc-400={audioRate}
-                class:text-zinc-500={!audioRate}
-              >
-                Audio lookahead
-              </span>
-            </button>
-          </Tooltip.Trigger>
-
-          <Tooltip.Content>Add audio time to output messages</Tooltip.Content>
-        </Tooltip.Root>
-      </div>
-    </div>
-
-    <!-- Timing -->
-    <div>
-      <span class="mb-2 block text-xs font-medium text-zinc-300">Timing</span>
-      <div class="flex flex-col gap-1">
-        <Tooltip.Root>
-          <Tooltip.Trigger>
-            <button
-              class="flex cursor-pointer items-center gap-1.5 transition-colors"
-              onclick={() => onSetClockMode(clockMode === 'manual' ? 'auto' : 'manual')}
-            >
-              <div
-                class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
-                class:border-zinc-500={clockMode === 'manual'}
-                class:bg-zinc-500={clockMode === 'manual'}
-                class:border-zinc-600={clockMode !== 'manual'}
-              ></div>
-
-              <span
-                class="text-xs"
-                class:text-zinc-400={clockMode === 'manual'}
-                class:text-zinc-500={clockMode !== 'manual'}
-              >
-                Manual clock
-              </span>
-            </button>
-          </Tooltip.Trigger>
-
-          <Tooltip.Content>Advance one step per bang on the clock inlet</Tooltip.Content>
-        </Tooltip.Root>
-      </div>
-    </div>
-
-    <!-- Display -->
-    <div>
-      <span class="mb-2 block text-xs font-medium text-zinc-300">Display</span>
-      <div class="flex flex-col gap-1">
-        <button
-          class="flex cursor-pointer items-center gap-1.5 transition-colors"
-          onclick={() => onSetResizable(!resizable)}
-        >
-          <div
-            class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
-            class:border-zinc-500={resizable}
-            class:bg-zinc-500={resizable}
-            class:border-zinc-600={!resizable}
-          ></div>
-          <span class="text-xs" class:text-zinc-400={resizable} class:text-zinc-500={!resizable}>
-            Resizable
-          </span>
-        </button>
-
-        <button
-          class="flex cursor-pointer items-center gap-1.5 transition-colors"
-          onclick={() => onSetShowVelocity(!showVelocity)}
-        >
-          <div
-            class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
-            class:border-zinc-500={showVelocity}
-            class:bg-zinc-500={showVelocity}
-            class:border-zinc-600={!showVelocity}
-          ></div>
-          <span
-            class="text-xs"
-            class:text-zinc-400={showVelocity}
-            class:text-zinc-500={!showVelocity}
-          >
-            Velocity lane
-          </span>
-        </button>
-
-        <button
-          class="flex cursor-pointer items-center gap-1.5 transition-colors"
-          onclick={() => onSetShowInTimeline(!showInTimeline)}
-        >
-          <div
-            class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
-            class:border-zinc-500={showInTimeline}
-            class:bg-zinc-500={showInTimeline}
-            class:border-zinc-600={!showInTimeline}
-          ></div>
-          <span
-            class="text-xs"
-            class:text-zinc-400={showInTimeline}
-            class:text-zinc-500={!showInTimeline}
-          >
-            Show in timeline
-          </span>
-        </button>
-      </div>
-    </div>
-
-    <!-- Swing -->
-    <div>
-      <span class="mb-2 block text-xs font-medium text-zinc-300">
-        Swing: {swing}%
-      </span>
-
-      <SettingsSlider
-        min={0}
-        max={100}
-        value={swing}
-        onpointerdown={swingTracker.onFocus}
-        onpointerup={swingTracker.onBlur}
-        onchange={onSetSwing}
-        class="nodrag"
-      />
-    </div>
-
-    <!-- Tracks -->
-    <div>
-      <div class="mb-2 flex items-center justify-between">
-        <span class="text-xs font-medium text-zinc-300">Tracks</span>
-        <Tooltip.Root>
-          <Tooltip.Trigger>
-            <button
-              onclick={onAddTrack}
-              disabled={tracks.length >= 8}
-              class="cursor-pointer rounded p-0.5 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-30"
-            >
-              <Plus class="h-3.5 w-3.5" />
-            </button>
-          </Tooltip.Trigger>
-
-          <Tooltip.Content>Add track (max 8)</Tooltip.Content>
-        </Tooltip.Root>
-      </div>
-
-      <div class="space-y-1.5">
-        {#each tracks as track, trackIdx (trackIdx)}
-          <div class="flex items-center gap-1.5">
-            <!-- Color swatch / native color picker -->
-            <NativeColorPicker
-              value={track.color}
-              ariaLabel="Track color"
-              class="h-5 w-5 cursor-pointer rounded border border-zinc-600 p-0"
-              swatchClass="block h-full w-full rounded"
-              onInput={(value) => onUpdateTrackColor(trackIdx, value)}
-            />
-
-            <!-- Name -->
-            <input
-              type="text"
-              value={track.name}
-              onchange={(e) => onUpdateTrackName(trackIdx, (e.target as HTMLInputElement).value)}
-              class="nodrag min-w-0 flex-1 rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-xs text-zinc-300 outline-none focus:ring-1 focus:ring-zinc-500"
-              maxlength="6"
-            />
-
-            <!-- Delete -->
-            <Tooltip.Root>
-              <Tooltip.Trigger>
-                <button
-                  onclick={() => onRemoveTrack(trackIdx)}
-                  disabled={tracks.length <= 1}
-                  class="cursor-pointer rounded p-0.5 text-zinc-600 hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-30"
+                <span
+                  class="text-xs"
+                  class:text-zinc-400={outletMode === 'single'}
+                  class:text-zinc-500={outletMode !== 'single'}
                 >
-                  <Trash2 class="h-3.5 w-3.5" />
-                </button>
-              </Tooltip.Trigger>
-              <Tooltip.Content>Remove track</Tooltip.Content>
-            </Tooltip.Root>
-          </div>
-        {/each}
+                  Single outlet
+                </span>
+              </button>
+            </Tooltip.Trigger>
+
+            <Tooltip.Content>One merged outlet instead of one per track</Tooltip.Content>
+          </Tooltip.Root>
+
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                class="flex cursor-pointer items-center gap-1.5 transition-colors"
+                onclick={toggleOutputMode}
+              >
+                <div
+                  class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
+                  class:border-zinc-500={outputValueMode}
+                  class:bg-zinc-500={outputValueMode}
+                  class:border-zinc-600={!outputValueMode}
+                ></div>
+
+                <span
+                  class="text-xs"
+                  class:text-zinc-400={outputValueMode}
+                  class:text-zinc-500={!outputValueMode}
+                >
+                  {outputValueLabel}
+                </span>
+              </button>
+            </Tooltip.Trigger>
+
+            <Tooltip.Content>{outputValueTip}</Tooltip.Content>
+          </Tooltip.Root>
+
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                class="flex cursor-pointer items-center gap-1.5 transition-colors"
+                onclick={() => onSetAudioRate(!audioRate)}
+              >
+                <div
+                  class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
+                  class:border-zinc-500={audioRate}
+                  class:bg-zinc-500={audioRate}
+                  class:border-zinc-600={!audioRate}
+                ></div>
+                <span
+                  class="text-xs"
+                  class:text-zinc-400={audioRate}
+                  class:text-zinc-500={!audioRate}
+                >
+                  Audio lookahead
+                </span>
+              </button>
+            </Tooltip.Trigger>
+
+            <Tooltip.Content>Add audio time to output messages</Tooltip.Content>
+          </Tooltip.Root>
+        </div>
+      </div>
+
+      <!-- Timing -->
+      <div>
+        <span class="mb-2 block text-xs font-medium text-zinc-300">Timing</span>
+        <div class="flex flex-col gap-1">
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                class="flex cursor-pointer items-center gap-1.5 transition-colors"
+                onclick={() => onSetClockMode(clockMode === 'manual' ? 'auto' : 'manual')}
+              >
+                <div
+                  class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
+                  class:border-zinc-500={clockMode === 'manual'}
+                  class:bg-zinc-500={clockMode === 'manual'}
+                  class:border-zinc-600={clockMode !== 'manual'}
+                ></div>
+
+                <span
+                  class="text-xs"
+                  class:text-zinc-400={clockMode === 'manual'}
+                  class:text-zinc-500={clockMode !== 'manual'}
+                >
+                  Manual clock
+                </span>
+              </button>
+            </Tooltip.Trigger>
+
+            <Tooltip.Content>Advance one step per bang on the clock inlet</Tooltip.Content>
+          </Tooltip.Root>
+        </div>
+      </div>
+
+      <!-- Display -->
+      <div>
+        <span class="mb-2 block text-xs font-medium text-zinc-300">Display</span>
+        <div class="flex flex-col gap-1">
+          <button
+            class="flex cursor-pointer items-center gap-1.5 transition-colors"
+            onclick={() => onSetResizable(!resizable)}
+          >
+            <div
+              class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
+              class:border-zinc-500={resizable}
+              class:bg-zinc-500={resizable}
+              class:border-zinc-600={!resizable}
+            ></div>
+            <span class="text-xs" class:text-zinc-400={resizable} class:text-zinc-500={!resizable}>
+              Resizable
+            </span>
+          </button>
+
+          <button
+            class="flex cursor-pointer items-center gap-1.5 transition-colors"
+            onclick={() => onSetShowVelocity(!showVelocity)}
+          >
+            <div
+              class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
+              class:border-zinc-500={showVelocity}
+              class:bg-zinc-500={showVelocity}
+              class:border-zinc-600={!showVelocity}
+            ></div>
+            <span
+              class="text-xs"
+              class:text-zinc-400={showVelocity}
+              class:text-zinc-500={!showVelocity}
+            >
+              Velocity lane
+            </span>
+          </button>
+
+          <button
+            class="flex cursor-pointer items-center gap-1.5 transition-colors"
+            onclick={() => onSetShowInTimeline(!showInTimeline)}
+          >
+            <div
+              class="h-3 w-3 shrink-0 rounded-sm border transition-colors"
+              class:border-zinc-500={showInTimeline}
+              class:bg-zinc-500={showInTimeline}
+              class:border-zinc-600={!showInTimeline}
+            ></div>
+            <span
+              class="text-xs"
+              class:text-zinc-400={showInTimeline}
+              class:text-zinc-500={!showInTimeline}
+            >
+              Show in timeline
+            </span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Swing -->
+      <div>
+        <span class="mb-2 block text-xs font-medium text-zinc-300">
+          Swing: {swing}%
+        </span>
+
+        <SettingsSlider
+          min={0}
+          max={100}
+          value={swing}
+          onpointerdown={swingTracker.onFocus}
+          onpointerup={swingTracker.onBlur}
+          onchange={onSetSwing}
+          class="nodrag"
+        />
+      </div>
+
+      <!-- Tracks -->
+      <div>
+        <div class="mb-2 flex items-center justify-between">
+          <span class="text-xs font-medium text-zinc-300">Tracks</span>
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              <button
+                onclick={onAddTrack}
+                disabled={tracks.length >= 8}
+                class="cursor-pointer rounded p-0.5 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-30"
+              >
+                <Plus class="h-3.5 w-3.5" />
+              </button>
+            </Tooltip.Trigger>
+
+            <Tooltip.Content>Add track (max 8)</Tooltip.Content>
+          </Tooltip.Root>
+        </div>
+
+        <div class="space-y-1.5">
+          {#each tracks as track, trackIdx (trackIdx)}
+            <div class="flex items-center gap-1.5">
+              <!-- Color swatch / native color picker -->
+              <NativeColorPicker
+                value={track.color}
+                ariaLabel="Track color"
+                class="h-5 w-5 cursor-pointer rounded border border-zinc-600 p-0"
+                swatchClass="block h-full w-full rounded"
+                onInput={(value) => onUpdateTrackColor(trackIdx, value)}
+              />
+
+              <!-- Name -->
+              <input
+                type="text"
+                value={track.name}
+                onchange={(e) => onUpdateTrackName(trackIdx, (e.target as HTMLInputElement).value)}
+                class="nodrag min-w-0 flex-1 rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-xs text-zinc-300 outline-none focus:ring-1 focus:ring-zinc-500"
+                maxlength="6"
+              />
+
+              <!-- Delete -->
+              <Tooltip.Root>
+                <Tooltip.Trigger>
+                  <button
+                    onclick={() => onRemoveTrack(trackIdx)}
+                    disabled={tracks.length <= 1}
+                    class="cursor-pointer rounded p-0.5 text-zinc-600 hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-30"
+                  >
+                    <Trash2 class="h-3.5 w-3.5" />
+                  </button>
+                </Tooltip.Trigger>
+                <Tooltip.Content>Remove track</Tooltip.Content>
+              </Tooltip.Root>
+            </div>
+          {/each}
+        </div>
       </div>
     </div>
+
+    {#if variant === 'floating' && hasMoreFloatingSettings}
+      <div
+        class="pointer-events-none absolute right-px bottom-px left-px flex h-10 items-end justify-center rounded-b-md bg-gradient-to-t from-zinc-900 via-zinc-900/90 to-transparent pb-1 text-[10px] text-zinc-400"
+        aria-hidden="true"
+      >
+        <span class="flex items-center gap-1">
+          Scroll for more
+          <ChevronDown class="h-3 w-3" />
+        </span>
+      </div>
+    {/if}
   </div>
 </div>

--- a/ui/src/lib/components/settings/SequencerSettings.svelte
+++ b/ui/src/lib/components/settings/SequencerSettings.svelte
@@ -5,6 +5,7 @@
   import NativeColorPicker from '$lib/components/settings/NativeColorPicker.svelte';
   import { ChevronDown, Plus, Trash2 } from '@lucide/svelte/icons';
   import type { TrackData } from '$lib/nodes/sequencer-constants';
+  import { useFloatingSettingsScroll } from './use-floating-settings-scroll.svelte';
 
   const STEP_COUNTS = [4, 8, 12, 16, 24, 32] as const;
 
@@ -74,42 +75,7 @@
       : 'Unchecked sends bang; checked sends velocity value'
   );
 
-  let floatingPanelElement = $state<HTMLDivElement>();
-  let isFloatingScrollable = $state(false);
-  let hasMoreFloatingSettings = $state(false);
-
-  function updateFloatingScrollIndicator(): void {
-    if (!floatingPanelElement || variant !== 'floating') {
-      isFloatingScrollable = false;
-      hasMoreFloatingSettings = false;
-      return;
-    }
-
-    isFloatingScrollable =
-      floatingPanelElement.scrollHeight > floatingPanelElement.clientHeight + 1;
-
-    hasMoreFloatingSettings =
-      isFloatingScrollable &&
-      floatingPanelElement.scrollTop + floatingPanelElement.clientHeight <
-        floatingPanelElement.scrollHeight - 1;
-  }
-
-  $effect(() => {
-    if (variant !== 'floating' || !floatingPanelElement) return;
-
-    const frame = requestAnimationFrame(updateFloatingScrollIndicator);
-    const observer = new ResizeObserver(updateFloatingScrollIndicator);
-    observer.observe(floatingPanelElement);
-
-    if (floatingPanelElement.firstElementChild) {
-      observer.observe(floatingPanelElement.firstElementChild);
-    }
-
-    return () => {
-      cancelAnimationFrame(frame);
-      observer.disconnect();
-    };
-  });
+  const floatingScroll = useFloatingSettingsScroll(() => variant === 'floating');
 
   function toggleOutputMode(): void {
     if (outletMode === 'single') {
@@ -123,12 +89,12 @@
 
 <div class={variant === 'floating' ? 'relative w-56' : 'w-full'}>
   <div
-    bind:this={floatingPanelElement}
-    onscroll={updateFloatingScrollIndicator}
+    bind:this={floatingScroll.element}
+    onscroll={floatingScroll.onScroll}
     class={variant === 'floating'
       ? [
           'nodrag max-h-[min(25rem,calc(100dvh-8rem))] overflow-y-auto overscroll-contain rounded-md border border-zinc-600 bg-zinc-900 p-4 shadow-xl',
-          isFloatingScrollable && 'nopan nowheel'
+          floatingScroll.isScrollable && 'nopan nowheel'
         ]
       : 'nodrag w-full'}
   >
@@ -404,7 +370,7 @@
       </div>
     </div>
 
-    {#if variant === 'floating' && hasMoreFloatingSettings}
+    {#if variant === 'floating' && floatingScroll.hasMore}
       <div
         class="pointer-events-none absolute right-px bottom-px left-px flex h-10 items-end justify-center rounded-b-md bg-gradient-to-t from-zinc-900 via-zinc-900/90 to-transparent pb-1 text-[10px] text-zinc-400"
         aria-hidden="true"

--- a/ui/src/lib/components/settings/SequencerSettings.svelte
+++ b/ui/src/lib/components/settings/SequencerSettings.svelte
@@ -34,7 +34,8 @@
     onAddTrack,
     onRemoveTrack,
     onUpdateTrackName,
-    onUpdateTrackColor
+    onUpdateTrackColor,
+    variant = 'floating'
   }: {
     steps: number;
     swing: number;
@@ -60,6 +61,7 @@
     onRemoveTrack: (idx: number) => void;
     onUpdateTrackName: (idx: number, name: string) => void;
     onUpdateTrackColor: (idx: number, color: string) => void;
+    variant?: 'floating' | 'sidebar';
   } = $props();
 
   const outputValueMode = $derived(
@@ -82,7 +84,14 @@
   }
 </script>
 
-<div class="nodrag w-56 rounded-md border border-zinc-600 bg-zinc-900 p-4 shadow-xl">
+<div
+  class={[
+    'nodrag',
+    variant === 'floating'
+      ? 'w-56 rounded-md border border-zinc-600 bg-zinc-900 p-4 shadow-xl'
+      : 'w-full'
+  ]}
+>
   <div class="flex flex-col gap-3">
     <!-- Steps -->
     <div>

--- a/ui/src/lib/components/settings/use-floating-settings-scroll.svelte.ts
+++ b/ui/src/lib/components/settings/use-floating-settings-scroll.svelte.ts
@@ -1,0 +1,60 @@
+export interface FloatingSettingsScrollController {
+  element: HTMLDivElement | undefined;
+  readonly isScrollable: boolean;
+  readonly hasMore: boolean;
+  onScroll: () => void;
+}
+
+/**
+ * Tracks overflow for a floating settings panel and keeps its scroll affordance
+ * in sync as the viewport or panel content changes.
+ */
+export function useFloatingSettingsScroll(
+  isEnabled: () => boolean
+): FloatingSettingsScrollController {
+  let element = $state<HTMLDivElement>();
+  let isScrollable = $state(false);
+  let hasMore = $state(false);
+
+  function update(): void {
+    if (!element || !isEnabled()) {
+      isScrollable = false;
+      hasMore = false;
+      return;
+    }
+
+    isScrollable = element.scrollHeight > element.clientHeight + 1;
+    hasMore = isScrollable && element.scrollTop + element.clientHeight < element.scrollHeight - 1;
+  }
+
+  $effect(() => {
+    if (!isEnabled() || !element) return;
+
+    const frame = requestAnimationFrame(update);
+    const observer = new ResizeObserver(update);
+    observer.observe(element);
+
+    if (element.firstElementChild) observer.observe(element.firstElementChild);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  });
+
+  return {
+    get element() {
+      return element;
+    },
+    set element(value) {
+      element = value;
+    },
+    get isScrollable() {
+      return isScrollable;
+    },
+    get hasMore() {
+      return hasMore;
+    },
+    onScroll: update
+  };
+}

--- a/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
+++ b/ui/src/lib/components/sidebar/SidebarObjectSettingsView.svelte
@@ -12,6 +12,7 @@
   import * as Popover from '$lib/components/ui/popover';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { useSettingsSidebarTargetSelection } from '$lib/settings/use-settings-sidebar-target-selection.svelte';
+  import { isSchemaSettingsSidebarTarget } from '../../../stores/settings-sidebar.store';
 
   let { class: className = '' }: { class?: string } = $props();
 
@@ -50,7 +51,7 @@
   }
 
   function hasDirtySettings(): boolean {
-    if (!activeTarget) return false;
+    if (!activeTarget || !isSchemaSettingsSidebarTarget(activeTarget)) return false;
 
     return activeTarget.schema.some((field) => {
       if (!('default' in field) || field.default === undefined) return false;
@@ -114,7 +115,7 @@
             </Command.Root>
           </Popover.Content>
         </Popover.Root>
-        {#if hasDirtySettingsValue}
+        {#if hasDirtySettingsValue && isSchemaSettingsSidebarTarget(activeTarget)}
           <Tooltip.Root>
             <Tooltip.Trigger>
               <button
@@ -159,17 +160,21 @@
 
     <div class="min-h-0 flex-1 px-4 py-3">
       {#key activeTarget.id}
-        <ObjectSettings
-          nodeId={activeTarget.id}
-          schema={activeTarget.schema}
-          values={activeTarget.values}
-          onValueChange={activeTarget.onValueChange}
-          onRevertAll={activeTarget.onRevertAll}
-          onClose={() => {}}
-          showCloseButton={false}
-          showRevertButton={false}
-          variant="sidebar"
-        />
+        {#if isSchemaSettingsSidebarTarget(activeTarget)}
+          <ObjectSettings
+            nodeId={activeTarget.id}
+            schema={activeTarget.schema}
+            values={activeTarget.values}
+            onValueChange={activeTarget.onValueChange}
+            onRevertAll={activeTarget.onRevertAll}
+            onClose={() => {}}
+            showCloseButton={false}
+            showRevertButton={false}
+            variant="sidebar"
+          />
+        {:else}
+          {@render activeTarget.content()}
+        {/if}
       {/key}
     </div>
   </div>

--- a/ui/src/lib/settings/use-settings-sidebar-target.svelte.ts
+++ b/ui/src/lib/settings/use-settings-sidebar-target.svelte.ts
@@ -1,5 +1,6 @@
 import type { SettingsSidebarTarget } from '../../stores/settings-sidebar.store';
 import {
+  isSchemaSettingsSidebarTarget,
   openObjectSettingsInSidebarIfPreferred,
   registerSettingsSidebarTarget
 } from '../../stores/settings-sidebar.store';
@@ -24,7 +25,7 @@ export function useSettingsSidebarTarget({ getTarget, floating }: SettingsSideba
 } {
   $effect(() => {
     const target = getTarget();
-    if (!target || target.schema.length === 0) return;
+    if (!target || (isSchemaSettingsSidebarTarget(target) && target.schema.length === 0)) return;
 
     return registerSettingsSidebarTarget(target);
   });

--- a/ui/src/objects/sequencer/SequencerNode.svelte
+++ b/ui/src/objects/sequencer/SequencerNode.svelte
@@ -7,6 +7,7 @@
     type NodeProps
   } from '@xyflow/svelte';
   import type { OutletMode, SequencerOutputMode } from './sequencer-output';
+  import { getHeightForTrackCountChange } from './sequencer-layout';
   import { getSequencerVisualStep } from './sequencer-scheduler';
   import { type TrackData, DEFAULT_TRACKS, TRACK_COLORS } from '$lib/nodes/sequencer-constants';
   import { useNodeDataTracker } from '$lib/history';
@@ -16,6 +17,7 @@
   import * as Tooltip from '$lib/components/ui/tooltip';
   import SequencerSettings from '$lib/components/settings/SequencerSettings.svelte';
   import { Settings, VolumeX, X } from '@lucide/svelte/icons';
+  import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
 
   let {
     id: nodeId,
@@ -84,6 +86,18 @@
 
   function applyTracks(newTracks: TrackData[]): void {
     const oldTracks = tracks;
+
+    if (newTracks.length !== oldTracks.length) {
+      updateNode(nodeId, {
+        height: getHeightForTrackCountChange(
+          nodeHeight,
+          oldTracks.length,
+          newTracks.length,
+          defaultGridHeight,
+          scale
+        )
+      });
+    }
 
     updateNodeData(nodeId, { ...data, tracks: newTracks });
     tracker.commit('tracks', oldTracks, newTracks);
@@ -176,7 +190,56 @@
 
     updateNodeData(nodeId, { ...data, tracks: newTracks });
   }
+
+  const settingsSidebarTarget = useSettingsSidebarTarget({
+    getTarget: () => ({ id: nodeId, label: 'sequencer', content: sidebarSettings }),
+    floating: {
+      isOpen: () => showSettings,
+      setOpen: (open) => (showSettings = open)
+    }
+  });
 </script>
+
+{#snippet sequencerSettings(variant: 'floating' | 'sidebar')}
+  <SequencerSettings
+    {steps}
+    {swing}
+    {outletMode}
+    {outputMode}
+    {audioRate}
+    {clockMode}
+    {showVelocity}
+    {showInTimeline}
+    {resizable}
+    {tracks}
+    {swingTracker}
+    onSetStepCount={setStepCount}
+    onSetSwing={(v) => updateNodeData(nodeId, { ...data, swing: v })}
+    onSetOutletMode={(v: OutletMode) => {
+      const newOutput = v === 'single' ? 'index' : 'bang';
+
+      const oldData = { outletMode, outputMode };
+      const newData = { outletMode: v, outputMode: newOutput };
+      updateNodeData(nodeId, { ...data, ...newData });
+      tracker.commit('outletMode', oldData, newData);
+    }}
+    onSetOutputMode={(v: string) => setNodeData('outputMode', v as SequencerOutputMode)}
+    onSetAudioRate={(v) => setNodeData('audioRate', v)}
+    onSetClockMode={(v) => setNodeData('clockMode', v)}
+    onSetShowVelocity={setShowVelocity}
+    onSetShowInTimeline={(v) => setNodeData('showInTimeline', v)}
+    onSetResizable={(v) => setNodeData('resizable', v)}
+    onAddTrack={addTrack}
+    onRemoveTrack={removeTrack}
+    onUpdateTrackName={updateTrackName}
+    onUpdateTrackColor={updateTrackColor}
+    {variant}
+  />
+{/snippet}
+
+{#snippet sidebarSettings()}
+  {@render sequencerSettings('sidebar')}
+{/snippet}
 
 <div class="relative h-full" style:width="{nodeWidth}px" style:height="{nodeHeight}px">
   <NodeResizer
@@ -211,7 +274,7 @@
             <button
               class="cursor-pointer rounded p-1 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-zinc-700 [@media(hover:none)]:opacity-100"
               class:opacity-100={showSettings}
-              onclick={() => (showSettings = !showSettings)}
+              onclick={(event) => settingsSidebarTarget.toggle(event)}
             >
               <Settings class="h-4 w-4 text-zinc-300" />
             </button>
@@ -382,39 +445,7 @@
         </button>
       </div>
 
-      <SequencerSettings
-        {steps}
-        {swing}
-        {outletMode}
-        {outputMode}
-        {audioRate}
-        {clockMode}
-        {showVelocity}
-        {showInTimeline}
-        {resizable}
-        {tracks}
-        {swingTracker}
-        onSetStepCount={setStepCount}
-        onSetSwing={(v) => updateNodeData(nodeId, { ...data, swing: v })}
-        onSetOutletMode={(v: OutletMode) => {
-          const newOutput = v === 'single' ? 'index' : 'bang';
-
-          const oldData = { outletMode, outputMode };
-          const newData = { outletMode: v, outputMode: newOutput };
-          updateNodeData(nodeId, { ...data, ...newData });
-          tracker.commit('outletMode', oldData, newData);
-        }}
-        onSetOutputMode={(v: string) => setNodeData('outputMode', v as SequencerOutputMode)}
-        onSetAudioRate={(v) => setNodeData('audioRate', v)}
-        onSetClockMode={(v) => setNodeData('clockMode', v)}
-        onSetShowVelocity={setShowVelocity}
-        onSetShowInTimeline={(v) => setNodeData('showInTimeline', v)}
-        onSetResizable={(v) => setNodeData('resizable', v)}
-        onAddTrack={addTrack}
-        onRemoveTrack={removeTrack}
-        onUpdateTrackName={updateTrackName}
-        onUpdateTrackColor={updateTrackColor}
-      />
+      {@render sequencerSettings('floating')}
     </div>
   {/if}
 </div>

--- a/ui/src/objects/sequencer/sequencer-layout.test.ts
+++ b/ui/src/objects/sequencer/sequencer-layout.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { getHeightForTrackCountChange } from './sequencer-layout';
+
+describe('sequencer track layout', () => {
+  it('grows and shrinks the node by one scaled track row', () => {
+    const gridHeight = 24;
+
+    expect(getHeightForTrackCountChange(126, 4, 5, gridHeight, 1)).toBe(154);
+    expect(getHeightForTrackCountChange(126, 4, 3, gridHeight, 1)).toBe(98);
+    expect(getHeightForTrackCountChange(189, 4, 5, gridHeight, 1.5)).toBe(231);
+  });
+
+  it('does not resize when tracks are edited without changing their count', () => {
+    expect(getHeightForTrackCountChange(126, 4, 4, 24, 1)).toBe(126);
+  });
+});

--- a/ui/src/objects/sequencer/sequencer-layout.ts
+++ b/ui/src/objects/sequencer/sequencer-layout.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns the node height after adding or removing sequencer tracks while
+ * preserving the current per-track cell size.
+ */
+export function getHeightForTrackCountChange(
+  currentNodeHeight: number,
+  previousTrackCount: number,
+  nextTrackCount: number,
+  gridHeight: number,
+  scale: number
+): number {
+  const trackCountDelta = nextTrackCount - previousTrackCount;
+  const trackHeight = 4 + gridHeight;
+
+  return currentNodeHeight + trackCountDelta * trackHeight * scale;
+}

--- a/ui/src/stores/settings-sidebar.store.ts
+++ b/ui/src/stores/settings-sidebar.store.ts
@@ -1,21 +1,38 @@
+import type { Snippet } from 'svelte';
 import { get, writable } from 'svelte/store';
 import type { SettingsSchema } from '$lib/settings';
 import { isSidebarOpen, sidebarView } from './ui.store';
 import { showSidebarTab } from './sidebar-visibility.store';
 import { openObjectSettingsInSidebar } from './editor-layout-settings.store';
 
-export interface SettingsSidebarTarget {
+interface SettingsSidebarTargetBase {
   id: string;
   label: string;
+}
+
+export interface SchemaSettingsSidebarTarget extends SettingsSidebarTargetBase {
   schema: SettingsSchema;
   values: Record<string, unknown>;
   onValueChange: (key: string, value: unknown) => void;
   onRevertAll: () => void;
 }
 
+export interface CustomSettingsSidebarTarget extends SettingsSidebarTargetBase {
+  /** Object-specific settings UI rendered by the sidebar. */
+  content: Snippet;
+}
+
+export type SettingsSidebarTarget = SchemaSettingsSidebarTarget | CustomSettingsSidebarTarget;
+
+export function isSchemaSettingsSidebarTarget(
+  target: SettingsSidebarTarget
+): target is SchemaSettingsSidebarTarget {
+  return 'schema' in target;
+}
+
 /**
- * Settings-schema views register their live callbacks here so the sidebar can
- * edit a node without coupling to a particular object implementation.
+ * Settings views register their live schema callbacks or bespoke content here
+ * so the sidebar can edit a node without coupling to its implementation.
  */
 export const settingsSidebarTargets = writable<Map<string, SettingsSidebarTarget>>(new Map());
 


### PR DESCRIPTION
- Show sequencer settings on the sidebar
- Resize the sequencer node's height when tracks are added or removed
- Cap the settings (both sequencer and general object settings) at 25em
- Refactor the settings scroll into a Svelte composable, `useFloatingSettingsScroll`