### PR TITLE
feat(uxn): add option to reduce preview resolution

### DIFF
--- a/docs/design-docs/specs/176-uxn-low-resolution-video-preview.md
+++ b/docs/design-docs/specs/176-uxn-low-resolution-video-preview.md
@@ -1,0 +1,22 @@
+# 176. Uxn Low-Resolution Video Preview
+
+## Problem
+
+Each Uxn node with an outgoing video connection creates and transfers a full-resolution `ImageBitmap` from its screen canvas on every animation frame. Patches that chain many Uxn nodes therefore spend substantial CPU, GPU, and transfer bandwidth on video data that is commonly viewed only as small node previews.
+
+## Design
+
+Uxn adds a persisted **Low Video Resolution** toggle in its overflow menu. When enabled, Uxn downsizes the bitmap it sends to the render worker with the shared `capPreviewSize()` rule: it fits within the same 252×164 maximum box used by visual-node previews and preserves the Uxn screen's aspect ratio. Pixelated scaling preserves Uxn's intended crisp pixels.
+
+The Uxn screen uses the shared visual-preview height (164 px) in the editor while its canvas backing buffer remains at the program-selected native resolution. Its width derives from the ROM's native aspect ratio, so there are no black bars, cropping, or stretching. A `ResizeObserver` refreshes React Flow's node bounds when a ROM changes screen dimensions. Keyboard and mouse interaction, screen rendering, and programs that change their screen size are unaffected. The image supplied through the Uxn video outlet uses the same reduced dimensions, so downstream video processing and previews trade sharpness for performance.
+
+The setting defaults to off to preserve existing patches. It is persisted in node data and participates in undo/redo.
+
+## Files Affected
+
+| File | Change |
+| --- | --- |
+| `ui/src/objects/uxn/UxnNode.svelte` | Persist the setting and resize outgoing bitmap frames |
+| `ui/src/objects/uxn/uxn/UxnFullLayout.svelte` | Expose the menu toggle |
+| `ui/src/objects/default-node-data.ts` | Set the default |
+| `ui/static/content/objects/uxn.md` | Document the performance control |

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -1058,8 +1058,8 @@ export class GLSystem {
     this.send('setBackgroundSize', { width, height });
   }
 
-  setBitmapSource(nodeId: string, source: ImageBitmapSource) {
-    createImageBitmap(source).then((bitmap) => {
+  setBitmapSource(nodeId: string, source: ImageBitmapSource, options?: ImageBitmapOptions) {
+    createImageBitmap(source, options).then((bitmap) => {
       this.setBitmap(nodeId, bitmap);
     });
   }

--- a/ui/src/lib/p5/P5Manager.test.ts
+++ b/ui/src/lib/p5/P5Manager.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
-import { P5Manager } from './P5Manager';
+import { installInlinePointerCoordinateNormalization, P5Manager } from './P5Manager';
 
 const executeJavaScript = vi.fn();
 
@@ -58,5 +58,56 @@ describe('P5Manager', () => {
         primaryButton: 'settings'
       }
     ]);
+  });
+
+  it('keeps mouse and previous-mouse coordinates in canvas space across scaled pointer events', () => {
+    const canvas = {
+      scrollWidth: 400,
+      scrollHeight: 300,
+      getBoundingClientRect: () => ({ width: 800, height: 600 })
+    } as HTMLCanvasElement;
+
+    const pointerSketch = {
+      _hasMouseInteracted: false,
+      mouseX: 0,
+      mouseY: 0,
+      pmouseX: 0,
+      pmouseY: 0,
+      canvas,
+      _updatePointerCoords(event: PointerEvent) {
+        this.mouseX = event.clientX;
+        this.mouseY = event.clientY;
+
+        if (!this._hasMouseInteracted) {
+          this.pmouseX = this.mouseX;
+          this.pmouseY = this.mouseY;
+          this._hasMouseInteracted = true;
+        }
+      }
+    };
+
+    installInlinePointerCoordinateNormalization(pointerSketch);
+
+    pointerSketch._updatePointerCoords!({ clientX: 200, clientY: 120 } as PointerEvent);
+
+    expect(pointerSketch).toMatchObject({
+      mouseX: 100,
+      mouseY: 60,
+      pmouseX: 100,
+      pmouseY: 60
+    });
+
+    // p5 saves the normalized current position at the end of the frame.
+    pointerSketch.pmouseX = pointerSketch.mouseX;
+    pointerSketch.pmouseY = pointerSketch.mouseY;
+
+    pointerSketch._updatePointerCoords!({ clientX: 300, clientY: 180 } as PointerEvent);
+
+    expect(pointerSketch).toMatchObject({
+      mouseX: 150,
+      mouseY: 90,
+      pmouseX: 100,
+      pmouseY: 60
+    });
   });
 });

--- a/ui/src/lib/p5/P5Manager.ts
+++ b/ui/src/lib/p5/P5Manager.ts
@@ -77,6 +77,53 @@ interface P5CanvasSnapshot {
   displayHeight: number;
 }
 
+type P5PointerSketch = {
+  _hasMouseInteracted?: boolean;
+  _updatePointerCoords?: (this: P5PointerSketch, event: PointerEvent) => void;
+  canvas?: HTMLCanvasElement;
+  mouseX: number;
+  mouseY: number;
+  pmouseX: number;
+  pmouseY: number;
+};
+
+/**
+ * Correct p5's pointer coordinates when the canvas is scaled by XYFlow.
+ *
+ * p5 measures pointer offsets against the untransformed layout width. Hooking
+ * its update method means its per-frame pmouse bookkeeping sees normalized
+ * coordinates, rather than repeatedly transforming a previous-frame value.
+ */
+export function installInlinePointerCoordinateNormalization(pointerSketch: P5PointerSketch) {
+  const updatePointerCoords = pointerSketch._updatePointerCoords;
+
+  if (!updatePointerCoords) return;
+
+  pointerSketch._updatePointerCoords = function (event: PointerEvent) {
+    const isFirstPointerUpdate = !this._hasMouseInteracted;
+    updatePointerCoords.call(this, event);
+
+    const canvas = this.canvas;
+    if (!canvas) return;
+
+    const bounds = canvas.getBoundingClientRect();
+    const scaleX = canvas.scrollWidth / bounds.width;
+    const scaleY = canvas.scrollHeight / bounds.height;
+
+    if (!Number.isFinite(scaleX) || !Number.isFinite(scaleY)) return;
+
+    this.mouseX *= scaleX;
+    this.mouseY *= scaleY;
+
+    // p5 initializes pmouse from mouse during its first pointer update. On
+    // following events it is already the previous normalized frame value.
+    if (isFirstPointerUpdate) {
+      this.pmouseX *= scaleX;
+      this.pmouseY *= scaleY;
+    }
+  };
+}
+
 export class P5Manager {
   public p5: Sketch | null = null;
   public glSystem = GLSystem.getInstance();
@@ -245,57 +292,9 @@ export class P5Manager {
           userCode?.preload?.call(p);
         };
 
-        // p5 derives pointer coordinates from the canvas's untransformed layout width.
-        // Inline canvases are scaled by XYFlow, so correct them immediately after p5
-        // receives an event. Doing this at the source keeps mouseX and pmouseX in the
-        // same coordinate space for draw(), including line(pmouseX, ..., mouseX, ...).
-        const installInlinePointerCoordinateNormalization = () => {
-          if (config.normalizeInlineMouseCoordinates === false) return;
-
-          const pointerSketch = p as Sketch & {
-            _hasMouseInteracted?: boolean;
-            _updatePointerCoords?: (event: PointerEvent) => void;
-            canvas?: HTMLCanvasElement;
-          };
-          const updatePointerCoords = pointerSketch._updatePointerCoords;
-
-          if (!updatePointerCoords) return;
-
-          pointerSketch._updatePointerCoords = function (event: PointerEvent) {
-            const isFirstPointerUpdate = !this._hasMouseInteracted;
-            updatePointerCoords.call(this, event);
-
-            const canvas = this.canvas;
-            if (!canvas) return;
-
-            const bounds = canvas.getBoundingClientRect();
-            const scaleX = canvas.scrollWidth / bounds.width;
-            const scaleY = canvas.scrollHeight / bounds.height;
-
-            if (!Number.isFinite(scaleX) || !Number.isFinite(scaleY)) return;
-
-            // p5's public coordinate properties are typed as readonly even though
-            // its own pointer implementation updates them at runtime.
-            const mutablePointerSketch = this as unknown as {
-              mouseX: number;
-              mouseY: number;
-              pmouseX: number;
-              pmouseY: number;
-            };
-
-            mutablePointerSketch.mouseX *= scaleX;
-            mutablePointerSketch.mouseY *= scaleY;
-
-            // p5 initializes pmouse from mouse during its first pointer update. On
-            // following events it is already the previous normalized frame value.
-            if (isFirstPointerUpdate) {
-              mutablePointerSketch.pmouseX *= scaleX;
-              mutablePointerSketch.pmouseY *= scaleY;
-            }
-          };
-        };
-
-        installInlinePointerCoordinateNormalization();
+        if (config.normalizeInlineMouseCoordinates !== false) {
+          installInlinePointerCoordinateNormalization(p as unknown as P5PointerSketch);
+        }
 
         // Guard: only dispatch mouse events that originate within the canvas bounds.
         // P5.js v2 listens on the window, so events outside the canvas still fire.

--- a/ui/src/objects/default-node-data.ts
+++ b/ui/src/objects/default-node-data.ts
@@ -272,7 +272,8 @@ export function getDefaultNodeData(nodeType: string): NodeData {
       code: '',
       showConsole: false,
       showEditor: false,
-      consoleOutput: ''
+      consoleOutput: '',
+      lowVideoResolution: false
     }))
     .with('mqtt', () => ({
       topics: [],

--- a/ui/src/objects/uxn/UxnNode.svelte
+++ b/ui/src/objects/uxn/UxnNode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Play, X } from '@lucide/svelte/icons';
   import { onMount, onDestroy, tick } from 'svelte';
-  import { useSvelteFlow } from '@xyflow/svelte';
+  import { useSvelteFlow, useUpdateNodeInternals } from '@xyflow/svelte';
   import { UxnEmulator, type UxnEmulatorOptions } from '$lib/uxn/UxnEmulator';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
   import { useCodeSidebarTarget } from '$lib/code-editor/use-code-sidebar-target.svelte';
@@ -11,6 +11,8 @@
   import { uxnMessages } from '$objects/uxn/schema';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import { GLSystem } from '$lib/canvas/GLSystem';
+  import { capPreviewSize } from '$lib/canvas/constants';
+  import { useNodeDataTracker } from '$lib/history';
   import UxnCompactLayout from './uxn/UxnCompactLayout.svelte';
   import UxnFullLayout from './uxn/UxnFullLayout.svelte';
   import { VirtualFilesystem } from '$lib/vfs';
@@ -27,15 +29,22 @@
       showConsole?: boolean;
       showEditor?: boolean;
       consoleOutput?: string;
-      /** Compact mode hides the screen and disables screen/input devices */
-      compact?: boolean;
+
       /** VFS path to the ROM file for persistence */
       vfsPath?: string;
+
+      /** Compact mode hides the screen and disables screen/input devices */
+      compact?: boolean;
+
+      /** Downscale outgoing video frames to reduce chained-video cost */
+      lowVideoResolution?: boolean;
     };
     selected: boolean;
   } = $props();
 
   const { updateNodeData } = useSvelteFlow();
+  const updateNodeInternals = useUpdateNodeInternals();
+  const tracker = $derived.by(() => useNodeDataTracker(nodeId));
 
   function getInitialState() {
     return {
@@ -63,6 +72,7 @@
   let bitmapFrameId: number | null = null;
   const fileName = $derived(data.fileName || 'No ROM loaded');
   const code = $derived(data.code || '');
+  const lowVideoResolution = $derived(data.lowVideoResolution ?? false);
 
   useCodeSidebarTarget(() => ({
     nodeId,
@@ -85,6 +95,20 @@
       previewContainerWidth = previewContainer.clientWidth;
     }
   }
+
+  $effect(() => {
+    const container = previewContainer;
+    if (!container) return;
+
+    const observer = new ResizeObserver(() => {
+      measureContainerWidth();
+      updateNodeInternals(nodeId);
+    });
+
+    observer.observe(container);
+
+    return () => observer.disconnect();
+  });
 
   // Compact mode button width matches CodeBlockBase: 100px
   const compactWidth = 100;
@@ -498,7 +522,19 @@
     if (!canvas || !emulator || isPaused) return;
 
     if (glSystem.hasOutgoingVideoConnections(nodeId)) {
-      await glSystem.setBitmapSource(nodeId, canvas);
+      let options: ImageBitmapOptions | undefined;
+
+      if (lowVideoResolution) {
+        const [previewWidth, previewHeight] = capPreviewSize(canvas.width, canvas.height);
+
+        options = {
+          resizeWidth: previewWidth,
+          resizeHeight: previewHeight,
+          resizeQuality: 'pixelated'
+        };
+      }
+
+      glSystem.setBitmapSource(nodeId, canvas, options);
     }
 
     bitmapFrameId = requestAnimationFrame(uploadBitmap);
@@ -506,6 +542,7 @@
 
   function startBitmapUpload() {
     if (bitmapFrameId !== null) return;
+
     bitmapFrameId = requestAnimationFrame(uploadBitmap);
   }
 
@@ -528,6 +565,16 @@
   function handleToggleEditor() {
     showEditor = !showEditor;
     updateNodeData(nodeId, { showEditor });
+  }
+
+  async function handleToggleLowVideoResolution() {
+    const nextValue = !lowVideoResolution;
+    updateNodeData(nodeId, { lowVideoResolution: nextValue });
+    tracker.commit('lowVideoResolution', lowVideoResolution, nextValue);
+
+    await tick();
+
+    measureContainerWidth();
   }
 
   async function toggleCompact() {
@@ -591,6 +638,8 @@
           onOpenFileDialog={openFileDialog}
           onToggleConsole={handleToggleConsole}
           onToggleEditor={handleToggleEditor}
+          {lowVideoResolution}
+          onToggleLowVideoResolution={handleToggleLowVideoResolution}
           onHideScreen={toggleCompact}
           onMeasureContainerWidth={measureContainerWidth}
         />

--- a/ui/src/objects/uxn/uxn/UxnFullLayout.svelte
+++ b/ui/src/objects/uxn/uxn/UxnFullLayout.svelte
@@ -3,6 +3,7 @@
     Code,
     EllipsisVertical,
     FolderOpen,
+    ImageDown,
     Monitor,
     Pause,
     Play,
@@ -11,6 +12,7 @@
   import * as Popover from '$lib/components/ui/popover';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import TypedHandle from '$lib/components/TypedHandle.svelte';
+  import { MAX_PREVIEW_SIZE } from '$lib/canvas/constants';
   import { uxnSchema } from '$objects/uxn/schema';
 
   let {
@@ -23,6 +25,8 @@
     onOpenFileDialog,
     onToggleConsole,
     onToggleEditor,
+    lowVideoResolution,
+    onToggleLowVideoResolution,
     onHideScreen,
     onMeasureContainerWidth
   }: {
@@ -35,6 +39,8 @@
     onOpenFileDialog: () => void;
     onToggleConsole: () => void;
     onToggleEditor: () => void;
+    lowVideoResolution: boolean;
+    onToggleLowVideoResolution: () => void;
     onHideScreen: () => void;
     onMeasureContainerWidth: () => void;
   } = $props();
@@ -112,6 +118,17 @@
         <button
           class="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-300 hover:bg-zinc-700"
           onclick={() => {
+            onToggleLowVideoResolution();
+            menuOpen = false;
+          }}
+        >
+          <ImageDown class="h-4 w-4" />
+          {lowVideoResolution ? 'Full Video Resolution' : 'Low Video Resolution'}
+        </button>
+
+        <button
+          class="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-300 hover:bg-zinc-700"
+          onclick={() => {
             onToggleConsole();
             menuOpen = false;
           }}
@@ -155,7 +172,9 @@
       ]}
       width={512}
       height={320}
-      style="width: 512px; height: 320px; image-rendering: pixelated; image-rendering: crisp-edges;"
+      style={lowVideoResolution
+        ? `width: auto; height: ${MAX_PREVIEW_SIZE[1]}px; image-rendering: pixelated; image-rendering: crisp-edges;`
+        : 'width: 512px; height: 320px; image-rendering: pixelated; image-rendering: crisp-edges;'}
     ></canvas>
   </div>
 

--- a/ui/static/content/objects/uxn.md
+++ b/ui/static/content/objects/uxn.md
@@ -17,6 +17,14 @@ Run programs like [Orca](https://100r.co/site/orca.html) and
 Supports video chaining - connect the video outlet to other visual objects
 (e.g. `hydra` and `glsl`) to process the Uxn screen output.
 
+For large chains, use Menu → **Low Video Resolution**. It sends video to
+downstream objects at the same maximum size as visual-node previews while
+preserving the Uxn screen's aspect ratio. This makes previews and video
+processing less demanding. The displayed Uxn screen uses the same height as
+visual-node previews, with its width derived from the ROM's aspect ratio—no
+black bars, cropping, or stretching. Programs continue to render at native
+resolution.
+
 ## Controls
 
 - **Load ROM**: Drop a `.rom` file, or use the menu
@@ -24,6 +32,8 @@ Supports video chaining - connect the video outlet to other visual objects
 - **Pause**: Pauses and resumes program execution
 - **Keyboard/Mouse**: Click on the canvas to focus it for input
 - **Edit Code**: Opens the Uxntal assembly code editor
+- **Low Video Resolution**: Reduces the resolution sent through the video outlet
+  for faster video chaining
 
 ## Headless Mode
 


### PR DESCRIPTION
Adds an option to `Uxn` object to reduce the preview resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **Low Video Resolution** mode for Uxn video previews, with aspect-ratio-preserving, pixelated scaling.
  * The setting is saved with the node, supports undo/redo, and adjusts layout when display dimensions change.
  * Native-resolution rendering remains available when the option is disabled.
* **Bug Fixes**
  * Improved pointer coordinate handling when canvases are displayed at scaled sizes.
* **Documentation**
  * Documented the Low Video Resolution option and its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->