### PR TITLE
fix(sidebar): remember targets and pinning in code & settings

### DIFF
--- a/ui/src/lib/code-editor/use-code-sidebar-target.svelte.ts
+++ b/ui/src/lib/code-editor/use-code-sidebar-target.svelte.ts
@@ -1,14 +1,17 @@
 import { fromStore } from 'svelte/store';
+import { untrack } from 'svelte';
 
 import { selectedNodeInfo } from '../../stores/ui.store';
 import { activateCodeEditorSidebarTarget } from '../../stores/code-editor-layout.store';
 
 import {
   codeSidebarTargets,
+  codeSidebarSelection,
   registerCodeSidebarTarget,
   requestCodeSidebarTargetId,
   type CodeSidebarTarget
 } from '../../stores/code-sidebar.store';
+import { useSidebarSelectionState } from '$lib/sidebar/use-sidebar-selection-state.svelte';
 
 /** Registers a code accessor so the Code sidebar can follow canvas selection. */
 export function useCodeSidebarTarget(getTarget: () => CodeSidebarTarget | null): void {
@@ -28,23 +31,27 @@ export function useCodeSidebarTargetSelection(): {
   togglePin: () => void;
 } {
   const targetsSource = fromStore(codeSidebarTargets);
+
+  const { state: selectionState, update: updateSelectionState } =
+    useSidebarSelectionState(codeSidebarSelection);
+
   const requestedTargetId = fromStore(requestCodeSidebarTargetId);
   const selectedNode = fromStore(selectedNodeInfo);
-
-  let activeTargetId = $state<string | null>(null);
-  let pinnedTargetId = $state<string | null>(null);
-  let lastSelectedNodeId = $state<string | null>(null);
-  let lastSelectedNodeTargetId = $state<string | null>(null);
 
   const targets = $derived(
     [...targetsSource.current.values()].sort((a, b) => a.label.localeCompare(b.label))
   );
 
   const activeTarget = $derived(
-    activeTargetId ? (targets.find((target) => target.nodeId === activeTargetId) ?? null) : null
+    selectionState.current.activeTargetId
+      ? (targets.find((target) => target.nodeId === selectionState.current.activeTargetId) ?? null)
+      : null
   );
 
   $effect(() => {
+    const { activeTargetId, pinnedTargetId, lastSelectedNodeId, lastSelectedNodeTargetId } =
+      untrack(() => selectionState.current);
+
     const requestedId = requestedTargetId.current;
 
     const requestedTarget = requestedId
@@ -52,7 +59,7 @@ export function useCodeSidebarTargetSelection(): {
       : undefined;
 
     if (requestedTarget) {
-      activeTargetId = requestedTarget.nodeId;
+      updateSelectionState({ activeTargetId: requestedTarget.nodeId });
       activateCodeEditorSidebarTarget(requestedTarget);
       requestCodeSidebarTargetId.set(null);
 
@@ -64,14 +71,14 @@ export function useCodeSidebarTargetSelection(): {
       : undefined;
 
     if (pinnedTarget) {
-      activeTargetId = pinnedTarget.nodeId;
+      updateSelectionState({ activeTargetId: pinnedTarget.nodeId });
       activateCodeEditorSidebarTarget(pinnedTarget);
 
       return;
     }
 
     if (pinnedTargetId) {
-      pinnedTargetId = null;
+      updateSelectionState({ pinnedTargetId: null });
     }
 
     const selectedId = selectedNode.current?.id ?? null;
@@ -85,29 +92,35 @@ export function useCodeSidebarTargetSelection(): {
       selectedTarget !== undefined && lastSelectedNodeTargetId === null;
 
     if (selectedTarget && (selectionChanged || selectedTargetRegisteredAfterSelection)) {
-      activeTargetId = selectedTarget.nodeId;
+      updateSelectionState({ activeTargetId: selectedTarget.nodeId });
       activateCodeEditorSidebarTarget(selectedTarget);
     } else if (!activeTargetId || !targets.some((target) => target.nodeId === activeTargetId)) {
-      activeTargetId = targets[0]?.nodeId ?? null;
+      updateSelectionState({ activeTargetId: targets[0]?.nodeId ?? null });
 
       if (targets[0]) {
         activateCodeEditorSidebarTarget(targets[0]);
       }
     }
 
-    lastSelectedNodeId = selectedId;
-    lastSelectedNodeTargetId = selectedTarget?.nodeId ?? null;
+    updateSelectionState({
+      lastSelectedNodeId: selectedId,
+      lastSelectedNodeTargetId: selectedTarget?.nodeId ?? null
+    });
   });
 
   return {
     selectTarget: (targetId) => {
-      activeTargetId = targetId;
+      updateSelectionState({ activeTargetId: targetId });
 
       const target = targets.find((candidate) => candidate.nodeId === targetId);
       if (target) activateCodeEditorSidebarTarget(target);
     },
     togglePin: () => {
-      pinnedTargetId = pinnedTargetId ? null : activeTargetId;
+      updateSelectionState({
+        pinnedTargetId: selectionState.current.pinnedTargetId
+          ? null
+          : selectionState.current.activeTargetId
+      });
     },
     get targets() {
       return targets;
@@ -116,7 +129,7 @@ export function useCodeSidebarTargetSelection(): {
       return activeTarget;
     },
     get pinnedTargetId() {
-      return pinnedTargetId;
+      return selectionState.current.pinnedTargetId;
     }
   };
 }

--- a/ui/src/lib/settings/use-settings-sidebar-target-selection.svelte.ts
+++ b/ui/src/lib/settings/use-settings-sidebar-target-selection.svelte.ts
@@ -1,12 +1,15 @@
 import { fromStore } from 'svelte/store';
+import { untrack } from 'svelte';
 
 import { selectedNodeInfo } from '../../stores/ui.store';
 
 import {
   requestSettingsSidebarTargetId,
+  settingsSidebarSelection,
   settingsSidebarTargets,
   type SettingsSidebarTarget
 } from '../../stores/settings-sidebar.store';
+import { useSidebarSelectionState } from '$lib/sidebar/use-sidebar-selection-state.svelte';
 
 export function useSettingsSidebarTargetSelection(): {
   readonly targets: SettingsSidebarTarget[];
@@ -15,11 +18,11 @@ export function useSettingsSidebarTargetSelection(): {
   selectTarget: (targetId: string) => void;
   togglePin: () => void;
 } {
-  let activeTargetId = $state<string | null>(null);
-  let pinnedTargetId = $state<string | null>(null);
-  let lastSelectedNodeId = $state<string | null>(null);
-
   const sidebarTargets = fromStore(settingsSidebarTargets);
+
+  const { state: selectionState, update: updateSelectionState } =
+    useSidebarSelectionState(settingsSidebarSelection);
+
   const requestedTargetId = fromStore(requestSettingsSidebarTargetId);
   const selectedNode = fromStore(selectedNodeInfo);
 
@@ -28,10 +31,15 @@ export function useSettingsSidebarTargetSelection(): {
   );
 
   const activeTarget = $derived(
-    activeTargetId ? (targets.find((target) => target.id === activeTargetId) ?? null) : null
+    selectionState.current.activeTargetId
+      ? (targets.find((target) => target.id === selectionState.current.activeTargetId) ?? null)
+      : null
   );
 
   $effect(() => {
+    const { activeTargetId, pinnedTargetId, lastSelectedNodeId } = untrack(
+      () => selectionState.current
+    );
     const requestedId = requestedTargetId.current;
 
     const requestedTarget = requestedId
@@ -39,7 +47,7 @@ export function useSettingsSidebarTargetSelection(): {
       : undefined;
 
     if (requestedTarget) {
-      activeTargetId = requestedTarget.id;
+      updateSelectionState({ activeTargetId: requestedTarget.id });
       requestSettingsSidebarTargetId.set(null);
       return;
     }
@@ -49,11 +57,11 @@ export function useSettingsSidebarTargetSelection(): {
       : undefined;
 
     if (pinnedTarget) {
-      activeTargetId = pinnedTarget.id;
+      updateSelectionState({ activeTargetId: pinnedTarget.id });
       return;
     }
 
-    if (pinnedTargetId) pinnedTargetId = null;
+    if (pinnedTargetId) updateSelectionState({ pinnedTargetId: null });
 
     const selectedTarget = selectedNode.current
       ? targets.find((target) => target.id === selectedNode.current?.id)
@@ -62,20 +70,24 @@ export function useSettingsSidebarTargetSelection(): {
     const selectedNodeId = selectedNode.current?.id ?? null;
 
     if (selectedTarget && selectedNodeId !== lastSelectedNodeId) {
-      activeTargetId = selectedTarget.id;
+      updateSelectionState({ activeTargetId: selectedTarget.id });
     } else if (!activeTargetId || !targets.some((target) => target.id === activeTargetId)) {
-      activeTargetId = targets[0]?.id ?? null;
+      updateSelectionState({ activeTargetId: targets[0]?.id ?? null });
     }
 
-    lastSelectedNodeId = selectedNodeId;
+    updateSelectionState({ lastSelectedNodeId: selectedNodeId });
   });
 
   function selectTarget(targetId: string): void {
-    activeTargetId = targetId;
+    updateSelectionState({ activeTargetId: targetId });
   }
 
   function togglePin(): void {
-    pinnedTargetId = pinnedTargetId ? null : activeTargetId;
+    updateSelectionState({
+      pinnedTargetId: selectionState.current.pinnedTargetId
+        ? null
+        : selectionState.current.activeTargetId
+    });
   }
 
   return {
@@ -89,7 +101,7 @@ export function useSettingsSidebarTargetSelection(): {
       return activeTarget;
     },
     get pinnedTargetId() {
-      return pinnedTargetId;
+      return selectionState.current.pinnedTargetId;
     }
   };
 }

--- a/ui/src/lib/settings/use-settings-sidebar-target-selection.svelte.ts
+++ b/ui/src/lib/settings/use-settings-sidebar-target-selection.svelte.ts
@@ -37,9 +37,8 @@ export function useSettingsSidebarTargetSelection(): {
   );
 
   $effect(() => {
-    const { activeTargetId, pinnedTargetId, lastSelectedNodeId } = untrack(
-      () => selectionState.current
-    );
+    const { activeTargetId, pinnedTargetId, lastSelectedNodeId, lastSelectedNodeTargetId } =
+      untrack(() => selectionState.current);
     const requestedId = requestedTargetId.current;
 
     const requestedTarget = requestedId
@@ -68,14 +67,22 @@ export function useSettingsSidebarTargetSelection(): {
       : undefined;
 
     const selectedNodeId = selectedNode.current?.id ?? null;
+    const selectedTargetRegisteredAfterSelection =
+      selectedTarget !== undefined && lastSelectedNodeTargetId === null;
 
-    if (selectedTarget && selectedNodeId !== lastSelectedNodeId) {
+    if (
+      selectedTarget &&
+      (selectedNodeId !== lastSelectedNodeId || selectedTargetRegisteredAfterSelection)
+    ) {
       updateSelectionState({ activeTargetId: selectedTarget.id });
     } else if (!activeTargetId || !targets.some((target) => target.id === activeTargetId)) {
       updateSelectionState({ activeTargetId: targets[0]?.id ?? null });
     }
 
-    updateSelectionState({ lastSelectedNodeId: selectedNodeId });
+    updateSelectionState({
+      lastSelectedNodeId: selectedNodeId,
+      lastSelectedNodeTargetId: selectedTarget?.id ?? null
+    });
   });
 
   function selectTarget(targetId: string): void {

--- a/ui/src/lib/sidebar/use-sidebar-selection-state.svelte.ts
+++ b/ui/src/lib/sidebar/use-sidebar-selection-state.svelte.ts
@@ -1,0 +1,20 @@
+import { fromStore, get, type Writable } from 'svelte/store';
+
+/**
+ * Exposes a tab-scoped selection store and updates it only when a value changes.
+ * Callers can read `state.current` reactively and safely update it from an effect.
+ */
+export function useSidebarSelectionState<State extends object>(store: Writable<State>) {
+  const state = fromStore(store);
+
+  function update(update: Partial<State>): void {
+    const current = get(store);
+    const next = { ...current, ...update };
+
+    if ((Object.keys(update) as Array<keyof State>).some((key) => next[key] !== current[key])) {
+      store.set(next);
+    }
+  }
+
+  return { state, update };
+}

--- a/ui/src/stores/code-sidebar.store.test.ts
+++ b/ui/src/stores/code-sidebar.store.test.ts
@@ -1,6 +1,7 @@
 import { get } from 'svelte/store';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  codeSidebarSelection,
   codeSidebarTargets,
   registerCodeSidebarTarget,
   requestCodeSidebarTargetId
@@ -8,6 +9,12 @@ import {
 
 afterEach(() => {
   codeSidebarTargets.set(new Map());
+  codeSidebarSelection.set({
+    activeTargetId: null,
+    pinnedTargetId: null,
+    lastSelectedNodeId: null,
+    lastSelectedNodeTargetId: null
+  });
   requestCodeSidebarTargetId.set(null);
 });
 
@@ -30,5 +37,19 @@ describe('code sidebar targets', () => {
 
     unregisterSecond();
     expect(get(codeSidebarTargets).size).toBe(0);
+  });
+
+  it('retains the selected and pinned target outside the tab component lifecycle', () => {
+    codeSidebarSelection.set({
+      activeTargetId: 'node-2',
+      pinnedTargetId: 'node-2',
+      lastSelectedNodeId: 'node-1',
+      lastSelectedNodeTargetId: 'node-1'
+    });
+
+    expect(get(codeSidebarSelection)).toMatchObject({
+      activeTargetId: 'node-2',
+      pinnedTargetId: 'node-2'
+    });
   });
 });

--- a/ui/src/stores/code-sidebar.store.ts
+++ b/ui/src/stores/code-sidebar.store.ts
@@ -12,6 +12,21 @@ export const codeSidebarTargets = writable<Map<string, CodeSidebarTarget>>(new M
 /** Set when an explicit Code action opens a node in the sidebar. */
 export const requestCodeSidebarTargetId = writable<string | null>(null);
 
+export interface CodeSidebarSelectionState {
+  activeTargetId: string | null;
+  pinnedTargetId: string | null;
+  lastSelectedNodeId: string | null;
+  lastSelectedNodeTargetId: string | null;
+}
+
+/** Preserves Code sidebar target choice while its tab is unmounted. */
+export const codeSidebarSelection = writable<CodeSidebarSelectionState>({
+  activeTargetId: null,
+  pinnedTargetId: null,
+  lastSelectedNodeId: null,
+  lastSelectedNodeTargetId: null
+});
+
 export function registerCodeSidebarTarget(target: CodeSidebarTarget): () => void {
   codeSidebarTargets.update((targets) => {
     const next = new Map(targets);

--- a/ui/src/stores/settings-sidebar.store.test.ts
+++ b/ui/src/stores/settings-sidebar.store.test.ts
@@ -1,0 +1,26 @@
+import { get } from 'svelte/store';
+import { afterEach, describe, expect, it } from 'vitest';
+import { settingsSidebarSelection } from './settings-sidebar.store';
+
+afterEach(() => {
+  settingsSidebarSelection.set({
+    activeTargetId: null,
+    pinnedTargetId: null,
+    lastSelectedNodeId: null
+  });
+});
+
+describe('settings sidebar selection', () => {
+  it('retains the selected and pinned target outside the tab component lifecycle', () => {
+    settingsSidebarSelection.set({
+      activeTargetId: 'node-2',
+      pinnedTargetId: 'node-2',
+      lastSelectedNodeId: 'node-1'
+    });
+
+    expect(get(settingsSidebarSelection)).toMatchObject({
+      activeTargetId: 'node-2',
+      pinnedTargetId: 'node-2'
+    });
+  });
+});

--- a/ui/src/stores/settings-sidebar.store.test.ts
+++ b/ui/src/stores/settings-sidebar.store.test.ts
@@ -6,7 +6,8 @@ afterEach(() => {
   settingsSidebarSelection.set({
     activeTargetId: null,
     pinnedTargetId: null,
-    lastSelectedNodeId: null
+    lastSelectedNodeId: null,
+    lastSelectedNodeTargetId: null
   });
 });
 
@@ -15,7 +16,8 @@ describe('settings sidebar selection', () => {
     settingsSidebarSelection.set({
       activeTargetId: 'node-2',
       pinnedTargetId: 'node-2',
-      lastSelectedNodeId: 'node-1'
+      lastSelectedNodeId: 'node-1',
+      lastSelectedNodeTargetId: 'node-1'
     });
 
     expect(get(settingsSidebarSelection)).toMatchObject({

--- a/ui/src/stores/settings-sidebar.store.ts
+++ b/ui/src/stores/settings-sidebar.store.ts
@@ -39,6 +39,19 @@ export const settingsSidebarTargets = writable<Map<string, SettingsSidebarTarget
 /** Set when a node action explicitly opens its settings in the sidebar. */
 export const requestSettingsSidebarTargetId = writable<string | null>(null);
 
+export interface SettingsSidebarSelectionState {
+  activeTargetId: string | null;
+  pinnedTargetId: string | null;
+  lastSelectedNodeId: string | null;
+}
+
+/** Preserves Settings sidebar target choice while its tab is unmounted. */
+export const settingsSidebarSelection = writable<SettingsSidebarSelectionState>({
+  activeTargetId: null,
+  pinnedTargetId: null,
+  lastSelectedNodeId: null
+});
+
 export function registerSettingsSidebarTarget(target: SettingsSidebarTarget): () => void {
   settingsSidebarTargets.update((targets) => {
     const next = new Map(targets);

--- a/ui/src/stores/settings-sidebar.store.ts
+++ b/ui/src/stores/settings-sidebar.store.ts
@@ -43,13 +43,15 @@ export interface SettingsSidebarSelectionState {
   activeTargetId: string | null;
   pinnedTargetId: string | null;
   lastSelectedNodeId: string | null;
+  lastSelectedNodeTargetId: string | null;
 }
 
 /** Preserves Settings sidebar target choice while its tab is unmounted. */
 export const settingsSidebarSelection = writable<SettingsSidebarSelectionState>({
   activeTargetId: null,
   pinnedTargetId: null,
-  lastSelectedNodeId: null
+  lastSelectedNodeId: null,
+  lastSelectedNodeTargetId: null
 });
 
 export function registerSettingsSidebarTarget(target: SettingsSidebarTarget): () => void {


### PR DESCRIPTION
Remember last selected targets and pinning states in code tab and settings tab in the sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sidebar selections now persist when switching tabs or when sidebar components are temporarily unmounted.
  - Active, pinned, and recently selected targets are retained independently for code and settings sidebars.
  - Pinning and fallback selection behavior remain consistent across sidebar navigation.

- **Bug Fixes**
  - Improved reliability of sidebar target selection state.

- **Tests**
  - Added coverage verifying selection and pinned-target persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->