### PR TITLE
feat(canvas.dom): add fluid widget resizing

### DIFF
--- a/docs/design-docs/specs/101-fluid-canvas-dom.md
+++ b/docs/design-docs/specs/101-fluid-canvas-dom.md
@@ -1,0 +1,26 @@
+# 101. Fluid canvas.dom widgets
+
+`canvas.dom` keeps its fixed-size behavior by default. Widgets can opt into a
+fluid canvas with `setFluidSize({ showResizer?: boolean })`.
+
+Fluid mode uses the node's dimensions as the canvas's logical drawing size.
+Calls to `setCanvasSize()` made during that run do not change the dimensions
+and report one warning to the node console. This makes a widget's displayed
+size, its mouse coordinates, and its video bitmap use the same coordinate
+space.
+
+`onCanvasResize(callback)` registers one callback for the current execution.
+It receives `{ width, height }` after a node resize. Resize work is coalesced
+to one callback per animation frame; code is not re-run because widgets often
+hold state and listeners.
+
+Fluid mode exposes an XYFlow `NodeResizer`. `showResizer` controls only its
+initial visibility. `resize` limits the allowed axis to `'horizontal'`,
+`'vertical'`, or `'both'` (the default). `keepAspectRatio` keeps the node's
+initial ratio and uses both dimensions, regardless of the axis option.
+`initialSize: { width, height }` defines the default in logical canvas pixels
+and applies only before the user has explicitly sized the node.
+
+The node overflow menu provides Enable/Disable resizing, and the user's
+persisted choice wins on later code runs. This is an editor control, not an
+object setting.

--- a/docs/design-docs/specs/101-fluid-canvas-dom.md
+++ b/docs/design-docs/specs/101-fluid-canvas-dom.md
@@ -24,3 +24,11 @@ and applies only before the user has explicitly sized the node.
 The node overflow menu provides Enable/Disable resizing, and the user's
 persisted choice wins on later code runs. This is an editor control, not an
 object setting.
+
+## Implementation boundary
+
+`useFluidCanvas.svelte.ts` owns fluid-mode state, the generated-code API,
+resize coalescing, node-size persistence, and the overflow action. `CanvasDom`
+provides canvas-specific adapters for dimensions, errors, bitmap output, and
+XYFlow rendering controls. This keeps the canvas execution lifecycle separate
+from the optional fluid-layout lifecycle.

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -163,6 +163,13 @@ describe('patchies completions', () => {
     expect(getCompletionLabels('canvas.dom', 'setP')).toContain('setPrimaryButton');
   });
 
+  it('shows fluid canvas completions only for canvas.dom nodes', () => {
+    expect(getCompletionLabels('canvas.dom', 'setF')).toContain('setFluidSize');
+    expect(getCompletionLabels('canvas.dom', 'onCanvasR')).toContain('onCanvasResize');
+    expect(getCompletionLabels('canvas', 'setF')).not.toContain('setFluidSize');
+    expect(getCompletionLabels('canvas', 'onCanvasR')).not.toContain('onCanvasResize');
+  });
+
   it('shows hideBorder completions only for native UI nodes', () => {
     expect(getCompletionLabels('dom', 'hideB')).toContain('hideBorder');
     expect(getCompletionLabels('vue', 'hideB')).toContain('hideBorder');

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -339,6 +339,21 @@ const patchiesAPICompletions: Completion[] = [
     apply: 'setCanvasSize(500, 500)'
   },
   {
+    label: 'setFluidSize',
+    type: 'function',
+    detail:
+      "(options?: { showResizer?: boolean; resize?: 'horizontal' | 'vertical' | 'both'; keepAspectRatio?: boolean; initialSize?: { width: number; height: number } }) => void",
+    info: 'Make a canvas.dom widget follow its node size. Set an initial logical canvas size, limit resizing to an axis, or preserve its aspect ratio; users can enable or disable resizing from the overflow menu.',
+    apply: 'setFluidSize({ initialSize: { width: 800, height: 600 } })'
+  },
+  {
+    label: 'onCanvasResize',
+    type: 'function',
+    detail: '(callback: (size: { width: number; height: number }) => void) => void',
+    info: 'Register a callback that runs after a fluid canvas resize.',
+    apply: 'onCanvasResize(({ width, height }) => {\n  \n})'
+  },
+  {
     label: 'setSize',
     type: 'function',
     detail: '(width: number, height: number) => void',
@@ -495,6 +510,8 @@ const topLevelOnlyFunctions = new Set([
   'redraw',
   'setAudioPortCount',
   'setCanvasSize',
+  'setFluidSize',
+  'onCanvasResize',
   'setDrawMode',
   'setHidePorts',
   'setKeepAlive',
@@ -602,6 +619,8 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   setAudioPortCount: ['dsp~'],
   showAudioInput: ['tone~', 'sonic~', 'elem~'],
   setCanvasSize: ['canvas.dom', 'textmode.dom', 'three.dom'],
+  setFluidSize: ['canvas.dom'],
+  onCanvasResize: ['canvas.dom'],
   setSize: ['dom', 'vue'],
   setHidePorts: [
     'p5',

--- a/ui/src/objects/canvas/CanvasDom.svelte
+++ b/ui/src/objects/canvas/CanvasDom.svelte
@@ -134,15 +134,16 @@
     updateNodeData,
     commitNodeData: (key, oldValue, newValue) => tracker.commit(key, oldValue, newValue),
     warn: (message) => customConsole.warn(message),
-    onResizeCallback: (callback) => {
+    previewScaleFactor: PREVIEW_SCALE_FACTOR,
+
+    onResizeCallback(callback) {
       try {
         callback({ width: outputWidth, height: outputHeight });
-        void sendBitmap();
+        sendBitmap();
       } catch (error) {
         handleCodeError(error, data.code, nodeId, customConsole, CANVAS_DOM_WRAPPER_OFFSET);
       }
-    },
-    previewScaleFactor: PREVIEW_SCALE_FACTOR
+    }
   });
 
   // Mouse state - coordinates scaled to canvas resolution
@@ -337,7 +338,7 @@
     outputWidth = width;
     outputHeight = height;
 
-    // Update canvas resolution
+    // CanvasDom owns bitmap dimensions. Reactive canvas width/height attributes would clear draws.
     canvas.width = width;
     canvas.height = height;
 
@@ -601,8 +602,6 @@
     nopan={!panEnabled}
     nowheel={!wheelEnabled}
     tabindex={0}
-    width={outputWidth}
-    height={outputHeight}
     style={`width: ${previewWidth}px; height: ${previewHeight}px;`}
     {selected}
     {editorReady}

--- a/ui/src/objects/canvas/CanvasDom.svelte
+++ b/ui/src/objects/canvas/CanvasDom.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import { Maximize2, Minimize2 } from '@lucide/svelte/icons';
   import {
     NodeResizer,
     NodeResizeControl,
     ResizeControlVariant,
     useSvelteFlow,
-    useUpdateNodeInternals,
-    type ControlPosition
+    useUpdateNodeInternals
   } from '@xyflow/svelte';
   import { onMount, onDestroy } from 'svelte';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
@@ -30,17 +28,10 @@
   import { SettingsManager, createSettingsAPI } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
-  import { stripJavaScriptComments, stripJavaScriptStrings } from '$lib/utils/javascript-comments';
   import { resetCanvasSize } from '$objects/dom/runtime-size';
   import { getBorderResetDataForRun } from '$lib/components/border-chrome';
   import { useNodeDataTracker } from '$lib/history';
-  import type { ExtraMenuItem } from '$lib/components/object-preview-menu-actions';
-  import { createDynamicCanvasDimension } from './dynamic-canvas-dimension';
-  import {
-    resolveFluidCanvasOptions,
-    type FluidCanvasOptions,
-    type FluidCanvasResizeAxis
-  } from './fluid-canvas-options';
+  import { useFluidCanvas } from './useFluidCanvas.svelte';
 
   let {
     id: nodeId,
@@ -103,21 +94,6 @@
   let editorReady = $state(false);
   let animationFrameId: number | null = null;
   let pausedCallback: FrameRequestCallback | null = null;
-  let fluidCanvas = $state(false);
-  let fluidCanvasResizerVisible = $state(false);
-  let fluidCanvasResizeAxis = $state<FluidCanvasResizeAxis>('both');
-  let fluidCanvasKeepAspectRatio = $state(false);
-  let canvasResizeCallback: ((size: { width: number; height: number }) => void) | undefined;
-  let fluidResizeFrame: number | null = null;
-  let warnedAboutFixedCanvasSize = false;
-  const horizontalResizeControlPositions: ControlPosition[] = ['left', 'right'];
-  const verticalResizeControlPositions: ControlPosition[] = ['top', 'bottom'];
-  const fluidCanvasResizeControlPositions = $derived(
-    fluidCanvasResizeAxis === 'horizontal'
-      ? horizontalResizeControlPositions
-      : verticalResizeControlPositions
-  );
-
   const { updateNode, updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
   const tracker = $derived.by(() => useNodeDataTracker(nodeId));
@@ -134,8 +110,6 @@
   let outputHeight = $state(defaultOutputHeight);
   let previewWidth = $derived(outputWidth / PREVIEW_SCALE_FACTOR);
   let previewHeight = $derived(outputHeight / PREVIEW_SCALE_FACTOR);
-  const widthDimension = createDynamicCanvasDimension(() => outputWidth);
-  const heightDimension = createDynamicCanvasDimension(() => outputHeight);
 
   let inletCount = $derived(data.inletCount ?? 1);
   let outletCount = $derived(data.outletCount ?? 0);
@@ -149,10 +123,26 @@
     }
   });
 
-  $effect(() => {
-    if (fluidCanvas && data.fluidCanvasResizerVisible !== undefined) {
-      fluidCanvasResizerVisible = data.fluidCanvasResizerVisible;
-    }
+  const fluidCanvas = useFluidCanvas({
+    getNodeId: () => nodeId,
+    getData: () => data,
+    getNodeSize: () => ({ width, height }),
+    getPreviewSize: () => ({ width: previewWidth, height: previewHeight }),
+    getCanvasSize: () => ({ width: outputWidth, height: outputHeight }),
+    setCanvasSize: ({ width, height }) => setCanvasDimensions(width, height),
+    updateNode,
+    updateNodeData,
+    commitNodeData: (key, oldValue, newValue) => tracker.commit(key, oldValue, newValue),
+    warn: (message) => customConsole.warn(message),
+    onResizeCallback: (callback) => {
+      try {
+        callback({ width: outputWidth, height: outputHeight });
+        void sendBitmap();
+      } catch (error) {
+        handleCodeError(error, data.code, nodeId, customConsole, CANVAS_DOM_WRAPPER_OFFSET);
+      }
+    },
+    previewScaleFactor: PREVIEW_SCALE_FACTOR
   });
 
   // Mouse state - coordinates scaled to canvas resolution
@@ -357,96 +347,6 @@
     canvas.style.height = `${height / PREVIEW_SCALE_FACTOR}px`;
   }
 
-  function setCanvasSize(width: number, height: number) {
-    if (fluidCanvas) {
-      if (!warnedAboutFixedCanvasSize) {
-        customConsole.warn('setCanvasSize() is ignored while fluid canvas mode is active.');
-        warnedAboutFixedCanvasSize = true;
-      }
-      return;
-    }
-
-    setCanvasDimensions(width, height);
-  }
-
-  function notifyCanvasResize() {
-    if (fluidResizeFrame !== null) return;
-
-    fluidResizeFrame = requestAnimationFrame(() => {
-      fluidResizeFrame = null;
-      if (!fluidCanvas || !canvasResizeCallback) return;
-
-      try {
-        canvasResizeCallback({ width: outputWidth, height: outputHeight });
-        void sendBitmap();
-      } catch (error) {
-        handleCodeError(error, data.code, nodeId, customConsole, CANVAS_DOM_WRAPPER_OFFSET);
-      }
-    });
-  }
-
-  function setFluidSize(options: FluidCanvasOptions = {}) {
-    fluidCanvas = true;
-    const resolvedOptions = resolveFluidCanvasOptions(options);
-    const showResizer = data.fluidCanvasResizerVisible ?? resolvedOptions.showResizer;
-    fluidCanvasResizerVisible = showResizer;
-    fluidCanvasResizeAxis = resolvedOptions.resize;
-    fluidCanvasKeepAspectRatio = resolvedOptions.keepAspectRatio;
-
-    if (resolvedOptions.initialSize && width === undefined && height === undefined) {
-      const { width: initialWidth, height: initialHeight } = resolvedOptions.initialSize;
-
-      updateNode(nodeId, {
-        width: initialWidth / PREVIEW_SCALE_FACTOR,
-        height: initialHeight / PREVIEW_SCALE_FACTOR
-      });
-      setCanvasDimensions(initialWidth, initialHeight);
-    } else {
-      setCanvasDimensions(
-        Math.round((width ?? previewWidth) * PREVIEW_SCALE_FACTOR),
-        Math.round((height ?? previewHeight) * PREVIEW_SCALE_FACTOR)
-      );
-    }
-
-    if (data.fluidCanvasResizerVisible === undefined) {
-      updateNodeData(nodeId, { fluidCanvasResizerVisible: showResizer });
-    }
-  }
-
-  function handleFluidCanvasResize(
-    _event: unknown,
-    { width, height }: { width: number; height: number }
-  ) {
-    if (!fluidCanvas) return;
-
-    setCanvasDimensions(
-      Math.round(width * PREVIEW_SCALE_FACTOR),
-      Math.round(height * PREVIEW_SCALE_FACTOR)
-    );
-    notifyCanvasResize();
-  }
-
-  function toggleFluidCanvasResizer() {
-    const oldValue = fluidCanvasResizerVisible;
-    const nextVisible = !oldValue;
-
-    fluidCanvasResizerVisible = nextVisible;
-    updateNodeData(nodeId, { fluidCanvasResizerVisible: nextVisible });
-    tracker.commit('fluidCanvasResizerVisible', oldValue, nextVisible);
-  }
-
-  const displayExtraMenuItems = $derived.by<ExtraMenuItem[] | undefined>(() => {
-    if (!fluidCanvas) return undefined;
-
-    return [
-      {
-        label: fluidCanvasResizerVisible ? 'Disable resizing' : 'Enable resizing',
-        icon: fluidCanvasResizerVisible ? Minimize2 : Maximize2,
-        onclick: toggleFluidCanvasResizer
-      }
-    ];
-  });
-
   async function sendBitmap() {
     if (!canvas) return;
     if (!glSystem.hasOutgoingVideoConnections(nodeId)) return;
@@ -504,16 +404,7 @@
     panEnabled = true;
     wheelEnabled = true;
     videoOutputEnabled = true;
-    fluidCanvas = false;
-    fluidCanvasResizerVisible = false;
-    fluidCanvasResizeAxis = 'both';
-    fluidCanvasKeepAspectRatio = false;
-    canvasResizeCallback = undefined;
-    warnedAboutFixedCanvasSize = false;
-    if (fluidResizeFrame !== null) {
-      cancelAnimationFrame(fluidResizeFrame);
-      fluidResizeFrame = null;
-    }
+    fluidCanvas.reset();
     updateNodeData(nodeId, getBorderResetDataForRun(data));
 
     const resetSize = resetCanvasSize(canvas, DEFAULT_OUTPUT_SIZE);
@@ -540,9 +431,7 @@
         return;
       }
 
-      const usesFluidCanvas = /\bsetFluidSize\s*\(/.test(
-        stripJavaScriptStrings(stripJavaScriptComments(processedCode))
-      );
+      const dimensions = fluidCanvas.getExecutionDimensions(processedCode);
 
       await jsRunner.executeJavaScript(nodeId, processedCode, {
         customConsole,
@@ -553,10 +442,8 @@
           settings: createSettingsAPI(settingsManager),
           canvas,
           ctx,
-          // Preserve primitive-number behavior for fixed canvases. Fluid canvases need
-          // live dimensions because JSRunner otherwise snapshots function parameters.
-          width: usesFluidCanvas ? widthDimension : outputWidth,
-          height: usesFluidCanvas ? heightDimension : outputHeight,
+          width: dimensions.width,
+          height: dimensions.height,
           mouse,
           noDrag: () => {
             dragEnabled = false;
@@ -579,11 +466,9 @@
             videoOutputEnabled = false;
             updateNodeInternals(nodeId);
           },
-          setCanvasSize: (width: number, height: number) => setCanvasSize(width, height),
-          setFluidSize: (options?: FluidCanvasOptions) => setFluidSize(options),
-          onCanvasResize: (callback: (size: { width: number; height: number }) => void) => {
-            canvasResizeCallback = callback;
-          },
+          setCanvasSize: fluidCanvas.setFixedCanvasSize,
+          setFluidSize: fluidCanvas.setFluidSize,
+          onCanvasResize: fluidCanvas.onCanvasResize,
           setPrimaryButton: (primaryButton: PrimaryButton) => {
             eventBus.dispatch({
               type: 'nodePrimaryButtonUpdate',
@@ -624,7 +509,7 @@
         }
       });
 
-      if (!fluidCanvas && (width !== undefined || height !== undefined)) {
+      if (!fluidCanvas.isFluid && (width !== undefined || height !== undefined)) {
         updateNode(nodeId, { width: undefined, height: undefined });
       }
     } catch (error) {
@@ -660,7 +545,7 @@
     if (animationFrameId !== null) {
       cancelAnimationFrame(animationFrameId);
     }
-    if (fluidResizeFrame !== null) cancelAnimationFrame(fluidResizeFrame);
+    fluidCanvas.reset();
     eventBus.removeEventListener('consoleOutput', handleConsoleOutput);
     glSystem?.removeNode(nodeId);
     jsRunner.destroy(nodeId);
@@ -679,24 +564,24 @@
 </script>
 
 <div class="relative">
-  {#if selected && fluidCanvas && fluidCanvasResizerVisible}
-    {#if fluidCanvasResizeAxis === 'both' || fluidCanvasKeepAspectRatio}
+  {#if selected && fluidCanvas.isFluid && fluidCanvas.resizerVisible}
+    {#if fluidCanvas.resizeAxis === 'both' || fluidCanvas.keepAspectRatio}
       <NodeResizer
         class="z-1"
         minWidth={100}
         minHeight={80}
-        keepAspectRatio={fluidCanvasKeepAspectRatio}
-        onResize={handleFluidCanvasResize}
+        keepAspectRatio={fluidCanvas.keepAspectRatio}
+        onResize={fluidCanvas.handleResize}
       />
     {:else}
-      {#each fluidCanvasResizeControlPositions as position (position)}
+      {#each fluidCanvas.resizeControlPositions as position (position)}
         <NodeResizeControl
           class="z-1"
           {position}
           variant={ResizeControlVariant.Line}
           minWidth={100}
           minHeight={80}
-          onResize={handleFluidCanvasResize}
+          onResize={fluidCanvas.handleResize}
         />
       {/each}
     {/if}
@@ -727,7 +612,7 @@
     onSettingsValueChange={(key, value) => settingsManager.setValue(key, value)}
     onSettingsRevertAll={() => settingsManager.revertAll()}
     hideBorder={data.hideBorder}
-    {displayExtraMenuItems}
+    displayExtraMenuItems={fluidCanvas.displayExtraMenuItems}
   >
     {#snippet topHandle()}
       {#each Array.from({ length: inletCount }) as _, index (index)}

--- a/ui/src/objects/canvas/CanvasDom.svelte
+++ b/ui/src/objects/canvas/CanvasDom.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-  import { useSvelteFlow, useUpdateNodeInternals } from '@xyflow/svelte';
+  import { Maximize2, Minimize2 } from '@lucide/svelte/icons';
+  import {
+    NodeResizer,
+    NodeResizeControl,
+    ResizeControlVariant,
+    useSvelteFlow,
+    useUpdateNodeInternals,
+    type ControlPosition
+  } from '@xyflow/svelte';
   import { onMount, onDestroy } from 'svelte';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
   import { JSRunner } from '$lib/js-runner/JSRunner';
@@ -22,13 +30,24 @@
   import { SettingsManager, createSettingsAPI } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
+  import { stripJavaScriptComments, stripJavaScriptStrings } from '$lib/utils/javascript-comments';
   import { resetCanvasSize } from '$objects/dom/runtime-size';
   import { getBorderResetDataForRun } from '$lib/components/border-chrome';
+  import { useNodeDataTracker } from '$lib/history';
+  import type { ExtraMenuItem } from '$lib/components/object-preview-menu-actions';
+  import { createDynamicCanvasDimension } from './dynamic-canvas-dimension';
+  import {
+    resolveFluidCanvasOptions,
+    type FluidCanvasOptions,
+    type FluidCanvasResizeAxis
+  } from './fluid-canvas-options';
 
   let {
     id: nodeId,
     data,
-    selected
+    selected,
+    width,
+    height
   }: {
     id: string;
     data: {
@@ -43,8 +62,11 @@
       settingsSchema?: SettingsSchema;
       settings?: Record<string, unknown>;
       hideBorder?: boolean;
+      fluidCanvasResizerVisible?: boolean;
     };
     selected?: boolean;
+    width?: number;
+    height?: number;
   } = $props();
 
   function initialNodeId() {
@@ -81,9 +103,24 @@
   let editorReady = $state(false);
   let animationFrameId: number | null = null;
   let pausedCallback: FrameRequestCallback | null = null;
+  let fluidCanvas = $state(false);
+  let fluidCanvasResizerVisible = $state(false);
+  let fluidCanvasResizeAxis = $state<FluidCanvasResizeAxis>('both');
+  let fluidCanvasKeepAspectRatio = $state(false);
+  let canvasResizeCallback: ((size: { width: number; height: number }) => void) | undefined;
+  let fluidResizeFrame: number | null = null;
+  let warnedAboutFixedCanvasSize = false;
+  const horizontalResizeControlPositions: ControlPosition[] = ['left', 'right'];
+  const verticalResizeControlPositions: ControlPosition[] = ['top', 'bottom'];
+  const fluidCanvasResizeControlPositions = $derived(
+    fluidCanvasResizeAxis === 'horizontal'
+      ? horizontalResizeControlPositions
+      : verticalResizeControlPositions
+  );
 
-  const { updateNodeData } = useSvelteFlow();
+  const { updateNode, updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
+  const tracker = $derived.by(() => useNodeDataTracker(nodeId));
 
   const settingsManager = new SettingsManager(
     () => data.settings ?? {},
@@ -97,6 +134,8 @@
   let outputHeight = $state(defaultOutputHeight);
   let previewWidth = $derived(outputWidth / PREVIEW_SCALE_FACTOR);
   let previewHeight = $derived(outputHeight / PREVIEW_SCALE_FACTOR);
+  const widthDimension = createDynamicCanvasDimension(() => outputWidth);
+  const heightDimension = createDynamicCanvasDimension(() => outputHeight);
 
   let inletCount = $derived(data.inletCount ?? 1);
   let outletCount = $derived(data.outletCount ?? 0);
@@ -107,6 +146,12 @@
     if (data.executeCode && data.executeCode !== previousExecuteCode) {
       previousExecuteCode = data.executeCode;
       runCode();
+    }
+  });
+
+  $effect(() => {
+    if (fluidCanvas && data.fluidCanvasResizerVisible !== undefined) {
+      fluidCanvasResizerVisible = data.fluidCanvasResizerVisible;
     }
   });
 
@@ -296,7 +341,7 @@
     ctx = canvas.getContext('2d');
   }
 
-  function setCanvasSize(width: number, height: number) {
+  function setCanvasDimensions(width: number, height: number) {
     if (!canvas) return;
 
     outputWidth = width;
@@ -311,6 +356,96 @@
     canvas.style.width = `${width / PREVIEW_SCALE_FACTOR}px`;
     canvas.style.height = `${height / PREVIEW_SCALE_FACTOR}px`;
   }
+
+  function setCanvasSize(width: number, height: number) {
+    if (fluidCanvas) {
+      if (!warnedAboutFixedCanvasSize) {
+        customConsole.warn('setCanvasSize() is ignored while fluid canvas mode is active.');
+        warnedAboutFixedCanvasSize = true;
+      }
+      return;
+    }
+
+    setCanvasDimensions(width, height);
+  }
+
+  function notifyCanvasResize() {
+    if (fluidResizeFrame !== null) return;
+
+    fluidResizeFrame = requestAnimationFrame(() => {
+      fluidResizeFrame = null;
+      if (!fluidCanvas || !canvasResizeCallback) return;
+
+      try {
+        canvasResizeCallback({ width: outputWidth, height: outputHeight });
+        void sendBitmap();
+      } catch (error) {
+        handleCodeError(error, data.code, nodeId, customConsole, CANVAS_DOM_WRAPPER_OFFSET);
+      }
+    });
+  }
+
+  function setFluidSize(options: FluidCanvasOptions = {}) {
+    fluidCanvas = true;
+    const resolvedOptions = resolveFluidCanvasOptions(options);
+    const showResizer = data.fluidCanvasResizerVisible ?? resolvedOptions.showResizer;
+    fluidCanvasResizerVisible = showResizer;
+    fluidCanvasResizeAxis = resolvedOptions.resize;
+    fluidCanvasKeepAspectRatio = resolvedOptions.keepAspectRatio;
+
+    if (resolvedOptions.initialSize && width === undefined && height === undefined) {
+      const { width: initialWidth, height: initialHeight } = resolvedOptions.initialSize;
+
+      updateNode(nodeId, {
+        width: initialWidth / PREVIEW_SCALE_FACTOR,
+        height: initialHeight / PREVIEW_SCALE_FACTOR
+      });
+      setCanvasDimensions(initialWidth, initialHeight);
+    } else {
+      setCanvasDimensions(
+        Math.round((width ?? previewWidth) * PREVIEW_SCALE_FACTOR),
+        Math.round((height ?? previewHeight) * PREVIEW_SCALE_FACTOR)
+      );
+    }
+
+    if (data.fluidCanvasResizerVisible === undefined) {
+      updateNodeData(nodeId, { fluidCanvasResizerVisible: showResizer });
+    }
+  }
+
+  function handleFluidCanvasResize(
+    _event: unknown,
+    { width, height }: { width: number; height: number }
+  ) {
+    if (!fluidCanvas) return;
+
+    setCanvasDimensions(
+      Math.round(width * PREVIEW_SCALE_FACTOR),
+      Math.round(height * PREVIEW_SCALE_FACTOR)
+    );
+    notifyCanvasResize();
+  }
+
+  function toggleFluidCanvasResizer() {
+    const oldValue = fluidCanvasResizerVisible;
+    const nextVisible = !oldValue;
+
+    fluidCanvasResizerVisible = nextVisible;
+    updateNodeData(nodeId, { fluidCanvasResizerVisible: nextVisible });
+    tracker.commit('fluidCanvasResizerVisible', oldValue, nextVisible);
+  }
+
+  const displayExtraMenuItems = $derived.by<ExtraMenuItem[] | undefined>(() => {
+    if (!fluidCanvas) return undefined;
+
+    return [
+      {
+        label: fluidCanvasResizerVisible ? 'Disable resizing' : 'Enable resizing',
+        icon: fluidCanvasResizerVisible ? Minimize2 : Maximize2,
+        onclick: toggleFluidCanvasResizer
+      }
+    ];
+  });
 
   async function sendBitmap() {
     if (!canvas) return;
@@ -369,6 +504,16 @@
     panEnabled = true;
     wheelEnabled = true;
     videoOutputEnabled = true;
+    fluidCanvas = false;
+    fluidCanvasResizerVisible = false;
+    fluidCanvasResizeAxis = 'both';
+    fluidCanvasKeepAspectRatio = false;
+    canvasResizeCallback = undefined;
+    warnedAboutFixedCanvasSize = false;
+    if (fluidResizeFrame !== null) {
+      cancelAnimationFrame(fluidResizeFrame);
+      fluidResizeFrame = null;
+    }
     updateNodeData(nodeId, getBorderResetDataForRun(data));
 
     const resetSize = resetCanvasSize(canvas, DEFAULT_OUTPUT_SIZE);
@@ -395,6 +540,10 @@
         return;
       }
 
+      const usesFluidCanvas = /\bsetFluidSize\s*\(/.test(
+        stripJavaScriptStrings(stripJavaScriptComments(processedCode))
+      );
+
       await jsRunner.executeJavaScript(nodeId, processedCode, {
         customConsole,
         setPortCount,
@@ -404,12 +553,10 @@
           settings: createSettingsAPI(settingsManager),
           canvas,
           ctx,
-          get width() {
-            return outputWidth;
-          },
-          get height() {
-            return outputHeight;
-          },
+          // Preserve primitive-number behavior for fixed canvases. Fluid canvases need
+          // live dimensions because JSRunner otherwise snapshots function parameters.
+          width: usesFluidCanvas ? widthDimension : outputWidth,
+          height: usesFluidCanvas ? heightDimension : outputHeight,
           mouse,
           noDrag: () => {
             dragEnabled = false;
@@ -433,6 +580,10 @@
             updateNodeInternals(nodeId);
           },
           setCanvasSize: (width: number, height: number) => setCanvasSize(width, height),
+          setFluidSize: (options?: FluidCanvasOptions) => setFluidSize(options),
+          onCanvasResize: (callback: (size: { width: number; height: number }) => void) => {
+            canvasResizeCallback = callback;
+          },
           setPrimaryButton: (primaryButton: PrimaryButton) => {
             eventBus.dispatch({
               type: 'nodePrimaryButtonUpdate',
@@ -472,6 +623,10 @@
           }
         }
       });
+
+      if (!fluidCanvas && (width !== undefined || height !== undefined)) {
+        updateNode(nodeId, { width: undefined, height: undefined });
+      }
     } catch (error) {
       handleCodeError(error, data.code, nodeId, customConsole, CANVAS_DOM_WRAPPER_OFFSET);
     }
@@ -491,7 +646,6 @@
 
     const cleanupMouse = setupMouseListeners();
     const cleanupKeyboard = setupKeyboardListeners();
-
     setTimeout(() => {
       runCode();
     }, 50);
@@ -506,6 +660,7 @@
     if (animationFrameId !== null) {
       cancelAnimationFrame(animationFrameId);
     }
+    if (fluidResizeFrame !== null) cancelAnimationFrame(fluidResizeFrame);
     eventBus.removeEventListener('consoleOutput', handleConsoleOutput);
     glSystem?.removeNode(nodeId);
     jsRunner.destroy(nodeId);
@@ -523,98 +678,124 @@
   });
 </script>
 
-<CanvasPreviewLayout
-  title={data.title ?? 'canvas.dom'}
-  objectType="canvas.dom"
-  codePlaceholder="Write your Canvas API code here..."
-  {nodeId}
-  onrun={runCode}
-  onPlaybackToggle={togglePlayback}
-  paused={data.paused}
-  showPauseButton={true}
-  bind:previewCanvas={canvas}
-  nodrag={!dragEnabled}
-  nopan={!panEnabled}
-  nowheel={!wheelEnabled}
-  tabindex={0}
-  width={outputWidth}
-  height={outputHeight}
-  style={`width: ${previewWidth}px; height: ${previewHeight}px;`}
-  {selected}
-  {editorReady}
-  hasError={lineErrors !== undefined}
-  settingsSchema={data.settingsSchema}
-  settingsValues={data.settings ?? {}}
-  onSettingsValueChange={(key, value) => settingsManager.setValue(key, value)}
-  onSettingsRevertAll={() => settingsManager.revertAll()}
-  hideBorder={data.hideBorder}
->
-  {#snippet topHandle()}
-    {#each Array.from({ length: inletCount }) as _, index (index)}
-      <TypedHandle
-        port="inlet"
-        spec={{ handleId: index }}
-        title={`Inlet ${index}`}
-        total={inletCount}
-        {index}
-        class={handleClass}
-        {nodeId}
+<div class="relative">
+  {#if selected && fluidCanvas && fluidCanvasResizerVisible}
+    {#if fluidCanvasResizeAxis === 'both' || fluidCanvasKeepAspectRatio}
+      <NodeResizer
+        class="z-1"
+        minWidth={100}
+        minHeight={80}
+        keepAspectRatio={fluidCanvasKeepAspectRatio}
+        onResize={handleFluidCanvasResize}
       />
-    {/each}
-  {/snippet}
-
-  {#snippet bottomHandle()}
-    {#if videoOutputEnabled}
-      <TypedHandle
-        port="outlet"
-        spec={{ handleType: 'video', handleId: '0' }}
-        title="Video output"
-        total={outletCount + 1}
-        index={0}
-        class={handleClass}
-        {nodeId}
-      />
+    {:else}
+      {#each fluidCanvasResizeControlPositions as position (position)}
+        <NodeResizeControl
+          class="z-1"
+          {position}
+          variant={ResizeControlVariant.Line}
+          minWidth={100}
+          minHeight={80}
+          onResize={handleFluidCanvasResize}
+        />
+      {/each}
     {/if}
+  {/if}
 
-    {#each Array.from({ length: outletCount }) as _, index (index)}
-      <TypedHandle
-        port="outlet"
-        spec={{ handleId: index }}
-        title={`Outlet ${index}`}
-        total={videoOutputEnabled ? outletCount + 1 : outletCount}
-        index={videoOutputEnabled ? index + 1 : index}
-        class={handleClass}
+  <CanvasPreviewLayout
+    title={data.title ?? 'canvas.dom'}
+    objectType="canvas.dom"
+    codePlaceholder="Write your Canvas API code here..."
+    {nodeId}
+    onrun={runCode}
+    onPlaybackToggle={togglePlayback}
+    paused={data.paused}
+    showPauseButton={true}
+    bind:previewCanvas={canvas}
+    nodrag={!dragEnabled}
+    nopan={!panEnabled}
+    nowheel={!wheelEnabled}
+    tabindex={0}
+    width={outputWidth}
+    height={outputHeight}
+    style={`width: ${previewWidth}px; height: ${previewHeight}px;`}
+    {selected}
+    {editorReady}
+    hasError={lineErrors !== undefined}
+    settingsSchema={data.settingsSchema}
+    settingsValues={data.settings ?? {}}
+    onSettingsValueChange={(key, value) => settingsManager.setValue(key, value)}
+    onSettingsRevertAll={() => settingsManager.revertAll()}
+    hideBorder={data.hideBorder}
+    {displayExtraMenuItems}
+  >
+    {#snippet topHandle()}
+      {#each Array.from({ length: inletCount }) as _, index (index)}
+        <TypedHandle
+          port="inlet"
+          spec={{ handleId: index }}
+          title={`Inlet ${index}`}
+          total={inletCount}
+          {index}
+          class={handleClass}
+          {nodeId}
+        />
+      {/each}
+    {/snippet}
+
+    {#snippet bottomHandle()}
+      {#if videoOutputEnabled}
+        <TypedHandle
+          port="outlet"
+          spec={{ handleType: 'video', handleId: '0' }}
+          title="Video output"
+          total={outletCount + 1}
+          index={0}
+          class={handleClass}
+          {nodeId}
+        />
+      {/if}
+
+      {#each Array.from({ length: outletCount }) as _, index (index)}
+        <TypedHandle
+          port="outlet"
+          spec={{ handleId: index }}
+          title={`Outlet ${index}`}
+          total={videoOutputEnabled ? outletCount + 1 : outletCount}
+          index={videoOutputEnabled ? index + 1 : index}
+          class={handleClass}
+          {nodeId}
+        />
+      {/each}
+    {/snippet}
+
+    {#snippet codeEditor()}
+      <CodeEditor
+        value={data.code}
+        language="javascript"
+        nodeType="canvas.dom"
+        placeholder="Write your Canvas API code here..."
+        class="nodrag h-64 w-full resize-none"
+        onrun={runCode}
+        onchange={(newCode) => {
+          updateNodeData(nodeId, { code: newCode });
+        }}
+        onready={() => (editorReady = true)}
+        {lineErrors}
         {nodeId}
       />
-    {/each}
-  {/snippet}
+    {/snippet}
 
-  {#snippet codeEditor()}
-    <CodeEditor
-      value={data.code}
-      language="javascript"
-      nodeType="canvas.dom"
-      placeholder="Write your Canvas API code here..."
-      class="nodrag h-64 w-full resize-none"
-      onrun={runCode}
-      onchange={(newCode) => {
-        updateNodeData(nodeId, { code: newCode });
-      }}
-      onready={() => (editorReady = true)}
-      {lineErrors}
-      {nodeId}
-    />
-  {/snippet}
-
-  {#snippet console()}
-    <!-- Always render VirtualConsole so it receives events even when hidden -->
-    <div class="mt-3 w-full" class:hidden={!data.showConsole}>
-      <VirtualConsole
-        bind:this={consoleRef}
-        {nodeId}
-        placeholder="Canvas errors will appear here."
-        maxHeight="200px"
-      />
-    </div>
-  {/snippet}
-</CanvasPreviewLayout>
+    {#snippet console()}
+      <!-- Always render VirtualConsole so it receives events even when hidden -->
+      <div class="mt-3 w-full" class:hidden={!data.showConsole}>
+        <VirtualConsole
+          bind:this={consoleRef}
+          {nodeId}
+          placeholder="Canvas errors will appear here."
+          maxHeight="200px"
+        />
+      </div>
+    {/snippet}
+  </CanvasPreviewLayout>
+</div>

--- a/ui/src/objects/canvas/canvas.dom.prompt.ts
+++ b/ui/src/objects/canvas/canvas.dom.prompt.ts
@@ -10,7 +10,9 @@ Interactive Canvas on main thread. Use for mouse/keyboard input and instant FFT.
 - noDrag(), noPan(), noWheel(), noInteract() - Interaction control
 - hideBorder() - Hide Patchies border and selected glow
 - noOutput() - Hide video output (call this when the sketch does not feed video to other nodes)
-- setCanvasSize(w, h) - Resize canvas
+- setCanvasSize(width, height) - Use a fixed logical canvas size
+- setFluidSize({ showResizer?, resize?, keepAspectRatio?, initialSize? }) - Use a resizable canvas. resize is 'horizontal', 'vertical', or 'both' (default); keepAspectRatio preserves the initial ratio; initialSize sets the initial logical canvas size, e.g. { width: 800, height: 600 }. Users can enable or disable resizing from the overflow menu.
+- onCanvasResize(({ width, height }) => {}) - Redraw a non-animated fluid widget after a resize; it runs at most once per animation frame
 - onKeyDown(event => {}) - Keyboard down events (event.key, event.code)
 - onKeyUp(event => {}) - Keyboard up events (event.key, event.code)
 - setPortCount(inlets, outlets) - Set inlet/outlet count (e.g. setPortCount(1, 0) if only an inlet is needed and no message outlet)
@@ -21,14 +23,14 @@ Interactive Canvas on main thread. Use for mouse/keyboard input and instant FFT.
 - Call noWheel() if the sketch uses scroll or wheel interaction.
 - Call setPortCount(1, 0) if the sketch only needs to receive messages (inlet) and does not send any output messages.
 
-**Font & element sizes:**
+**Canvas sizing and layout:**
 - The node is displayed very zoomed out in the patch canvas.
 - Use large font sizes (18px minimum, 24–32px for primary text) so text remains readable.
 - Similarly, make shapes, lines, and UI elements larger than you would for a full-screen sketch.
-- Call setCanvasSize(width, height) with appropriate dimensions.
-  Minimum: 800x600. Maximum: 2000x2000.
-- When using setCanvasSize, make sure to define width and height variables:
-  e.g. const width = 800, height = 600; setCanvasSize(width, height);
+- Choose one sizing mode; do not call setCanvasSize() after setFluidSize().
+- For a fixed widget, call setCanvasSize(width, height) with an appropriate size. Minimum: 800x600. Maximum: 2000x2000.
+- For a resizable widget, call setFluidSize({ initialSize: { width: 800, height: 600 } }) instead. Use resize: 'horizontal' for faders, resize: 'vertical' for meters, or keepAspectRatio: true for square widgets.
+- Fluid widgets always read their current logical size from width and height. A requestAnimationFrame draw loop automatically redraws at the new size. Static widgets should register onCanvasResize(draw). Use width and height for arithmetic and formatting; when a primitive is required, copy with Number(width) or Number(height).
 
 ${typographyInstructions}
 

--- a/ui/src/objects/canvas/dynamic-canvas-dimension.test.ts
+++ b/ui/src/objects/canvas/dynamic-canvas-dimension.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { createDynamicCanvasDimension } from './dynamic-canvas-dimension';
+
+describe('createDynamicCanvasDimension', () => {
+  it('coerces to the latest canvas dimension for each arithmetic read', () => {
+    let value = 200;
+    const dimension = createDynamicCanvasDimension(() => value);
+
+    expect(dimension / 4).toBe(50);
+
+    value = 400;
+
+    expect(dimension / 4).toBe(100);
+    expect(`${dimension}`).toBe('400');
+    expect(dimension.toFixed(1)).toBe('400.0');
+    expect(dimension.toExponential(1)).toBe('4.0e+2');
+    expect(dimension.toPrecision(3)).toBe('400');
+  });
+});

--- a/ui/src/objects/canvas/dynamic-canvas-dimension.ts
+++ b/ui/src/objects/canvas/dynamic-canvas-dimension.ts
@@ -1,0 +1,17 @@
+/**
+ * JSRunner passes context values as function parameters, which snapshots primitive numbers.
+ * This fluid-canvas-only number-like object resolves to the latest dimension on coercion.
+ * It cannot emulate every primitive-number behavior (such as `typeof` or `Number.isFinite`).
+ */
+export function createDynamicCanvasDimension(getValue: () => number): number {
+  return {
+    valueOf: getValue,
+    toString: () => String(getValue()),
+    [Symbol.toPrimitive]: (hint: string) => (hint === 'string' ? String(getValue()) : getValue()),
+    toFixed: (digits?: number) => getValue().toFixed(digits),
+    toExponential: (digits?: number) => getValue().toExponential(digits),
+    toPrecision: (precision?: number) => getValue().toPrecision(precision),
+    toLocaleString: (locales?: string | string[], options?: Intl.NumberFormatOptions) =>
+      getValue().toLocaleString(locales, options)
+  } as unknown as number;
+}

--- a/ui/src/objects/canvas/fluid-canvas-options.test.ts
+++ b/ui/src/objects/canvas/fluid-canvas-options.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { resolveFluidCanvasOptions } from './fluid-canvas-options';
+
+describe('resolveFluidCanvasOptions', () => {
+  it('defaults to a visible freeform resizer', () => {
+    expect(resolveFluidCanvasOptions()).toEqual({
+      showResizer: true,
+      resize: 'both',
+      keepAspectRatio: false,
+      initialSize: undefined
+    });
+  });
+
+  it('preserves each supported resize constraint', () => {
+    expect(resolveFluidCanvasOptions({ resize: 'horizontal' })).toMatchObject({
+      resize: 'horizontal'
+    });
+    expect(resolveFluidCanvasOptions({ resize: 'vertical' })).toMatchObject({ resize: 'vertical' });
+    expect(resolveFluidCanvasOptions({ showResizer: false })).toMatchObject({ showResizer: false });
+    expect(resolveFluidCanvasOptions({ keepAspectRatio: true })).toMatchObject({
+      keepAspectRatio: true
+    });
+    expect(resolveFluidCanvasOptions({ initialSize: { width: 800, height: 600 } })).toMatchObject({
+      initialSize: { width: 800, height: 600 }
+    });
+  });
+});

--- a/ui/src/objects/canvas/fluid-canvas-options.ts
+++ b/ui/src/objects/canvas/fluid-canvas-options.ts
@@ -1,0 +1,27 @@
+export type FluidCanvasResizeAxis = 'horizontal' | 'vertical' | 'both';
+
+export type FluidCanvasOptions = {
+  showResizer?: boolean;
+  resize?: FluidCanvasResizeAxis;
+  keepAspectRatio?: boolean;
+  /** Logical canvas pixels, using the same coordinate space as width and height. */
+  initialSize?: { width: number; height: number };
+};
+
+export type ResolvedFluidCanvasOptions = {
+  showResizer: boolean;
+  resize: FluidCanvasResizeAxis;
+  keepAspectRatio: boolean;
+  initialSize?: { width: number; height: number };
+};
+
+export function resolveFluidCanvasOptions(
+  options: FluidCanvasOptions = {}
+): ResolvedFluidCanvasOptions {
+  return {
+    showResizer: options.showResizer ?? true,
+    resize: options.resize ?? 'both',
+    keepAspectRatio: options.keepAspectRatio ?? false,
+    initialSize: options.initialSize
+  };
+}

--- a/ui/src/objects/canvas/useFluidCanvas.svelte.ts
+++ b/ui/src/objects/canvas/useFluidCanvas.svelte.ts
@@ -1,0 +1,196 @@
+import { Maximize2, Minimize2 } from '@lucide/svelte/icons';
+import type { ExtraMenuItem } from '$lib/components/object-preview-menu-actions';
+import { stripJavaScriptComments, stripJavaScriptStrings } from '$lib/utils/javascript-comments';
+import { createDynamicCanvasDimension } from './dynamic-canvas-dimension';
+import {
+  resolveFluidCanvasOptions,
+  type FluidCanvasOptions,
+  type FluidCanvasResizeAxis
+} from './fluid-canvas-options';
+
+type CanvasSize = { width: number; height: number };
+
+type FluidCanvasData = {
+  fluidCanvasResizerVisible?: boolean;
+};
+
+type UseFluidCanvasOptions = {
+  getNodeId: () => string;
+  getData: () => FluidCanvasData;
+  getNodeSize: () => Partial<CanvasSize>;
+  getPreviewSize: () => CanvasSize;
+  getCanvasSize: () => CanvasSize;
+  setCanvasSize: (size: CanvasSize) => void;
+  updateNode: (nodeId: string, size: Partial<CanvasSize>) => void;
+  updateNodeData: (nodeId: string, data: FluidCanvasData) => void;
+  commitNodeData: (key: string, oldValue: unknown, newValue: unknown) => void;
+  warn: (message: string) => void;
+  onResizeCallback: (callback: (size: CanvasSize) => void) => void;
+  previewScaleFactor: number;
+};
+
+const usesFluidCanvas = (code: string) =>
+  /\bsetFluidSize\s*\(/.test(stripJavaScriptStrings(stripJavaScriptComments(code)));
+
+const HORIZONTAL_RESIZE_POSITIONS = ['left', 'right'] as const;
+const VERTICAL_RESIZE_POSITIONS = ['top', 'bottom'] as const;
+
+export function useFluidCanvas(options: UseFluidCanvasOptions) {
+  let isFluid = $state(false);
+  let defaultResizerVisible = $state(false);
+  let resizeAxis = $state<FluidCanvasResizeAxis>('both');
+  let keepAspectRatio = $state(false);
+  let resizeCallback: ((size: CanvasSize) => void) | undefined;
+  let resizeFrame: number | null = null;
+  let warnedAboutFixedCanvasSize = false;
+
+  const widthDimension = createDynamicCanvasDimension(() => options.getCanvasSize().width);
+  const heightDimension = createDynamicCanvasDimension(() => options.getCanvasSize().height);
+
+  const resizeControlPositions = $derived(
+    resizeAxis === 'horizontal' ? HORIZONTAL_RESIZE_POSITIONS : VERTICAL_RESIZE_POSITIONS
+  );
+
+  const resizerVisible = $derived(
+    options.getData().fluidCanvasResizerVisible ?? defaultResizerVisible
+  );
+
+  function reset() {
+    isFluid = false;
+    defaultResizerVisible = false;
+    resizeAxis = 'both';
+    keepAspectRatio = false;
+    resizeCallback = undefined;
+    warnedAboutFixedCanvasSize = false;
+
+    if (resizeFrame !== null) {
+      cancelAnimationFrame(resizeFrame);
+      resizeFrame = null;
+    }
+  }
+
+  function setFluidSize(fluidOptions: FluidCanvasOptions = {}) {
+    isFluid = true;
+
+    const resolvedOptions = resolveFluidCanvasOptions(fluidOptions);
+    const data = options.getData();
+    const nodeSize = options.getNodeSize();
+    const showResizer = data.fluidCanvasResizerVisible ?? resolvedOptions.showResizer;
+
+    defaultResizerVisible = showResizer;
+    resizeAxis = resolvedOptions.resize;
+    keepAspectRatio = resolvedOptions.keepAspectRatio;
+
+    if (
+      resolvedOptions.initialSize &&
+      nodeSize.width === undefined &&
+      nodeSize.height === undefined
+    ) {
+      const { width, height } = resolvedOptions.initialSize;
+
+      options.updateNode(options.getNodeId(), {
+        width: width / options.previewScaleFactor,
+        height: height / options.previewScaleFactor
+      });
+
+      options.setCanvasSize({ width, height });
+    } else {
+      const previewSize = options.getPreviewSize();
+
+      options.setCanvasSize({
+        width: Math.round((nodeSize.width ?? previewSize.width) * options.previewScaleFactor),
+        height: Math.round((nodeSize.height ?? previewSize.height) * options.previewScaleFactor)
+      });
+    }
+
+    if (data.fluidCanvasResizerVisible === undefined) {
+      options.updateNodeData(options.getNodeId(), { fluidCanvasResizerVisible: showResizer });
+    }
+  }
+
+  function setFixedCanvasSize(width: number, height: number) {
+    if (isFluid) {
+      if (!warnedAboutFixedCanvasSize) {
+        options.warn('setCanvasSize() is ignored while fluid canvas mode is active.');
+        warnedAboutFixedCanvasSize = true;
+      }
+
+      return;
+    }
+
+    options.setCanvasSize({ width, height });
+  }
+
+  function onCanvasResize(callback: (size: CanvasSize) => void) {
+    resizeCallback = callback;
+  }
+
+  function handleResize(_event: unknown, size: CanvasSize) {
+    if (!isFluid) return;
+
+    options.setCanvasSize({
+      width: Math.round(size.width * options.previewScaleFactor),
+      height: Math.round(size.height * options.previewScaleFactor)
+    });
+
+    if (resizeFrame !== null) return;
+
+    resizeFrame = requestAnimationFrame(() => {
+      resizeFrame = null;
+
+      if (!isFluid || !resizeCallback) return;
+
+      options.onResizeCallback(resizeCallback);
+    });
+  }
+
+  function toggleResizer() {
+    const oldValue = resizerVisible;
+    const nextVisible = !oldValue;
+
+    options.updateNodeData(options.getNodeId(), { fluidCanvasResizerVisible: nextVisible });
+    options.commitNodeData('fluidCanvasResizerVisible', oldValue, nextVisible);
+  }
+
+  const displayExtraMenuItems = $derived.by<ExtraMenuItem[] | undefined>(() => {
+    if (!isFluid) return undefined;
+
+    return [
+      {
+        label: resizerVisible ? 'Disable resizing' : 'Enable resizing',
+        icon: resizerVisible ? Minimize2 : Maximize2,
+        onclick: toggleResizer
+      }
+    ];
+  });
+
+  return {
+    get isFluid() {
+      return isFluid;
+    },
+    get resizerVisible() {
+      return resizerVisible;
+    },
+    get resizeAxis() {
+      return resizeAxis;
+    },
+    get keepAspectRatio() {
+      return keepAspectRatio;
+    },
+    get resizeControlPositions() {
+      return resizeControlPositions;
+    },
+    get displayExtraMenuItems() {
+      return displayExtraMenuItems;
+    },
+    getExecutionDimensions: (code: string) =>
+      usesFluidCanvas(code)
+        ? { width: widthDimension, height: heightDimension }
+        : options.getCanvasSize(),
+    reset,
+    setFluidSize,
+    setFixedCanvasSize,
+    onCanvasResize,
+    handleResize
+  };
+}

--- a/ui/static/content/objects/canvas.dom.md
+++ b/ui/static/content/objects/canvas.dom.md
@@ -63,6 +63,55 @@ Resize the canvas resolution dynamically:
 setCanvasSize(800, 600);
 ```
 
+## Resizable Widgets
+
+Build a widget that fills its Patchies node instead of choosing a fixed canvas size:
+
+```javascript
+setFluidSize();
+
+function draw() {
+  ctx.fillStyle = '#18181b';
+  ctx.fillRect(0, 0, width, height);
+}
+
+onCanvasResize(draw);
+draw();
+```
+
+The node's resize handles update `width`, `height`, the canvas bitmap, and mouse coordinates.
+Use `onCanvasResize()` when your widget only draws on demand. An animation loop that reads
+`width` and `height` redraws at the new size automatically.
+
+In a fluid widget, `width` and `height` act like live numbers for arithmetic and common
+formatting methods such as `toFixed()`. Do not use `typeof`, `Number.isFinite()`, or JSON
+serialization on them; copy them first with `const currentWidth = Number(width)` when needed.
+
+Set a starting size and choose how people can resize the widget:
+
+```javascript
+setFluidSize({
+  initialSize: { width: 800, height: 600 },
+  resize: 'horizontal'
+});
+```
+
+Open the node overflow menu to enable or disable resizing. Pass
+`setFluidSize({ showResizer: false })` to hide the handles initially; the menu remains available.
+You can also limit a controller to one resize axis, or preserve its shape:
+
+```javascript
+setFluidSize({ resize: 'horizontal' }); // e.g. a fader
+setFluidSize({ resize: 'vertical' });   // e.g. a meter
+setFluidSize({ keepAspectRatio: true }); // e.g. a square pad grid
+setFluidSize({ initialSize: { width: 800, height: 600 } }); // starting size
+```
+
+`resize` defaults to `'both'`. `keepAspectRatio` uses both dimensions to preserve the
+node's initial ratio. `initialSize` uses logical canvas pixels (the same coordinate space as
+`width` and `height`) and applies only before a user has set an explicit node size.
+In fluid mode, `setCanvasSize()` is ignored and reports a one-time console warning.
+
 ## Special Functions
 
 All [Patchies JavaScript Runner](/docs/javascript-runner) functions are available, plus:


### PR DESCRIPTION
## Summary

Adds fluid, user-resizable `canvas.dom` widgets, including the generated-code API and the editor controls that support them.

## `setFluidSize` API

`setFluidSize(options?)` opts a `canvas.dom` widget into fluid layout:

- `initialSize: { width, height }` sets the initial logical canvas dimensions (the same coordinate space as `width`, `height`, and `setCanvasSize`) without overwriting an explicit user resize.
- `resize: 'horizontal' | 'vertical' | 'both'` limits resize controls; the default is `both`.
- `keepAspectRatio: true` preserves the initial ratio and takes precedence over the axis constraint.
- `showResizer: false` hides the controls initially. Users can toggle Enable/Disable resizing from the overflow menu below Freeze frame.
- `onCanvasResize(({ width, height }) => ...)` lets static widgets redraw after a resize. Animation loops using `width` and `height` adapt automatically.
- Fixed `setCanvasSize` warns and does nothing while fluid mode is active.

## Why

Widget authors need controls such as pads, faders, and meters that fit a user-resized Patchies node instead of remaining at a fixed canvas size.

## Implementation

The JS runner bound `width` and `height` at initial execution, so render loops continued drawing with stale dimensions. Fluid dimensions now use dynamic numeric coercion and the canvas follows XYFlow resize events. This also avoids the ResizeObserver feedback loop that caused canvas flashing.

## Validation

- `bun run check`
- `bun run test -- patchies-completions.test.ts fluid-canvas-options.test.ts dynamic-canvas-dimension.test.ts`
- `bun run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added fluid resizing for `canvas.dom` widgets, including horizontal, vertical, or freeform resizing.
  - Added optional aspect-ratio preservation, initial dimensions, resize controls, and resize callbacks.
  - Canvas dimensions now update dynamically as widgets are resized.

- **Documentation**
  - Documented fluid sizing behavior, configuration options, resize callbacks, and size constraints.
  - Added editor completion guidance for the new canvas helpers.

- **Tests**
  - Added coverage for fluid sizing options, dynamic dimensions, and context-specific editor completions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->