### PR TITLE
fix(expr~): do not autorun on every code edit

### DIFF
--- a/ui/src/lib/canvas/detached-code-editor-change.test.ts
+++ b/ui/src/lib/canvas/detached-code-editor-change.test.ts
@@ -5,6 +5,7 @@ import { commitDetachedCodeEditorChange } from './detached-code-editor-change';
 describe('detached code editor changes', () => {
   it('updates xyflow node data and invokes the target change callback', () => {
     const onchange = vi.fn();
+
     const target: CodeEditorTarget = {
       nodeId: 'bytebeat-1',
       dataKey: 'expr',
@@ -29,5 +30,24 @@ describe('detached code editor changes', () => {
     expect(onchange).toHaveBeenCalledOnce();
     expect(onchange).toHaveBeenCalledWith('t * 2');
     expect(events).toEqual(['updateNodeData', 'onchange']);
+  });
+
+  it('defers persistence when the target opts into explicit runs', () => {
+    const onchange = vi.fn();
+    const updateNodeData = vi.fn();
+
+    const target: CodeEditorTarget = {
+      nodeId: 'expr-1',
+      dataKey: 'expr',
+      language: 'javascript',
+      onchange,
+      persistOnChange: false,
+      mode: 'overlay'
+    };
+
+    commitDetachedCodeEditorChange(target, 's * 0.5', updateNodeData);
+
+    expect(updateNodeData).not.toHaveBeenCalled();
+    expect(onchange).toHaveBeenCalledWith('s * 0.5');
   });
 });

--- a/ui/src/lib/canvas/detached-code-editor-change.ts
+++ b/ui/src/lib/canvas/detached-code-editor-change.ts
@@ -7,6 +7,9 @@ export function commitDetachedCodeEditorChange(
   nextValue: string,
   updateNodeData: UpdateNodeData
 ): void {
-  updateNodeData(target.nodeId, { [target.dataKey]: nextValue });
+  if (target.persistOnChange !== false) {
+    updateNodeData(target.nodeId, { [target.dataKey]: nextValue });
+  }
+
   target.onchange?.(nextValue);
 }

--- a/ui/src/lib/code-editor/common-expr-editor-target.ts
+++ b/ui/src/lib/code-editor/common-expr-editor-target.ts
@@ -10,7 +10,8 @@ interface CommonExprEditorTargetOptions {
   title?: string;
   placeholder?: string;
   onchange?: (value: string) => void | Promise<void>;
-  onrun?: () => void;
+  onrun?: (code?: string) => void;
+  persistOnChange?: boolean;
   customActions?: Snippet;
   customSettings?: Snippet;
 }
@@ -24,6 +25,7 @@ export function createCommonExprEditorTarget({
   placeholder,
   onchange,
   onrun,
+  persistOnChange,
   customActions,
   customSettings
 }: CommonExprEditorTargetOptions): OpenCodeEditorOverlayTarget {
@@ -36,6 +38,7 @@ export function createCommonExprEditorTarget({
     placeholder,
     onchange,
     onrun,
+    persistOnChange,
     customActions,
     customSettings
   };

--- a/ui/src/objects/bytebeat~/BytebeatNode.svelte
+++ b/ui/src/objects/bytebeat~/BytebeatNode.svelte
@@ -141,9 +141,9 @@
     }
   }
 
-  async function handleRun() {
+  async function handleRun(expression = expr) {
     warnIfNoOutletConnection();
-    await audioService.send(nodeId, 'expr', expr);
+    await audioService.send(nodeId, 'expr', expression);
     await play();
   }
 
@@ -334,6 +334,7 @@
           editorClass="bytebeat-node-code-editor"
           previewContainerClass="bytebeat-node-preview-container"
           onExpressionChange={handleExpressionChange}
+          persistOnInput={autoEval}
           exitOnRun={false}
           onRun={handleRun}
           hasError={!!errorMessage}

--- a/ui/src/objects/expression/CommonExprLayout.svelte
+++ b/ui/src/objects/expression/CommonExprLayout.svelte
@@ -60,6 +60,7 @@
     language = 'javascript',
     onExpressionChange = () => {},
     onRun = () => {},
+    persistOnInput = true,
     exitOnRun = true,
     runOnExit = false,
     extraExtensions = [],
@@ -90,8 +91,10 @@
     class?: string;
     fontSize?: string;
     language?: SupportedLanguage;
-    onRun?: () => void;
+    onRun?: (expr?: string) => void;
     onExpressionChange?: (expr: string) => void;
+    /** Persist each edit immediately. Runtime-managed nodes can defer until run or blur. */
+    persistOnInput?: boolean;
     exitOnRun?: boolean;
     runOnExit?: boolean;
     extraExtensions?: any[];
@@ -173,15 +176,10 @@
   function exitEditingMode(save: boolean = true) {
     isEditing = false;
 
-    if (runOnExit) {
-      onRun?.();
-    }
-
     if (!save) {
       // Restore original expression on escape
       expr = originalExpr;
-      updateNodeData(nodeId, { expr: originalExpr });
-      onExpressionChange(originalExpr);
+      persistExpression(originalExpr);
 
       // If the original expression was empty, delete the node (unless empty is allowed)
       if (!originalExpr.trim() && !allowEmptyExpr) {
@@ -193,12 +191,16 @@
     if (save) {
       if (expr.trim()) {
         const trimmedExpr = expr.trim();
-        updateNodeData(nodeId, { expr: trimmedExpr });
-        onExpressionChange(trimmedExpr);
+        expr = trimmedExpr;
+        persistExpression(trimmedExpr);
       } else if (!allowEmptyExpr) {
         // If trying to save with empty expression, delete the node (unless empty is allowed)
         deleteElements({ nodes: [{ id: nodeId }] });
       }
+    }
+
+    if (save && runOnExit) {
+      onRun?.(expr);
     }
   }
 
@@ -210,8 +212,25 @@
 
   function handleExpressionUpdate(value: string) {
     expr = value;
+
+    if (persistOnInput) {
+      persistExpression(value);
+    }
+  }
+
+  function persistExpression(value: string) {
     updateNodeData(nodeId, { expr: value });
     onExpressionChange(value);
+  }
+
+  function handleDetachedRun(value?: string) {
+    const expression = value ?? expr;
+
+    if (!persistOnInput) {
+      persistExpression(expression);
+    }
+
+    onRun?.(expression);
   }
 
   useCodeSidebarTarget(() => ({
@@ -224,7 +243,8 @@
     placeholder,
     value: expr,
     onchange: handleExpressionUpdate,
-    onrun: onRun,
+    onrun: handleDetachedRun,
+    persistOnChange: persistOnInput,
     customActions: detachedActions,
     customSettings: detachedSettings,
     lineWrap
@@ -259,8 +279,9 @@
         nodeType,
         title: detachedEditorTitle,
         placeholder,
-        onchange: onExpressionChange,
-        onrun: onRun,
+        onchange: handleExpressionUpdate,
+        onrun: handleDetachedRun,
+        persistOnChange: persistOnInput,
         customActions: detachedActions,
         customSettings: detachedSettings
       })
@@ -298,9 +319,15 @@
                 value={expr}
                 onchange={handleExpressionUpdate}
                 onrun={() => {
-                  if (exitOnRun) exitEditingMode(true);
+                  if (exitOnRun) {
+                    exitEditingMode(true);
 
-                  onRun?.();
+                    if (runOnExit) return;
+                  } else if (!persistOnInput) {
+                    persistExpression(expr);
+                  }
+
+                  onRun?.(expr);
                 }}
                 {language}
                 class={`${editorClass} rounded-lg border !border-transparent focus:outline-none`}

--- a/ui/src/objects/expr~/AudioExprNode.svelte
+++ b/ui/src/objects/expr~/AudioExprNode.svelte
@@ -65,8 +65,8 @@
     updateNodeData(nodeId, { expr: newExpr });
   }
 
-  function handleRun() {
-    const parsed = parseMultiOutletExpressions(data.expr || '');
+  function handleRun(expression = data.expr) {
+    const parsed = parseMultiOutletExpressions(expression || '');
 
     // Send multi-outlet expressions to audio node (triggers worklet recreation if outlet count changed)
     audioService.send(nodeId, 'expressions', {
@@ -146,6 +146,7 @@
   handles={audioHandles}
   outlets={audioOutlets}
   onRun={handleRun}
+  persistOnInput={false}
   exitOnRun={false}
   runOnExit
 />

--- a/ui/src/objects/expr~/AudioFExprNode.svelte
+++ b/ui/src/objects/expr~/AudioFExprNode.svelte
@@ -65,8 +65,8 @@
     updateNodeData(nodeId, { expr: newExpr });
   }
 
-  function handleRun() {
-    const parsed = parseMultiOutletExpressions(data.expr || '');
+  function handleRun(expression = data.expr) {
+    const parsed = parseMultiOutletExpressions(expression || '');
 
     // Send multi-outlet expressions to audio node (triggers worklet recreation if outlet count changed)
     audioService.send(nodeId, 'expressions', {
@@ -146,6 +146,7 @@
   handles={audioHandles}
   outlets={audioOutlets}
   onRun={handleRun}
+  persistOnInput={false}
   exitOnRun={false}
   runOnExit
 />

--- a/ui/src/stores/code-editor-layout.store.ts
+++ b/ui/src/stores/code-editor-layout.store.ts
@@ -25,6 +25,10 @@ export interface CodeEditorTarget {
   placeholder?: string;
   onchange?: (value: string) => void | Promise<void>;
   onrun?: (code?: string) => void;
+
+  /** Persist input immediately. Runtime-managed nodes can defer until an explicit run. */
+  persistOnChange?: boolean;
+
   lineErrors?: Record<number, string[]>;
   inlineDecorations?: InlineDecoration[];
   extraExtensions?: Extension[];


### PR DESCRIPTION
Do not autorun `expr~` and `fexpr~` on every code edits