### PR TITLE
feat(settings): add precise value input for sliders

### DIFF
--- a/docs/design-docs/specs/91-dynamic-object-settings-api.md
+++ b/docs/design-docs/specs/91-dynamic-object-settings-api.md
@@ -235,7 +235,7 @@ Each field type maps to a UI element:
 | `boolean`  | Compact checkbox button (SequencerSettings pattern), NOT bits-ui Switch                         |
 | `select`   | Pill button group (SequencerSettings output/clock mode pattern)                                 |
 | `color`    | Color swatch grid (PostItNode pattern) or swatch+picker (SequencerSettings track color pattern) |
-| `slider`   | `<SettingsSlider>` component (`$lib/components/SettingsSlider.svelte`) with label+value header  |
+| `slider`   | `<SettingsSlider>` component (`$lib/components/SettingsSlider.svelte`) with label+value header. The value is double-clickable on desktop and tappable on touch devices for precise numeric entry. |
 
 ### UI Patterns (Reference Components)
 
@@ -258,6 +258,14 @@ The `<ObjectSettings>` component MUST follow the established UI patterns from ex
   />
 </div>
 ```
+
+The displayed value is a keyboard-accessible precision affordance. Hovering it
+reveals that it can be edited; double-clicking with a mouse or tapping on a
+touch device swaps it for an inline number input. The input selects the current
+value, uses the slider's `step` for arrow-key increments, accepts typed decimal
+precision beyond that step, constrains commits to the configured `min` and
+`max`, commits on Enter or blur, and cancels on Escape. This keeps slider drags
+accidental-edit free while allowing values such as `0.807`.
 
 **Select fields** — pill button group, NOT a `<select>` dropdown (SequencerSettings/ScopeNode pattern):
 

--- a/ui/src/lib/components/settings/ObjectSettings.svelte
+++ b/ui/src/lib/components/settings/ObjectSettings.svelte
@@ -2,6 +2,7 @@
   import { Check, ChevronDown, ChevronsUpDown, RotateCcw, X } from '@lucide/svelte/icons';
   import SettingsSlider from '$lib/components/SettingsSlider.svelte';
   import NativeColorPicker from '$lib/components/settings/NativeColorPicker.svelte';
+  import SliderValueEditor from '$lib/components/settings/SliderValueEditor.svelte';
   import * as Command from '$lib/components/ui/command';
   import * as Popover from '$lib/components/ui/popover';
   import * as Tooltip from '$lib/components/ui/tooltip';
@@ -235,13 +236,6 @@
             {@const sliderTracker = makeTracker(field)}
             {@const rawValue = (getCurrentValue(field) as number) ?? field.min}
 
-            {@const decimals =
-              field.step != null && field.step < 1
-                ? Math.max(0, Math.ceil(-Math.log10(field.step)))
-                : 0}
-
-            {@const displayValue = decimals > 0 ? rawValue.toFixed(decimals) : rawValue}
-
             <div>
               <div class="mb-1 flex items-start justify-between gap-2">
                 {#if field.description}
@@ -257,7 +251,16 @@
                   <span class="text-xs font-medium text-zinc-300">{field.label}</span>
                 {/if}
 
-                <span class="shrink-0 text-xs text-zinc-500 tabular-nums">{displayValue}</span>
+                <SliderValueEditor
+                  label={field.label}
+                  value={rawValue}
+                  min={field.min}
+                  max={field.max}
+                  step={field.step}
+                  onchange={(value) => onValueChange(field.key, value)}
+                  oneditstart={sliderTracker.onFocus}
+                  oneditend={sliderTracker.onBlur}
+                />
               </div>
 
               <SettingsSlider

--- a/ui/src/lib/components/settings/SliderValueEditor.svelte
+++ b/ui/src/lib/components/settings/SliderValueEditor.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import * as Tooltip from '$lib/components/ui/tooltip';
+
+  let {
+    label,
+    value,
+    min,
+    max,
+    step,
+    onchange,
+    oneditstart,
+    oneditend
+  }: {
+    label: string;
+    value: number;
+    min: number;
+    max: number;
+    step?: number;
+    onchange: (value: number) => void;
+    oneditstart?: () => void;
+    oneditend?: () => void;
+  } = $props();
+
+  let isEditing = $state(false);
+  let draft = $state<string | number | undefined>('');
+  let input = $state<HTMLInputElement>();
+
+  $effect(() => {
+    if (isEditing && input) {
+      input.focus();
+      input.select();
+    }
+  });
+
+  function beginEditing() {
+    if (isEditing) return;
+
+    draft = String(value);
+    isEditing = true;
+
+    oneditstart?.();
+  }
+
+  function finishEditing() {
+    if (!isEditing) return;
+
+    isEditing = false;
+    draft = '';
+
+    oneditend?.();
+  }
+
+  function commit() {
+    const rawDraft = String(draft ?? '');
+    const nextValue = Number(rawDraft);
+
+    if (rawDraft.trim() !== '' && Number.isFinite(nextValue)) {
+      onchange(Math.min(max, Math.max(min, nextValue)));
+    }
+
+    finishEditing();
+  }
+</script>
+
+{#if isEditing}
+  <input
+    bind:this={input}
+    bind:value={draft}
+    type="number"
+    {min}
+    {max}
+    step={step ?? 1}
+    aria-label={`Precise ${label} value`}
+    class="nodrag h-5 w-16 shrink-0 rounded border border-zinc-500 bg-zinc-800 px-1 text-right text-xs text-zinc-100 tabular-nums ring-1 ring-zinc-400 outline-none"
+    onblur={commit}
+    onkeydown={(event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+
+        commit();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+
+        finishEditing();
+      }
+    }}
+  />
+{:else}
+  <Tooltip.Root>
+    <Tooltip.Trigger>
+      <button
+        type="button"
+        aria-label={`Edit ${label} value precisely`}
+        class="nodrag shrink-0 cursor-pointer rounded px-1 text-xs text-zinc-500 tabular-nums transition-colors hover:bg-zinc-800 hover:text-zinc-200 focus-visible:ring-1 focus-visible:ring-zinc-400 focus-visible:outline-none"
+        ondblclick={beginEditing}
+        onpointerup={(event) => {
+          if (event.pointerType === 'touch') {
+            beginEditing();
+          }
+        }}
+        onkeydown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+
+            beginEditing();
+          }
+        }}>{value}</button
+      >
+    </Tooltip.Trigger>
+
+    <Tooltip.Content>Double-click or tap to edit precisely</Tooltip.Content>
+  </Tooltip.Root>
+{/if}


### PR DESCRIPTION
Adds a precise value input for sliders. Sometimes you want to input a precise number, and not use imprecise sliders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slider values can now be edited precisely by double-clicking, touching, or using the keyboard.
  * Inline editing supports decimal values, step-based arrow adjustments, and automatic minimum/maximum validation.
  * Press Enter or leave the field to save changes, or press Escape to cancel.
  * Added guidance tooltip explaining available slider editing interactions.

* **Documentation**
  * Updated slider interaction guidance to describe keyboard-accessible precision editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->