### PR TITLE
feat(sidebar): support code sidebar for all code-based objects

### DIFF
--- a/docs/design-docs/specs/148-code-editor-detached-layouts.md
+++ b/docs/design-docs/specs/148-code-editor-detached-layouts.md
@@ -148,6 +148,11 @@ changing the editor until unpinned. Explicit Code actions still select their
 own target. Nodes without an applicable code accessor leave the pinned or last
 available target unchanged.
 
+Every code-capable node must register a sidebar accessor, including nodes that
+use `CanvasPreviewLayout` and standalone editors. This keeps selection behavior
+consistent for render nodes such as `canvas`, `canvas.dom`, `three`, and
+`three.dom`, as well as non-preview code editors.
+
 ## Settings
 
 Add editor layout preferences to `SettingsModal.svelte`.

--- a/ui/src/lib/code-editor/use-code-editor-overlay-target.svelte.ts
+++ b/ui/src/lib/code-editor/use-code-editor-overlay-target.svelte.ts
@@ -1,0 +1,20 @@
+import { fromStore } from 'svelte/store';
+
+import {
+  activeCodeEditorTarget,
+  isCodeEditorOverlayTarget
+} from '../../stores/code-editor-layout.store';
+
+/** Reactively reports whether this code field is open in the detached overlay. */
+export function useCodeEditorOverlayTarget(
+  getNodeId: () => string | undefined,
+  getDataKey: () => string
+): { readonly isOpen: boolean } {
+  const activeTarget = fromStore(activeCodeEditorTarget);
+
+  return {
+    get isOpen() {
+      return isCodeEditorOverlayTarget(activeTarget.current, getNodeId(), getDataKey());
+    }
+  };
+}

--- a/ui/src/lib/code-editor/use-code-sidebar-target.svelte.ts
+++ b/ui/src/lib/code-editor/use-code-sidebar-target.svelte.ts
@@ -75,12 +75,12 @@ export function useCodeSidebarTargetSelection(): {
     }
 
     const selectedId = selectedNode.current?.id ?? null;
+    const selectionChanged = selectedId !== lastSelectedNodeId;
 
     const selectedTarget = selectedId
       ? targets.find((target) => target.nodeId === selectedId)
       : undefined;
 
-    const selectionChanged = selectedId !== lastSelectedNodeId;
     const selectedTargetRegisteredAfterSelection =
       selectedTarget !== undefined && lastSelectedNodeTargetId === null;
 

--- a/ui/src/lib/code-editor/use-code-sidebar-target.svelte.ts
+++ b/ui/src/lib/code-editor/use-code-sidebar-target.svelte.ts
@@ -34,6 +34,7 @@ export function useCodeSidebarTargetSelection(): {
   let activeTargetId = $state<string | null>(null);
   let pinnedTargetId = $state<string | null>(null);
   let lastSelectedNodeId = $state<string | null>(null);
+  let lastSelectedNodeTargetId = $state<string | null>(null);
 
   const targets = $derived(
     [...targetsSource.current.values()].sort((a, b) => a.label.localeCompare(b.label))
@@ -79,7 +80,11 @@ export function useCodeSidebarTargetSelection(): {
       ? targets.find((target) => target.nodeId === selectedId)
       : undefined;
 
-    if (selectedTarget && selectedId !== lastSelectedNodeId) {
+    const selectionChanged = selectedId !== lastSelectedNodeId;
+    const selectedTargetRegisteredAfterSelection =
+      selectedTarget !== undefined && lastSelectedNodeTargetId === null;
+
+    if (selectedTarget && (selectionChanged || selectedTargetRegisteredAfterSelection)) {
       activeTargetId = selectedTarget.nodeId;
       activateCodeEditorSidebarTarget(selectedTarget);
     } else if (!activeTargetId || !targets.some((target) => target.nodeId === activeTargetId)) {
@@ -91,6 +96,7 @@ export function useCodeSidebarTargetSelection(): {
     }
 
     lastSelectedNodeId = selectedId;
+    lastSelectedNodeTargetId = selectedTarget?.nodeId ?? null;
   });
 
   return {

--- a/ui/src/lib/components/CodeEditor.svelte
+++ b/ui/src/lib/components/CodeEditor.svelte
@@ -186,6 +186,7 @@
   let valueWidgetRunTimeout: ReturnType<typeof setTimeout> | null = null;
   let lastValueWidgetRunAt = 0;
   let pendingValueWidgetRunCode: string | undefined;
+  let languageRequestVersion = 0;
 
   function runValueWidgetCode(code: string | undefined) {
     onrun(code);
@@ -622,10 +623,11 @@
   $effect(() => {
     const autocomplete = $editorAutocompleteEnabled;
     const hoverHints = $editorHoverHintsEnabled;
+    const requestVersion = ++languageRequestVersion;
 
     loadLanguageExtension(language, { nodeType }, { autocomplete, hoverHints }).then(
       (languageExtension) => {
-        if (editorView) {
+        if (editorView && requestVersion === languageRequestVersion) {
           editorView.dispatch({
             effects: [
               languageComp.reconfigure(languageExtension),

--- a/ui/src/lib/components/CodeEditor.svelte
+++ b/ui/src/lib/components/CodeEditor.svelte
@@ -124,6 +124,7 @@
 
   let languageComp = new Compartment();
   let autocompleteComp = new Compartment();
+  let placeholderComp = new Compartment();
 
   let {
     value = $bindable(),
@@ -317,6 +318,7 @@
         search(),
 
         languageComp.of(languageExtension),
+        placeholderComp.of(placeholder ? cmPlaceholder(placeholder) : []),
 
         // Error line highlighting with hover tooltips
         tooltips({ parent: document.body }),
@@ -540,11 +542,6 @@
         extensions.push(vim({ status: false }));
       }
 
-      // Add placeholder if provided
-      if (placeholder) {
-        extensions.push(cmPlaceholder(placeholder));
-      }
-
       // Add line wrapping if enabled
       if (lineWrap) {
         extensions.push(EditorView.lineWrapping);
@@ -631,7 +628,8 @@
           editorView.dispatch({
             effects: [
               languageComp.reconfigure(languageExtension),
-              autocompleteComp.reconfigure(autocomplete ? autocompletion() : [])
+              autocompleteComp.reconfigure(autocomplete ? autocompletion() : []),
+              placeholderComp.reconfigure(placeholder ? cmPlaceholder(placeholder) : [])
             ]
           });
         }

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -24,7 +24,6 @@
   import { helpViewStore } from '../../stores/help-view.store';
   import { overrideOutputNodeId, previewBackgroundColor } from '../../stores/renderer.store';
   import {
-    activeCodeEditorTarget,
     closeCodeEditorOverlay,
     openCodeEditorOverlay,
     openCodeEditorSidebar,
@@ -34,6 +33,7 @@
   import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
   import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
   import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
+  import { useCodeEditorOverlayTarget } from '$lib/code-editor/use-code-editor-overlay-target.svelte';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { CanvasPreviewExpandController } from '$lib/canvas/CanvasPreviewExpandController';
   import { SurfaceListeners } from '$lib/canvas/SurfaceListeners';
@@ -273,10 +273,9 @@
     showExpandOption && nodeId !== undefined && $outputTarget === 'background'
   );
 
-  let isCodeEditorDetached = $derived(
-    nodeId !== undefined &&
-      $activeCodeEditorTarget?.nodeId === nodeId &&
-      $activeCodeEditorTarget.dataKey === codeDataKey
+  const codeEditorOverlay = useCodeEditorOverlayTarget(
+    () => nodeId,
+    () => codeDataKey
   );
   const detachedSettings = $derived(
     settingsSchema && settingsSchema.length > 0
@@ -440,7 +439,7 @@
   }
 
   function openInlineCodeEditor() {
-    if (isCodeEditorDetached) {
+    if (codeEditorOverlay.isOpen) {
       closeCodeEditorOverlay();
     }
 
@@ -600,7 +599,7 @@
     </div>
   {/if}
 
-  {#if showEditor && !isCodeEditorDetached}
+  {#if showEditor && !codeEditorOverlay.isOpen}
     <div class="absolute" style="left: {editorLeftPos}px;">
       {#if editorReady !== false}
         <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
@@ -653,7 +652,7 @@
               <button
                 onclick={() => {
                   showEditor = false;
-                  if (isCodeEditorDetached) closeCodeEditorOverlay();
+                  if (codeEditorOverlay.isOpen) closeCodeEditorOverlay();
                 }}
                 class="cursor-pointer rounded p-1 hover:bg-zinc-700"
                 aria-label="Close editor"

--- a/ui/src/lib/components/sidebar/SidebarCodeEditorView.svelte
+++ b/ui/src/lib/components/sidebar/SidebarCodeEditorView.svelte
@@ -121,6 +121,7 @@
         {/if}
       </div>
     </div>
+
     {#if target}
       <p class="mt-1.5 truncate font-mono text-[11px] text-zinc-500">
         {pinnedTargetId ? 'Pinned' : 'Following canvas selection'}
@@ -130,17 +131,19 @@
 
   <div class="sidebar-code-editor min-h-0 flex-1 overflow-hidden">
     {#if target}
-      <CodeEditor
-        value={target.value}
-        onchange={target.onchange ?? (() => {})}
-        language={target.language}
-        nodeType={target.nodeType}
-        placeholder={target.placeholder ?? ''}
-        class="nodrag nopan nowheel h-full w-full resize-none"
-        onrun={target.onrun}
-        nodeId={target.nodeId}
-        dataKey={target.dataKey}
-      />
+      {#key `${target.nodeId}:${target.dataKey}`}
+        <CodeEditor
+          value={target.value}
+          onchange={target.onchange ?? (() => {})}
+          language={target.language}
+          nodeType={target.nodeType}
+          placeholder={target.placeholder ?? ''}
+          class="nodrag nopan nowheel h-full w-full resize-none"
+          onrun={target.onrun}
+          nodeId={target.nodeId}
+          dataKey={target.dataKey}
+        />
+      {/key}
     {:else}
       <div class="flex h-full items-center justify-center px-4 text-center">
         <div class="flex max-w-[220px] flex-col items-center gap-3">

--- a/ui/src/objects/asm/AssemblyMachine.svelte
+++ b/ui/src/objects/asm/AssemblyMachine.svelte
@@ -27,6 +27,7 @@
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import { useNodeDataTracker } from '$lib/history';
   import { toast } from 'svelte-sonner';
+  import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
 
   const eventBus = PatchiesEventBus.getInstance();
 
@@ -62,6 +63,19 @@
 
   const { updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
+
+  useCodeSidebarTarget(() => ({
+    nodeId,
+    dataKey: 'code',
+    language: 'assembly',
+    nodeType: 'asm',
+    label: data.title ?? 'asm',
+    title: data.title ?? 'asm',
+    placeholder: 'Enter assembly code...',
+    value: data.code,
+    onchange: (newCode) => updateNodeData(nodeId, { code: newCode }),
+    onrun: playMachine
+  }));
 
   function getInitialNodeId() {
     return nodeId;

--- a/ui/src/objects/audio-code/SimpleDspLayout.svelte
+++ b/ui/src/objects/audio-code/SimpleDspLayout.svelte
@@ -8,7 +8,6 @@
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings';
   import {
-    activeCodeEditorTarget,
     closeCodeEditorOverlay,
     openCodeEditorOverlay,
     openCodeEditorSidebar,
@@ -19,6 +18,7 @@
   import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
   import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
   import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
+  import { useCodeEditorOverlayTarget } from '$lib/code-editor/use-code-editor-overlay-target.svelte';
   import { editorFontFamily } from '../../stores/editor.store';
 
   let {
@@ -77,8 +77,9 @@
   const showAudioInput = $derived(data.showAudioInput ?? false);
   const visibleInletCount = $derived((showAudioInput ? 1 : 0) + messageInletCount);
 
-  const isCodeEditorDetached = $derived(
-    $activeCodeEditorTarget?.nodeId === nodeId && $activeCodeEditorTarget.dataKey === 'code'
+  const codeEditorOverlay = useCodeEditorOverlayTarget(
+    () => nodeId,
+    () => 'code'
   );
 
   const detachedSettings = $derived(
@@ -157,7 +158,7 @@
   }
 
   function openInlineEditor() {
-    if (isCodeEditorDetached) {
+    if (codeEditorOverlay.isOpen) {
       closeCodeEditorOverlay();
     }
 
@@ -361,7 +362,7 @@
     </div>
   </div>
 
-  {#if showEditor && !isCodeEditorDetached}
+  {#if showEditor && !codeEditorOverlay.isOpen}
     <div class="absolute" style="left: {contentWidth + 10}px">
       <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
         <Tooltip.Root>

--- a/ui/src/objects/canvas/CanvasDom.svelte
+++ b/ui/src/objects/canvas/CanvasDom.svelte
@@ -592,6 +592,7 @@
     title={data.title ?? 'canvas.dom'}
     objectType="canvas.dom"
     codePlaceholder="Write your Canvas API code here..."
+    onCodeChange={(newCode) => updateNodeData(nodeId, { code: newCode })}
     {nodeId}
     onrun={runCode}
     onPlaybackToggle={togglePlayback}

--- a/ui/src/objects/canvas/JSCanvasNode.svelte
+++ b/ui/src/objects/canvas/JSCanvasNode.svelte
@@ -279,6 +279,7 @@
   title={data.title ?? 'canvas'}
   objectType="canvas"
   codePlaceholder="Write your Canvas API code here..."
+  onCodeChange={(newCode) => updateNodeData(nodeId, { code: newCode })}
   {nodeId}
   onrun={updateCanvas}
   onPlaybackToggle={togglePlayback}

--- a/ui/src/objects/code/CodeBlockBase.svelte
+++ b/ui/src/objects/code/CodeBlockBase.svelte
@@ -28,7 +28,6 @@
   import type { SettingsSchema } from '$lib/settings';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import {
-    activeCodeEditorTarget,
     closeCodeEditorOverlay,
     openCodeEditorOverlay,
     openCodeEditorSidebar,
@@ -38,6 +37,7 @@
   import { defaultEditorLayout } from '../../stores/editor-layout-settings.store';
   import { openEditorLayout } from '$lib/code-editor/open-editor-layout';
   import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
+  import { useCodeEditorOverlayTarget } from '$lib/code-editor/use-code-editor-overlay-target.svelte';
 
   let contentContainer: HTMLDivElement | null = null;
   let inlineConsoleRef: VirtualConsole | null = $state(null);
@@ -158,8 +158,9 @@
   const code = $derived(data.code || '');
   let previousExecuteCode = $state<number | undefined>(undefined);
 
-  let isCodeEditorDetached = $derived(
-    $activeCodeEditorTarget?.nodeId === nodeId && $activeCodeEditorTarget.dataKey === 'code'
+  const codeEditorOverlay = useCodeEditorOverlayTarget(
+    () => nodeId,
+    () => 'code'
   );
 
   const detachedSettings = $derived(
@@ -310,7 +311,7 @@
   }
 
   function openInlineEditor() {
-    if (isCodeEditorDetached) {
+    if (codeEditorOverlay.isOpen) {
       closeCodeEditorOverlay();
     }
 
@@ -670,7 +671,7 @@
     </div>
   </div>
 
-  {#if showEditor && !isCodeEditorDetached}
+  {#if showEditor && !codeEditorOverlay.isOpen}
     <div class="absolute" style="left: {contentWidth + 10}px">
       <div class="absolute -top-7 left-0 flex w-full justify-end gap-x-1">
         {#if !(supportsLibraries && data.libraryName)}

--- a/ui/src/objects/dom/DomRuntimeNode.svelte
+++ b/ui/src/objects/dom/DomRuntimeNode.svelte
@@ -335,6 +335,8 @@
   title={data.title ?? titleFallback}
   {objectType}
   {nodeId}
+  {codePlaceholder}
+  onCodeChange={(newCode) => updateNodeData(nodeId, { code: newCode })}
   onrun={runCode}
   {editorReady}
   settingsSchema={data.settingsSchema}

--- a/ui/src/objects/dsp~/DSPNode.svelte
+++ b/ui/src/objects/dsp~/DSPNode.svelte
@@ -15,6 +15,7 @@
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { logger } from '$lib/utils/logger';
   import { editorFontFamily } from '../../stores/editor.store';
+  import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
 
   let contentContainer: HTMLDivElement | null = null;
 
@@ -63,6 +64,20 @@
   });
 
   const code = $derived(data.code || '');
+
+  useCodeSidebarTarget(() => ({
+    nodeId,
+    dataKey: 'code',
+    language: 'javascript',
+    nodeType: 'dsp~',
+    label: data.title ?? 'dsp~',
+    title: data.title ?? 'dsp~',
+    placeholder: 'Enter dsp code here...',
+    value: code,
+    onchange: handleCodeChange,
+    onrun: runDSP,
+    lineErrors
+  }));
   const messageInletCount = $derived(data.messageInletCount ?? 0);
   const messageOutletCount = $derived(data.messageOutletCount ?? 0);
   const audioInletCount = $derived(data.audioInletCount ?? 1);

--- a/ui/src/objects/expression/CommonExprLayout.svelte
+++ b/ui/src/objects/expression/CommonExprLayout.svelte
@@ -9,12 +9,12 @@
   import { highlightUiua } from '$lib/uiua/uiua-highlight';
   import type { SupportedLanguage } from '$lib/codemirror/types';
   import {
-    activeCodeEditorTarget,
     closeCodeEditorOverlay,
     openCodeEditorOverlay
   } from '../../stores/code-editor-layout.store';
   import { createCommonExprEditorTarget } from '$lib/code-editor/common-expr-editor-target';
   import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
+  import { useCodeEditorOverlayTarget } from '$lib/code-editor/use-code-editor-overlay-target.svelte';
   import { editorFontFamily } from '../../stores/editor.store';
 
   import 'highlight.js/styles/tokyo-night-dark.css';
@@ -115,8 +115,9 @@
   let codeEditorRef: CodeEditor | null = $state(null);
   let originalExpr = expr; // Store original for escape functionality
 
-  const isCodeEditorDetached = $derived(
-    $activeCodeEditorTarget?.nodeId === nodeId && $activeCodeEditorTarget.dataKey === dataKey
+  const codeEditorOverlay = useCodeEditorOverlayTarget(
+    () => nodeId,
+    () => dataKey
   );
 
   // Escape HTML for safe display
@@ -152,7 +153,7 @@
   });
 
   function enterEditingMode() {
-    if (isCodeEditorDetached) {
+    if (codeEditorOverlay.isOpen) {
       closeCodeEditorOverlay();
     }
 
@@ -269,7 +270,7 @@
   }
 
   export function closeExpandedEditor() {
-    if (isCodeEditorDetached) {
+    if (codeEditorOverlay.isOpen) {
       closeCodeEditorOverlay();
     }
   }
@@ -282,7 +283,7 @@
         {@render handles?.()}
 
         <div class="relative">
-          {#if isEditing && !isCodeEditorDetached}
+          {#if isEditing && !codeEditorOverlay.isOpen}
             <div
               class={[
                 'expr-editor-container nodrag w-full max-w-[400px] min-w-[40px] resize-none rounded-lg border font-mono text-zinc-200',

--- a/ui/src/objects/patchbay/PatchbayNode.svelte
+++ b/ui/src/objects/patchbay/PatchbayNode.svelte
@@ -7,7 +7,6 @@
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { useNodeDataTracker } from '$lib/history';
   import {
-    activeCodeEditorTarget,
     closeCodeEditorOverlay,
     openCodeEditorOverlay,
     syncActiveCodeEditorTargetLineErrors
@@ -35,6 +34,7 @@
   import { getPatchbayObjectPorts } from '$objects/patchbay/patchbay-object-ports';
   import { requestFitView } from '../../stores/ui.store';
   import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
+  import { useCodeEditorOverlayTarget } from '$lib/code-editor/use-code-editor-overlay-target.svelte';
 
   import type { ObjectContext } from '$lib/objects/v2/ObjectContext';
   import type { PatchbayDiagnostic } from '$lib/patchbay/patchbay-parser';
@@ -91,8 +91,9 @@
   const runOnEdit = $derived(data.runOnEdit ?? true);
   const allowResize = $derived(data.allowResize ?? true);
 
-  const isCodeEditorDetached = $derived(
-    $activeCodeEditorTarget?.nodeId === nodeId && $activeCodeEditorTarget.dataKey === 'code'
+  const codeEditorOverlay = useCodeEditorOverlayTarget(
+    () => nodeId,
+    () => 'code'
   );
 
   const lineErrors = $derived.by(() => {
@@ -314,7 +315,7 @@
     unsubscribeVideoRegistryChange?.();
     unsubscribeVideoRegistryChange = null;
 
-    if (isCodeEditorDetached) {
+    if (codeEditorOverlay.isOpen) {
       closeCodeEditorOverlay();
     }
 
@@ -388,7 +389,7 @@
     ]}
     style="width: {width ?? defaultWidth}px; height: {height ?? defaultHeight}px"
   >
-    {#if !isCodeEditorDetached}
+    {#if !codeEditorOverlay.isOpen}
       <CodeEditor
         value={code}
         onchange={handleCodeChange}

--- a/ui/src/objects/peek/PeekNode.svelte
+++ b/ui/src/objects/peek/PeekNode.svelte
@@ -9,6 +9,7 @@
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { JSRunner } from '$lib/js-runner/JSRunner';
   import { editorFontFamily } from '../../stores/editor.store';
+  import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
 
   let {
     id: nodeId,
@@ -30,6 +31,27 @@
   let latestValue = $state<unknown>(undefined);
   let evaluatedValue = $state<unknown>(undefined);
   let hasError = $state(false);
+
+  function reevaluateExpression() {
+    if (latestValue !== undefined) {
+      evaluate(latestValue).then((result) => {
+        evaluatedValue = result;
+      });
+    }
+  }
+
+  useCodeSidebarTarget(() => ({
+    nodeId,
+    dataKey: 'expr',
+    language: 'javascript',
+    nodeType: 'peek',
+    label: 'peek',
+    title: 'peek',
+    placeholder: '$1.type',
+    value: expr,
+    onchange: (value) => updateNodeData(nodeId, { expr: value }),
+    onrun: reevaluateExpression
+  }));
 
   // Format value for display
   function formatValue(value: unknown): string {
@@ -122,14 +144,7 @@
         <CodeEditor
           value={expr}
           onchange={(value) => updateNodeData(nodeId, { expr: value })}
-          onrun={() => {
-            // Re-evaluate with current value if we have one
-            if (latestValue !== undefined) {
-              evaluate(latestValue).then((result) => {
-                evaluatedValue = result;
-              });
-            }
-          }}
+          onrun={reevaluateExpression}
           language="javascript"
           placeholder="$1.type"
           class="peek-node-code-editor rounded-lg border !border-transparent focus:outline-none"

--- a/ui/src/objects/regl/ReglNode.svelte
+++ b/ui/src/objects/regl/ReglNode.svelte
@@ -288,6 +288,7 @@
   title={data.title ?? 'regl'}
   objectType="regl"
   codePlaceholder="Write your regl code here..."
+  onCodeChange={(newCode) => updateNodeData(nodeId, { code: newCode })}
   {nodeId}
   onrun={updateRegl}
   bind:previewCanvas

--- a/ui/src/objects/strudel/StrudelNode.svelte
+++ b/ui/src/objects/strudel/StrudelNode.svelte
@@ -25,6 +25,7 @@
     openDetachedStrudelEditor
   } from '../../stores/detached-strudel-editor.store';
   import { overlayEditorTransparency } from '../../stores/editor-layout-settings.store';
+  import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
 
   // Get node data from XY Flow - nodes receive their data as props
   let {
@@ -63,6 +64,18 @@
 
   const code = $derived(data.code || '');
   const customConsole = createCustomConsole(initialNodeId());
+
+  useCodeSidebarTarget(() => ({
+    nodeId,
+    dataKey: 'code',
+    language: 'plain',
+    nodeType: 'strudel',
+    label: 'strudel',
+    title: 'strudel',
+    value: code,
+    onchange: setCode,
+    onrun: evaluate
+  }));
 
   const setCode = (newCode: string) => {
     updateNodeData(nodeId, { code: newCode });

--- a/ui/src/objects/surface/SurfaceNode.svelte
+++ b/ui/src/objects/surface/SurfaceNode.svelte
@@ -725,6 +725,7 @@
   title={data.title ?? 'surface'}
   objectType="surface"
   codePlaceholder="Write your surface interaction code here..."
+  onCodeChange={(newCode) => updateNodeData(nodeId, { code: newCode })}
   {nodeId}
   onrun={runCode}
   onPlaybackToggle={togglePlayback}

--- a/ui/src/objects/swgl/SwissGLNode.svelte
+++ b/ui/src/objects/swgl/SwissGLNode.svelte
@@ -228,6 +228,7 @@
   title="swgl"
   objectType="swgl"
   codePlaceholder="Write your SwissGL code here..."
+  onCodeChange={(newCode) => updateNodeData(nodeId, { code: newCode })}
   {nodeId}
   onrun={updateSwissGL}
   onPlaybackToggle={togglePause}

--- a/ui/src/objects/textmode/TextmodeDom.svelte
+++ b/ui/src/objects/textmode/TextmodeDom.svelte
@@ -430,6 +430,7 @@
   title={data.title ?? 'textmode.dom'}
   objectType="textmode.dom"
   codePlaceholder="Write your Textmode.js code here..."
+  onCodeChange={(newCode) => updateNodeData(nodeId, { code: newCode })}
   {nodeId}
   onrun={runCode}
   onPlaybackToggle={togglePlayback}

--- a/ui/src/objects/textmode/TextmodeNode.svelte
+++ b/ui/src/objects/textmode/TextmodeNode.svelte
@@ -272,6 +272,7 @@
   title={data.title ?? 'textmode'}
   objectType="textmode"
   codePlaceholder="Write your Textmode.js code here..."
+  onCodeChange={(newCode) => updateNodeData(nodeId, { code: newCode })}
   {nodeId}
   onrun={updateTextmode}
   bind:previewCanvas

--- a/ui/src/objects/three/ThreeDom.svelte
+++ b/ui/src/objects/three/ThreeDom.svelte
@@ -503,6 +503,7 @@
   title={data.title ?? 'three.dom'}
   objectType="three.dom"
   codePlaceholder="Write your Three.js code here..."
+  onCodeChange={(newCode) => updateNodeData(nodeId, { code: newCode })}
   {nodeId}
   onrun={runCode}
   onPlaybackToggle={togglePlayback}

--- a/ui/src/objects/three/ThreeNode.svelte
+++ b/ui/src/objects/three/ThreeNode.svelte
@@ -341,6 +341,7 @@
   title={data.title ?? 'three'}
   objectType="three"
   codePlaceholder="Write your Three.js code here..."
+  onCodeChange={(newCode) => updateNodeData(nodeId, { code: newCode })}
   {nodeId}
   onrun={updateThree}
   bind:previewCanvas

--- a/ui/src/objects/uxn/UxnNode.svelte
+++ b/ui/src/objects/uxn/UxnNode.svelte
@@ -4,6 +4,7 @@
   import { useSvelteFlow } from '@xyflow/svelte';
   import { UxnEmulator, type UxnEmulatorOptions } from '$lib/uxn/UxnEmulator';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
+  import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
   import { MessageContext } from '$lib/messages/MessageContext';
   import type { MessageCallbackFn } from '$lib/messages/MessageSystem';
   import { match } from 'ts-pattern';
@@ -62,6 +63,19 @@
   let bitmapFrameId: number | null = null;
   const fileName = $derived(data.fileName || 'No ROM loaded');
   const code = $derived(data.code || '');
+
+  useCodeSidebarTarget(() => ({
+    nodeId,
+    dataKey: 'code',
+    language: 'assembly',
+    nodeType: 'uxn',
+    label: 'uxn',
+    title: 'uxn',
+    placeholder: 'Write Uxntal code here...',
+    value: code,
+    onchange: (newCode) => updateNodeData(nodeId, { code: newCode }),
+    onrun: assembleAndLoad
+  }));
 
   const editorGap = 10;
   let previewContainerWidth = $state(0);

--- a/ui/src/objects/wgpu.compute/WGPUNode.svelte
+++ b/ui/src/objects/wgpu.compute/WGPUNode.svelte
@@ -12,6 +12,7 @@
   import { parseWGSL, serializeStructToBuffer } from '$lib/webgpu/wgsl-parser';
   import { WebGPUComputeSystem } from '$lib/webgpu/WebGPUComputeSystem';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+  import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
 
   let {
     id: nodeId,
@@ -53,6 +54,20 @@
   let inferredDispatch = $state<[number, number, number] | null>(null);
 
   const code = $derived(data.code || '');
+
+  useCodeSidebarTarget(() => ({
+    nodeId,
+    dataKey: 'code',
+    language: 'wgsl',
+    nodeType: 'wgpu.compute',
+    label: data.title ?? 'wgpu.compute',
+    title: data.title ?? 'wgpu.compute',
+    placeholder: 'Write your WGSL compute shader here...',
+    value: code,
+    onchange: (newCode) => updateNodeData(nodeId, { code: newCode }),
+    onrun: compileShader
+  }));
+
   const parseResult = $derived(parseWGSL(code));
   const inputBindings = $derived(parseResult.inputs);
   const outputBindings = $derived(parseResult.outputs);

--- a/ui/src/stores/code-editor-layout.store.test.ts
+++ b/ui/src/stores/code-editor-layout.store.test.ts
@@ -66,6 +66,7 @@ describe('code editor layout store', () => {
     expect(get(sidebarView)).toBe('code');
     expect(get(isSidebarOpen)).toBe(true);
     expect(get(sidebarVisibleTabs).has('code')).toBe(true);
+    expect(isDetachedCodeEditorTarget('node-2', 'code')).toBe(false);
 
     closeCodeEditorOverlay();
   });

--- a/ui/src/stores/code-editor-layout.store.ts
+++ b/ui/src/stores/code-editor-layout.store.ts
@@ -133,22 +133,23 @@ export function hasCodeEditorTargetSettings(
   target: CodeEditorTarget | CodeEditorTargetSettingsState | null | undefined
 ): boolean {
   if (!target) return false;
-
   if (target.customSettings) return true;
 
   return (target.settings?.schema.length ?? 0) > 0;
 }
 
-export function hasCodeEditorTargetConsole(
+export const hasCodeEditorTargetConsole = (
   target: CodeEditorTarget | CodeEditorTargetConsoleState | null | undefined
-): boolean {
-  return Boolean(target?.console);
-}
+): boolean => Boolean(target?.console);
 
 export function isDetachedCodeEditorTarget(nodeId: string | undefined, dataKey: string): boolean {
   if (!nodeId) return false;
 
-  const target = get(activeCodeEditorTarget);
-
-  return target?.nodeId === nodeId && target.dataKey === dataKey;
+  return isCodeEditorOverlayTarget(get(activeCodeEditorTarget), nodeId, dataKey);
 }
+
+export const isCodeEditorOverlayTarget = (
+  target: CodeEditorTarget | null,
+  nodeId: string | undefined,
+  dataKey: string
+): boolean => target?.mode === 'overlay' && target.nodeId === nodeId && target.dataKey === dataKey;


### PR DESCRIPTION
## What changed

- Register code sidebar targets for shared preview, standalone, and strudel code objects.
- Keep the selected target in sync when it registers after selection.
- Reconfigure CodeMirror placeholders when the active target changes.

## Why

Selecting a code-based node could leave the sidebar showing a previous node or its stale placeholder.

## Validation

- `bun run check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Code-capable nodes can now be opened and managed consistently through the code sidebar.
  - Added sidebar editing and run support for assembly, DSP, JavaScript expression, Strudel, Uxntal, and WGSL code editors.
  - Canvas and preview editors now save code changes back to the corresponding node.
- **Bug Fixes**
  - Improved switching between detached editors without displaying duplicate or stale editors.
  - Editor placeholders and language settings now update reliably, while outdated asynchronous updates are ignored.
- **Documentation**
  - Updated sidebar requirements for standalone and preview-based code editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->