### PR TITLE
feat(settings): add json field type for object settings

### DIFF
--- a/docs/design-docs/specs/91-dynamic-object-settings-api.md
+++ b/docs/design-docs/specs/91-dynamic-object-settings-api.md
@@ -22,7 +22,8 @@ A data-driven settings system that lets nodes declare a settings schema and rend
 | onChange trigger         | On-commit (debounced)                          | Fires on blur for text, pointerup for slider, click for toggle/select. Not every keystroke.   |
 | Revert                   | Single "Revert All" button                     | Resets all fields to defaults. Shown only when schema has defaults and current values differ. |
 | Worker support           | Main-thread only (v1)                          | ✅ v2: `worker`, `canvas`, `hydra` supported via `workerSettingsProxy.ts`.                    |
-| Field types (v1)         | number, string, boolean, select, color, slider | Covers most use cases. Extensible later.                                                      |
+| Field types (v1)         | number, string, boolean, select, color, slider | Covers most UI-controlled use cases.                                                           |
+| Hidden data fields       | `json`                                        | Stores portable JSON state without adding a settings control.                                  |
 
 ## Settings Schema
 
@@ -77,6 +78,15 @@ interface SliderField extends SettingsFieldBase {
   step?: number
 }
 
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue }
+
+interface JsonField {
+  key: string
+  type: 'json'
+  default?: JsonValue
+  persistence?: SettingsPersistence
+}
+
 type SettingsField =
   | NumberField
   | StringField
@@ -84,6 +94,7 @@ type SettingsField =
   | SelectField
   | ColorField
   | SliderField
+  | JsonField
 
 type SettingsSchema = SettingsField[]
 ```
@@ -102,6 +113,12 @@ Fields with `persistence: 'none'` are NOT stored in `settings` — they exist on
 Fields with `persistence: 'kv'` are stored in the node's KV store under the key `settings:${key}`. They are NOT in `settings` either, so they don't get exported with the patch.
 
 Fields with `persistence: 'node'` (the default) are stored in `settings` and exported with the patch.
+
+`json` fields use the same persistence modes but do not render in `<ObjectSettings>`. They accept
+only JSON values and snapshot values on `set()`, `get()`, `getAll()`, and `onChange()`. This keeps
+mutable arrays and objects from changing saved node data without an explicit `set()`. A JSON-only
+schema does not show a settings gear. Validation and snapshotting run in both direct and worker
+runtimes, so invalid values fail before worker code updates its local cache.
 
 ## JSRunner API
 
@@ -236,6 +253,7 @@ Each field type maps to a UI element:
 | `select`   | Pill button group (SequencerSettings output/clock mode pattern)                                 |
 | `color`    | Color swatch grid (PostItNode pattern) or swatch+picker (SequencerSettings track color pattern) |
 | `slider`   | `<SettingsSlider>` component (`$lib/components/SettingsSlider.svelte`) with label+value header. The value is double-clickable on desktop and tappable on touch devices for precise numeric entry. |
+| `json`     | Nothing. The value is hidden state managed through the `settings` API. |
 
 ### UI Patterns (Reference Components)
 

--- a/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
+++ b/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
@@ -93,7 +93,7 @@ export const jsRunnerInstructions = `
 - only add a few settings by default where it makes sense.
   - tell the user in the response what settings they have and how to show it i.e. in the overflow menu > "Settings"
   - do NOT add too much settings, 1 - 3 is enough. users can always ask to add more in a follow-up.
-- await settings.define([...schema]) - expose a settings panel on the node (gear icon appears)
+- await settings.define([...schema]) - register settings. A schema with UI fields exposes a settings panel on the node (gear icon appears).
   - on P5.js: do NOT await in setup() - do it at top level outside setup()
 - settings.get(key) - read current value (sync, after define resolves)
   - IMPORTANT: do NOT access settings[key] - that does NOT exist!
@@ -102,9 +102,10 @@ export const jsRunnerInstructions = `
   - useful for updating sliders/toggles from recv() messages or clock callbacks
 - settings.onChange((key, value, all) => {}) - react to value changes (from UI or settings.set)
 - settings.clear() - reset all settings to defaults and clear persisted values
-- Each field: { key, label, type, default?, persistence?: 'node'|'kv'|'none', ...type-specific }
-- Schema field types: slider, number, boolean, string, select, color
+- UI fields: { key, label, type, default?, persistence?: 'node'|'kv'|'none', ...type-specific }
+- Schema field types: slider, number, boolean, string, select, color, json
 - slider: requires min, max. Add step for float precision (e.g. step: 0.01 for 2 decimal places; omitting step defaults to integer steps)
+- json: hidden JSON-serializable node state. Use { key, type: 'json', default?, persistence? } with no label or UI properties. It accepts null, booleans, finite numbers, strings, arrays, and plain objects. \`get()\` returns a snapshot: after mutating an array/object, call \`settings.set(key, value)\` to persist it. A JSON-only schema does not show a gear.
 - For full settings docs call get_doc_content({ kind: 'topic', slug: 'object-settings' })
 `.trim();
 

--- a/ui/src/lib/canvas/shader-code-to-uniform-def.test.ts
+++ b/ui/src/lib/canvas/shader-code-to-uniform-def.test.ts
@@ -178,7 +178,7 @@ describe('uniformDefsToSettingsSchema', () => {
       { name: 'strength', type: 'float', min: 0, max: 1, description: 'Aberration strength' }
     ]);
 
-    expect(fields[0].label).toBe('Aberration strength');
+    expect(fields[0]).toMatchObject({ label: 'Aberration strength' });
   });
 
   it('generates slider for int with min/max', () => {
@@ -192,7 +192,7 @@ describe('uniformDefsToSettingsSchema', () => {
       { name: 'invert', type: 'bool', description: 'Invert output' }
     ]);
 
-    expect(fields[0].label).toBe('Invert output');
+    expect(fields[0]).toMatchObject({ label: 'Invert output' });
   });
 });
 

--- a/ui/src/lib/components/DetachedCodeEditorOverlay.svelte
+++ b/ui/src/lib/components/DetachedCodeEditorOverlay.svelte
@@ -12,6 +12,7 @@
   import { overlayEditorTransparency } from '../../stores/editor-layout-settings.store';
   import { isSidebarOpen } from '../../stores/ui.store';
   import { isFullscreenActive } from '$lib/canvas/SurfaceOverlay';
+  import { hasVisibleSettingsFields } from '$lib/settings';
 
   let {
     onClose,
@@ -146,7 +147,7 @@
           <div class="absolute top-11 right-0">
             {#if customSettings}
               {@render customSettings()}
-            {:else if settings && settings.schema.length > 0 && nodeId}
+            {:else if settings && hasVisibleSettingsFields(settings.schema) && nodeId}
               <ObjectSettings
                 {nodeId}
                 schema={settings.schema}

--- a/ui/src/lib/components/ObjectPreviewLayout.svelte
+++ b/ui/src/lib/components/ObjectPreviewLayout.svelte
@@ -16,6 +16,7 @@
   import { useSvelteFlow } from '@xyflow/svelte';
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings';
+  import { hasVisibleSettingsFields } from '$lib/settings';
   import type { ExtraMenuItem } from './object-preview-menu-actions';
   import type { SupportedLanguage } from '$lib/codemirror/types';
   import { outputTarget } from '../../stores/canvas.store';
@@ -148,7 +149,10 @@
   // Resolved primary — falls back to 'code' if the requested mode isn't usable
   // (e.g. 'settings' selected but no schema yet, 'run' selected but no onrun).
   let resolvedPrimary = $derived.by<PrimaryButton>(() => {
-    if (primaryButton === 'settings' && (!settingsSchema || settingsSchema.length === 0)) {
+    if (
+      primaryButton === 'settings' &&
+      (!settingsSchema || !hasVisibleSettingsFields(settingsSchema))
+    ) {
       return 'code';
     }
 
@@ -290,7 +294,7 @@
   );
 
   const detachedSettings = $derived(
-    settingsSchema && settingsSchema.length > 0
+    settingsSchema && hasVisibleSettingsFields(settingsSchema)
       ? {
           schema: settingsSchema,
           values: settingsValues,
@@ -329,7 +333,7 @@
 
   const settingsSidebarTarget = useSettingsSidebarTarget({
     getTarget: () =>
-      nodeId && settingsSchema && settingsSchema.length > 0
+      nodeId && settingsSchema && hasVisibleSettingsFields(settingsSchema)
         ? {
             id: nodeId,
             label: title,
@@ -598,7 +602,7 @@
     />
   </ContextMenu.Root>
 
-  {#if showSettings && settingsSchema && settingsSchema.length > 0 && nodeId}
+  {#if showSettings && settingsSchema && hasVisibleSettingsFields(settingsSchema) && nodeId}
     <div class="absolute top-0" style="left: {editorLeftPos}px;">
       <ObjectSettings
         {nodeId}

--- a/ui/src/lib/components/object-preview-menu-actions.ts
+++ b/ui/src/lib/components/object-preview-menu-actions.ts
@@ -14,6 +14,7 @@ import {
   Shrink
 } from '@lucide/svelte/icons';
 import type { SettingsSchema } from '$lib/settings';
+import { hasVisibleSettingsFields } from '$lib/settings';
 import type { Component } from 'svelte';
 
 export interface ExtraMenuItem {
@@ -64,7 +65,7 @@ export interface ObjectPreviewMenuGroup {
 }
 
 function hasSettings(settingsSchema?: SettingsSchema) {
-  return settingsSchema !== undefined && settingsSchema.length > 0;
+  return settingsSchema !== undefined && hasVisibleSettingsFields(settingsSchema);
 }
 
 export function getObjectPreviewMenuGroups({

--- a/ui/src/lib/components/settings/ObjectSettings.svelte
+++ b/ui/src/lib/components/settings/ObjectSettings.svelte
@@ -10,6 +10,7 @@
   import type { SettingsField, SettingsSchema } from '$lib/settings/types';
   import { filterSettingsOptions, normalizeSettingsOptions } from '$lib/settings/options';
   import { isSettingsFieldVisible } from '$lib/settings/visibility';
+  import { jsonValuesEqual } from '$lib/settings/json';
   import { useFloatingSettingsScroll } from './use-floating-settings-scroll.svelte';
 
   let {
@@ -83,7 +84,10 @@
     return schema.some((field) => {
       if (!('default' in field) || field.default === undefined) return false;
 
-      return !settingsValueEquals(getCurrentValue(field), field.default);
+      const currentValue = getCurrentValue(field);
+      return field.type === 'json'
+        ? !jsonValuesEqual(currentValue as typeof field.default, field.default)
+        : !settingsValueEquals(currentValue, field.default);
     });
   }
 

--- a/ui/src/lib/components/settings/ObjectSettings.svelte
+++ b/ui/src/lib/components/settings/ObjectSettings.svelte
@@ -85,6 +85,7 @@
       if (!('default' in field) || field.default === undefined) return false;
 
       const currentValue = getCurrentValue(field);
+
       return field.type === 'json'
         ? !jsonValuesEqual(currentValue as typeof field.default, field.default)
         : !settingsValueEquals(currentValue, field.default);

--- a/ui/src/lib/runtime/services/GraphObserver.test.ts
+++ b/ui/src/lib/runtime/services/GraphObserver.test.ts
@@ -167,6 +167,7 @@ describe('GraphObserver', () => {
       objects: [{ id: 'fragment', type: 'js', data: { tags: ['shader/foo/function'] } }],
       connections: []
     }));
+
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const snapshots: string[][] = [];
 
@@ -179,6 +180,30 @@ describe('GraphObserver', () => {
       );
 
       expect(snapshots).toEqual([['fragment']]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('contains rejected subscription callbacks', async () => {
+    const observer = new GraphObserver(() => ({
+      objects: [{ id: 'fragment', type: 'js', data: { tags: ['shader/foo/function'] } }],
+      connections: []
+    }));
+
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    try {
+      observer.subscribe({ tags: ['shader/foo/*'] }, async () => {
+        throw new Error('rejected callback');
+      });
+
+      await Promise.resolve();
+
+      expect(warn).toHaveBeenCalledWith(
+        'Error in onGraphChange() handler:',
+        expect.objectContaining({ message: 'rejected callback' })
+      );
     } finally {
       warn.mockRestore();
     }

--- a/ui/src/lib/runtime/services/GraphObserver.test.ts
+++ b/ui/src/lib/runtime/services/GraphObserver.test.ts
@@ -6,6 +6,20 @@ import { GraphObserver } from './GraphObserver';
 import type { RuntimeGraphSpec } from '../types/runtime-object';
 
 describe('GraphObserver', () => {
+  it('does not read the graph when there are no subscriptions', async () => {
+    const getGraph = vi.fn(() => ({ objects: [], connections: [] }));
+    const observer = new GraphObserver(getGraph);
+
+    observer.notify({
+      changedObjectIds: new Set(['fragment']),
+      changedConnectionNodeIds: new Set()
+    });
+
+    await Promise.resolve();
+
+    expect(getGraph).not.toHaveBeenCalled();
+  });
+
   it('does not call a subscription when no nodes match its tags', async () => {
     const observer = new GraphObserver(() => ({
       objects: [{ id: 'output', type: 'glsl', data: { tags: ['shader/output'] } }],

--- a/ui/src/lib/runtime/services/GraphObserver.ts
+++ b/ui/src/lib/runtime/services/GraphObserver.ts
@@ -60,6 +60,8 @@ export class GraphObserver {
   }
 
   notify(change?: GraphChange): void {
+    if (this.subscriptions.size === 0) return;
+
     if (change) {
       for (const nodeId of change.changedObjectIds) {
         this.changedObjectIds.add(nodeId);

--- a/ui/src/lib/runtime/services/GraphObserver.ts
+++ b/ui/src/lib/runtime/services/GraphObserver.ts
@@ -149,7 +149,11 @@ export class GraphObserver {
     subscription.lastSnapshotKey = snapshotKey;
 
     try {
-      subscription.callback(snapshot);
+      const result = subscription.callback(snapshot) as unknown;
+
+      if (result instanceof Promise) {
+        result.catch((error) => logger.warn('Error in onGraphChange() handler:', error));
+      }
     } catch (error) {
       logger.warn('Error in onGraphChange() handler:', error);
     }

--- a/ui/src/lib/runtime/services/GraphObserver.ts
+++ b/ui/src/lib/runtime/services/GraphObserver.ts
@@ -153,9 +153,9 @@ export class GraphObserver {
     try {
       const result = subscription.callback(snapshot) as unknown;
 
-      if (result instanceof Promise) {
-        result.catch((error) => logger.warn('Error in onGraphChange() handler:', error));
-      }
+      Promise.resolve(result).catch((error) =>
+        logger.warn('Error in onGraphChange() handler:', error)
+      );
     } catch (error) {
       logger.warn('Error in onGraphChange() handler:', error);
     }

--- a/ui/src/lib/runtime/services/OnGraphChange.integration.test.ts
+++ b/ui/src/lib/runtime/services/OnGraphChange.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { MessageSystem } from '$lib/messages';
+import { logger } from '$lib/utils/logger';
 
 import { createTestPatchRuntime } from '../utils/runtime-test-utils';
 
@@ -13,6 +14,7 @@ describe('js onGraphChange', () => {
     messageSystem.unregisterNode(compilerId);
     messageSystem.unregisterNode(glslId);
     messageSystem.updateEdges([]);
+    logger.clearNodeLogs(compilerId);
   });
 
   it('emits generated source for tagged fragments through its output edge', async () => {
@@ -89,6 +91,38 @@ describe('js onGraphChange', () => {
     });
 
     expect(received).toHaveLength(2);
+
+    runtime.destroy();
+  });
+
+  it('routes callback errors to the subscribing JS node', async () => {
+    const runtime = createTestPatchRuntime();
+
+    await runtime.setGraph({
+      objects: [
+        {
+          id: compilerId,
+          type: 'js',
+          data: {
+            runOnMount: true,
+            code: `onGraphChange({ tags: ['shader/foo/*'] }, () => { throw new Error('broken graph callback') })`
+          }
+        },
+        {
+          id: 'fragment',
+          type: 'js',
+          data: { tags: ['shader/foo/function'] }
+        }
+      ],
+      connections: []
+    });
+
+    expect(logger.getNodeLogs(compilerId)).toMatchObject([
+      {
+        level: 'error',
+        args: ['broken graph callback']
+      }
+    ]);
 
     runtime.destroy();
   });

--- a/ui/src/lib/runtime/services/OnGraphChange.integration.test.ts
+++ b/ui/src/lib/runtime/services/OnGraphChange.integration.test.ts
@@ -126,4 +126,38 @@ describe('js onGraphChange', () => {
 
     runtime.destroy();
   });
+
+  it('routes rejected callbacks to the subscribing JS node', async () => {
+    const runtime = createTestPatchRuntime();
+
+    await runtime.setGraph({
+      objects: [
+        {
+          id: compilerId,
+          type: 'js',
+          data: {
+            runOnMount: true,
+            code: `onGraphChange({ tags: ['shader/foo/*'] }, async () => { throw new Error('rejected graph callback') })`
+          }
+        },
+        {
+          id: 'fragment',
+          type: 'js',
+          data: { tags: ['shader/foo/function'] }
+        }
+      ],
+      connections: []
+    });
+
+    await Promise.resolve();
+
+    expect(logger.getNodeLogs(compilerId)).toMatchObject([
+      {
+        level: 'error',
+        args: ['rejected graph callback']
+      }
+    ]);
+
+    runtime.destroy();
+  });
 });

--- a/ui/src/lib/settings/SettingsManager.test.ts
+++ b/ui/src/lib/settings/SettingsManager.test.ts
@@ -4,6 +4,7 @@ import type { KVStore } from '$lib/storage';
 
 import { SettingsManager } from './SettingsManager';
 import { createSettingsAPI } from './create-settings-api';
+import { cloneJsonValue } from './json';
 import type { SettingsSchema } from './types';
 
 const fakeKVStore = {
@@ -13,6 +14,29 @@ const fakeKVStore = {
 } as unknown as KVStore;
 
 describe('SettingsManager', () => {
+  it('clones JSON object keys and dense array values without invoking accessors', () => {
+    const withProtoKey = JSON.parse('{"__proto__":{"x":1}}');
+    const cloned = cloneJsonValue(withProtoKey) as Record<string, unknown>;
+
+    expect(Object.hasOwn(cloned, '__proto__')).toBe(true);
+    expect(cloned.__proto__).toEqual({ x: 1 });
+    expect(Object.getPrototypeOf(cloned)).toBe(Object.prototype);
+    expect(() => cloneJsonValue(Array.from({ length: 1 }))).toThrow(TypeError);
+
+    const accessorArray: unknown[] = [];
+
+    Object.defineProperty(accessorArray, 0, {
+      enumerable: true,
+      get: () => {
+        throw new Error('array getter should not run');
+      }
+    });
+
+    accessorArray.length = 1;
+
+    expect(() => cloneJsonValue(accessorArray)).toThrow(TypeError);
+  });
+
   it('preserves earlier synchronous node-persisted settings updates', async () => {
     const persistedSettings: Record<string, unknown> = {};
     const updates: Record<string, unknown>[] = [];

--- a/ui/src/lib/settings/SettingsManager.test.ts
+++ b/ui/src/lib/settings/SettingsManager.test.ts
@@ -4,6 +4,7 @@ import type { KVStore } from '$lib/storage';
 
 import { SettingsManager } from './SettingsManager';
 import { createSettingsAPI } from './create-settings-api';
+import type { SettingsSchema } from './types';
 
 const fakeKVStore = {
   get: async () => undefined,
@@ -49,14 +50,73 @@ describe('SettingsManager', () => {
     await manager.define([
       { key: 'node', label: 'Node', type: 'number', default: 1 },
       { key: 'kv', label: 'KV', type: 'number', persistence: 'kv', default: 2 },
-      { key: 'none', label: 'None', type: 'number', persistence: 'none', default: 3 }
+      { key: 'none', label: 'None', type: 'number', persistence: 'none', default: 3 },
+      { key: 'jsonNode', type: 'json', default: { enabled: true } },
+      { key: 'jsonKv', type: 'json', persistence: 'kv', default: { enabled: true } },
+      { key: 'jsonNone', type: 'json', persistence: 'none', default: { enabled: true } }
     ]);
 
     manager.setValue('node', 10);
     manager.setValue('kv', 20);
     manager.setValue('none', 30);
+    manager.setValue('jsonNode', { enabled: false });
+    manager.setValue('jsonKv', { enabled: false });
+    manager.setValue('jsonNone', { enabled: false });
     manager.revertAll();
 
-    expect(manager.getAll()).toEqual({ node: 1, kv: 2, none: 3 });
+    expect(manager.getAll()).toEqual({
+      node: 1,
+      kv: 2,
+      none: 3,
+      jsonNode: { enabled: true },
+      jsonKv: { enabled: true },
+      jsonNone: { enabled: true }
+    });
+  });
+
+  it('persists JSON values as isolated snapshots', async () => {
+    let persistedSettings: Record<string, unknown> = {};
+    const manager = new SettingsManager(
+      () => persistedSettings,
+      (settings) => {
+        persistedSettings = settings;
+      },
+      fakeKVStore
+    );
+
+    await manager.define([{ key: 'grid', type: 'json', default: [[false, true]] }]);
+
+    const defaultGrid = manager.get('grid') as boolean[][];
+    defaultGrid[0][0] = true;
+    expect(manager.get('grid')).toEqual([[false, true]]);
+
+    const nextGrid = [[true, false]];
+    manager.onChange((_key, value, allValues) => {
+      (value as boolean[][])[0][0] = false;
+      (allValues.grid as boolean[][])[0][1] = true;
+    });
+    manager.setValue('grid', nextGrid);
+    nextGrid[0][1] = true;
+
+    expect(persistedSettings).toEqual({ grid: [[true, false]] });
+    expect(manager.get('grid')).toEqual([[true, false]]);
+  });
+
+  it('rejects values that cannot round-trip through JSON', async () => {
+    const manager = new SettingsManager(
+      () => ({}),
+      () => {},
+      fakeKVStore
+    );
+
+    await manager.define([{ key: 'data', type: 'json' }]);
+
+    expect(() => manager.setValue('data', { invalid: undefined })).toThrow(TypeError);
+    expect(() => manager.setValue('data', new Map())).toThrow(TypeError);
+    expect(() => manager.setValue('data', Infinity)).toThrow(TypeError);
+    const invalidSchema = [
+      { key: 'invalidDefault', type: 'json', default: { invalid: undefined } }
+    ] as unknown as SettingsSchema;
+    await expect(manager.define(invalidSchema)).rejects.toThrow(TypeError);
   });
 });

--- a/ui/src/lib/settings/SettingsManager.ts
+++ b/ui/src/lib/settings/SettingsManager.ts
@@ -240,11 +240,14 @@ export class SettingsManager {
       if (field.default === undefined) continue;
 
       const current = this.get(field.key);
-      if (
+      const clonedJsonValue = current as ReturnType<typeof cloneJsonValue>;
+
+      const hasChangedFromDefault =
         field.type === 'json'
-          ? !jsonValuesEqual(current as ReturnType<typeof cloneJsonValue>, field.default)
-          : current !== field.default
-      ) {
+          ? !jsonValuesEqual(clonedJsonValue, field.default)
+          : current !== field.default;
+
+      if (hasChangedFromDefault) {
         return true;
       }
     }

--- a/ui/src/lib/settings/SettingsManager.ts
+++ b/ui/src/lib/settings/SettingsManager.ts
@@ -1,6 +1,12 @@
 import type { SettingsField, SettingsSchema } from './types';
 import type { KVStore } from '$lib/storage/KVStore';
 import { match } from 'ts-pattern';
+import {
+  cloneJsonValue,
+  cloneSettingsFieldValue,
+  jsonValuesEqual,
+  normalizeSettingsSchema
+} from './json';
 
 type ChangeCallback = (key: string, value: unknown, allValues: Record<string, unknown>) => void;
 
@@ -43,10 +49,10 @@ export class SettingsManager {
   ) {}
 
   async define(fields: SettingsField[]): Promise<void> {
-    this.schema = fields;
+    this.schema = normalizeSettingsSchema(fields);
 
     // Load KV-persisted field values before returning
-    for (const field of fields) {
+    for (const field of this.schema) {
       if (field.persistence === 'kv') {
         const value = await this.kvStore.get(`settings:${field.key}`);
 
@@ -60,15 +66,15 @@ export class SettingsManager {
     const currentSettings = this.getCurrentNodeSettings();
     const nextSettings: Record<string, unknown> = { ...currentSettings };
 
-    for (const field of fields) {
+    for (const field of this.schema) {
       if (!field.persistence || field.persistence === 'node') {
         if (nextSettings[field.key] === undefined && field.default !== undefined) {
-          nextSettings[field.key] = field.default;
+          nextSettings[field.key] = cloneSettingsFieldValue(field, field.default);
         }
       }
     }
 
-    this.updateNodeSettingsWithCache(nextSettings, fields);
+    this.updateNodeSettingsWithCache(nextSettings, this.schema);
   }
 
   get(key: string): unknown {
@@ -81,7 +87,8 @@ export class SettingsManager {
       .with('node', () => this.getCurrentNodeSettings()[key])
       .exhaustive();
 
-    return value !== undefined ? value : field.default;
+    const resolvedValue = value !== undefined ? value : field.default;
+    return resolvedValue === undefined ? undefined : cloneSettingsFieldValue(field, resolvedValue);
   }
 
   getAll(): Record<string, unknown> {
@@ -100,18 +107,20 @@ export class SettingsManager {
     const field = this.schema.find((f) => f.key === key);
     if (!field) return;
 
+    const storedValue = cloneSettingsFieldValue(field, value);
+
     match(field.persistence ?? 'node')
       .with('none', () => {
-        this.memoryStore.set(key, value);
+        this.memoryStore.set(key, storedValue);
       })
       .with('kv', () => {
-        this.kvCache.set(key, value);
-        this.kvStore.set(`settings:${key}`, value);
+        this.kvCache.set(key, storedValue);
+        this.kvStore.set(`settings:${key}`, storedValue);
       })
       .with('node', () => {
         const settings = this.getCurrentNodeSettings();
 
-        this.updateNodeSettingsWithCache({ ...settings, [key]: value }, this.schema);
+        this.updateNodeSettingsWithCache({ ...settings, [key]: storedValue }, this.schema);
       })
       .exhaustive();
 
@@ -120,7 +129,7 @@ export class SettingsManager {
 
     for (const callback of this.changeCallbacks) {
       try {
-        callback(key, value, settingsValues);
+        callback(key, cloneSettingsFieldValue(field, storedValue), settingsValues);
       } catch (error) {
         console.error('settings.onChange callback error:', error);
       }
@@ -136,15 +145,16 @@ export class SettingsManager {
       match(field.persistence ?? 'node')
         .with('none', () => {
           if (hasDefault) {
-            this.memoryStore.set(field.key, field.default);
+            this.memoryStore.set(field.key, cloneSettingsFieldValue(field, field.default));
           } else {
             this.memoryStore.delete(field.key);
           }
         })
         .with('kv', () => {
           if (hasDefault) {
-            this.kvCache.set(field.key, field.default);
-            this.kvStore.set(`settings:${field.key}`, field.default);
+            const defaultValue = cloneSettingsFieldValue(field, field.default);
+            this.kvCache.set(field.key, defaultValue);
+            this.kvStore.set(`settings:${field.key}`, defaultValue);
           } else {
             this.kvCache.delete(field.key);
             this.kvStore.delete(`settings:${field.key}`);
@@ -152,7 +162,7 @@ export class SettingsManager {
         })
         .with('node', () => {
           if (hasDefault) {
-            newSettings[field.key] = field.default;
+            newSettings[field.key] = cloneSettingsFieldValue(field, field.default);
           }
         })
         .exhaustive();
@@ -230,7 +240,13 @@ export class SettingsManager {
       if (field.default === undefined) continue;
 
       const current = this.get(field.key);
-      if (current !== field.default) return true;
+      if (
+        field.type === 'json'
+          ? !jsonValuesEqual(current as ReturnType<typeof cloneJsonValue>, field.default)
+          : current !== field.default
+      ) {
+        return true;
+      }
     }
 
     return false;

--- a/ui/src/lib/settings/index.ts
+++ b/ui/src/lib/settings/index.ts
@@ -1,4 +1,10 @@
-export type { SettingsField, SettingsSchema, SettingsAPI, SettingsPersistence } from './types';
+export type {
+  SettingsField,
+  SettingsSchema,
+  SettingsAPI,
+  SettingsPersistence,
+  JsonValue
+} from './types';
 export type {
   NumberField,
   StringField,
@@ -8,8 +14,10 @@ export type {
   ColorField,
   SliderField,
   Vec2Field,
+  JsonField,
   SettingsOption
 } from './types';
 export { SettingsManager } from './SettingsManager';
 export { createSettingsAPI } from './create-settings-api';
 export { createWorkerSettingsCallbacks } from './create-worker-settings-callbacks';
+export { hasVisibleSettingsFields, isSettingsFieldVisible } from './visibility';

--- a/ui/src/lib/settings/json.ts
+++ b/ui/src/lib/settings/json.ts
@@ -6,21 +6,18 @@ import type { JsonValue, SettingsField, SettingsSchema } from './types';
  * This avoids a JSON stringify/parse round trip for large persisted values
  * while ensuring the value will survive Patchies' JSON patch format unchanged.
  */
-export function cloneJsonValue(value: unknown): JsonValue {
-  return cloneJsonValueAt(value, '$', new Set<object>());
-}
+export const cloneJsonValue = (value: unknown): JsonValue =>
+  cloneJsonValueAt(value, '$', new Set<object>());
 
-export function cloneSettingsFieldValue(field: SettingsField, value: unknown): unknown {
-  return field.type === 'json' ? cloneJsonValue(value) : value;
-}
+export const cloneSettingsFieldValue = (field: SettingsField, value: unknown): unknown =>
+  field.type === 'json' ? cloneJsonValue(value) : value;
 
-export function normalizeSettingsSchema(schema: SettingsSchema): SettingsSchema {
-  return schema.map((field) => {
+export const normalizeSettingsSchema = (schema: SettingsSchema): SettingsSchema =>
+  schema.map((field) => {
     if (field.type !== 'json' || field.default === undefined) return field;
 
     return { ...field, default: cloneJsonValue(field.default) };
   });
-}
 
 export function jsonValuesEqual(left: JsonValue, right: JsonValue): boolean {
   if (Object.is(left, right)) return true;
@@ -52,6 +49,7 @@ function cloneJsonValueAt(value: unknown, path: string, ancestors: Set<object>):
 
   if (typeof value === 'number') {
     if (Number.isFinite(value)) return value;
+
     throw new TypeError(`Invalid JSON value at ${path}: numbers must be finite`);
   }
 
@@ -64,6 +62,7 @@ function cloneJsonValueAt(value: unknown, path: string, ancestors: Set<object>):
   }
 
   ancestors.add(value);
+
   try {
     if (Array.isArray(value)) {
       return value.map((item, index) => cloneJsonValueAt(item, `${path}[${index}]`, ancestors));
@@ -75,13 +74,17 @@ function cloneJsonValueAt(value: unknown, path: string, ancestors: Set<object>):
     }
 
     const result: { [key: string]: JsonValue } = {};
+
     for (const key of Object.keys(value)) {
       const descriptor = Object.getOwnPropertyDescriptor(value, key);
+
       if (!descriptor || !('value' in descriptor)) {
         throw new TypeError(`Invalid JSON value at ${path}.${key}: accessors are not supported`);
       }
+
       result[key] = cloneJsonValueAt(descriptor.value, `${path}.${key}`, ancestors);
     }
+
     return result;
   } finally {
     ancestors.delete(value);

--- a/ui/src/lib/settings/json.ts
+++ b/ui/src/lib/settings/json.ts
@@ -1,0 +1,89 @@
+import type { JsonValue, SettingsField, SettingsSchema } from './types';
+
+/**
+ * Validate and copy a JSON value in one pass.
+ *
+ * This avoids a JSON stringify/parse round trip for large persisted values
+ * while ensuring the value will survive Patchies' JSON patch format unchanged.
+ */
+export function cloneJsonValue(value: unknown): JsonValue {
+  return cloneJsonValueAt(value, '$', new Set<object>());
+}
+
+export function cloneSettingsFieldValue(field: SettingsField, value: unknown): unknown {
+  return field.type === 'json' ? cloneJsonValue(value) : value;
+}
+
+export function normalizeSettingsSchema(schema: SettingsSchema): SettingsSchema {
+  return schema.map((field) => {
+    if (field.type !== 'json' || field.default === undefined) return field;
+
+    return { ...field, default: cloneJsonValue(field.default) };
+  });
+}
+
+export function jsonValuesEqual(left: JsonValue, right: JsonValue): boolean {
+  if (Object.is(left, right)) return true;
+
+  if (typeof left !== 'object' || left === null || typeof right !== 'object' || right === null) {
+    return false;
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => jsonValuesEqual(value, right[index]))
+    );
+  }
+
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every((key) => Object.hasOwn(right, key) && jsonValuesEqual(left[key], right[key]))
+  );
+}
+
+function cloneJsonValueAt(value: unknown, path: string, ancestors: Set<object>): JsonValue {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') return value;
+
+  if (typeof value === 'number') {
+    if (Number.isFinite(value)) return value;
+    throw new TypeError(`Invalid JSON value at ${path}: numbers must be finite`);
+  }
+
+  if (typeof value !== 'object') {
+    throw new TypeError(`Invalid JSON value at ${path}: expected JSON data`);
+  }
+
+  if (ancestors.has(value)) {
+    throw new TypeError(`Invalid JSON value at ${path}: circular references are not supported`);
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item, index) => cloneJsonValueAt(item, `${path}[${index}]`, ancestors));
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError(`Invalid JSON value at ${path}: expected a plain object`);
+    }
+
+    const result: { [key: string]: JsonValue } = {};
+    for (const key of Object.keys(value)) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || !('value' in descriptor)) {
+        throw new TypeError(`Invalid JSON value at ${path}.${key}: accessors are not supported`);
+      }
+      result[key] = cloneJsonValueAt(descriptor.value, `${path}.${key}`, ancestors);
+    }
+    return result;
+  } finally {
+    ancestors.delete(value);
+  }
+}

--- a/ui/src/lib/settings/json.ts
+++ b/ui/src/lib/settings/json.ts
@@ -65,7 +65,21 @@ function cloneJsonValueAt(value: unknown, path: string, ancestors: Set<object>):
 
   try {
     if (Array.isArray(value)) {
-      return value.map((item, index) => cloneJsonValueAt(item, `${path}[${index}]`, ancestors));
+      const result: JsonValue[] = [];
+
+      for (let index = 0; index < value.length; index++) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, index);
+
+        if (!descriptor || !('value' in descriptor)) {
+          throw new TypeError(
+            `Invalid JSON value at ${path}[${index}]: sparse arrays and accessors are not supported`
+          );
+        }
+
+        result.push(cloneJsonValueAt(descriptor.value, `${path}[${index}]`, ancestors));
+      }
+
+      return result;
     }
 
     const prototype = Object.getPrototypeOf(value);
@@ -82,7 +96,12 @@ function cloneJsonValueAt(value: unknown, path: string, ancestors: Set<object>):
         throw new TypeError(`Invalid JSON value at ${path}.${key}: accessors are not supported`);
       }
 
-      result[key] = cloneJsonValueAt(descriptor.value, `${path}.${key}`, ancestors);
+      Object.defineProperty(result, key, {
+        value: cloneJsonValueAt(descriptor.value, `${path}.${key}`, ancestors),
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
     }
 
     return result;

--- a/ui/src/lib/settings/types.ts
+++ b/ui/src/lib/settings/types.ts
@@ -26,6 +26,9 @@ export type SettingsOption = {
   description?: string;
 };
 
+export type JsonPrimitive = null | boolean | number | string;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
 export interface NumberField extends SettingsFieldBase {
   type: 'number';
   default?: number;
@@ -83,6 +86,19 @@ export interface Vec2Field extends SettingsFieldBase {
   step?: number;
 }
 
+/**
+ * Persist arbitrary JSON data without rendering a settings control.
+ *
+ * JSON fields deliberately omit UI-only properties such as `label` and
+ * `visibleWhen`. Update them through `settings.set()`.
+ */
+export interface JsonField {
+  key: string;
+  type: 'json';
+  default?: JsonValue;
+  persistence?: SettingsPersistence;
+}
+
 export type SettingsField =
   | NumberField
   | StringField
@@ -91,7 +107,8 @@ export type SettingsField =
   | ComboboxField
   | ColorField
   | SliderField
-  | Vec2Field;
+  | Vec2Field
+  | JsonField;
 
 export type SettingsSchema = SettingsField[];
 

--- a/ui/src/lib/settings/use-settings-sidebar-target.svelte.ts
+++ b/ui/src/lib/settings/use-settings-sidebar-target.svelte.ts
@@ -1,4 +1,5 @@
 import type { SettingsSidebarTarget } from '../../stores/settings-sidebar.store';
+import { hasVisibleSettingsFields } from './visibility';
 import {
   isSchemaSettingsSidebarTarget,
   openObjectSettingsInSidebarIfPreferred,
@@ -25,7 +26,11 @@ export function useSettingsSidebarTarget({ getTarget, floating }: SettingsSideba
 } {
   $effect(() => {
     const target = getTarget();
-    if (!target || (isSchemaSettingsSidebarTarget(target) && target.schema.length === 0)) return;
+    if (
+      !target ||
+      (isSchemaSettingsSidebarTarget(target) && !hasVisibleSettingsFields(target.schema))
+    )
+      return;
 
     return registerSettingsSidebarTarget(target);
   });

--- a/ui/src/lib/settings/use-settings-sidebar-target.svelte.ts
+++ b/ui/src/lib/settings/use-settings-sidebar-target.svelte.ts
@@ -26,18 +26,24 @@ export function useSettingsSidebarTarget({ getTarget, floating }: SettingsSideba
 } {
   $effect(() => {
     const target = getTarget();
-    if (
+
+    const targetUnavailable =
       !target ||
-      (isSchemaSettingsSidebarTarget(target) && !hasVisibleSettingsFields(target.schema))
-    )
-      return;
+      (isSchemaSettingsSidebarTarget(target) && !hasVisibleSettingsFields(target.schema));
+
+    if (targetUnavailable) return;
 
     return registerSettingsSidebarTarget(target);
   });
 
   function toggle(event?: MouseEvent): void {
     const target = getTarget();
-    if (!target) return;
+
+    const targetUnavailable =
+      !target ||
+      (isSchemaSettingsSidebarTarget(target) && !hasVisibleSettingsFields(target.schema));
+
+    if (targetUnavailable) return;
 
     if (openObjectSettingsInSidebarIfPreferred(target.id, event?.shiftKey)) {
       floating.setOpen(false);
@@ -47,7 +53,9 @@ export function useSettingsSidebarTarget({ getTarget, floating }: SettingsSideba
     const nextOpen = !floating.isOpen();
     floating.setOpen(nextOpen);
 
-    if (nextOpen) floating.onOpenFloating?.();
+    if (nextOpen) {
+      floating.onOpenFloating?.();
+    }
   }
 
   return { toggle };

--- a/ui/src/lib/settings/visibility.test.ts
+++ b/ui/src/lib/settings/visibility.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { SettingsSchema } from './types';
-import { isSettingsFieldVisible } from './visibility';
+import { hasVisibleSettingsFields, isSettingsFieldVisible } from './visibility';
 
 describe('settings field visibility', () => {
   const schema: SettingsSchema = [
@@ -92,5 +92,13 @@ describe('settings field visibility', () => {
     expect(
       isSettingsFieldVisible(negatedConditionSchema, { kit: 'Custom' }, negatedConditionSchema[2])
     ).toBe(false);
+  });
+
+  it('hides JSON fields and does not treat a JSON-only schema as renderable', () => {
+    const jsonSchema: SettingsSchema = [{ key: 'grid', type: 'json', default: [[false]] }];
+
+    expect(isSettingsFieldVisible(jsonSchema, {}, jsonSchema[0])).toBe(false);
+    expect(hasVisibleSettingsFields(jsonSchema)).toBe(false);
+    expect(hasVisibleSettingsFields([...jsonSchema, schema[0]])).toBe(true);
   });
 });

--- a/ui/src/lib/settings/visibility.ts
+++ b/ui/src/lib/settings/visibility.ts
@@ -17,9 +17,15 @@ export function isSettingsFieldVisible(
   values: Record<string, unknown>,
   field: SettingsField
 ): boolean {
+  if (field.type === 'json') return false;
   if (!field.visibleWhen) return true;
 
   return isVisibilityConditionMet(schema, values, field.visibleWhen);
+}
+
+/** Whether a schema has at least one field that can render a settings control. */
+export function hasVisibleSettingsFields(schema: SettingsSchema): boolean {
+  return schema.some((field) => field.type !== 'json');
 }
 
 function isVisibilityConditionMet(

--- a/ui/src/lib/settings/visibility.ts
+++ b/ui/src/lib/settings/visibility.ts
@@ -9,6 +9,7 @@ export function getSettingsFieldValue(
   if (value !== undefined) return value;
 
   const field = schema.find((candidate) => candidate.key === key);
+
   return field && 'default' in field ? field.default : undefined;
 }
 
@@ -24,9 +25,8 @@ export function isSettingsFieldVisible(
 }
 
 /** Whether a schema has at least one field that can render a settings control. */
-export function hasVisibleSettingsFields(schema: SettingsSchema): boolean {
-  return schema.some((field) => field.type !== 'json');
-}
+export const hasVisibleSettingsFields = (schema: SettingsSchema): boolean =>
+  schema.some((field) => field.type !== 'json');
 
 function isVisibilityConditionMet(
   schema: SettingsSchema,

--- a/ui/src/objects/audio-code/SimpleDspLayout.svelte
+++ b/ui/src/objects/audio-code/SimpleDspLayout.svelte
@@ -7,6 +7,7 @@
   import * as Tooltip from '$lib/components/ui/tooltip';
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings';
+  import { hasVisibleSettingsFields } from '$lib/settings';
   import {
     closeCodeEditorOverlay,
     openCodeEditorOverlay,
@@ -83,7 +84,7 @@
   );
 
   const detachedSettings = $derived(
-    settingsSchema && settingsSchema.length > 0
+    settingsSchema && hasVisibleSettingsFields(settingsSchema)
       ? {
           schema: settingsSchema,
           values: settingsValues,
@@ -213,7 +214,7 @@
 
   const settingsSidebarTarget = useSettingsSidebarTarget({
     getTarget: () =>
-      settingsSchema && settingsSchema.length > 0
+      settingsSchema && hasVisibleSettingsFields(settingsSchema)
         ? {
             id: nodeId,
             label: displayTitle,
@@ -246,7 +247,7 @@
         <div class="flex items-center">
           {@render actionButtons?.()}
 
-          {#if settingsSchema && settingsSchema.length > 0}
+          {#if settingsSchema && hasVisibleSettingsFields(settingsSchema)}
             <Tooltip.Root>
               <Tooltip.Trigger>
                 <button
@@ -445,7 +446,7 @@
     </div>
   {/if}
 
-  {#if showSettings && settingsSchema && settingsSchema.length > 0}
+  {#if showSettings && settingsSchema && hasVisibleSettingsFields(settingsSchema)}
     <div class="absolute top-0" style="left: {contentWidth + 10}px">
       <ObjectSettings
         {nodeId}

--- a/ui/src/objects/code/CodeBlockBase.svelte
+++ b/ui/src/objects/code/CodeBlockBase.svelte
@@ -26,6 +26,7 @@
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
   import type { SettingsSchema } from '$lib/settings';
+  import { hasVisibleSettingsFields } from '$lib/settings';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import {
     closeCodeEditorOverlay,
@@ -150,7 +151,11 @@
   // Resolved primary — falls back to 'code' if 'settings' is requested but no
   // schema exists, or if 'run' is requested (not supported in CodeBlockBase).
   let resolvedPrimary = $derived.by<'code' | 'settings'>(() => {
-    if (primaryButton === 'settings' && settingsSchema && settingsSchema.length > 0) {
+    if (
+      primaryButton === 'settings' &&
+      settingsSchema &&
+      hasVisibleSettingsFields(settingsSchema)
+    ) {
       return 'settings';
     }
 
@@ -166,7 +171,7 @@
   );
 
   const detachedSettings = $derived(
-    settingsSchema && settingsSchema.length > 0
+    settingsSchema && hasVisibleSettingsFields(settingsSchema)
       ? {
           schema: settingsSchema,
           values: settingsValues,
@@ -411,7 +416,7 @@
 
   const settingsSidebarTarget = useSettingsSidebarTarget({
     getTarget: () =>
-      settingsSchema && settingsSchema.length > 0
+      settingsSchema && hasVisibleSettingsFields(settingsSchema)
         ? {
             id: nodeId,
             label: settingsSidebarLabel,
@@ -498,7 +503,7 @@
 
         <div class="node-floating-controls flex items-center sm:group-hover/header:opacity-100">
           {#if !(supportsLibraries && data.libraryName)}
-            {#if settingsSchema && settingsSchema.length > 0}
+            {#if settingsSchema && hasVisibleSettingsFields(settingsSchema)}
               <CodeBlockOverflowMenu
                 showConsole={data.showConsole ?? false}
                 {showSettings}
@@ -744,7 +749,7 @@
     </div>
   {/if}
 
-  {#if showSettings && settingsSchema && settingsSchema.length > 0}
+  {#if showSettings && settingsSchema && hasVisibleSettingsFields(settingsSchema)}
     <div class="absolute top-0" style="left: {contentWidth + 10}px">
       <ObjectSettings
         {nodeId}

--- a/ui/src/objects/code/CodeBlockOverflowMenu.svelte
+++ b/ui/src/objects/code/CodeBlockOverflowMenu.svelte
@@ -3,6 +3,7 @@
   import * as Popover from '$lib/components/ui/popover';
   import * as Tooltip from '$lib/components/ui/tooltip';
   import type { SettingsSchema } from '$lib/settings';
+  import { hasVisibleSettingsFields } from '$lib/settings';
 
   let {
     showConsole,
@@ -35,7 +36,7 @@
   </Tooltip.Root>
 
   <Popover.Content class="flex w-auto flex-col p-1" align="end" sideOffset={4}>
-    {#if settingsSchema.length > 0}
+    {#if hasVisibleSettingsFields(settingsSchema)}
       <Popover.Close class="contents">
         <button
           class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-zinc-700"

--- a/ui/src/objects/js/JSObject.test.ts
+++ b/ui/src/objects/js/JSObject.test.ts
@@ -113,6 +113,42 @@ describe('JSObject', () => {
     context.destroy();
   });
 
+  it('routes graph callback errors to the node virtual console', async () => {
+    let graphCallback: GraphChangeCallback | undefined;
+    const messageContext = new MessageContext(compilerId);
+
+    const context = new ObjectContext(
+      compilerId,
+      messageContext,
+      [],
+      {
+        code: `onGraphChange({ tags: ['shader/foo/*'] }, () => { throw new Error('broken graph callback') })`,
+        runOnMount: true
+      },
+      {
+        subscribeGraph: (_query, callback) => {
+          graphCallback = callback;
+          return () => {};
+        }
+      }
+    );
+
+    const object = new JSObject(compilerId, context);
+    await object.create();
+
+    expect(() => graphCallback?.({ nodes: [], edges: [] })).not.toThrow();
+
+    expect(logger.getNodeLogs(compilerId)).toMatchObject([
+      {
+        level: 'error',
+        args: ['broken graph callback']
+      }
+    ]);
+
+    object.destroy();
+    context.destroy();
+  });
+
   it('clears the graph subscription indicator after the final unsubscribe', async () => {
     const unsubscribe = vi.fn();
 

--- a/ui/src/objects/js/JSObject.test.ts
+++ b/ui/src/objects/js/JSObject.test.ts
@@ -149,6 +149,42 @@ describe('JSObject', () => {
     context.destroy();
   });
 
+  it('routes rejected graph callbacks to the node virtual console', async () => {
+    let graphCallback: GraphChangeCallback | undefined;
+    const messageContext = new MessageContext(compilerId);
+    const context = new ObjectContext(
+      compilerId,
+      messageContext,
+      [],
+      {
+        code: `onGraphChange({ tags: ['shader/foo/*'] }, async () => { throw new Error('rejected graph callback') })`,
+        runOnMount: true
+      },
+      {
+        subscribeGraph: (_query, callback) => {
+          graphCallback = callback;
+          return () => {};
+        }
+      }
+    );
+
+    const object = new JSObject(compilerId, context);
+    await object.create();
+
+    expect(() => graphCallback?.({ nodes: [], edges: [] })).not.toThrow();
+    await Promise.resolve();
+
+    expect(logger.getNodeLogs(compilerId)).toMatchObject([
+      {
+        level: 'error',
+        args: ['rejected graph callback']
+      }
+    ]);
+
+    object.destroy();
+    context.destroy();
+  });
+
   it('clears the graph subscription indicator after the final unsubscribe', async () => {
     const unsubscribe = vi.fn();
 

--- a/ui/src/objects/js/JSObject.ts
+++ b/ui/src/objects/js/JSObject.ts
@@ -183,6 +183,7 @@ export class JSObject implements RuntimeObject<JSObjectData> {
           this.context.setData({ runOnMount }, { notifyUI: true }),
 
         setTitle: (title) => this.context.setData({ title }, { notifyUI: true }),
+
         setTags: (tags) =>
           this.context.setData(
             { tags: replaceUserTags(this.context.getData().tags, tags) },
@@ -194,11 +195,9 @@ export class JSObject implements RuntimeObject<JSObjectData> {
             try {
               const result = callback(snapshot) as unknown;
 
-              if (result instanceof Promise) {
-                return result.catch((error) =>
-                  handleCodeError(error, code, this.nodeId, customConsole)
-                );
-              }
+              Promise.resolve(result).catch((error) =>
+                handleCodeError(error, code, this.nodeId, customConsole)
+              );
             } catch (error) {
               handleCodeError(error, code, this.nodeId, customConsole);
             }

--- a/ui/src/objects/js/JSObject.ts
+++ b/ui/src/objects/js/JSObject.ts
@@ -190,7 +190,21 @@ export class JSObject implements RuntimeObject<JSObjectData> {
           ),
 
         onGraphChange: (query, callback) => {
-          const unsubscribe = this.context.subscribeGraph(query, callback);
+          const notifyGraphChange = (snapshot: Parameters<typeof callback>[0]) => {
+            try {
+              const result = callback(snapshot) as unknown;
+
+              if (result instanceof Promise) {
+                return result.catch((error) =>
+                  handleCodeError(error, code, this.nodeId, customConsole)
+                );
+              }
+            } catch (error) {
+              handleCodeError(error, code, this.nodeId, customConsole);
+            }
+          };
+
+          const unsubscribe = this.context.subscribeGraph(query, notifyGraphChange);
 
           if (!unsubscribe) return () => {};
 

--- a/ui/src/objects/mediapipe/components/MediaPipeNodeLayout.svelte
+++ b/ui/src/objects/mediapipe/components/MediaPipeNodeLayout.svelte
@@ -4,6 +4,7 @@
   import TypedHandle from '$lib/components/TypedHandle.svelte';
   import ObjectSettings from '$lib/components/settings/ObjectSettings.svelte';
   import type { SettingsSchema } from '$lib/settings/types';
+  import { hasVisibleSettingsFields } from '$lib/settings';
   import { useNodeSetPaused } from '$lib/canvas/use-node-set-paused.svelte';
   import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
 
@@ -68,7 +69,7 @@
 
   const settingsSidebarTarget = useSettingsSidebarTarget({
     getTarget: () =>
-      schema.length > 0
+      hasVisibleSettingsFields(schema)
         ? {
             id: nodeId,
             label: title,

--- a/ui/src/objects/smplr/SmplrNodeLayout.svelte
+++ b/ui/src/objects/smplr/SmplrNodeLayout.svelte
@@ -8,6 +8,7 @@
   import { AudioService } from '$lib/audio/v2/AudioService';
   import { getPatchRuntimeViewRevisionTracker } from '$lib/runtime';
   import type { SettingsSchema } from '$lib/settings';
+  import { hasVisibleSettingsFields } from '$lib/settings';
   import { useSettingsSidebarTarget } from '$lib/settings/use-settings-sidebar-target.svelte';
 
   import type { SmplrRuntimeStatus } from './SmplrInstrumentAudioNode';
@@ -98,7 +99,7 @@
 
   const settingsSidebarTarget = useSettingsSidebarTarget({
     getTarget: () =>
-      settingsSchema.length > 0
+      hasVisibleSettingsFields(settingsSchema)
         ? {
             id: node.id,
             label: descriptor.title,
@@ -126,24 +127,22 @@
       return descriptor.settingsSchema;
     }
 
-    return descriptor.settingsSchema.map((field) =>
-      field.key === 'instrument'
-        ? {
-            key: field.key,
-            label: field.label,
-            description: field.description,
-            persistence: field.persistence,
-            type: 'combobox' as const,
-            options: instrumentNames,
-            default: instrumentNames[0] ?? '',
-            searchPlaceholder:
-              descriptor.type === 'soundfont2~'
-                ? 'Search SF2 instruments...'
-                : 'Search instruments...',
-            emptyMessage: 'No instrument found.'
-          }
-        : field
-    );
+    return descriptor.settingsSchema.map((field) => {
+      if (field.key !== 'instrument' || field.type === 'json') return field;
+
+      return {
+        key: field.key,
+        label: field.label,
+        description: field.description,
+        persistence: field.persistence,
+        type: 'combobox' as const,
+        options: instrumentNames,
+        default: instrumentNames[0] ?? '',
+        searchPlaceholder:
+          descriptor.type === 'soundfont2~' ? 'Search SF2 instruments...' : 'Search instruments...',
+        emptyMessage: 'No instrument found.'
+      };
+    });
   }
 
   async function loadInstrumentCatalogPatch(): Promise<Record<string, unknown>> {

--- a/ui/src/stores/code-editor-layout.store.ts
+++ b/ui/src/stores/code-editor-layout.store.ts
@@ -4,6 +4,7 @@ import type { Snippet } from 'svelte';
 import type { InlineDecoration } from '$lib/codemirror/inline-decorations';
 import type { SupportedLanguage } from '$lib/codemirror/types';
 import type { SettingsSchema } from '$lib/settings';
+import { hasVisibleSettingsFields } from '$lib/settings';
 import { isSidebarOpen, sidebarView } from './ui.store';
 import { showSidebarTab } from './sidebar-visibility.store';
 import { requestCodeSidebarTargetId } from './code-sidebar.store';
@@ -139,7 +140,7 @@ export function hasCodeEditorTargetSettings(
   if (!target) return false;
   if (target.customSettings) return true;
 
-  return (target.settings?.schema.length ?? 0) > 0;
+  return target.settings !== undefined && hasVisibleSettingsFields(target.settings.schema);
 }
 
 export const hasCodeEditorTargetConsole = (

--- a/ui/src/workers/shared/workerSettingsProxy.test.ts
+++ b/ui/src/workers/shared/workerSettingsProxy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { createWorkerSettingsProxy } from './workerSettingsProxy';
+
+describe('worker settings proxy', () => {
+  it('validates and snapshots JSON fields before posting writes', async () => {
+    const messages: Array<Record<string, unknown>> = [];
+    const proxy = createWorkerSettingsProxy('node-1', (message) =>
+      messages.push(message as Record<string, unknown>)
+    );
+
+    const definition = proxy.settings.define([{ key: 'grid', type: 'json', default: [[false]] }]);
+    const defineMessage = messages[0];
+    proxy._receiveValuesInit(defineMessage.requestId as string, { grid: [[false]] });
+    await definition;
+
+    const readGrid = proxy.settings.get('grid') as boolean[][];
+    readGrid[0][0] = true;
+    expect(proxy.settings.get('grid')).toEqual([[false]]);
+
+    expect(() => proxy.settings.set('grid', { invalid: undefined })).toThrow(TypeError);
+    expect(messages).toHaveLength(1);
+
+    const nextGrid = [[true, false]];
+    proxy.settings.set('grid', nextGrid);
+    nextGrid[0][1] = true;
+
+    expect(messages[1]).toMatchObject({ type: 'settingsSet', key: 'grid', value: [[true, false]] });
+    expect(proxy.settings.get('grid')).toEqual([[true, false]]);
+  });
+});

--- a/ui/src/workers/shared/workerSettingsProxy.ts
+++ b/ui/src/workers/shared/workerSettingsProxy.ts
@@ -109,6 +109,7 @@ export function createWorkerSettingsProxy(
         cachedValues = Object.fromEntries(
           Object.entries(values).map(([key, value]) => {
             const field = schema.find((candidate) => candidate.key === key);
+
             return [key, field ? cloneSettingsFieldValue(field, value) : value];
           })
         );

--- a/ui/src/workers/shared/workerSettingsProxy.ts
+++ b/ui/src/workers/shared/workerSettingsProxy.ts
@@ -49,6 +49,7 @@ export function createWorkerSettingsProxy(
     async define(nextSchema: SettingsSchema): Promise<void> {
       const requestId = `settings-${nodeId}-${++requestIdCounter}`;
       const normalizedSchema = normalizeSettingsSchema(nextSchema);
+
       schema = normalizedSchema;
 
       return new Promise<void>((resolve) => {
@@ -61,6 +62,7 @@ export function createWorkerSettingsProxy(
     get(key: string): unknown {
       const field = schema.find((candidate) => candidate.key === key);
       const value = cachedValues[key];
+
       return field && value !== undefined ? cloneSettingsFieldValue(field, value) : value;
     },
 
@@ -71,7 +73,9 @@ export function createWorkerSettingsProxy(
     set(key: string, value: unknown): void {
       const field = schema.find((candidate) => candidate.key === key);
       const storedValue = field ? cloneSettingsFieldValue(field, value) : value;
+
       cachedValues[key] = storedValue;
+
       postMessage({ type: 'settingsSet', nodeId, key, value: storedValue });
     },
 

--- a/ui/src/workers/shared/workerSettingsProxy.ts
+++ b/ui/src/workers/shared/workerSettingsProxy.ts
@@ -1,4 +1,5 @@
 import type { SettingsSchema } from '$lib/settings/types';
+import { cloneSettingsFieldValue, normalizeSettingsSchema } from '$lib/settings/json';
 
 type ChangeCallback = (key: string, value: unknown, allValues: Record<string, unknown>) => void;
 
@@ -40,34 +41,38 @@ export function createWorkerSettingsProxy(
   const pendingDefines = new Map<string, (values: Record<string, unknown>) => void>();
 
   let cachedValues: Record<string, unknown> = {};
+  let schema: SettingsSchema = [];
   let requestIdCounter = 0;
   let onChangeCallbacks: ChangeCallback[] = [];
 
   const settings = {
-    async define(schema: SettingsSchema): Promise<void> {
+    async define(nextSchema: SettingsSchema): Promise<void> {
       const requestId = `settings-${nodeId}-${++requestIdCounter}`;
+      const normalizedSchema = normalizeSettingsSchema(nextSchema);
+      schema = normalizedSchema;
 
       return new Promise<void>((resolve) => {
-        pendingDefines.set(requestId, (values) => {
-          cachedValues = values;
-          resolve();
-        });
+        pendingDefines.set(requestId, () => resolve());
 
-        postMessage({ type: 'settingsDefine', nodeId, requestId, schema });
+        postMessage({ type: 'settingsDefine', nodeId, requestId, schema: normalizedSchema });
       });
     },
 
     get(key: string): unknown {
-      return cachedValues[key];
+      const field = schema.find((candidate) => candidate.key === key);
+      const value = cachedValues[key];
+      return field && value !== undefined ? cloneSettingsFieldValue(field, value) : value;
     },
 
     getAll(): Record<string, unknown> {
-      return { ...cachedValues };
+      return Object.fromEntries(Object.keys(cachedValues).map((key) => [key, settings.get(key)]));
     },
 
     set(key: string, value: unknown): void {
-      cachedValues[key] = value;
-      postMessage({ type: 'settingsSet', nodeId, key, value });
+      const field = schema.find((candidate) => candidate.key === key);
+      const storedValue = field ? cloneSettingsFieldValue(field, value) : value;
+      cachedValues[key] = storedValue;
+      postMessage({ type: 'settingsSet', nodeId, key, value: storedValue });
     },
 
     onChange(callback: ChangeCallback): void {
@@ -94,25 +99,34 @@ export function createWorkerSettingsProxy(
       }
       pendingDefines.clear();
       cachedValues = {};
+      schema = [];
     },
 
     _receiveValuesInit(requestId: string, values: Record<string, unknown>) {
       const resolve = pendingDefines.get(requestId);
 
       if (resolve) {
+        cachedValues = Object.fromEntries(
+          Object.entries(values).map(([key, value]) => {
+            const field = schema.find((candidate) => candidate.key === key);
+            return [key, field ? cloneSettingsFieldValue(field, value) : value];
+          })
+        );
         pendingDefines.delete(requestId);
         resolve(values);
       }
     },
 
     _receiveValueChanged(key: string, value: unknown) {
-      cachedValues[key] = value;
+      const field = schema.find((candidate) => candidate.key === key);
+      cachedValues[key] = field ? cloneSettingsFieldValue(field, value) : value;
 
-      const allValues = { ...cachedValues };
+      const callbackValue = settings.get(key);
+      const allValues = settings.getAll();
 
       for (const callback of onChangeCallbacks) {
         try {
-          callback(key, value, allValues);
+          callback(key, callbackValue, allValues);
         } catch {
           // ignore callback errors
         }

--- a/ui/static/content/topics/object-settings.md
+++ b/ui/static/content/topics/object-settings.md
@@ -191,6 +191,37 @@ Use `presets` to show a swatch grid above the picker:
 }
 ```
 
+### `json`
+
+Store JSON data without adding a control to the settings panel. Use it for state that
+belongs to the node, such as a sequencer grid or saved drawing data.
+
+```javascript
+await settings.define([
+  {
+    key: 'grid',
+    type: 'json',
+    default: [
+      [false, false, false, false],
+      [false, false, false, false]
+    ]
+  }
+]);
+
+const grid = settings.get('grid');
+grid[0][1] = true;
+settings.set('grid', grid); // Persist an updated snapshot
+```
+
+JSON fields accept `null`, booleans, finite numbers, strings, arrays, and plain objects.
+They reject values that cannot round-trip through a patch file, including `undefined`,
+functions, `Date`, `Map`, `Set`, and circular references. `get()`, `getAll()`, and
+`onChange()` return snapshots, so mutate a value and pass it back to `set()` to save it.
+
+`json` fields use the same `node`, `kv`, and `none` persistence modes as other fields.
+They do not use `label`, `description`, or `visibleWhen`, and a JSON-only schema does not
+show a settings gear.
+
 ## Common Field Properties
 
 All field types use these properties:
@@ -198,10 +229,10 @@ All field types use these properties:
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | `key` | string | Unique identifier, used with `settings.get(key)` |
-| `label` | string | Display name shown in the panel |
-| `type` | string | Field type: `slider`, `number`, `boolean`, `string`, `select`, `color` |
+| `label` | string | Display name shown in the panel; not used by `json` |
+| `type` | string | Field type: `slider`, `number`, `boolean`, `string`, `select`, `color`, `json` |
 | `description` | string | Optional tooltip shown on the label |
-| `default` | any | Default value |
+| `default` | any | Default value; a JSON value for `json` |
 | `persistence` | string | Where to store the value (see below) |
 
 ## Persistence


### PR DESCRIPTION
## What changed

Adds a hidden `json` field type to the Object Settings API for portable node state such as boolean grids.

- Supports `node`, `kv`, and `none` persistence.
- Hides JSON fields from settings panels and suppresses the gear for JSON-only schemas.
- Validates JSON values and snapshots reads, writes, defaults, and callbacks in direct and worker runtimes.
- Documents the API and updates the settings design spec.

## Why

Previously the API only supported values that corresponded to visible form controls, making structured node state awkward to persist.

## Validation

- `bun run test --run src/lib/settings/SettingsManager.test.ts src/lib/settings/visibility.test.ts src/workers/shared/workerSettingsProxy.test.ts`
- `bun run check`
- `bun run lint`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a hidden JSON settings field for storing portable, persistent JSON state without displaying a settings control.
  - JSON values are validated, safely cloned, and compared by content.
  - JSON settings work consistently across direct and worker runtimes, including reads, updates, callbacks, resets, and persistence.

- **Bug Fixes**
  - Settings controls, menus, and sidebars no longer appear when only hidden JSON fields are present.
  - Improved protection against accidental mutation of settings values and defaults.
  - Graph callback errors are now safely caught and logged.

- **Documentation**
  - Documented JSON field behavior, supported values, persistence options, and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->