### PR TITLE
Insert objects from an edge

### DIFF
--- a/docs/design-docs/specs/177-insert-object-into-edge.md
+++ b/docs/design-docs/specs/177-insert-object-into-edge.md
@@ -30,12 +30,13 @@ analysis, audio-parameter, and accepts-float behavior. Only schema ports that re
 participate, plus object-owned dynamic ports where available; objects without a known compatible
 inlet and outlet are placed without rewiring.
 
-GLSL sampler uniforms are dynamic video inlets. When a default `glsl` generator is inserted into a
-video edge, Patchies initializes it as an editable pass-through shader with a `source` sampler so it
-can participate in the chain immediately.
+When an object has a companion `name>` pipe preset, inserting its base object name into a selected
+edge creates that pipe preset instead. This includes `js>`, `hydra>`, `glsl>`, `regl>`, `swgl>`,
+`three>`, and `tone>`. This applies equally to Object Browser cards and typed Quick Insert names.
 
-The `hydra>`, `three>`, and `regl>` video pipe presets expose one video inlet and outlet when
-inserted into a video edge, including when their preset data omits the default port counts.
+GLSL sampler uniforms are dynamic video inlets and are derived before edge compatibility is checked.
+The video pipe presets expose one video inlet and outlet when inserted into a video edge, including
+when their preset data omits the default port counts.
 
 ## Verification
 

--- a/docs/design-docs/specs/177-insert-object-into-edge.md
+++ b/docs/design-docs/specs/177-insert-object-into-edge.md
@@ -20,6 +20,9 @@ When exactly one edge is selected, insertion is contextual:
   without connections.
 - The insertion and any edge replacement are one undoable action.
 - The inserted node renders above its replacement edges.
+- Provisional Quick Insert edges are editor-only: they are never autosaved, and cancelling restores
+  the selected edge.
+- Edge midpoint calculations use canvas positions, including endpoints nested in visual groups.
 
 Normal insertion behavior remains unchanged when zero or multiple edges are selected.
 

--- a/docs/design-docs/specs/177-insert-object-into-edge.md
+++ b/docs/design-docs/specs/177-insert-object-into-edge.md
@@ -1,0 +1,46 @@
+# 177. Insert Object into Edge
+
+## Problem
+
+Adding a processing object between two connected objects currently requires creating it, deleting the
+existing edge, and manually making two new connections. This makes small patch edits unnecessarily
+slow.
+
+## Behavior
+
+When exactly one edge is selected, insertion is contextual:
+
+- Pressing Enter opens the normal Quick Insert `ObjectNode` at the midpoint of the selected edge.
+- Opening the object browser, including its toolbar and keyboard shortcuts, keeps the selected edge as
+  the insertion target.
+- Confirming an object or preset from either surface inserts it at that midpoint.
+- Patchies finds the first compatible inlet and the first compatible outlet on the new node. If both
+  exist, it replaces `Left → Right` with `Left → New → Right`.
+- If either side is not compatible, Patchies leaves the original edge unchanged and inserts the node
+  without connections.
+- The insertion and any edge replacement are one undoable action.
+- The inserted node renders above its replacement edges.
+
+Normal insertion behavior remains unchanged when zero or multiple edges are selected.
+
+## Compatibility
+
+Compatibility uses the same handle validation as manual wiring, including message, audio, video,
+analysis, audio-parameter, and accepts-float behavior. Only schema ports that render a static handle
+participate, plus object-owned dynamic ports where available; objects without a known compatible
+inlet and outlet are placed without rewiring.
+
+GLSL sampler uniforms are dynamic video inlets. When a default `glsl` generator is inserted into a
+video edge, Patchies initializes it as an editable pass-through shader with a `source` sampler so it
+can participate in the chain immediately.
+
+The `hydra>`, `three>`, and `regl>` video pipe presets expose one video inlet and outlet when
+inserted into a video edge, including when their preset data omits the default port counts.
+
+## Verification
+
+- Insert a message pass-through node into a selected message edge and verify the original edge is
+  replaced by two message edges.
+- Insert an incompatible audio-only node into that edge and verify the original edge remains.
+- Verify undo restores the original edge and removes the inserted node; redo restores the insertion.
+- Verify Enter Quick Insert and object-browser object and preset cards have the same behavior.

--- a/docs/design-docs/specs/177-insert-object-into-edge.md
+++ b/docs/design-docs/specs/177-insert-object-into-edge.md
@@ -48,3 +48,9 @@ when their preset data omits the default port counts.
 - Insert an incompatible audio-only node into that edge and verify the original edge remains.
 - Verify undo restores the original edge and removes the inserted node; redo restores the insertion.
 - Verify Enter Quick Insert and object-browser object and preset cards have the same behavior.
+
+## Implementation Boundary
+
+`use-edge-insertion.svelte.ts` owns the provisional splice state, preset preparation, final
+compatibility rewiring, and insertion history. `FlowCanvasInner.svelte` only supplies user events,
+selected-edge IDs, and fallback positions.

--- a/ui/src/lib/canvas/edge-insertion-adapters.ts
+++ b/ui/src/lib/canvas/edge-insertion-adapters.ts
@@ -1,0 +1,29 @@
+import type { Edge, Node } from '@xyflow/svelte';
+import { prepareGlslForEdgeInsertion } from '$objects/glsl/edge-insertion';
+
+type EdgeInsertionAdapter = (node: Node, edge: Edge) => Node;
+
+const adapters: Record<string, EdgeInsertionAdapter | undefined> = {
+  glsl: prepareGlslForEdgeInsertion,
+  hydra: prepareVideoPipeForEdgeInsertion,
+  three: prepareVideoPipeForEdgeInsertion,
+  regl: prepareVideoPipeForEdgeInsertion
+};
+
+function prepareVideoPipeForEdgeInsertion(node: Node, edge: Edge): Node {
+  if (!edge.sourceHandle?.startsWith('video-out')) return node;
+
+  return {
+    ...node,
+    data: {
+      ...node.data,
+      videoInletCount: (node.data?.videoInletCount as number | undefined) ?? 1,
+      videoOutletCount: (node.data?.videoOutletCount as number | undefined) ?? 1
+    }
+  };
+}
+
+/** Applies object-owned setup needed before a node can be connected into an edge. */
+export function prepareNodeForEdgeInsertion(node: Node, edge: Edge): Node {
+  return adapters[node.type ?? '']?.(node, edge) ?? node;
+}

--- a/ui/src/lib/canvas/edge-insertion-adapters.ts
+++ b/ui/src/lib/canvas/edge-insertion-adapters.ts
@@ -1,5 +1,7 @@
 import type { Edge, Node } from '@xyflow/svelte';
 import { prepareGlslForEdgeInsertion } from '$objects/glsl/edge-insertion';
+import { OBJECT_PIPE_PRESETS } from '$lib/presets/preset-packs';
+import { PRESETS } from '$lib/presets/presets';
 
 type EdgeInsertionAdapter = (node: Node, edge: Edge) => Node;
 
@@ -9,6 +11,25 @@ const adapters: Record<string, EdgeInsertionAdapter | undefined> = {
   three: prepareVideoPipeForEdgeInsertion,
   regl: prepareVideoPipeForEdgeInsertion
 };
+
+/** Uses an object's companion pipe preset when that object is inserted into an edge. */
+export function getEdgeInsertionObjectName(name: string): string {
+  const pipePresetName = `${name}>`;
+  return OBJECT_PIPE_PRESETS.includes(pipePresetName) ? pipePresetName : name;
+}
+
+/** Replaces a Quick Insert base object with its companion pipe preset. */
+export function applyEdgeInsertionPipePreset(node: Node, objectName: string): Node {
+  const presetName = getEdgeInsertionObjectName(objectName);
+  const preset = PRESETS[presetName];
+  if (presetName === objectName || !preset) return node;
+
+  return {
+    ...node,
+    type: preset.type,
+    data: preset.data as Record<string, unknown>
+  };
+}
 
 function prepareVideoPipeForEdgeInsertion(node: Node, edge: Edge): Node {
   if (!edge.sourceHandle?.startsWith('video-out')) return node;
@@ -24,6 +45,5 @@ function prepareVideoPipeForEdgeInsertion(node: Node, edge: Edge): Node {
 }
 
 /** Applies object-owned setup needed before a node can be connected into an edge. */
-export function prepareNodeForEdgeInsertion(node: Node, edge: Edge): Node {
-  return adapters[node.type ?? '']?.(node, edge) ?? node;
-}
+export const prepareNodeForEdgeInsertion = (node: Node, edge: Edge): Node =>
+  adapters[node.type ?? '']?.(node, edge) ?? node;

--- a/ui/src/lib/canvas/edge-insertion-adapters.ts
+++ b/ui/src/lib/canvas/edge-insertion-adapters.ts
@@ -15,12 +15,14 @@ const adapters: Record<string, EdgeInsertionAdapter | undefined> = {
 /** Uses an object's companion pipe preset when that object is inserted into an edge. */
 export function getEdgeInsertionObjectName(name: string): string {
   const pipePresetName = `${name}>`;
+
   return OBJECT_PIPE_PRESETS.includes(pipePresetName) ? pipePresetName : name;
 }
 
 /** Replaces a Quick Insert base object with its companion pipe preset. */
 export function applyEdgeInsertionPipePreset(node: Node, objectName: string): Node {
   const presetName = getEdgeInsertionObjectName(objectName);
+
   const preset = PRESETS[presetName];
   if (presetName === objectName || !preset) return node;
 

--- a/ui/src/lib/canvas/edge-insertion.test.ts
+++ b/ui/src/lib/canvas/edge-insertion.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from 'vitest';
+import type { Edge, Node } from '@xyflow/svelte';
+import type { ObjectSchemaRegistry } from '$lib/objects/schemas';
+import { glslSchema } from '$objects/glsl/schema';
+import { hydraSchema } from '$objects/hydra/schema';
+import { threeSchema } from '$objects/three/schema';
+import { reglSchema } from '$objects/regl/schema';
+import { prepareNodeForEdgeInsertion } from './edge-insertion-adapters';
+import { DEFAULT_GLSL_CODE } from '$lib/canvas/constants';
+import {
+  createEdgeInsertionPreview,
+  getCenteredNodeInsertionPosition,
+  getEdgeInsertionPosition,
+  planEdgeInsertion
+} from './edge-insertion';
+
+const schema = {
+  pass: {
+    type: 'pass',
+    category: 'test',
+    description: '',
+    inlets: [{ id: 'in', description: '', handle: { handleType: 'message' } }],
+    outlets: [{ id: 'out', description: '', handle: { handleType: 'message' } }]
+  },
+  audioOnly: {
+    type: 'audioOnly',
+    category: 'test',
+    description: '',
+    inlets: [{ id: 'in', description: '', handle: { handleType: 'audio', handleId: 0 } }],
+    outlets: [{ id: 'out', description: '', handle: { handleType: 'audio', handleId: 0 } }]
+  }
+} satisfies ObjectSchemaRegistry;
+
+const edge: Edge = {
+  id: 'edge-1',
+  source: 'left',
+  sourceHandle: 'message-out',
+  target: 'right',
+  targetHandle: 'message-in'
+};
+const inserted: Node = { id: 'pass-1', type: 'pass', position: { x: 0, y: 0 }, data: {} };
+const target: Node = { id: 'right', type: 'right', position: { x: 100, y: 100 }, data: {} };
+
+describe('planEdgeInsertion', () => {
+  test('uses the first compatible inlet and outlet', () => {
+    expect(planEdgeInsertion(edge, inserted, target, schema, (node) => node.type)).toEqual({
+      sourceHandle: 'message-out',
+      insertedInletHandle: 'message-in',
+      insertedOutletHandle: 'message-out',
+      targetHandle: 'message-in'
+    });
+  });
+
+  test('does not create a partial route when either side is incompatible', () => {
+    expect(
+      planEdgeInsertion(
+        edge,
+        { ...inserted, type: 'audioOnly' },
+        target,
+        schema,
+        (node) => node.type
+      )
+    ).toBeNull();
+  });
+
+  test('uses GLSL sampler uniforms as dynamic video inlets', () => {
+    const videoEdge: Edge = {
+      ...edge,
+      sourceHandle: 'video-out',
+      targetHandle: 'video-in-0-source-sampler2D'
+    };
+    const glslNode: Node = {
+      id: 'glsl-1',
+      type: 'glsl',
+      position: { x: 0, y: 0 },
+      data: {
+        glUniformDefs: [{ name: 'source', type: 'sampler2D' }]
+      }
+    };
+    const glslTarget: Node = { ...target, type: 'glsl' };
+
+    expect(
+      planEdgeInsertion(videoEdge, glslNode, glslTarget, { glsl: glslSchema }, (node) => node.type)
+    ).toEqual({
+      sourceHandle: 'video-out',
+      insertedInletHandle: 'video-in-0-source-sampler2D',
+      insertedOutletHandle: 'video-out-out',
+      targetHandle: 'video-in-0-source-sampler2D'
+    });
+  });
+
+  test('turns a default GLSL generator into a video pass-through when inserted into a video edge', () => {
+    const videoEdge: Edge = { ...edge, sourceHandle: 'video-out' };
+    const prepared = prepareNodeForEdgeInsertion(
+      {
+        id: 'glsl-1',
+        type: 'glsl',
+        position: { x: 0, y: 0 },
+        data: { code: DEFAULT_GLSL_CODE }
+      },
+      videoEdge
+    );
+
+    expect((prepared.data.glUniformDefs as { name: string }[])[0]?.name).toBe('source');
+    expect(prepared.data.code as string).toContain('texture(source, uv)');
+  });
+
+  test.each([
+    ['hydra', hydraSchema],
+    ['three', threeSchema],
+    ['regl', reglSchema]
+  ])('uses the default video ports for the %s pipe preset', (type, objectSchema) => {
+    const videoEdge: Edge = {
+      ...edge,
+      sourceHandle: 'video-out-0',
+      targetHandle: 'video-in-0'
+    };
+    const prepared = prepareNodeForEdgeInsertion(
+      { id: `${type}-1`, type, position: { x: 0, y: 0 }, data: { code: 'pipe preset' } },
+      videoEdge
+    );
+
+    expect(
+      planEdgeInsertion(
+        videoEdge,
+        prepared,
+        { ...target, type },
+        { [type]: objectSchema },
+        (node) => node.type
+      )
+    ).toEqual({
+      sourceHandle: 'video-out-0',
+      insertedInletHandle: 'video-in-0',
+      insertedOutletHandle: 'video-out-0',
+      targetHandle: 'video-in-0'
+    });
+  });
+});
+
+describe('getEdgeInsertionPosition', () => {
+  test('places the node at the midpoint of the connected nodes', () => {
+    expect(
+      getEdgeInsertionPosition(edge, [
+        { id: 'left', position: { x: 0, y: 0 }, width: 20, height: 20, data: {} },
+        { id: 'right', position: { x: 100, y: 40 }, width: 20, height: 20, data: {} }
+      ])
+    ).toEqual({ x: 60, y: 30 });
+  });
+
+  test('centers the inserted node on the edge midpoint', () => {
+    const nodes = [
+      { id: 'left', position: { x: 0, y: 0 }, width: 20, height: 20, data: {} },
+      { id: 'right', position: { x: 100, y: 40 }, width: 20, height: 20, data: {} }
+    ];
+
+    expect(
+      getCenteredNodeInsertionPosition(edge, nodes, {
+        id: 'inserted',
+        position: { x: 0, y: 0 },
+        measured: { width: 40, height: 10 },
+        data: {}
+      })
+    ).toEqual({ x: 40, y: 25 });
+  });
+});
+
+describe('createEdgeInsertionPreview', () => {
+  test('temporarily routes both ends of the selected edge through generic object handles', () => {
+    expect(
+      createEdgeInsertionPreview(edge, 'quick-add', ['preview-left', 'preview-right'])
+    ).toEqual([
+      {
+        id: 'preview-left',
+        source: 'left',
+        sourceHandle: 'message-out',
+        target: 'quick-add',
+        targetHandle: 'message-in',
+        zIndex: 0,
+        data: { edgeInsertionPreview: true }
+      },
+      {
+        id: 'preview-right',
+        source: 'quick-add',
+        sourceHandle: 'message-out',
+        target: 'right',
+        targetHandle: 'message-in',
+        zIndex: 0,
+        data: { edgeInsertionPreview: true }
+      }
+    ]);
+  });
+});

--- a/ui/src/lib/canvas/edge-insertion.test.ts
+++ b/ui/src/lib/canvas/edge-insertion.test.ts
@@ -2,10 +2,16 @@ import { describe, expect, test } from 'vitest';
 import type { Edge, Node } from '@xyflow/svelte';
 import type { ObjectSchemaRegistry } from '$lib/objects/schemas';
 import { glslSchema } from '$objects/glsl/schema';
+import { preset as glslPipePreset } from '$presets/glsl/passthru';
+import { PRESETS } from '$lib/presets/presets';
 import { hydraSchema } from '$objects/hydra/schema';
 import { threeSchema } from '$objects/three/schema';
 import { reglSchema } from '$objects/regl/schema';
-import { prepareNodeForEdgeInsertion } from './edge-insertion-adapters';
+import {
+  applyEdgeInsertionPipePreset,
+  getEdgeInsertionObjectName,
+  prepareNodeForEdgeInsertion
+} from './edge-insertion-adapters';
 import { DEFAULT_GLSL_CODE } from '$lib/canvas/constants';
 import {
   createEdgeInsertionPreview,
@@ -89,7 +95,7 @@ describe('planEdgeInsertion', () => {
     });
   });
 
-  test('turns a default GLSL generator into a video pass-through when inserted into a video edge', () => {
+  test('turns a default GLSL generator into the GLSL pipe preset when inserted into a video edge', () => {
     const videoEdge: Edge = { ...edge, sourceHandle: 'video-out' };
     const prepared = prepareNodeForEdgeInsertion(
       {
@@ -101,8 +107,23 @@ describe('planEdgeInsertion', () => {
       videoEdge
     );
 
-    expect((prepared.data.glUniformDefs as { name: string }[])[0]?.name).toBe('source');
-    expect(prepared.data.code as string).toContain('texture(source, uv)');
+    expect((prepared.data.glUniformDefs as { name: string }[])[0]?.name).toBe('image');
+    expect(prepared.data.code).toBe(glslPipePreset.data.code);
+  });
+
+  test('keeps the glsl pipe preset code and derives its sampler inlet', () => {
+    const prepared = prepareNodeForEdgeInsertion(
+      {
+        id: 'glsl-1',
+        type: 'glsl',
+        position: { x: 0, y: 0 },
+        data: { code: 'uniform sampler2D image;' }
+      },
+      { ...edge, sourceHandle: 'video-out' }
+    );
+
+    expect(prepared.data.code).toBe('uniform sampler2D image;');
+    expect(prepared.data.glUniformDefs).toMatchObject([{ name: 'image', type: 'sampler2D' }]);
   });
 
   test.each([
@@ -135,6 +156,33 @@ describe('planEdgeInsertion', () => {
       targetHandle: 'video-in-0'
     });
   });
+});
+
+describe('getEdgeInsertionObjectName', () => {
+  test.each(['js', 'glsl', 'hydra', 'regl', 'swgl', 'three', 'tone'])(
+    'uses the %s pipe preset for edge insertion',
+    (name) => {
+      expect(getEdgeInsertionObjectName(name)).toBe(`${name}>`);
+    }
+  );
+
+  test('keeps objects without a pipe preset unchanged', () => {
+    expect(getEdgeInsertionObjectName('p5')).toBe('p5');
+  });
+
+  test.each(['js', 'glsl', 'hydra', 'regl', 'swgl', 'three', 'tone'])(
+    'replaces the %s Quick Insert node with its pipe preset data',
+    (name) => {
+      const pipePresetName = `${name}>`;
+      const node = applyEdgeInsertionPipePreset(
+        { id: `${name}-1`, type: name, position: { x: 0, y: 0 }, data: {} },
+        name
+      );
+
+      expect(node.type).toBe(PRESETS[pipePresetName]?.type);
+      expect(node.data).toEqual(PRESETS[pipePresetName]?.data);
+    }
+  );
 });
 
 describe('getEdgeInsertionPosition', () => {

--- a/ui/src/lib/canvas/edge-insertion.test.ts
+++ b/ui/src/lib/canvas/edge-insertion.test.ts
@@ -17,6 +17,7 @@ import {
   createEdgeInsertionPreview,
   getCenteredNodeInsertionPosition,
   getEdgeInsertionPosition,
+  isEdgeInsertionPreview,
   planEdgeInsertion
 } from './edge-insertion';
 
@@ -195,6 +196,30 @@ describe('getEdgeInsertionPosition', () => {
     ).toEqual({ x: 60, y: 30 });
   });
 
+  test('uses absolute positions for nodes inside visual groups', () => {
+    expect(
+      getEdgeInsertionPosition(edge, [
+        { id: 'group', position: { x: 100, y: 200 }, data: {} },
+        {
+          id: 'left',
+          parentId: 'group',
+          position: { x: 10, y: 20 },
+          width: 20,
+          height: 20,
+          data: {}
+        },
+        {
+          id: 'right',
+          parentId: 'group',
+          position: { x: 110, y: 60 },
+          width: 20,
+          height: 20,
+          data: {}
+        }
+      ])
+    ).toEqual({ x: 170, y: 250 });
+  });
+
   test('centers the inserted node on the edge midpoint', () => {
     const nodes = [
       { id: 'left', position: { x: 0, y: 0 }, width: 20, height: 20, data: {} },
@@ -236,5 +261,12 @@ describe('createEdgeInsertionPreview', () => {
         data: { edgeInsertionPreview: true }
       }
     ]);
+  });
+
+  test('marks previews so persistence can exclude them', () => {
+    expect(
+      isEdgeInsertionPreview(createEdgeInsertionPreview(edge, 'quick-add', ['left', 'right'])[0]!)
+    ).toBe(true);
+    expect(isEdgeInsertionPreview(edge)).toBe(false);
   });
 });

--- a/ui/src/lib/canvas/edge-insertion.ts
+++ b/ui/src/lib/canvas/edge-insertion.ts
@@ -1,7 +1,9 @@
 import type { Edge, Node } from '@xyflow/svelte';
+
 import type { ObjectSchemaRegistry } from '$lib/objects/schemas';
 import type { InletSchema } from '$lib/objects/schemas/types';
 import { deriveHandleId } from '$lib/utils/handle-id';
+
 import {
   isAcceptsFloatInlet,
   isAudioParamInlet,
@@ -52,25 +54,29 @@ function getInletCandidates(
 ): InletCandidate[] {
   const staticInlets = getStaticInletCandidates(schemaInlets);
   const uniformDefs = (node.data as { glUniformDefs?: unknown } | undefined)?.glUniformDefs;
+
   const patternInlets = getDynamicVideoHandles(
     node,
     dynamicVideoInletTemplate,
     'videoInletCount'
   ).map((handle) => ({ handle }));
+
   if (!Array.isArray(uniformDefs)) return [...staticInlets, ...patternInlets];
 
   const dynamicInlets = uniformDefs.flatMap((uniform, index) => {
-    if (
+    const withoutInlets =
       !uniform ||
       typeof uniform !== 'object' ||
       (uniform as { hideInlet?: unknown }).hideInlet === true ||
       typeof (uniform as { name?: unknown }).name !== 'string' ||
-      typeof (uniform as { type?: unknown }).type !== 'string'
-    ) {
+      typeof (uniform as { type?: unknown }).type !== 'string';
+
+    if (withoutInlets) {
       return [];
     }
 
     const { name, type } = uniform as { name: string; type: string };
+
     return [
       {
         handle: deriveHandleId({
@@ -91,6 +97,10 @@ export interface EdgeInsertionPlan {
   insertedOutletHandle: string;
   targetHandle: string;
 }
+
+/** Preview edges only exist while a Quick Insert object is awaiting confirmation. */
+export const isEdgeInsertionPreview = (edge: Edge): boolean =>
+  (edge.data as { edgeInsertionPreview?: unknown } | undefined)?.edgeInsertionPreview === true;
 
 /**
  * Creates the temporary pair of edges shown while a Quick Insert object is
@@ -140,6 +150,7 @@ export function planEdgeInsertion(
 
   const insertedName = getNodeName(insertedNode);
   const targetName = getNodeName(targetNode);
+
   const schema = insertedName ? schemas[insertedName] : undefined;
   if (!schema) return null;
 
@@ -202,10 +213,36 @@ export function getEdgeInsertionPosition(
   const target = nodes.find((node) => node.id === edge.target);
   if (!source || !target) return null;
 
-  const center = (node: Node) => ({
-    x: node.position.x + (node.measured?.width ?? node.width ?? 0) / 2,
-    y: node.position.y + (node.measured?.height ?? node.height ?? 0) / 2
-  });
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+
+  const getAbsolutePosition = (
+    node: Node,
+    visited = new Set<string>()
+  ): { x: number; y: number } => {
+    if (!node.parentId || visited.has(node.id)) return node.position;
+
+    const parent = nodesById.get(node.parentId);
+    if (!parent) return node.position;
+
+    visited.add(node.id);
+
+    const parentPosition = getAbsolutePosition(parent, visited);
+
+    return {
+      x: parentPosition.x + node.position.x,
+      y: parentPosition.y + node.position.y
+    };
+  };
+
+  const center = (node: Node) => {
+    const position = getAbsolutePosition(node);
+
+    return {
+      x: position.x + (node.measured?.width ?? node.width ?? 0) / 2,
+      y: position.y + (node.measured?.height ?? node.height ?? 0) / 2
+    };
+  };
+
   const sourceCenter = center(source);
   const targetCenter = center(target);
 
@@ -222,6 +259,7 @@ export function getCenteredNodeInsertionPosition(
   insertedNode: Node
 ): { x: number; y: number } | null {
   const midpoint = getEdgeInsertionPosition(edge, nodes);
+
   const width = insertedNode.measured?.width ?? insertedNode.width;
   const height = insertedNode.measured?.height ?? insertedNode.height;
   if (!midpoint || width === undefined || height === undefined) return midpoint;

--- a/ui/src/lib/canvas/edge-insertion.ts
+++ b/ui/src/lib/canvas/edge-insertion.ts
@@ -1,0 +1,230 @@
+import type { Edge, Node } from '@xyflow/svelte';
+import type { ObjectSchemaRegistry } from '$lib/objects/schemas';
+import type { InletSchema } from '$lib/objects/schemas/types';
+import { deriveHandleId } from '$lib/utils/handle-id';
+import {
+  isAcceptsFloatInlet,
+  isAudioParamInlet,
+  isValidConnectionBetweenHandles
+} from '$lib/utils/connection-validation';
+
+type NodeName = (node: Node) => string | undefined;
+
+interface InletCandidate {
+  handle: string;
+  isAudioParam?: boolean;
+}
+
+function getStaticInletCandidates(schemaInlets: InletSchema[]): InletCandidate[] {
+  return schemaInlets.flatMap((port) => {
+    if (!port.handle) return [];
+
+    return [
+      {
+        handle: deriveHandleId({
+          port: 'inlet',
+          type: port.handle.handleType,
+          id: port.handle.handleId
+        }),
+        isAudioParam: port.isAudioParam
+      }
+    ];
+  });
+}
+
+function getDynamicVideoHandles(
+  node: Node,
+  template: string | undefined,
+  countKey: 'videoInletCount' | 'videoOutletCount'
+): string[] {
+  const count = (node.data as Record<string, unknown> | undefined)?.[countKey];
+  if (!template || typeof count !== 'number' || count <= 0) return [];
+
+  return Array.from({ length: Math.floor(count) }, (_, index) =>
+    template.replace('{index}', index.toString())
+  );
+}
+
+function getInletCandidates(
+  node: Node,
+  schemaInlets: InletSchema[],
+  dynamicVideoInletTemplate?: string
+): InletCandidate[] {
+  const staticInlets = getStaticInletCandidates(schemaInlets);
+  const uniformDefs = (node.data as { glUniformDefs?: unknown } | undefined)?.glUniformDefs;
+  const patternInlets = getDynamicVideoHandles(
+    node,
+    dynamicVideoInletTemplate,
+    'videoInletCount'
+  ).map((handle) => ({ handle }));
+  if (!Array.isArray(uniformDefs)) return [...staticInlets, ...patternInlets];
+
+  const dynamicInlets = uniformDefs.flatMap((uniform, index) => {
+    if (
+      !uniform ||
+      typeof uniform !== 'object' ||
+      (uniform as { hideInlet?: unknown }).hideInlet === true ||
+      typeof (uniform as { name?: unknown }).name !== 'string' ||
+      typeof (uniform as { type?: unknown }).type !== 'string'
+    ) {
+      return [];
+    }
+
+    const { name, type } = uniform as { name: string; type: string };
+    return [
+      {
+        handle: deriveHandleId({
+          port: 'inlet',
+          type: type === 'sampler2D' ? 'video' : 'message',
+          id: `${index}-${name}-${type}`
+        })
+      }
+    ];
+  });
+
+  return [...staticInlets, ...patternInlets, ...dynamicInlets];
+}
+
+export interface EdgeInsertionPlan {
+  sourceHandle: string;
+  insertedInletHandle: string;
+  insertedOutletHandle: string;
+  targetHandle: string;
+}
+
+/**
+ * Creates the temporary pair of edges shown while a Quick Insert object is
+ * still being named. They are intentionally marked as preview-only so the
+ * patch runtime never treats the generic handles as a real connection.
+ */
+export function createEdgeInsertionPreview(
+  edge: Edge,
+  insertedNodeId: string,
+  edgeIds: [string, string]
+): Edge[] {
+  return [
+    {
+      id: edgeIds[0],
+      source: edge.source,
+      sourceHandle: edge.sourceHandle,
+      target: insertedNodeId,
+      targetHandle: 'message-in',
+      zIndex: 0,
+      data: { edgeInsertionPreview: true }
+    },
+    {
+      id: edgeIds[1],
+      source: insertedNodeId,
+      sourceHandle: 'message-out',
+      target: edge.target,
+      targetHandle: edge.targetHandle,
+      zIndex: 0,
+      data: { edgeInsertionPreview: true }
+    }
+  ];
+}
+
+/**
+ * Finds the first inlet and outlet on an inserted node that can replace an edge.
+ * The edge is only rewired when both sides are compatible, preserving the original
+ * connection rather than leaving a partial route behind.
+ */
+export function planEdgeInsertion(
+  edge: Edge,
+  insertedNode: Node,
+  targetNode: Node | undefined,
+  schemas: ObjectSchemaRegistry,
+  getNodeName: NodeName
+): EdgeInsertionPlan | null {
+  if (!edge.sourceHandle || !edge.targetHandle || !targetNode) return null;
+
+  const insertedName = getNodeName(insertedNode);
+  const targetName = getNodeName(targetNode);
+  const schema = insertedName ? schemas[insertedName] : undefined;
+  if (!schema) return null;
+
+  const inlet = getInletCandidates(
+    insertedNode,
+    schema.inlets,
+    schema.handlePatterns?.inlet?.handleType === 'video'
+      ? schema.handlePatterns.inlet.template
+      : undefined
+  ).find((candidate) => {
+    return isValidConnectionBetweenHandles(edge.sourceHandle, candidate.handle, {
+      isTargetAudioParam:
+        candidate.isAudioParam ?? isAudioParamInlet(insertedName, candidate.handle),
+      isTargetAcceptsFloat: isAcceptsFloatInlet(insertedName, candidate.handle)
+    });
+  });
+
+  const outlet = [
+    ...schema.outlets.flatMap((port) => {
+      if (!port.handle) return [];
+
+      return [
+        deriveHandleId({
+          port: 'outlet',
+          type: port.handle.handleType,
+          id: port.handle.handleId
+        })
+      ];
+    }),
+    ...getDynamicVideoHandles(
+      insertedNode,
+      schema.handlePatterns?.outlet?.handleType === 'video'
+        ? schema.handlePatterns.outlet.template
+        : undefined,
+      'videoOutletCount'
+    )
+  ].find((handle) => {
+    return isValidConnectionBetweenHandles(handle, edge.targetHandle, {
+      isTargetAudioParam: isAudioParamInlet(targetName, edge.targetHandle),
+      isTargetAcceptsFloat: isAcceptsFloatInlet(targetName, edge.targetHandle)
+    });
+  });
+
+  if (!inlet || !outlet) return null;
+
+  return {
+    sourceHandle: edge.sourceHandle,
+    insertedInletHandle: inlet.handle,
+    insertedOutletHandle: outlet,
+    targetHandle: edge.targetHandle
+  };
+}
+
+/** Returns the visual midpoint between the edge's source and target nodes. */
+export function getEdgeInsertionPosition(
+  edge: Edge,
+  nodes: Node[]
+): { x: number; y: number } | null {
+  const source = nodes.find((node) => node.id === edge.source);
+  const target = nodes.find((node) => node.id === edge.target);
+  if (!source || !target) return null;
+
+  const center = (node: Node) => ({
+    x: node.position.x + (node.measured?.width ?? node.width ?? 0) / 2,
+    y: node.position.y + (node.measured?.height ?? node.height ?? 0) / 2
+  });
+  const sourceCenter = center(source);
+  const targetCenter = center(target);
+
+  return {
+    x: (sourceCenter.x + targetCenter.x) / 2,
+    y: (sourceCenter.y + targetCenter.y) / 2
+  };
+}
+
+/** Returns a top-left position that places the inserted node's center on the edge midpoint. */
+export function getCenteredNodeInsertionPosition(
+  edge: Edge,
+  nodes: Node[],
+  insertedNode: Node
+): { x: number; y: number } | null {
+  const midpoint = getEdgeInsertionPosition(edge, nodes);
+  const width = insertedNode.measured?.width ?? insertedNode.width;
+  const height = insertedNode.measured?.height ?? insertedNode.height;
+  if (!midpoint || width === undefined || height === undefined) return midpoint;
+
+  return { x: midpoint.x - width / 2, y: midpoint.y - height / 2 };
+}

--- a/ui/src/lib/canvas/use-edge-insertion.svelte.ts
+++ b/ui/src/lib/canvas/use-edge-insertion.svelte.ts
@@ -1,0 +1,255 @@
+import { tick } from 'svelte';
+import { SvelteSet } from 'svelte/reactivity';
+import type { Edge, Node } from '@xyflow/svelte';
+
+import { AddEdgesCommand, AddNodeCommand, BatchCommand, DeleteEdgesCommand } from '$lib/history';
+import { getObjectNameFromExpr } from '$lib/objects/object-definitions';
+import { objectSchemas } from '$lib/objects/schemas';
+
+import {
+  createEdgeInsertionPreview,
+  getCenteredNodeInsertionPosition,
+  getEdgeInsertionPosition,
+  planEdgeInsertion
+} from '$lib/canvas/edge-insertion';
+
+import {
+  applyEdgeInsertionPipePreset,
+  getEdgeInsertionObjectName,
+  prepareNodeForEdgeInsertion
+} from '$lib/canvas/edge-insertion-adapters';
+
+import { CanvasContext } from '$lib/services/CanvasContext';
+import { NodeOperationsService } from '$lib/services/NodeOperationsService';
+
+const INSERTED_NODE_Z_INDEX = 1001;
+
+interface PendingEdgeInsertion {
+  edge: Edge;
+  previewEdgeIds: string[];
+}
+
+/** Owns the temporary splice and final rewiring used when inserting into a selected edge. */
+export function useEdgeInsertion(canvasContext: CanvasContext, nodeOps: NodeOperationsService) {
+  let pendingEdgeInsertion = $state.raw<PendingEdgeInsertion | null>(null);
+  const confirmedQuickInsertNodeIds = new SvelteSet<string>();
+
+  function getSingleSelectedEdge(selectedEdgeIds: string[]): Edge | undefined {
+    if (selectedEdgeIds.length !== 1) return undefined;
+
+    return canvasContext.edges.find((edge) => edge.id === selectedEdgeIds[0]);
+  }
+
+  function beginObjectBrowser(selectedEdgeIds: string[]) {
+    const edge = getSingleSelectedEdge(selectedEdgeIds);
+
+    pendingEdgeInsertion = edge ? { edge, previewEdgeIds: [] } : null;
+  }
+
+  function clearPendingInsertion() {
+    pendingEdgeInsertion = null;
+  }
+
+  function quickAdd(selectedEdgeIds: string[], fallbackPosition: { x: number; y: number }) {
+    const edge = getSingleSelectedEdge(selectedEdgeIds);
+    const position = edge ? getEdgeInsertionPosition(edge, canvasContext.nodes) : null;
+
+    createQuickInsertNode(position ?? fallbackPosition, edge);
+  }
+
+  async function selectObject(name: string, fallbackPosition: { x: number; y: number }) {
+    const edge = pendingEdgeInsertion?.edge;
+
+    const position =
+      (edge && getEdgeInsertionPosition(edge, canvasContext.nodes)) ?? fallbackPosition;
+
+    const nodeId = nodeOps.createNodeFromName(
+      edge ? getEdgeInsertionObjectName(name) : name,
+      position,
+      { skipHistory: true }
+    );
+
+    await recordInsertedNode(nodeId);
+  }
+
+  async function confirmQuickAdd(finalNodeId: string, objectName: string) {
+    if (confirmedQuickInsertNodeIds.has(finalNodeId)) return;
+
+    confirmedQuickInsertNodeIds.add(finalNodeId);
+
+    await recordInsertedNode(finalNodeId, objectName);
+  }
+
+  function cancelQuickAdd(nodeId: string) {
+    canvasContext.nodes = canvasContext.nodes.filter((node) => node.id !== nodeId);
+
+    const pending = pendingEdgeInsertion;
+    pendingEdgeInsertion = null;
+
+    if (!pending) return;
+
+    canvasContext.edges = [
+      ...canvasContext.edges.filter((edge) => !pending.previewEdgeIds.includes(edge.id)),
+      ...(canvasContext.edges.some((edge) => edge.id === pending.edge.id) ? [] : [pending.edge])
+    ];
+  }
+
+  function createQuickInsertNode(position: { x: number; y: number }, edge?: Edge) {
+    const nodeId = nodeOps.createNode('object', position, undefined, { skipHistory: true });
+    if (!edge) return;
+
+    const previewEdges = createEdgeInsertionPreview(edge, nodeId, [
+      canvasContext.nextEdgeId(),
+      canvasContext.nextEdgeId()
+    ]);
+
+    pendingEdgeInsertion = { edge, previewEdgeIds: previewEdges.map((preview) => preview.id) };
+
+    canvasContext.nodes = canvasContext.nodes.map((node) =>
+      node.id === nodeId ? { ...node, zIndex: INSERTED_NODE_Z_INDEX } : node
+    );
+
+    canvasContext.edges = [
+      ...canvasContext.edges.filter((candidate) => candidate.id !== edge.id),
+      ...previewEdges
+    ];
+
+    centerQuickInsertPreview(nodeId, edge);
+  }
+
+  async function centerQuickInsertPreview(nodeId: string, edge: Edge) {
+    await tick();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    const node = canvasContext.nodes.find((candidate) => candidate.id === nodeId);
+    if (!node || pendingEdgeInsertion?.edge.id !== edge.id) return;
+
+    const position = getCenteredNodeInsertionPosition(edge, canvasContext.nodes, node);
+    if (!position) return;
+
+    canvasContext.nodes = canvasContext.nodes.map((candidate) =>
+      candidate.id === nodeId ? { ...candidate, position } : candidate
+    );
+  }
+
+  async function recordInsertedNode(nodeId: string, quickInsertObjectName?: string) {
+    await tick();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    let node = canvasContext.nodes.find((candidate) => candidate.id === nodeId);
+    if (!node) return;
+
+    const pending = pendingEdgeInsertion;
+    const edge = pending?.edge;
+    pendingEdgeInsertion = null;
+
+    if (!edge) {
+      const command = new AddNodeCommand({ ...node }, canvasContext.canvasAccessors);
+      canvasContext.historyManager.record(command);
+
+      return;
+    }
+
+    if (quickInsertObjectName) {
+      node = applyEdgeInsertionPipePreset(node, quickInsertObjectName);
+    }
+
+    node = prepareNodeForEdgeInsertion(node, edge);
+
+    const centeredPosition = getCenteredNodeInsertionPosition(edge, canvasContext.nodes, node);
+
+    if (centeredPosition) {
+      node = { ...node, position: centeredPosition };
+    }
+
+    node = { ...node, zIndex: INSERTED_NODE_Z_INDEX };
+
+    canvasContext.nodes = canvasContext.nodes.map((candidate) =>
+      candidate.id === nodeId ? node : candidate
+    );
+
+    const plan = planEdgeInsertion(
+      edge,
+      node,
+      canvasContext.nodes.find((candidate) => candidate.id === edge.target),
+      objectSchemas,
+      getNodeObjectName
+    );
+
+    if (!plan) {
+      if (!canvasContext.edges.some((candidate) => candidate.id === edge.id)) {
+        canvasContext.edges = [
+          ...canvasContext.edges.filter(
+            (candidate) => !pending.previewEdgeIds.includes(candidate.id)
+          ),
+          edge
+        ];
+      } else if (pending.previewEdgeIds.length > 0) {
+        canvasContext.edges = canvasContext.edges.filter(
+          (candidate) => !pending.previewEdgeIds.includes(candidate.id)
+        );
+      }
+
+      const command = new AddNodeCommand({ ...node }, canvasContext.canvasAccessors);
+      canvasContext.historyManager.record(command);
+
+      return;
+    }
+
+    const insertedEdges: Edge[] = [
+      {
+        id: canvasContext.nextEdgeId(),
+        source: edge.source,
+        sourceHandle: plan.sourceHandle,
+        target: node.id,
+        targetHandle: plan.insertedInletHandle,
+        zIndex: 0
+      },
+      {
+        id: canvasContext.nextEdgeId(),
+        source: node.id,
+        sourceHandle: plan.insertedOutletHandle,
+        target: edge.target,
+        targetHandle: plan.targetHandle,
+        zIndex: 0
+      }
+    ];
+
+    canvasContext.edges = [
+      ...canvasContext.edges.filter(
+        (candidate) => candidate.id !== edge.id && !pending.previewEdgeIds.includes(candidate.id)
+      ),
+      ...insertedEdges
+    ];
+
+    canvasContext.historyManager.record(
+      new BatchCommand(
+        [
+          new AddNodeCommand({ ...node }, canvasContext.canvasAccessors),
+          new DeleteEdgesCommand([edge], canvasContext.canvasAccessors),
+          new AddEdgesCommand(insertedEdges, canvasContext.canvasAccessors)
+        ],
+        `Insert ${getNodeObjectName(node) ?? 'object'} into connection`
+      )
+    );
+  }
+
+  return {
+    beginObjectBrowser,
+    cancelQuickAdd,
+    clearPendingInsertion,
+    confirmQuickAdd,
+    quickAdd,
+    selectObject
+  };
+}
+
+function getNodeObjectName(node: Node): string | undefined {
+  if (node.type === 'object') {
+    const data = node.data as { name?: string; expr?: string };
+
+    return data.name ?? (data.expr ? getObjectNameFromExpr(data.expr) : undefined);
+  }
+
+  return node.type;
+}

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -60,6 +60,14 @@
   } from '../../stores/canvas.store';
 
   import { getObjectNameFromExpr } from '$lib/objects/object-definitions';
+  import { objectSchemas } from '$lib/objects/schemas';
+  import {
+    createEdgeInsertionPreview,
+    getCenteredNodeInsertionPosition,
+    getEdgeInsertionPosition,
+    planEdgeInsertion
+  } from '$lib/canvas/edge-insertion';
+  import { prepareNodeForEdgeInsertion } from '$lib/canvas/edge-insertion-adapters';
   import { deleteSearchParam } from '$lib/utils/search-params';
 
   import { Toaster } from '$lib/components/ui/sonner';
@@ -122,6 +130,7 @@
   import {
     HistoryManager,
     AddNodeCommand,
+    AddEdgesCommand,
     DeleteNodesCommand,
     ReplaceNodesCommand,
     UpdateNodeDataCommand,
@@ -154,6 +163,14 @@
   import { buildChatViewportSummary } from '$lib/ai/chat/viewport-summary';
 
   const AUTOSAVE_INTERVAL = 2500;
+  // Svelte Flow raises a selected edge to z-index 1000. Keep the inserted node
+  // above that layer so the selected wire is visually split by the node body.
+  const INSERTED_NODE_Z_INDEX = 1001;
+
+  interface PendingEdgeInsertion {
+    edge: Edge;
+    previewEdgeIds: string[];
+  }
 
   // Initial nodes and edges
   let nodes = $state.raw<Node[]>([]);
@@ -387,6 +404,7 @@
 
   let selectedNodeIds = $state.raw<string[]>([]);
   let selectedEdgeIds = $state.raw<string[]>([]);
+  let pendingEdgeInsertion = $state.raw<PendingEdgeInsertion | null>(null);
   let visualGroupSelectionStartIds = $state.raw<string[]>([]);
 
   // Track node positions at drag start for undo/redo
@@ -855,7 +873,7 @@
       toggleSidebar: () => {
         if (!$isFullscreenActive) $isSidebarOpen = !$isSidebarOpen;
       },
-      openObjectBrowser: () => ($isObjectBrowserOpen = true),
+      openObjectBrowser: openObjectBrowser,
       openSettings: () => ($isSettingsOpen = true),
       openCommandPalette: triggerCommandPalette,
       togglePlayPause: () => {
@@ -872,9 +890,9 @@
       triggerAiPrompt,
       checkGeminiApiKey: checkAndHandleGeminiApiKey,
       quickAddNode: () => {
-        const position = screenToFlowPosition(lastMousePosition);
-
-        nodeOps.createNode('object', position, undefined, { skipHistory: true });
+        const edge = getSingleSelectedEdge();
+        const position = edge ? getEdgeInsertionPosition(edge, nodes) : null;
+        createQuickInsertNode(position ?? screenToFlowPosition(lastMousePosition), edge);
       },
       toggleAllPreviews: () => {
         const willDisable = !$allPreviewsDisabled;
@@ -1105,19 +1123,26 @@
   }
 
   // Handle Quick Add confirmation - record the final node to history
-  function handleQuickAddConfirmed(event: { type: 'quickAddConfirmed'; finalNodeId: string }) {
-    const node = nodes.find((n) => n.id === event.finalNodeId);
-
-    if (node) {
-      // Record the final node state (after any transformation) to history
-      historyManager.record(new AddNodeCommand({ ...node }, canvasAccessors));
-    }
+  async function handleQuickAddConfirmed(event: {
+    type: 'quickAddConfirmed';
+    finalNodeId: string;
+  }) {
+    await recordInsertedNode(event.finalNodeId);
   }
 
   // Handle Quick Add cancellation - remove node directly without history
   function handleQuickAddCancelled(event: { type: 'quickAddCancelled'; nodeId: string }) {
     // Remove the node directly, bypassing SvelteFlow's onbeforedelete (which records to history)
     nodes = nodes.filter((n) => n.id !== event.nodeId);
+
+    const pending = pendingEdgeInsertion;
+    pendingEdgeInsertion = null;
+    if (!pending) return;
+
+    edges = [
+      ...edges.filter((edge) => !pending.previewEdgeIds.includes(edge.id)),
+      ...(edges.some((edge) => edge.id === pending.edge.id) ? [] : [pending.edge])
+    ];
   }
 
   // Handle ObjectNode data commit (undo tracking for expr/name/params changes)
@@ -1173,14 +1198,159 @@
     };
   }
 
-  function handleObjectBrowserSelect(name: string) {
+  async function handleObjectBrowserSelect(name: string) {
     // Get the center of the viewport in screen coordinates
     const viewportCenterX = window.innerWidth / 2;
     const viewportCenterY = window.innerHeight / 2;
 
     // Convert to flow coordinates (accounts for pan and zoom)
-    const position = screenToFlowPosition({ x: viewportCenterX, y: viewportCenterY });
-    nodeOps.createNodeFromName(name, position);
+    const edge = pendingEdgeInsertion?.edge;
+    const position =
+      (edge && getEdgeInsertionPosition(edge, nodes)) ??
+      screenToFlowPosition({ x: viewportCenterX, y: viewportCenterY });
+    const nodeId = nodeOps.createNodeFromName(name, position, { skipHistory: true });
+    await recordInsertedNode(nodeId);
+  }
+
+  function getSingleSelectedEdge(): Edge | undefined {
+    if (selectedEdgeIds.length !== 1) return undefined;
+    return edges.find((edge) => edge.id === selectedEdgeIds[0]);
+  }
+
+  function openObjectBrowser() {
+    const edge = getSingleSelectedEdge();
+    pendingEdgeInsertion = edge ? { edge, previewEdgeIds: [] } : null;
+    $isObjectBrowserOpen = true;
+  }
+
+  function createQuickInsertNode(position: { x: number; y: number }, edge?: Edge) {
+    const nodeId = nodeOps.createNode('object', position, undefined, { skipHistory: true });
+    if (!edge) return;
+
+    const previewEdges = createEdgeInsertionPreview(edge, nodeId, [
+      canvasContext.nextEdgeId(),
+      canvasContext.nextEdgeId()
+    ]);
+
+    pendingEdgeInsertion = { edge, previewEdgeIds: previewEdges.map((preview) => preview.id) };
+    nodes = nodes.map((node) =>
+      node.id === nodeId ? { ...node, zIndex: INSERTED_NODE_Z_INDEX } : node
+    );
+    edges = [...edges.filter((candidate) => candidate.id !== edge.id), ...previewEdges];
+    void centerQuickInsertPreview(nodeId, edge);
+  }
+
+  async function centerQuickInsertPreview(nodeId: string, edge: Edge) {
+    await tick();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    const node = nodes.find((candidate) => candidate.id === nodeId);
+    if (!node || pendingEdgeInsertion?.edge.id !== edge.id) return;
+
+    const position = getCenteredNodeInsertionPosition(edge, nodes, node);
+    if (!position) return;
+
+    nodes = nodes.map((candidate) =>
+      candidate.id === nodeId ? { ...candidate, position } : candidate
+    );
+  }
+
+  function getNodeObjectName(node: Node): string | undefined {
+    if (node.type === 'object') {
+      const data = node.data as { name?: string; expr?: string };
+      return data.name ?? (data.expr ? getObjectNameFromExpr(data.expr) : undefined);
+    }
+
+    return node.type;
+  }
+
+  async function recordInsertedNode(nodeId: string) {
+    await tick();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    let node = nodes.find((candidate) => candidate.id === nodeId);
+    if (!node) return;
+
+    const pending = pendingEdgeInsertion;
+    const edge = pending?.edge;
+    pendingEdgeInsertion = null;
+
+    if (!edge) {
+      historyManager.record(new AddNodeCommand({ ...node }, canvasAccessors));
+      return;
+    }
+
+    node = prepareNodeForEdgeInsertion(node, edge);
+
+    const centeredPosition = getCenteredNodeInsertionPosition(edge, nodes, node);
+
+    if (centeredPosition) {
+      node = { ...node, position: centeredPosition };
+    }
+
+    node = { ...node, zIndex: INSERTED_NODE_Z_INDEX };
+    nodes = nodes.map((candidate) => (candidate.id === nodeId ? node : candidate));
+
+    const plan = planEdgeInsertion(
+      edge,
+      node,
+      nodes.find((candidate) => candidate.id === edge.target),
+      objectSchemas,
+      getNodeObjectName
+    );
+
+    if (!plan) {
+      if (!edges.some((candidate) => candidate.id === edge.id)) {
+        edges = [
+          ...edges.filter((candidate) => !pending.previewEdgeIds.includes(candidate.id)),
+          edge
+        ];
+      } else if (pending.previewEdgeIds.length > 0) {
+        edges = edges.filter((candidate) => !pending.previewEdgeIds.includes(candidate.id));
+      }
+
+      historyManager.record(new AddNodeCommand({ ...node }, canvasAccessors));
+      return;
+    }
+
+    const insertedEdges: Edge[] = [
+      {
+        id: canvasContext.nextEdgeId(),
+        source: edge.source,
+        sourceHandle: plan.sourceHandle,
+        target: node.id,
+        targetHandle: plan.insertedInletHandle,
+        zIndex: 0
+      },
+      {
+        id: canvasContext.nextEdgeId(),
+        source: node.id,
+        sourceHandle: plan.insertedOutletHandle,
+        target: edge.target,
+        targetHandle: plan.targetHandle,
+        zIndex: 0
+      }
+    ];
+
+    // The new node is already mounted (so Quick Add can edit it); record the equivalent
+    // atomic command for undo/redo, then apply only the edge replacement now.
+    edges = [
+      ...edges.filter(
+        (candidate) => candidate.id !== edge.id && !pending.previewEdgeIds.includes(candidate.id)
+      ),
+      ...insertedEdges
+    ];
+
+    historyManager.record(
+      new BatchCommand(
+        [
+          new AddNodeCommand({ ...node }, canvasAccessors),
+          new DeleteEdgesCommand([edge], canvasAccessors),
+          new AddEdgesCommand(insertedEdges, canvasAccessors)
+        ],
+        `Insert ${getNodeObjectName(node) ?? 'object'} into connection`
+      )
+    );
   }
 
   const isValidConnection: IsValidConnection = (connection) => {
@@ -1216,13 +1386,15 @@
   }
 
   function insertObjectWithButton() {
+    const edge = getSingleSelectedEdge();
+    const edgePosition = edge ? getEdgeInsertionPosition(edge, nodes) : null;
     const position = screenToFlowPosition({
       x: $isMobile ? window.innerWidth / 2 : window.innerWidth / 2 - 200,
       y: $isMobile ? window.innerHeight / 3 : 50
     });
 
     setTimeout(() => {
-      nodeOps.createNode('object', position);
+      createQuickInsertNode(edgePosition ?? position, edge);
     }, 50);
   }
 
@@ -1649,7 +1821,7 @@
             if (tab) startupInitialTab = tab;
             showStartupModal = true;
           }}
-          onBrowseObjects={() => ($isObjectBrowserOpen = true)}
+          onBrowseObjects={openObjectBrowser}
           onSavePatch={() => (showSavePatchModal = true)}
           onExportPatch={() => (showExportPatchModal = true)}
           onLoadPatch={() => {
@@ -1685,7 +1857,7 @@
         {startupInitialTab}
         onDelete={() => nodeOps.deleteSelectedElements(selectedNodeIds, selectedEdgeIds)}
         onInsertObject={insertObjectWithButton}
-        onBrowseObjects={() => ($isObjectBrowserOpen = true)}
+        onBrowseObjects={openObjectBrowser}
         onCopy={copySelectedNodes}
         onPaste={() => pasteNode('button')}
         onCancelConnectionMode={cancelConnectionMode}
@@ -1720,6 +1892,7 @@
     <ObjectBrowserModal
       bind:open={$isObjectBrowserOpen}
       onSelectObject={handleObjectBrowserSelect}
+      onClose={() => (pendingEdgeInsertion = null)}
     />
 
     <!-- Settings Modal -->

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -67,7 +67,11 @@
     getEdgeInsertionPosition,
     planEdgeInsertion
   } from '$lib/canvas/edge-insertion';
-  import { prepareNodeForEdgeInsertion } from '$lib/canvas/edge-insertion-adapters';
+  import {
+    applyEdgeInsertionPipePreset,
+    getEdgeInsertionObjectName,
+    prepareNodeForEdgeInsertion
+  } from '$lib/canvas/edge-insertion-adapters';
   import { deleteSearchParam } from '$lib/utils/search-params';
 
   import { Toaster } from '$lib/components/ui/sonner';
@@ -1126,8 +1130,9 @@
   async function handleQuickAddConfirmed(event: {
     type: 'quickAddConfirmed';
     finalNodeId: string;
+    objectName: string;
   }) {
-    await recordInsertedNode(event.finalNodeId);
+    await recordInsertedNode(event.finalNodeId, event.objectName);
   }
 
   // Handle Quick Add cancellation - remove node directly without history
@@ -1208,7 +1213,11 @@
     const position =
       (edge && getEdgeInsertionPosition(edge, nodes)) ??
       screenToFlowPosition({ x: viewportCenterX, y: viewportCenterY });
-    const nodeId = nodeOps.createNodeFromName(name, position, { skipHistory: true });
+    const nodeId = nodeOps.createNodeFromName(
+      edge ? getEdgeInsertionObjectName(name) : name,
+      position,
+      { skipHistory: true }
+    );
     await recordInsertedNode(nodeId);
   }
 
@@ -1264,7 +1273,7 @@
     return node.type;
   }
 
-  async function recordInsertedNode(nodeId: string) {
+  async function recordInsertedNode(nodeId: string, quickInsertObjectName?: string) {
     await tick();
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
@@ -1278,6 +1287,10 @@
     if (!edge) {
       historyManager.record(new AddNodeCommand({ ...node }, canvasAccessors));
       return;
+    }
+
+    if (quickInsertObjectName) {
+      node = applyEdgeInsertionPipePreset(node, quickInsertObjectName);
     }
 
     node = prepareNodeForEdgeInsertion(node, edge);

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -409,6 +409,7 @@
   let selectedNodeIds = $state.raw<string[]>([]);
   let selectedEdgeIds = $state.raw<string[]>([]);
   let pendingEdgeInsertion = $state.raw<PendingEdgeInsertion | null>(null);
+  const confirmedQuickInsertNodeIds = new SvelteSet<string>();
   let visualGroupSelectionStartIds = $state.raw<string[]>([]);
 
   // Track node positions at drag start for undo/redo
@@ -1132,6 +1133,9 @@
     finalNodeId: string;
     objectName: string;
   }) {
+    if (confirmedQuickInsertNodeIds.has(event.finalNodeId)) return;
+
+    confirmedQuickInsertNodeIds.add(event.finalNodeId);
     await recordInsertedNode(event.finalNodeId, event.objectName);
   }
 
@@ -1142,6 +1146,7 @@
 
     const pending = pendingEdgeInsertion;
     pendingEdgeInsertion = null;
+
     if (!pending) return;
 
     edges = [

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -60,18 +60,7 @@
   } from '../../stores/canvas.store';
 
   import { getObjectNameFromExpr } from '$lib/objects/object-definitions';
-  import { objectSchemas } from '$lib/objects/schemas';
-  import {
-    createEdgeInsertionPreview,
-    getCenteredNodeInsertionPosition,
-    getEdgeInsertionPosition,
-    planEdgeInsertion
-  } from '$lib/canvas/edge-insertion';
-  import {
-    applyEdgeInsertionPipePreset,
-    getEdgeInsertionObjectName,
-    prepareNodeForEdgeInsertion
-  } from '$lib/canvas/edge-insertion-adapters';
+  import { useEdgeInsertion } from '$lib/canvas/use-edge-insertion.svelte';
   import { deleteSearchParam } from '$lib/utils/search-params';
 
   import { Toaster } from '$lib/components/ui/sonner';
@@ -133,8 +122,6 @@
 
   import {
     HistoryManager,
-    AddNodeCommand,
-    AddEdgesCommand,
     DeleteNodesCommand,
     ReplaceNodesCommand,
     UpdateNodeDataCommand,
@@ -167,15 +154,6 @@
   import { buildChatViewportSummary } from '$lib/ai/chat/viewport-summary';
 
   const AUTOSAVE_INTERVAL = 2500;
-  // Svelte Flow raises a selected edge to z-index 1000. Keep the inserted node
-  // above that layer so the selected wire is visually split by the node body.
-  const INSERTED_NODE_Z_INDEX = 1001;
-
-  interface PendingEdgeInsertion {
-    edge: Edge;
-    previewEdgeIds: string[];
-  }
-
   // Initial nodes and edges
   let nodes = $state.raw<Node[]>([]);
   let edges = $state.raw<Edge[]>([]);
@@ -203,6 +181,7 @@
 
   // Node operations service for creating/deleting/replacing nodes
   const nodeOps = new NodeOperationsService(canvasContext);
+  const edgeInsertion = useEdgeInsertion(canvasContext, nodeOps);
 
   // AI operations service for AI-related node insertion/editing
   const aiOps = new AiOperationsService(canvasContext, nodeOps);
@@ -408,8 +387,6 @@
 
   let selectedNodeIds = $state.raw<string[]>([]);
   let selectedEdgeIds = $state.raw<string[]>([]);
-  let pendingEdgeInsertion = $state.raw<PendingEdgeInsertion | null>(null);
-  const confirmedQuickInsertNodeIds = new SvelteSet<string>();
   let visualGroupSelectionStartIds = $state.raw<string[]>([]);
 
   // Track node positions at drag start for undo/redo
@@ -894,11 +871,8 @@
       saveAs: () => (showSavePatchModal = true),
       triggerAiPrompt,
       checkGeminiApiKey: checkAndHandleGeminiApiKey,
-      quickAddNode: () => {
-        const edge = getSingleSelectedEdge();
-        const position = edge ? getEdgeInsertionPosition(edge, nodes) : null;
-        createQuickInsertNode(position ?? screenToFlowPosition(lastMousePosition), edge);
-      },
+      quickAddNode: () =>
+        edgeInsertion.quickAdd(selectedEdgeIds, screenToFlowPosition(lastMousePosition)),
       toggleAllPreviews: () => {
         const willDisable = !$allPreviewsDisabled;
         $allPreviewsDisabled = willDisable;
@@ -1127,33 +1101,14 @@
     }
   }
 
-  // Handle Quick Add confirmation - record the final node to history
-  async function handleQuickAddConfirmed(event: {
+  const handleQuickAddConfirmed = (event: {
     type: 'quickAddConfirmed';
     finalNodeId: string;
     objectName: string;
-  }) {
-    if (confirmedQuickInsertNodeIds.has(event.finalNodeId)) return;
+  }) => edgeInsertion.confirmQuickAdd(event.finalNodeId, event.objectName);
 
-    confirmedQuickInsertNodeIds.add(event.finalNodeId);
-    await recordInsertedNode(event.finalNodeId, event.objectName);
-  }
-
-  // Handle Quick Add cancellation - remove node directly without history
-  function handleQuickAddCancelled(event: { type: 'quickAddCancelled'; nodeId: string }) {
-    // Remove the node directly, bypassing SvelteFlow's onbeforedelete (which records to history)
-    nodes = nodes.filter((n) => n.id !== event.nodeId);
-
-    const pending = pendingEdgeInsertion;
-    pendingEdgeInsertion = null;
-
-    if (!pending) return;
-
-    edges = [
-      ...edges.filter((edge) => !pending.previewEdgeIds.includes(edge.id)),
-      ...(edges.some((edge) => edge.id === pending.edge.id) ? [] : [pending.edge])
-    ];
-  }
+  const handleQuickAddCancelled = (event: { type: 'quickAddCancelled'; nodeId: string }) =>
+    edgeInsertion.cancelQuickAdd(event.nodeId);
 
   // Handle ObjectNode data commit (undo tracking for expr/name/params changes)
   function handleObjectDataCommit(event: ObjectDataCommitEvent) {
@@ -1213,162 +1168,15 @@
     const viewportCenterX = window.innerWidth / 2;
     const viewportCenterY = window.innerHeight / 2;
 
-    // Convert to flow coordinates (accounts for pan and zoom)
-    const edge = pendingEdgeInsertion?.edge;
-    const position =
-      (edge && getEdgeInsertionPosition(edge, nodes)) ??
-      screenToFlowPosition({ x: viewportCenterX, y: viewportCenterY });
-    const nodeId = nodeOps.createNodeFromName(
-      edge ? getEdgeInsertionObjectName(name) : name,
-      position,
-      { skipHistory: true }
+    await edgeInsertion.selectObject(
+      name,
+      screenToFlowPosition({ x: viewportCenterX, y: viewportCenterY })
     );
-    await recordInsertedNode(nodeId);
-  }
-
-  function getSingleSelectedEdge(): Edge | undefined {
-    if (selectedEdgeIds.length !== 1) return undefined;
-    return edges.find((edge) => edge.id === selectedEdgeIds[0]);
   }
 
   function openObjectBrowser() {
-    const edge = getSingleSelectedEdge();
-    pendingEdgeInsertion = edge ? { edge, previewEdgeIds: [] } : null;
+    edgeInsertion.beginObjectBrowser(selectedEdgeIds);
     $isObjectBrowserOpen = true;
-  }
-
-  function createQuickInsertNode(position: { x: number; y: number }, edge?: Edge) {
-    const nodeId = nodeOps.createNode('object', position, undefined, { skipHistory: true });
-    if (!edge) return;
-
-    const previewEdges = createEdgeInsertionPreview(edge, nodeId, [
-      canvasContext.nextEdgeId(),
-      canvasContext.nextEdgeId()
-    ]);
-
-    pendingEdgeInsertion = { edge, previewEdgeIds: previewEdges.map((preview) => preview.id) };
-    nodes = nodes.map((node) =>
-      node.id === nodeId ? { ...node, zIndex: INSERTED_NODE_Z_INDEX } : node
-    );
-    edges = [...edges.filter((candidate) => candidate.id !== edge.id), ...previewEdges];
-    void centerQuickInsertPreview(nodeId, edge);
-  }
-
-  async function centerQuickInsertPreview(nodeId: string, edge: Edge) {
-    await tick();
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-
-    const node = nodes.find((candidate) => candidate.id === nodeId);
-    if (!node || pendingEdgeInsertion?.edge.id !== edge.id) return;
-
-    const position = getCenteredNodeInsertionPosition(edge, nodes, node);
-    if (!position) return;
-
-    nodes = nodes.map((candidate) =>
-      candidate.id === nodeId ? { ...candidate, position } : candidate
-    );
-  }
-
-  function getNodeObjectName(node: Node): string | undefined {
-    if (node.type === 'object') {
-      const data = node.data as { name?: string; expr?: string };
-      return data.name ?? (data.expr ? getObjectNameFromExpr(data.expr) : undefined);
-    }
-
-    return node.type;
-  }
-
-  async function recordInsertedNode(nodeId: string, quickInsertObjectName?: string) {
-    await tick();
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-
-    let node = nodes.find((candidate) => candidate.id === nodeId);
-    if (!node) return;
-
-    const pending = pendingEdgeInsertion;
-    const edge = pending?.edge;
-    pendingEdgeInsertion = null;
-
-    if (!edge) {
-      historyManager.record(new AddNodeCommand({ ...node }, canvasAccessors));
-      return;
-    }
-
-    if (quickInsertObjectName) {
-      node = applyEdgeInsertionPipePreset(node, quickInsertObjectName);
-    }
-
-    node = prepareNodeForEdgeInsertion(node, edge);
-
-    const centeredPosition = getCenteredNodeInsertionPosition(edge, nodes, node);
-
-    if (centeredPosition) {
-      node = { ...node, position: centeredPosition };
-    }
-
-    node = { ...node, zIndex: INSERTED_NODE_Z_INDEX };
-    nodes = nodes.map((candidate) => (candidate.id === nodeId ? node : candidate));
-
-    const plan = planEdgeInsertion(
-      edge,
-      node,
-      nodes.find((candidate) => candidate.id === edge.target),
-      objectSchemas,
-      getNodeObjectName
-    );
-
-    if (!plan) {
-      if (!edges.some((candidate) => candidate.id === edge.id)) {
-        edges = [
-          ...edges.filter((candidate) => !pending.previewEdgeIds.includes(candidate.id)),
-          edge
-        ];
-      } else if (pending.previewEdgeIds.length > 0) {
-        edges = edges.filter((candidate) => !pending.previewEdgeIds.includes(candidate.id));
-      }
-
-      historyManager.record(new AddNodeCommand({ ...node }, canvasAccessors));
-      return;
-    }
-
-    const insertedEdges: Edge[] = [
-      {
-        id: canvasContext.nextEdgeId(),
-        source: edge.source,
-        sourceHandle: plan.sourceHandle,
-        target: node.id,
-        targetHandle: plan.insertedInletHandle,
-        zIndex: 0
-      },
-      {
-        id: canvasContext.nextEdgeId(),
-        source: node.id,
-        sourceHandle: plan.insertedOutletHandle,
-        target: edge.target,
-        targetHandle: plan.targetHandle,
-        zIndex: 0
-      }
-    ];
-
-    // The new node is already mounted (so Quick Add can edit it); record the equivalent
-    // atomic command for undo/redo, then apply only the edge replacement now.
-    edges = [
-      ...edges.filter(
-        (candidate) => candidate.id !== edge.id && !pending.previewEdgeIds.includes(candidate.id)
-      ),
-      ...insertedEdges
-    ];
-
-    historyManager.record(
-      new BatchCommand(
-        [
-          new AddNodeCommand({ ...node }, canvasAccessors),
-          new DeleteEdgesCommand([edge], canvasAccessors),
-          new AddEdgesCommand(insertedEdges, canvasAccessors)
-        ],
-        `Insert ${getNodeObjectName(node) ?? 'object'} into connection`
-      )
-    );
   }
 
   const isValidConnection: IsValidConnection = (connection) => {
@@ -1404,15 +1212,13 @@
   }
 
   function insertObjectWithButton() {
-    const edge = getSingleSelectedEdge();
-    const edgePosition = edge ? getEdgeInsertionPosition(edge, nodes) : null;
     const position = screenToFlowPosition({
       x: $isMobile ? window.innerWidth / 2 : window.innerWidth / 2 - 200,
       y: $isMobile ? window.innerHeight / 3 : 50
     });
 
     setTimeout(() => {
-      createQuickInsertNode(edgePosition ?? position, edge);
+      edgeInsertion.quickAdd(selectedEdgeIds, position);
     }, 50);
   }
 
@@ -1910,7 +1716,7 @@
     <ObjectBrowserModal
       bind:open={$isObjectBrowserOpen}
       onSelectObject={handleObjectBrowserSelect}
-      onClose={() => (pendingEdgeInsertion = null)}
+      onClose={edgeInsertion.clearPendingInsertion}
     />
 
     <!-- Settings Modal -->

--- a/ui/src/lib/components/object-browser/ObjectBrowserModal.svelte
+++ b/ui/src/lib/components/object-browser/ObjectBrowserModal.svelte
@@ -93,7 +93,7 @@
     $isSidebarOpen = true;
     $sidebarView = 'help';
     $selectedNodeInfo = { type: objectName, id: 'browser' };
-    open = false;
+    handleClose();
   }
 
   const objectCategories = $derived(

--- a/ui/src/lib/components/object-browser/ObjectBrowserModal.svelte
+++ b/ui/src/lib/components/object-browser/ObjectBrowserModal.svelte
@@ -68,8 +68,13 @@
 
   let {
     open = $bindable(false),
-    onSelectObject
-  }: { open?: boolean; onSelectObject: (name: string) => void } = $props();
+    onSelectObject,
+    onClose = () => {}
+  }: {
+    open?: boolean;
+    onSelectObject: (name: string) => void | Promise<void>;
+    onClose?: () => void;
+  } = $props();
 
   let searchQuery = $state('');
   let searchInput = $state<HTMLInputElement>();
@@ -420,10 +425,11 @@
     expandedPackId = null;
     mobileCategoryOpen = false;
     $objectBrowserMode = 'insert';
+    onClose();
   }
 
-  function handleSelectObject(name: string) {
-    onSelectObject(name);
+  async function handleSelectObject(name: string) {
+    await onSelectObject(name);
     handleClose();
   }
 

--- a/ui/src/lib/eventbus/events.ts
+++ b/ui/src/lib/eventbus/events.ts
@@ -372,6 +372,9 @@ export interface QuickAddConfirmedEvent {
    * transformed during quick add.
    **/
   finalNodeId: string;
+
+  /** The object name entered into the Quick Insert node before it transformed. */
+  objectName: string;
 }
 
 export interface QuickAddCancelledEvent {

--- a/ui/src/lib/runtime/utils/editor-reconciler.ts
+++ b/ui/src/lib/runtime/utils/editor-reconciler.ts
@@ -1,5 +1,7 @@
 import type { Edge, Node } from '@xyflow/svelte';
 
+import { isEdgeInsertionPreview } from '$lib/canvas/edge-insertion';
+
 import type { EditorRuntime } from '../types/editor-runtime';
 import type { RuntimeConnectionSpec, RuntimeObjectSpec } from '../types/runtime-object';
 
@@ -14,13 +16,6 @@ interface EditorTextObjectData {
 
   [key: string]: unknown;
 }
-
-interface PreviewEdgeData {
-  edgeInsertionPreview?: unknown;
-}
-
-const isEdgeInsertionPreview = (edge: Edge): boolean =>
-  (edge.data as PreviewEdgeData | undefined)?.edgeInsertionPreview === true;
 
 /**
  * Using the XYFlow nodes and edges, update the patcher's headless runtime graph.

--- a/ui/src/lib/runtime/utils/editor-reconciler.ts
+++ b/ui/src/lib/runtime/utils/editor-reconciler.ts
@@ -15,6 +15,13 @@ interface EditorTextObjectData {
   [key: string]: unknown;
 }
 
+interface PreviewEdgeData {
+  edgeInsertionPreview?: unknown;
+}
+
+const isEdgeInsertionPreview = (edge: Edge): boolean =>
+  (edge.data as PreviewEdgeData | undefined)?.edgeInsertionPreview === true;
+
 /**
  * Using the XYFlow nodes and edges, update the patcher's headless runtime graph.
  */
@@ -25,7 +32,9 @@ export const setRuntimeGraphFromEditorGraph = async (
 ): Promise<void> =>
   runtime.setGraph({
     objects: nodes.flatMap(getRuntimeObjectSpecFromEditorNode),
-    connections: edges.map(getRuntimeConnectionSpecFromEditorEdge)
+    connections: edges
+      .filter((edge) => !isEdgeInsertionPreview(edge))
+      .map(getRuntimeConnectionSpecFromEditorEdge)
   });
 
 export const setRuntimeObjectsFromEditorNodes = async (
@@ -36,7 +45,12 @@ export const setRuntimeObjectsFromEditorNodes = async (
 export const setRuntimeConnectionsFromEditorEdges = (
   runtime: EditorRuntime,
   edges: Edge[]
-): Promise<void> => runtime.setConnections(edges.map(getRuntimeConnectionSpecFromEditorEdge));
+): Promise<void> =>
+  runtime.setConnections(
+    edges
+      .filter((edge) => !isEdgeInsertionPreview(edge))
+      .map(getRuntimeConnectionSpecFromEditorEdge)
+  );
 
 const getRuntimeConnectionSpecFromEditorEdge = (edge: Edge): RuntimeConnectionSpec => ({
   id: edge.id,

--- a/ui/src/lib/services/NodeOperationsService.ts
+++ b/ui/src/lib/services/NodeOperationsService.ts
@@ -66,16 +66,25 @@ export class NodeOperationsService {
    * Textual objects (like out~, expr, adsr) are created as 'object' nodes.
    * Visual nodes (like p5, hydra, glsl) are created with their actual type.
    */
-  createNodeFromName(name: string, position: { x: number; y: number }): string {
+  createNodeFromName(
+    name: string,
+    position: { x: number; y: number },
+    options?: CreateNodeOptions
+  ): string {
     // Check if it's a visual node type
     if (nodeTypes[name as keyof typeof nodeTypes]) {
-      return this.createNode(name, position);
+      return this.createNode(name, position, undefined, options);
     }
 
     // Check if it's a preset
     const preset = PRESETS[name];
     if (preset) {
-      return this.createNode(preset.type, position, preset.data as Record<string, unknown>);
+      return this.createNode(
+        preset.type,
+        position,
+        preset.data as Record<string, unknown>,
+        options
+      );
     }
 
     // Check if it's a textual object (audio or text object)
@@ -85,21 +94,22 @@ export class NodeOperationsService {
     if (audioRegistry.isDefined(name) || objectRegistry.isDefined(name)) {
       // Create an 'object' node with the textual object name and default params
       const defaultParams = parseObjectParamFromString(name, []);
-      return this.createNode('object', position, {
-        expr: name,
-        name: name,
-        params: defaultParams
-      });
+      return this.createNode(
+        'object',
+        position,
+        { expr: name, name: name, params: defaultParams },
+        options
+      );
     }
 
     // Fallback: try shorthand transformation
     const shorthandResult = ObjectShorthandRegistry.getInstance().tryTransform(name);
     if (shorthandResult) {
-      return this.createNode(shorthandResult.nodeType, position, shorthandResult.data);
+      return this.createNode(shorthandResult.nodeType, position, shorthandResult.data, options);
     }
 
     // Last resort: create as-is
-    return this.createNode(name, position);
+    return this.createNode(name, position, undefined, options);
   }
 
   /**

--- a/ui/src/lib/services/PatchManager.ts
+++ b/ui/src/lib/services/PatchManager.ts
@@ -100,13 +100,13 @@ export class PatchManager {
     const isEmbed = embedParam === 'true';
     const helpMode = get(helpModeObject);
 
-    // Do not autosave while a Quick Insert preview has temporarily replaced an edge.
-    // The original edge is restored or permanently replaced when the object is confirmed.
+    // Do not autosave when in embed mode, help mode, read-only mode, or shared patch session
     if (
       isEmbed ||
       helpMode ||
       isReadOnlyMode ||
       this._isSharedPatchSession ||
+      // A Quick Insert preview temporarily replaces an edge until the object is confirmed.
       this.ctx.edges.some(isEdgeInsertionPreview)
     ) {
       return false;

--- a/ui/src/lib/services/PatchManager.ts
+++ b/ui/src/lib/services/PatchManager.ts
@@ -20,6 +20,7 @@ import { GLSystem } from '$lib/canvas/GLSystem';
 import { get } from 'svelte/store';
 import type { CanvasContext } from './CanvasContext';
 import { logger } from '$lib/utils/logger';
+import { isEdgeInsertionPreview } from '$lib/canvas/edge-insertion';
 
 export interface LoadPatchResult {
   mode: 'autosave' | 'help' | 'src' | 'shared' | 'none';
@@ -99,8 +100,15 @@ export class PatchManager {
     const isEmbed = embedParam === 'true';
     const helpMode = get(helpModeObject);
 
-    // Do not autosave when in embed mode, help mode, read-only mode, or shared patch session
-    if (isEmbed || helpMode || isReadOnlyMode || this._isSharedPatchSession) {
+    // Do not autosave while a Quick Insert preview has temporarily replaced an edge.
+    // The original edge is restored or permanently replaced when the object is confirmed.
+    if (
+      isEmbed ||
+      helpMode ||
+      isReadOnlyMode ||
+      this._isSharedPatchSession ||
+      this.ctx.edges.some(isEdgeInsertionPreview)
+    ) {
       return false;
     }
 

--- a/ui/src/objects/glsl/edge-insertion.ts
+++ b/ui/src/objects/glsl/edge-insertion.ts
@@ -1,28 +1,25 @@
 import type { Edge, Node } from '@xyflow/svelte';
 import { DEFAULT_GLSL_CODE } from '$lib/canvas/constants';
 import { shaderCodeToUniformDefs } from '$lib/canvas/shader-code-to-uniform-def';
-
-const EDGE_INSERTION_PASSTHRU_CODE = `uniform sampler2D source;
-
-void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-  fragColor = texture(source, uv);
-}`;
+import { preset as glslPipePreset } from '$presets/glsl/passthru';
 
 /**
- * A new GLSL object is a generator by default and has no video inlet. When it is
- * inserted into a video edge, start it as a pass-through effect so the connection
- * represents a real visual chain that the user can edit from there.
+ * GLSL pipe presets expose their sampler uniforms dynamically. Derive those handles
+ * before edge compatibility is evaluated. A bare GLSL generator is upgraded to an
+ * editable pass-through shader when inserted into a video edge.
  */
 export function prepareGlslForEdgeInsertion(node: Node, edge: Edge): Node {
   const code = (node.data as { code?: unknown } | undefined)?.code;
-  if (code !== DEFAULT_GLSL_CODE || !edge.sourceHandle?.startsWith('video-out')) return node;
+  if (!edge.sourceHandle?.startsWith('video-out') || typeof code !== 'string') return node;
+
+  const edgeInsertionCode = code === DEFAULT_GLSL_CODE ? glslPipePreset.data.code : code;
 
   return {
     ...node,
     data: {
       ...node.data,
-      code: EDGE_INSERTION_PASSTHRU_CODE,
-      glUniformDefs: shaderCodeToUniformDefs(EDGE_INSERTION_PASSTHRU_CODE)
+      code: edgeInsertionCode,
+      glUniformDefs: shaderCodeToUniformDefs(edgeInsertionCode)
     }
   };
 }

--- a/ui/src/objects/glsl/edge-insertion.ts
+++ b/ui/src/objects/glsl/edge-insertion.ts
@@ -1,0 +1,28 @@
+import type { Edge, Node } from '@xyflow/svelte';
+import { DEFAULT_GLSL_CODE } from '$lib/canvas/constants';
+import { shaderCodeToUniformDefs } from '$lib/canvas/shader-code-to-uniform-def';
+
+const EDGE_INSERTION_PASSTHRU_CODE = `uniform sampler2D source;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  fragColor = texture(source, uv);
+}`;
+
+/**
+ * A new GLSL object is a generator by default and has no video inlet. When it is
+ * inserted into a video edge, start it as a pass-through effect so the connection
+ * represents a real visual chain that the user can edit from there.
+ */
+export function prepareGlslForEdgeInsertion(node: Node, edge: Edge): Node {
+  const code = (node.data as { code?: unknown } | undefined)?.code;
+  if (code !== DEFAULT_GLSL_CODE || !edge.sourceHandle?.startsWith('video-out')) return node;
+
+  return {
+    ...node,
+    data: {
+      ...node.data,
+      code: EDGE_INSERTION_PASSTHRU_CODE,
+      glUniformDefs: shaderCodeToUniformDefs(EDGE_INSERTION_PASSTHRU_CODE)
+    }
+  };
+}

--- a/ui/src/objects/object/ObjectNode.svelte
+++ b/ui/src/objects/object/ObjectNode.svelte
@@ -896,7 +896,7 @@
         </div>
 
         <!-- Dynamic outlets -->
-        {#if outlets}
+        {#if outlets.length > 0}
           {#each outlets as outlet, index (index)}
             <StandardHandle
               port="outlet"
@@ -909,6 +909,9 @@
               {nodeId}
             />
           {/each}
+        {:else if !objectMeta}
+          <!-- Fallback generic outlet while Quick Insert is waiting for an object name. -->
+          <StandardHandle port="outlet" type="message" total={1} index={0} {nodeId} />
         {/if}
       </div>
     </div>

--- a/ui/src/objects/object/ObjectNode.svelte
+++ b/ui/src/objects/object/ObjectNode.svelte
@@ -284,13 +284,14 @@
 
     if (save) {
       if (expr.trim()) {
+        const objectName = getNameAndParams().name;
         handleNameChange();
 
         // For Quick Add nodes, emit event so FlowCanvasInner can record to history
         // We use setTimeout to ensure the node transformation (if any) is complete
         if (isQuickAdd) {
           setTimeout(() => {
-            eventBus.dispatch({ type: 'quickAddConfirmed', finalNodeId });
+            eventBus.dispatch({ type: 'quickAddConfirmed', finalNodeId, objectName });
           }, 0);
         } else {
           // For existing nodes, commit undo tracking after data is updated


### PR DESCRIPTION
We want to insert objects from an edge, in-between two nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Insert objects directly into a selected connection using Quick Add, the toolbar, command palette, or object browser.
  - New objects are centered on the connection, with live previews showing resulting connections.
  - Compatible connections are rewired automatically, including supported GLSL and video workflows.
  - Insertion and rewiring are grouped into a single undoable action.

- **Bug Fixes**
  - Incompatible connections remain unchanged.
  - Temporary preview connections no longer affect runtime behavior.
  - Added fallback messaging when object outlet information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->