### PR TITLE
feat(p5): createSurfaceCanvas should use preview dimension

### DIFF
--- a/docs/design-docs/specs/147-canvas-preview-expand.md
+++ b/docs/design-docs/specs/147-canvas-preview-expand.md
@@ -52,6 +52,14 @@ lifecycle, and exit affordance, but must not use `SurfaceMouseForwarder`,
 `SurfaceListeners`, output override pinning, canvas swapping, or output-window
 mirroring. Its direct DOM event handlers remain the source of interaction.
 
+`p5` surface mode already moves its live P5 canvas into the same custom-content
+host. Its Expand view must also use contain-fit sizing so a
+`createSurfaceCanvas()` sketch remains interactive without cropping or
+stretching. Ordinary P5 `createCanvas()` sketches also support Expand: their
+live canvas moves into a black focused host and does not forward pointer events
+or mirror to the secondary output window. `createSurfaceCanvas()` retains its
+transparent overlay, render-node forwarding, and output-window mirroring.
+
 `ObjectPreviewLayout` should own the shared menu action because it already owns
 background-output pinning and the overflow/context menus used by
 `CanvasPreviewLayout`.

--- a/ui/src/lib/p5/P5Manager.ts
+++ b/ui/src/lib/p5/P5Manager.ts
@@ -52,6 +52,11 @@ interface P5SketchConfig {
   onSurfaceFrame?: (canvas: HTMLCanvasElement) => void;
   onSurfacePointer?: (x: number, y: number, buttons: number, type: string) => void;
 
+  onCanvasCreated?: (
+    canvas: HTMLCanvasElement,
+    dimensions: { width: number; height: number }
+  ) => void;
+
   onSurfaceWheel?: (event: {
     x: number;
     y: number;
@@ -200,6 +205,12 @@ export class P5Manager {
         p.setup = function () {
           try {
             userCode?.setup?.call(p);
+
+            const canvas = (p as unknown as { canvas?: unknown }).canvas;
+
+            if (canvas instanceof HTMLCanvasElement) {
+              config.onCanvasCreated?.(canvas, { width: p.width, height: p.height });
+            }
 
             if (!userCode?.draw) {
               requestAnimationFrame(signalFrameReady);

--- a/ui/src/lib/p5/use-p5-surface-mode.svelte.ts
+++ b/ui/src/lib/p5/use-p5-surface-mode.svelte.ts
@@ -14,27 +14,24 @@ type P5SurfaceModeOptions = {
   getGlSystem: () => GLSystem;
   getP5Manager: () => P5Manager | null;
   getPreviewContainer: () => HTMLElement | null;
-  isSurfaceModeEnabled: () => boolean | undefined;
+  isSurfaceCanvasEnabled: () => boolean | undefined;
   measureWidth: (timeout: number) => void;
   updateSketch: () => void;
 };
 
 export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
   let isExpanded = $state(false);
+  let isSurfaceCanvasExpanded = false;
   const mouseForwarder = new SurfaceMouseForwarder(options.getNodes);
 
-  const menuItems: ExtraMenuItem[] = $derived(
-    options.isSurfaceModeEnabled()
-      ? [
-          {
-            label: isExpanded ? 'Exit surface' : 'Expand',
-            icon: isExpanded ? Shrink : Expand,
-            onclick: () => (isExpanded ? exit() : enter()),
-            variant: isExpanded ? 'danger' : 'default'
-          }
-        ]
-      : []
-  );
+  const menuItems: ExtraMenuItem[] = $derived([
+    {
+      label: isExpanded ? 'Exit surface' : 'Expand',
+      icon: isExpanded ? Shrink : Expand,
+      onclick: () => (isExpanded ? exit() : enter()),
+      variant: isExpanded ? 'danger' : 'default'
+    }
+  ]);
 
   function getCanvasSize() {
     const [width, height] = options.getGlSystem().outputSize;
@@ -42,11 +39,16 @@ export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
     return { width, height };
   }
 
-  function styleCanvas(canvas: HTMLCanvasElement) {
-    const { width, height } = getCanvasSize();
+  function styleCanvas(canvas: HTMLCanvasElement, dimensions = getCanvasSize()) {
+    applyCanvasStyle(canvas, dimensions);
+  }
 
+  function applyCanvasStyle(
+    canvas: HTMLCanvasElement,
+    { width, height }: { width: number; height: number }
+  ) {
     if (isExpanded) {
-      const scale = Math.max(window.innerWidth / width, window.innerHeight / height);
+      const scale = Math.min(window.innerWidth / width, window.innerHeight / height);
       const displayWidth = width * scale;
       const displayHeight = height * scale;
 
@@ -79,7 +81,7 @@ export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
   }
 
   function requestMirrorFrame(canvas: HTMLCanvasElement) {
-    if (!isExpanded) return;
+    if (!isExpanded || !isSurfaceCanvasExpanded) return;
 
     options.getGlSystem().ipcSystem.requestSurfaceOverlayFrame(canvas);
   }
@@ -91,14 +93,14 @@ export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
   function setMouseForwarding(rules?: SurfaceMouseForwardingRules) {
     mouseForwarder.setForwardingRules(rules);
 
-    if (isExpanded) {
+    if (isExpanded && isSurfaceCanvasExpanded) {
       mouseForwarder.forceHydraScope('local');
       mouseForwarder.forceHydraScope('global');
     }
   }
 
   function forwardPointer(x: number, y: number, buttons: number, type: string) {
-    if (!isExpanded) return;
+    if (!isExpanded || !isSurfaceCanvasExpanded) return;
 
     mouseForwarder.forward(x, y, buttons, type);
   }
@@ -110,7 +112,7 @@ export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
     deltaY: number;
     deltaMode: number;
   }) {
-    if (!isExpanded) return;
+    if (!isExpanded || !isSurfaceCanvasExpanded) return;
 
     mouseForwarder.forwardWheel(event);
   }
@@ -118,33 +120,49 @@ export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
   function enter() {
     const p5Manager = options.getP5Manager();
 
-    if (isExpanded || !options.isSurfaceModeEnabled() || !p5Manager) return;
+    if (isExpanded || !p5Manager) return;
 
     isExpanded = true;
+    isSurfaceCanvasExpanded = Boolean(options.isSurfaceCanvasEnabled());
 
     const glSystem = options.getGlSystem();
     const overlay = SurfaceOverlay.getInstance();
     const nodes = options.getNodes().map((node) => ({ id: node.id, type: node.type }));
-    const presentation = glSystem.ipcSystem.hasConnectedOutputWindow() ? 'secondary' : 'main';
+
+    const presentation =
+      isSurfaceCanvasExpanded && glSystem.ipcSystem.hasConnectedOutputWindow()
+        ? 'secondary'
+        : 'main';
 
     overlay.activate(options.nodeId, nodes, () => exit(), {
       presentation,
       content: 'custom'
     });
 
-    glSystem.ipcSystem.sendSurfaceOverlayState({ active: true });
+    overlay.customHost.style.background = isSurfaceCanvasExpanded ? 'transparent' : 'black';
+
+    if (isSurfaceCanvasExpanded) {
+      glSystem.ipcSystem.sendSurfaceOverlayState({ active: true });
+    }
+
     p5Manager.setContainer(overlay.customHost);
 
-    mouseForwarder.refreshForwardingTargets();
-    mouseForwarder.forceHydraScope('global');
+    if (isSurfaceCanvasExpanded) {
+      mouseForwarder.refreshForwardingTargets();
+      mouseForwarder.forceHydraScope('global');
+    }
 
     options.updateSketch();
   }
 
   function deactivateMouse() {
     SurfaceOverlay.getInstance().deactivate(options.nodeId);
-    options.getGlSystem().ipcSystem.sendSurfaceOverlayState(null);
-    mouseForwarder.forceHydraScope('local');
+    SurfaceOverlay.getInstance().customHost.style.background = '';
+
+    if (isSurfaceCanvasExpanded) {
+      options.getGlSystem().ipcSystem.sendSurfaceOverlayState(null);
+      mouseForwarder.forceHydraScope('local');
+    }
   }
 
   function exit() {
@@ -152,6 +170,7 @@ export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
 
     isExpanded = false;
     deactivateMouse();
+    isSurfaceCanvasExpanded = false;
 
     options.getP5Manager()?.setContainer(options.getPreviewContainer());
 
@@ -172,6 +191,9 @@ export function createP5SurfaceMode(options: P5SurfaceModeOptions) {
   return {
     get isExpanded() {
       return isExpanded;
+    },
+    get isSurfaceCanvasExpanded() {
+      return isExpanded && isSurfaceCanvasExpanded;
     },
     get menuItems() {
       return menuItems;

--- a/ui/src/objects/p5/P5CanvasNode.svelte
+++ b/ui/src/objects/p5/P5CanvasNode.svelte
@@ -20,6 +20,7 @@
   import { createKVStore } from '$lib/storage';
   import type { SettingsSchema } from '$lib/settings';
   import { getBorderChromeClass, getBorderResetDataForRun } from '$lib/components/border-chrome';
+  import { getP5PreviewDimensions } from './preview-dimensions';
 
   let consoleRef: VirtualConsole | null = $state(null);
 
@@ -93,7 +94,7 @@
     getGlSystem: () => glSystem,
     getP5Manager: () => p5Manager,
     getPreviewContainer: () => containerElement ?? null,
-    isSurfaceModeEnabled: () => isSurfaceModeAvailable,
+    isSurfaceCanvasEnabled: () => isSurfaceModeAvailable,
     measureWidth,
     updateSketch: () => void updateSketch()
   });
@@ -310,13 +311,24 @@
           onRuntimeError: (error) => handleRuntimeError(error, nextCode),
           onPreserveFrame: surfaceMode.isExpanded ? undefined : preserveFrameCanvas,
           onFrameReady: ({ width, height }) => {
-            preloadCanvasWidth = width;
-            preloadCanvasHeight = height;
+            const previewDimensions = getP5PreviewDimensions({
+              width,
+              height,
+              isSurfaceCanvas: nextSurfaceModeEnabled
+            });
+
+            preloadCanvasWidth = previewDimensions.width;
+            preloadCanvasHeight = previewDimensions.height;
 
             clearPreservedFrameCanvas();
             setVideoOutputEnabled(nextVideoOutputEnabled);
           },
           getSurfaceCanvasSize: surfaceMode.getCanvasSize,
+          onCanvasCreated: (canvas, dimensions) => {
+            if (surfaceMode.isExpanded) {
+              surfaceMode.styleCanvas(canvas, dimensions);
+            }
+          },
           onSurfaceModeChange: (enabled) => {
             nextSurfaceModeEnabled = enabled;
 
@@ -341,7 +353,7 @@
           updateNodeData(nodeId, { surfaceMode: nextSurfaceModeEnabled });
         }
 
-        if (!nextSurfaceModeEnabled && surfaceMode.isExpanded) {
+        if (!nextSurfaceModeEnabled && surfaceMode.isSurfaceCanvasExpanded) {
           surfaceMode.exit();
         }
 

--- a/ui/src/objects/p5/preview-dimensions.test.ts
+++ b/ui/src/objects/p5/preview-dimensions.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getP5PreviewDimensions } from './preview-dimensions';
+
+describe('getP5PreviewDimensions', () => {
+  it('uses the surface preview scale for createSurfaceCanvas containers', () => {
+    expect(getP5PreviewDimensions({ width: 1280, height: 720, isSurfaceCanvas: true })).toEqual({
+      width: 320,
+      height: 180
+    });
+  });
+
+  it('keeps ordinary createCanvas dimensions unchanged', () => {
+    expect(getP5PreviewDimensions({ width: 400, height: 400, isSurfaceCanvas: false })).toEqual({
+      width: 400,
+      height: 400
+    });
+  });
+});

--- a/ui/src/objects/p5/preview-dimensions.ts
+++ b/ui/src/objects/p5/preview-dimensions.ts
@@ -1,0 +1,20 @@
+import { PREVIEW_SCALE_FACTOR } from '$lib/canvas/constants';
+
+export function getP5PreviewDimensions({
+  width,
+  height,
+  isSurfaceCanvas
+}: {
+  width: number;
+  height: number;
+  isSurfaceCanvas: boolean;
+}) {
+  if (!isSurfaceCanvas) {
+    return { width, height };
+  }
+
+  return {
+    width: Math.max(1, Math.round(width / PREVIEW_SCALE_FACTOR)),
+    height: Math.max(1, Math.round(height / PREVIEW_SCALE_FACTOR))
+  };
+}

--- a/ui/static/content/objects/p5.md
+++ b/ui/static/content/objects/p5.md
@@ -25,6 +25,15 @@ function draw() {
 
 By default, mouse interactions are passed through to the canvas for panning/dragging. To enable interactivity in your sketch (sliders, mousePressed, etc.), call `noInteract()` in `setup()`. See [Canvas Interaction](/docs/canvas-interaction) for details.
 
+## Focused Interactive View
+
+Open the node overflow menu and choose **Expand** to focus any p5 canvas.
+The live sketch keeps receiving mouse, touch, and keyboard input while Patchies
+hides the editor. The canvas preserves its aspect ratio, fits inside the screen,
+and leaves black borders when needed.
+
+Use **Exit surface** or `Shift+Esc` to return to the patch.
+
 ## Special Functions
 
 See the [Patchies JavaScript Runner](/docs/javascript-runner) for all available functions like `send()`, `recv()`, `setPortCount()`, `onCleanup()`, and more.
@@ -56,7 +65,7 @@ function draw() {
 }
 ```
 
-After running code that calls `createSurfaceCanvas()`, use **Expand** in the node menu to enter the transparent overlay. Use `clear()` when you want the visuals underneath to show through. Use `background()` only when you intentionally want the p5 sketch to cover the output.
+After running code that calls `createSurfaceCanvas()`, use **Expand** in the node menu to enter the transparent overlay. The live sketch remains interactive and scales to fit the screen without stretching or cropping. Use `clear()` when you want the visuals underneath to show through. Use `background()` only when you intentionally want the p5 sketch to cover the output.
 
 By default, expanded p5 surface sketches forward mouse interaction to render nodes in the patch. Use `setMouseForwarding()` to restrict or disable that behavior:
 


### PR DESCRIPTION
- Interactively expand P5 canvas
- Make `createSurfaceCanvas(...)` use the correct dimension

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added **Expand** support for p5 canvases.
  - Surface canvases preserve interactive overlays, input forwarding, and mirrored output when expanded.
  - Standard canvases display in a focused view with aspect-ratio-preserving sizing and black borders.
  - Added controls for entering and exiting expanded canvas view.

- **Documentation**
  - Documented Expand behavior, interaction support, display scaling, and exit controls.

- **Tests**
  - Added coverage for preview dimension scaling across canvas modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->