### PR TITLE
feat(canvas.dom): expand interactively without stretching

### DIFF
--- a/docs/design-docs/specs/147-canvas-preview-expand.md
+++ b/docs/design-docs/specs/147-canvas-preview-expand.md
@@ -27,9 +27,16 @@ This pass covers existing render nodes that already participate in
 `SurfaceMouseForwarder`: `glsl`, `swgl`, `regl`, `hydra`, `canvas`, `textmode`,
 `shaderpark`, and `three`.
 
-DOM-renderer objects that use `CanvasPreviewLayout` can still be pinned as
-background output if they already upload bitmap frames through `GLSystem`, but
-their DOM-specific local preview input is not moved into the overlay.
+`canvas.dom` has a dedicated expanded path. It moves its existing live DOM
+canvas into `SurfaceOverlay`'s custom-content host instead of displaying its
+render-output bitmap. The canvas keeps its own mouse, touch, and keyboard
+listeners, and its bitmap resolution remains unchanged. The expanded display
+must preserve that bitmap's aspect ratio, use the largest contain-fit inside
+the viewport, and leave black letterboxing where needed.
+
+Other DOM-renderer objects can still be pinned as background output if they
+already upload bitmap frames through `GLSystem`, but their DOM-specific local
+preview input is not moved into the overlay by this pass.
 
 ## Implementation Notes
 
@@ -39,6 +46,11 @@ rather than duplicating surface-specific code in every node component.
 `surface` keeps its custom implementation because it draws directly into the
 overlay canvas and exposes surface-specific JavaScript APIs such as `expandSurface()`,
 `collapseSurface()`, `onTouch()`, and `hideExitButton()`.
+
+The `canvas.dom` path reuses the overlay's custom-content mode, UI-hiding
+lifecycle, and exit affordance, but must not use `SurfaceMouseForwarder`,
+`SurfaceListeners`, output override pinning, canvas swapping, or output-window
+mirroring. Its direct DOM event handlers remain the source of interaction.
 
 `ObjectPreviewLayout` should own the shared menu action because it already owns
 background-output pinning and the overflow/context menus used by
@@ -56,3 +68,9 @@ Add unit coverage for the controller:
 - entering stores and replaces the current background override
 - pointer and wheel events use the default forwarding rules
 - exiting restores the previous override and disposes listeners/forwarder
+
+Add unit coverage for the `canvas.dom` controller:
+
+- entering activates custom overlay content without changing render output
+  routing
+- exit and displaced-overlay callbacks restore the inline canvas state

--- a/ui/src/lib/canvas/CanvasDomExpandController.test.ts
+++ b/ui/src/lib/canvas/CanvasDomExpandController.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Node } from '@xyflow/svelte';
+import { CanvasDomExpandController } from './CanvasDomExpandController';
+
+const renderNode = (id: string, type: string): Node => ({
+  id,
+  type,
+  data: {},
+  position: { x: 0, y: 0 }
+});
+
+describe('CanvasDomExpandController', () => {
+  it('uses custom overlay content and keeps the live canvas focused', () => {
+    let overlayExit: (() => void) | undefined;
+    let active = false;
+    const focusCanvas = vi.fn();
+
+    const overlay = {
+      activate: vi.fn(
+        (_nodeId: string, _nodes: { id: string; type?: string }[], onExit: () => void) => {
+          overlayExit = onExit;
+        }
+      ),
+      deactivate: vi.fn()
+    };
+
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+
+      return 0;
+    });
+
+    const controller = new CanvasDomExpandController({
+      nodeId: 'canvas-dom-1',
+      getNodes: () => [renderNode('canvas-dom-1', 'canvas.dom'), renderNode('glsl-1', 'glsl')],
+      overlay,
+      onActiveChange: (next) => {
+        active = next;
+      },
+      focusCanvas
+    });
+
+    controller.enter();
+
+    expect(active).toBe(true);
+    expect(focusCanvas).toHaveBeenCalledOnce();
+
+    expect(overlay.activate).toHaveBeenCalledWith(
+      'canvas-dom-1',
+      [
+        { id: 'canvas-dom-1', type: 'canvas.dom' },
+        { id: 'glsl-1', type: 'glsl' }
+      ],
+      expect.any(Function),
+      { content: 'custom' }
+    );
+
+    (overlayExit as () => void)();
+
+    expect(active).toBe(false);
+    expect(overlay.deactivate).toHaveBeenCalledWith('canvas-dom-1');
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/ui/src/lib/canvas/CanvasDomExpandController.ts
+++ b/ui/src/lib/canvas/CanvasDomExpandController.ts
@@ -1,0 +1,58 @@
+import type { Node } from '@xyflow/svelte';
+import type { SurfaceOverlay } from './SurfaceOverlay';
+
+type CanvasDomExpandOverlay = Pick<SurfaceOverlay, 'activate' | 'deactivate'>;
+
+export type CanvasDomExpandControllerOptions = {
+  nodeId: string;
+  getNodes: () => Node[];
+  overlay: CanvasDomExpandOverlay;
+  onActiveChange: (active: boolean) => void;
+  focusCanvas: () => void;
+};
+
+/**
+ * Presents the live canvas.dom element in SurfaceOverlay's custom-content host.
+ *
+ * Unlike render-node expansion, this never replaces the canvas with a bitmap or
+ * routes input through the render graph. The DOM canvas keeps its own listeners.
+ */
+export class CanvasDomExpandController {
+  private active = false;
+
+  constructor(private options: CanvasDomExpandControllerOptions) {}
+
+  get isActive(): boolean {
+    return this.active;
+  }
+
+  enter(): void {
+    if (this.active) return;
+
+    const nodes = this.options.getNodes().map((node) => ({
+      id: node.id,
+      type: node.type
+    }));
+
+    this.options.overlay.activate(this.options.nodeId, nodes, () => this.exit(), {
+      content: 'custom'
+    });
+
+    this.active = true;
+    this.options.onActiveChange(true);
+
+    requestAnimationFrame(() => {
+      if (this.active) {
+        this.options.focusCanvas();
+      }
+    });
+  }
+
+  exit(): void {
+    if (!this.active) return;
+
+    this.active = false;
+    this.options.onActiveChange(false);
+    this.options.overlay.deactivate(this.options.nodeId);
+  }
+}

--- a/ui/src/lib/components/CanvasPreviewLayout.svelte
+++ b/ui/src/lib/components/CanvasPreviewLayout.svelte
@@ -9,6 +9,7 @@
   import { useCookStatus } from '$lib/canvas/use-cook-status.svelte';
   import { COOK_DEBUG_RENDER_NODE_TYPES } from '../../workers/rendering/cooking/policies';
   import { getBorderChromeClass } from './border-chrome';
+  import { portal } from '$lib/dom/portal';
 
   const COOK_DEBUG_OBJECT_TYPES = new Set<string>(COOK_DEBUG_RENDER_NODE_TYPES);
 
@@ -54,6 +55,9 @@
     displayExtraMenuItems = undefined,
     showBgOutputOption = true,
     showExpandOption = true,
+    onCustomExpandToggle = undefined,
+    customExpanded = false,
+    previewPortalTarget = undefined,
     showCookDebugOption = undefined,
     noBorder = false,
     class: className = ''
@@ -99,6 +103,9 @@
     displayExtraMenuItems?: ExtraMenuItem[];
     showBgOutputOption?: boolean;
     showExpandOption?: boolean;
+    onCustomExpandToggle?: () => void;
+    customExpanded?: boolean;
+    previewPortalTarget?: HTMLElement | null;
     showCookDebugOption?: boolean;
     noBorder?: boolean;
     class?: string;
@@ -151,6 +158,8 @@
   {showPauseButton}
   {showBgOutputOption}
   {showExpandOption}
+  {onCustomExpandToggle}
+  {customExpanded}
   {topHandle}
   {bottomHandle}
   {codeEditor}
@@ -169,13 +178,25 @@
   class={className}
 >
   {#snippet preview()}
-    <div class="relative">
+    <div
+      use:portal={previewPortalTarget}
+      class={customExpanded
+        ? 'fixed inset-0 flex items-center justify-center overflow-hidden bg-black'
+        : 'relative'}
+    >
       <canvas
         bind:this={previewCanvas}
-        class={['rounded-md border', chromeClass, interactionClass]}
+        class={[
+          'rounded-md border',
+          customExpanded ? 'shadow-none' : chromeClass,
+          interactionClass
+        ]}
         {tabindex}
         width={typeof width === 'number' ? width : undefined}
         height={typeof height === 'number' ? height : undefined}
+        style:border-width={customExpanded ? '0' : undefined}
+        style:border-radius={customExpanded ? '0' : undefined}
+        style:box-shadow={customExpanded ? 'none' : undefined}
         style={typeof width === 'number' && typeof height === 'number'
           ? `width:${width}px;height:${height}px;background-color:${$previewBackgroundColor};${pixelated ? 'image-rendering:pixelated;' : ''}${style}`
           : `background-color:${$previewBackgroundColor};${pixelated ? 'image-rendering:pixelated;' : ''}${style}`}

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -59,6 +59,8 @@
     showPauseButton = false,
     showBgOutputOption = false,
     showExpandOption = false,
+    onCustomExpandToggle = undefined,
+    customExpanded = false,
 
     topHandle,
     bottomHandle,
@@ -91,6 +93,8 @@
     showPauseButton?: boolean;
     showBgOutputOption?: boolean;
     showExpandOption?: boolean;
+    onCustomExpandToggle?: () => void;
+    customExpanded?: boolean;
 
     topHandle?: Snippet;
     bottomHandle?: Snippet;
@@ -264,19 +268,27 @@
   });
 
   let canPin = $derived($transportStore.isPlaying);
+  let expanded = $derived(onCustomExpandToggle ? customExpanded : isExpanded);
 
   let isOutputOverride = $derived(
     showBgOutputOption && nodeId !== undefined && $overrideOutputNodeId === nodeId
   );
 
-  let canExpand = $derived(
+  let canRenderExpand = $derived(
     showExpandOption && nodeId !== undefined && $outputTarget === 'background'
+  );
+
+  let expandToggle = $derived(
+    showExpandOption
+      ? (onCustomExpandToggle ?? (canRenderExpand ? handleExpandToggle : undefined))
+      : undefined
   );
 
   const codeEditorOverlay = useCodeEditorOverlayTarget(
     () => nodeId,
     () => codeDataKey
   );
+
   const detachedSettings = $derived(
     settingsSchema && settingsSchema.length > 0
       ? {
@@ -416,7 +428,7 @@
   }
 
   function handleExpandToggle() {
-    if (!canExpand) return;
+    if (!canRenderExpand) return;
 
     const controller = getExpandController();
     if (!controller) return;
@@ -485,8 +497,8 @@
                 {previewVisible}
                 onSettingsToggle={settingsSidebarTarget.toggle}
                 onCodeToggle={resolvedPrimary === 'code' ? undefined : handleCodeOpen}
-                onExpandToggle={canExpand ? handleExpandToggle : undefined}
-                {isExpanded}
+                onExpandToggle={expandToggle}
+                isExpanded={expanded}
                 onBgOutputToggle={handleBgOutputToggle}
                 onPlaybackToggle={handlePlaybackToggle}
                 onSaveAsPreset={nodeId ? handleSaveAsPreset : undefined}
@@ -575,8 +587,8 @@
       {showSettings}
       onSettingsToggle={settingsSidebarTarget.toggle}
       onCodeToggle={handleCodeOpen}
-      onExpandToggle={canExpand ? handleExpandToggle : undefined}
-      {isExpanded}
+      onExpandToggle={expandToggle}
+      isExpanded={expanded}
       onBgOutputToggle={handleBgOutputToggle}
       onPlaybackToggle={handlePlaybackToggle}
       onSaveAsPreset={nodeId ? handleSaveAsPreset : undefined}

--- a/ui/src/objects/canvas/CanvasDom.svelte
+++ b/ui/src/objects/canvas/CanvasDom.svelte
@@ -32,6 +32,8 @@
   import { getBorderResetDataForRun } from '$lib/components/border-chrome';
   import { useNodeDataTracker } from '$lib/history';
   import { useFluidCanvas } from './useFluidCanvas.svelte';
+  import { SurfaceOverlay } from '$lib/canvas/SurfaceOverlay';
+  import { CanvasDomExpandController } from '$lib/canvas/CanvasDomExpandController';
 
   let {
     id: nodeId,
@@ -94,7 +96,7 @@
   let editorReady = $state(false);
   let animationFrameId: number | null = null;
   let pausedCallback: FrameRequestCallback | null = null;
-  const { updateNode, updateNodeData } = useSvelteFlow();
+  const { updateNode, updateNodeData, getNodes } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
   const tracker = $derived.by(() => useNodeDataTracker(nodeId));
 
@@ -113,7 +115,21 @@
 
   let inletCount = $derived(data.inletCount ?? 1);
   let outletCount = $derived(data.outletCount ?? 0);
+
+  let isExpanded = $state(false);
   let previousExecuteCode = $state<number | undefined>(undefined);
+
+  let expandController: CanvasDomExpandController | null = null;
+
+  const expandedPreviewPortalTarget = $derived(
+    isExpanded && typeof document !== 'undefined' ? SurfaceOverlay.getInstance().customHost : null
+  );
+
+  const canvasDisplayStyle = $derived(
+    isExpanded
+      ? 'width:auto;height:auto;max-width:100vw;max-height:100vh;'
+      : `width: ${previewWidth}px; height: ${previewHeight}px;`
+  );
 
   // Watch for executeCode timestamp changes and re-run when it changes
   $effect(() => {
@@ -325,9 +341,7 @@
     canvas.width = outputWidth;
     canvas.height = outputHeight;
 
-    // Display at preview size
-    canvas.style.width = `${previewWidth}px`;
-    canvas.style.height = `${previewHeight}px`;
+    applyCanvasDisplaySize();
 
     ctx = canvas.getContext('2d');
   }
@@ -342,11 +356,34 @@
     canvas.width = width;
     canvas.height = height;
 
-    // Update display size - calculate directly instead of using $derived values
-    // which may not have updated yet in the same synchronous execution
-    canvas.style.width = `${width / PREVIEW_SCALE_FACTOR}px`;
-    canvas.style.height = `${height / PREVIEW_SCALE_FACTOR}px`;
+    applyCanvasDisplaySize(width, height);
   }
+
+  function applyCanvasDisplaySize(width = outputWidth, height = outputHeight) {
+    if (!canvas) return;
+
+    if (isExpanded) {
+      Object.assign(canvas.style, {
+        width: 'auto',
+        height: 'auto',
+        maxWidth: '100vw',
+        maxHeight: '100vh'
+      });
+      return;
+    }
+
+    Object.assign(canvas.style, {
+      width: `${width / PREVIEW_SCALE_FACTOR}px`,
+      height: `${height / PREVIEW_SCALE_FACTOR}px`,
+      maxWidth: '',
+      maxHeight: ''
+    });
+  }
+
+  $effect(() => {
+    isExpanded;
+    applyCanvasDisplaySize();
+  });
 
   async function sendBitmap() {
     if (!canvas) return;
@@ -530,6 +567,16 @@
 
     setupCanvas();
 
+    expandController = new CanvasDomExpandController({
+      nodeId,
+      getNodes,
+      overlay: SurfaceOverlay.getInstance(),
+      onActiveChange: (active) => {
+        isExpanded = active;
+      },
+      focusCanvas: () => canvas?.focus()
+    });
+
     const cleanupMouse = setupMouseListeners();
     const cleanupKeyboard = setupKeyboardListeners();
     setTimeout(() => {
@@ -543,6 +590,7 @@
   });
 
   onDestroy(() => {
+    expandController?.exit();
     if (animationFrameId !== null) {
       cancelAnimationFrame(animationFrameId);
     }
@@ -551,6 +599,16 @@
     glSystem?.removeNode(nodeId);
     jsRunner.destroy(nodeId);
   });
+
+  function toggleExpandedCanvas() {
+    if (!expandController) return;
+
+    if (expandController.isActive) {
+      expandController.exit();
+    } else {
+      expandController.enter();
+    }
+  }
 
   const handleClass = $derived.by(() => {
     // only apply the custom handles if setHidePorts(true) is set
@@ -603,7 +661,10 @@
     nopan={!panEnabled}
     nowheel={!wheelEnabled}
     tabindex={0}
-    style={`width: ${previewWidth}px; height: ${previewHeight}px;`}
+    style={canvasDisplayStyle}
+    onCustomExpandToggle={toggleExpandedCanvas}
+    customExpanded={isExpanded}
+    previewPortalTarget={expandedPreviewPortalTarget}
     {selected}
     {editorReady}
     hasError={lineErrors !== undefined}

--- a/ui/static/content/objects/canvas.dom.md
+++ b/ui/static/content/objects/canvas.dom.md
@@ -63,6 +63,15 @@ Resize the canvas resolution dynamically:
 setCanvasSize(800, 600);
 ```
 
+## Focused Interactive View
+
+Open the node overflow menu and choose **Expand** to focus the live canvas.
+Your canvas keeps receiving mouse, touch, and keyboard input while Patchies
+hides the rest of the editor. The view preserves the canvas aspect ratio and
+fits it inside the screen, leaving black borders when needed.
+
+Use **Exit surface** or `Shift+Esc` to return to the patch.
+
 ## Resizable Widgets
 
 Build a widget that fills its Patchies node instead of choosing a fixed canvas size:


### PR DESCRIPTION
When clicking on the `Expand` button in `canvas.dom`, it should expand it interactively to full screen without stretching. It should preserve the aspect ratio of the original canvas size.