### PR TITLE
feat(renderer): composite images of different dimensions

### DIFF
--- a/docs/design-docs/specs/179-aspect-aware-video-compositing.md
+++ b/docs/design-docs/specs/179-aspect-aware-video-compositing.md
@@ -36,6 +36,10 @@ downstream consumer. They do not copy or rescale a frame into their own FBO.
 When a routing node is selected as the patch output, the renderer uses the
 same resolved source texture.
 
+Virtual video-channel edges are included in graph cycle analysis. A feedback
+loop that passes through `send.vdo` and `recv.vdo` therefore reads the source
+node's previous-frame texture, just like a loop made with visible cables.
+
 ### Output resolution
 
 Normal effect nodes continue to render at their configured FBO resolution,
@@ -54,3 +58,5 @@ on this contract without changing existing shaders.
    with Over and Composite.
 4. Existing shaders that sample `texture(source, uv)` retain their current
    full-frame behaviour.
+5. A feedback loop routed through `send.vdo` and `recv.vdo` has a one-frame
+   delay and does not sample its active framebuffer.

--- a/docs/design-docs/specs/179-aspect-aware-video-compositing.md
+++ b/docs/design-docs/specs/179-aspect-aware-video-compositing.md
@@ -1,0 +1,56 @@
+# 179. Aspect-Aware Video Compositing
+
+## Problem
+
+Patchies video sources can have different native dimensions. A normal GLSL
+sampler maps the source's full UV range to the consumer's full output FBO, so
+an image becomes stretched when its aspect ratio differs from the patch output.
+`send.vdo` and `recv.vdo` also resample their input through a full-output FBO,
+which changes a source even when they are only used for routing.
+
+## Goals
+
+- Preserve a source texture's native dimensions while it is routed through a
+  patch.
+- Let users intentionally fit, transform, and alpha-composite mixed-aspect
+  sources.
+- Keep existing shaders' normalized-UV behaviour unchanged.
+
+## Design
+
+### Explicit placement
+
+The built-in **Fit** and **Transform** GLSL presets derive the source aspect
+from `textureSize(source, 0)`. They offer explicit stretch, contain, and cover
+behaviour; Transform also applies translation, scale, and rotation in an
+aspect-correct coordinate system. Pixels outside a contained source are
+transparent, so the existing **Over** and **Composite** presets can layer it
+over another video input.
+
+### Routing aliases
+
+`send.vdo` and `recv.vdo` are routing nodes, not image-processing nodes. The
+renderer resolves their inlet texture recursively and binds that texture to a
+downstream consumer. They do not copy or rescale a frame into their own FBO.
+
+When a routing node is selected as the patch output, the renderer uses the
+same resolved source texture.
+
+### Output resolution
+
+Normal effect nodes continue to render at their configured FBO resolution,
+which defaults to the patch output. Preserving a routed source's native
+dimensions does not implicitly change an effect node's output resolution.
+Future input-resolution FBO modes and a dedicated multi-layer node can build
+on this contract without changing existing shaders.
+
+## Acceptance Criteria
+
+1. A non-16:9 image can pass through `send.vdo` and `recv.vdo` without a
+   dimension-changing blit.
+2. Fit and Transform can contain or cover a source without an `inputAspect`
+   setting.
+3. A contained Transform produces transparent margins that compose correctly
+   with Over and Composite.
+4. Existing shaders that sample `texture(source, uv)` retain their current
+   full-frame behaviour.

--- a/ui/src/presets/glsl/fit.ts
+++ b/ui/src/presets/glsl/fit.ts
@@ -3,19 +3,18 @@ import type { GLSLPreset } from './types';
 const code = `// @title Fit
 // @primaryButton settings
 // @param mode 0 (0: Contain, 1: Cover, 2: Stretch) "Mode"
-// @param inputAspect 1.7778 0.1 4.0 0.0001 "Input Aspect"
 // @param background color #000000 "Background"
 // @param backgroundAlpha 0.0 0.0 1.0 0.001 "Background Alpha"
 
 uniform sampler2D source;
 uniform float mode;
-uniform float inputAspect;
 uniform vec3 background;
 uniform float backgroundAlpha;
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   float outputAspect = iResolution.x / max(iResolution.y, 0.0001);
-  float sourceAspect = max(inputAspect, 0.0001);
+  ivec2 sourceSize = textureSize(source, 0);
+  float sourceAspect = float(sourceSize.x) / max(float(sourceSize.y), 0.0001);
   vec2 p = uv;
 
   if (mode < 1.5) {

--- a/ui/src/presets/glsl/transform.ts
+++ b/ui/src/presets/glsl/transform.ts
@@ -6,7 +6,7 @@ const code = `// @title Transform
 // @param translateY 0.0 -1.0 1.0 0.001 "Translate Y"
 // @param scale 1.0 0.05 4.0 0.001 "Scale"
 // @param rotation 0.0 -3.1416 3.1416 0.001 "Rotation"
-// @param fitMode 0 (0: Stretch, 1: Contain, 2: Cover) "Fit"
+// @param fitMode 0 (0: Contain, 1: Cover, 2: Stretch) "Fit"
 // @param repeatMode 0 (0: Clamp, 1: Repeat, 2: Mirror) "Repeat Mode"
 
 uniform sampler2D source;
@@ -42,15 +42,16 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
   vec2 sampleUv;
 
-  if (fitMode < 0.5) {
-    // Stretch deliberately preserves the historical full-frame behaviour.
-    sampleUv = p / vec2(outputAspect, 1.0) + 0.5;
-  } else {
-    float fitScale = fitMode < 1.5
+  if (fitMode < 1.5) {
+    float fitScale = fitMode < 0.5
       ? min(outputAspect / sourceAspect, 1.0)
       : max(outputAspect / sourceAspect, 1.0);
 
     sampleUv = p / vec2(sourceAspect * fitScale, fitScale) + 0.5;
+  } else {
+    // Stretch remains available when filling the output matters more than
+    // preserving the source proportions.
+    sampleUv = p / vec2(outputAspect, 1.0) + 0.5;
   }
 
   float alpha = 1.0;

--- a/ui/src/presets/glsl/transform.ts
+++ b/ui/src/presets/glsl/transform.ts
@@ -6,6 +6,7 @@ const code = `// @title Transform
 // @param translateY 0.0 -1.0 1.0 0.001 "Translate Y"
 // @param scale 1.0 0.05 4.0 0.001 "Scale"
 // @param rotation 0.0 -3.1416 3.1416 0.001 "Rotation"
+// @param fitMode 0 (0: Stretch, 1: Contain, 2: Cover) "Fit"
 // @param repeatMode 0 (0: Clamp, 1: Repeat, 2: Mirror) "Repeat Mode"
 
 uniform sampler2D source;
@@ -13,30 +14,54 @@ uniform float translateX;
 uniform float translateY;
 uniform float scale;
 uniform float rotation;
+uniform float fitMode;
 uniform float repeatMode;
 
 vec2 mirrorRepeat(vec2 p) {
   vec2 f = fract(p);
   vec2 tile = mod(floor(p), 2.0);
+
   return mix(f, 1.0 - f, tile);
 }
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-  vec2 p = uv - 0.5;
+  float outputAspect = iResolution.x / max(iResolution.y, 0.0001);
+  ivec2 sourceSize = textureSize(source, 0);
+  float sourceAspect = float(sourceSize.x) / max(float(sourceSize.y), 0.0001);
+
+  // Physical output-height units keep rotation and uniform scale visually
+  // consistent on non-square outputs.
+  vec2 p = (uv - 0.5) * vec2(outputAspect, 1.0);
+  p -= vec2(translateX * outputAspect, translateY);
+
   float c = cos(rotation);
   float s = sin(rotation);
+
   p = mat2(c, -s, s, c) * p;
   p = p / max(scale, 0.0001);
-  p += 0.5 - vec2(translateX, translateY);
 
-  vec2 sampleUv = p;
-  float alpha = 1.0;
-  if (repeatMode > 1.5) {
-    sampleUv = mirrorRepeat(p);
-  } else if (repeatMode > 0.5) {
-    sampleUv = fract(p);
+  vec2 sampleUv;
+
+  if (fitMode < 0.5) {
+    // Stretch deliberately preserves the historical full-frame behaviour.
+    sampleUv = p / vec2(outputAspect, 1.0) + 0.5;
   } else {
-    alpha = step(0.0, p.x) * step(0.0, p.y) * step(p.x, 1.0) * step(p.y, 1.0);
+    float fitScale = fitMode < 1.5
+      ? min(outputAspect / sourceAspect, 1.0)
+      : max(outputAspect / sourceAspect, 1.0);
+
+    sampleUv = p / vec2(sourceAspect * fitScale, fitScale) + 0.5;
+  }
+
+  float alpha = 1.0;
+
+  if (repeatMode > 1.5) {
+    sampleUv = mirrorRepeat(sampleUv);
+  } else if (repeatMode > 0.5) {
+    sampleUv = fract(sampleUv);
+  } else {
+    alpha = step(0.0, sampleUv.x) * step(0.0, sampleUv.y) *
+      step(sampleUv.x, 1.0) * step(sampleUv.y, 1.0);
   }
 
   vec4 color = texture(source, sampleUv);

--- a/ui/src/workers/rendering/CaptureRenderer.ts
+++ b/ui/src/workers/rendering/CaptureRenderer.ts
@@ -21,6 +21,13 @@ interface PendingVideoFrameBatch {
   format: VideoFrameFormat;
 }
 
+export interface VideoFrameCaptureSource {
+  framebuffer: regl.Framebuffer2D;
+  width: number;
+  height: number;
+  previewSize: [number, number];
+}
+
 /**
  * CaptureRenderer handles on-demand frame capture for video frames and LLM previews.
  *
@@ -115,7 +122,8 @@ export class CaptureRenderer {
       format?: VideoFrameFormat;
     }>,
     fboNodes: Map<string, FBONode>,
-    externalTextures?: Map<string, regl.Texture2D>
+    externalTextures?: Map<string, regl.Texture2D>,
+    resolvedSources?: Map<string, VideoFrameCaptureSource>
   ): void {
     // Track temporary FBOs created for external textures (need cleanup after read)
     const tempFbos: regl.Framebuffer2D[] = [];
@@ -145,29 +153,52 @@ export class CaptureRenderer {
 
         // Check if we already have a read for this source at this resolution
         const cachedRead = readCache.get(cacheKey);
+
         if (cachedRead) {
           reads.push(cachedRead);
           continue;
         }
 
+        const resolvedSource = resolvedSources?.get(sourceId);
+
+        if (resolvedSource) {
+          const read = this.initiateVideoFrameRead(
+            sourceId,
+            resolvedSource.framebuffer,
+            [resolvedSource.width, resolvedSource.height],
+            validResolution ?? resolvedSource.previewSize
+          );
+
+          if (read) {
+            readCache.set(cacheKey, read);
+            reads.push(read);
+          }
+
+          continue;
+        }
+
         // Check external textures first (img, webcam nodes)
         const externalTexture = externalTextures?.get(sourceId);
+
         if (externalTexture) {
           // Create a temporary framebuffer wrapping the texture
           const tempFbo = this.regl.framebuffer({ color: externalTexture });
           tempFbos.push(tempFbo);
 
-          const texSize: [number, number] = [externalTexture.width, externalTexture.height];
+          const textureSize: [number, number] = [externalTexture.width, externalTexture.height];
+
           const read = this.initiateVideoFrameRead(
             sourceId,
             tempFbo,
-            texSize,
-            validResolution ?? texSize
+            textureSize,
+            validResolution ?? textureSize
           );
+
           if (read) {
             readCache.set(cacheKey, read);
             reads.push(read);
           }
+
           continue;
         }
 

--- a/ui/src/workers/rendering/fboRenderer.passthrough.test.ts
+++ b/ui/src/workers/rendering/fboRenderer.passthrough.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { RenderNode } from '$lib/rendering/types';
+import type { RenderGraph, RenderNode } from '$lib/rendering/types';
 import type { FBORenderer } from './fboRenderer';
 
 vi.mock('./hydraRenderer', () => ({ HydraRenderer: class {} }));
@@ -66,5 +66,103 @@ describe('send.vdo and recv.vdo routing', () => {
     ).getInputTextureMap(consumer);
 
     expect(textureMap.get(0)).toBe(sourceTexture);
+  });
+
+  it('uses the previous frame when wireless routing closes a feedback loop', async () => {
+    vi.stubGlobal('self', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      setTimeout,
+      clearTimeout,
+      setInterval,
+      clearInterval
+    });
+
+    const { FBORenderer } = await import('./fboRenderer');
+    const currentTexture = { width: 1280, height: 720 };
+    const previousTexture = { width: 1280, height: 720 };
+    const renderer = Object.create(FBORenderer.prototype) as FBORenderer;
+
+    const feedback = {
+      id: 'feedback',
+      type: 'glsl',
+      inputs: ['source', 'receive'],
+      outputs: ['send'],
+      inletMap: new Map([
+        [0, { sourceNodeId: 'source', outletIndex: 0 }],
+        [1, { sourceNodeId: 'receive', outletIndex: 0 }]
+      ]),
+      data: {},
+      backEdgeInlets: new Set<number>()
+    } as RenderNode;
+    const send = {
+      id: 'send',
+      type: 'send.vdo',
+      inputs: ['feedback'],
+      outputs: [],
+      inletMap: new Map([[0, { sourceNodeId: 'feedback', outletIndex: 0 }]]),
+      data: { channel: 'loop' },
+      backEdgeInlets: new Set<number>()
+    } as RenderNode;
+    const receive = {
+      id: 'receive',
+      type: 'recv.vdo',
+      inputs: [],
+      outputs: ['feedback'],
+      inletMap: new Map<number, { sourceNodeId: string; outletIndex: number }>(),
+      data: { channel: 'loop' },
+      backEdgeInlets: new Set<number>()
+    } as RenderNode;
+
+    const baseGraph = {
+      nodes: [feedback, send, receive],
+      edges: [],
+      sortedNodes: [],
+      outputNodeId: null,
+      outputOutletIndex: 0,
+      backEdges: new Set<string>(),
+      feedbackNodes: new Set<string>()
+    } as RenderGraph;
+
+    const mergedGraph = (
+      renderer as never as {
+        mergeVirtualEdges: (graph: RenderGraph, edges: RenderGraph['edges']) => RenderGraph;
+      }
+    ).mergeVirtualEdges(baseGraph, [
+      {
+        id: 'virtual-video-loop-send-receive',
+        source: 'send',
+        target: 'receive',
+        sourceHandle: 'video-out',
+        targetHandle: 'video-in-0'
+      }
+    ]);
+
+    const state = renderer as unknown as {
+      fboNodes: Map<string, unknown>;
+      renderGraph: RenderGraph;
+      videoTextures: { getDestinationTexture: () => undefined };
+    };
+    state.fboNodes = new Map([
+      [
+        'feedback',
+        {
+          colorAttachments: [currentTexture],
+          prevTextures: [previousTexture],
+          texture: currentTexture
+        }
+      ]
+    ]);
+    state.renderGraph = mergedGraph;
+    state.videoTextures = { getDestinationTexture: () => undefined };
+
+    expect(mergedGraph.feedbackNodes).toEqual(new Set(['feedback']));
+    expect(send.backEdgeInlets).toEqual(new Set([0]));
+
+    const textureMap = (
+      renderer as never as { getInputTextureMap: (node: RenderNode) => Map<number, unknown> }
+    ).getInputTextureMap(feedback);
+
+    expect(textureMap.get(1)).toBe(previousTexture);
   });
 });

--- a/ui/src/workers/rendering/fboRenderer.passthrough.test.ts
+++ b/ui/src/workers/rendering/fboRenderer.passthrough.test.ts
@@ -46,16 +46,19 @@ describe('send.vdo and recv.vdo routing', () => {
       type: 'send.vdo',
       inletMap: new Map([[0, { sourceNodeId: 'webcam', outletIndex: 0 }]])
     } as RenderNode;
+
     const receive = {
       id: 'receive',
       type: 'recv.vdo',
       inletMap: new Map([[0, { sourceNodeId: 'send', outletIndex: 0 }]])
     } as RenderNode;
+
     const consumer = {
       id: 'consumer',
       type: 'glsl',
       inletMap: new Map([[0, { sourceNodeId: 'receive', outletIndex: 0 }]])
     } as RenderNode;
+
     state.renderGraph = { nodes: [send, receive, consumer] };
 
     const textureMap = (

--- a/ui/src/workers/rendering/fboRenderer.passthrough.test.ts
+++ b/ui/src/workers/rendering/fboRenderer.passthrough.test.ts
@@ -24,7 +24,7 @@ describe('send.vdo and recv.vdo routing', () => {
 
     const { FBORenderer } = await import('./fboRenderer');
 
-    const sourceTexture = { width: 640, height: 480 };
+    const sourceTexture = { width: 1080, height: 1920 };
     const renderer = Object.create(FBORenderer.prototype) as FBORenderer;
 
     const state = renderer as unknown as {
@@ -61,10 +61,19 @@ describe('send.vdo and recv.vdo routing', () => {
 
     state.renderGraph = { nodes: [send, receive, consumer] };
 
+    const source = (
+      renderer as never as {
+        resolveVideoSource: (
+          nodeId: string
+        ) => { texture: unknown; width: number; height: number } | null;
+      }
+    ).resolveVideoSource('receive');
+
     const textureMap = (
       renderer as never as { getInputTextureMap: (node: RenderNode) => Map<number, unknown> }
     ).getInputTextureMap(consumer);
 
+    expect(source).toEqual({ texture: sourceTexture, width: 1080, height: 1920 });
     expect(textureMap.get(0)).toBe(sourceTexture);
   });
 
@@ -95,6 +104,7 @@ describe('send.vdo and recv.vdo routing', () => {
       data: {},
       backEdgeInlets: new Set<number>()
     } as RenderNode;
+
     const send = {
       id: 'send',
       type: 'send.vdo',
@@ -104,6 +114,7 @@ describe('send.vdo and recv.vdo routing', () => {
       data: { channel: 'loop' },
       backEdgeInlets: new Set<number>()
     } as RenderNode;
+
     const receive = {
       id: 'receive',
       type: 'recv.vdo',
@@ -114,9 +125,17 @@ describe('send.vdo and recv.vdo routing', () => {
       backEdgeInlets: new Set<number>()
     } as RenderNode;
 
+    const virtualEdge = {
+      id: 'virtual-video-loop-send-receive',
+      source: 'send',
+      target: 'receive',
+      sourceHandle: 'video-out',
+      targetHandle: 'video-in-0'
+    };
+
     const baseGraph = {
-      nodes: [feedback, send, receive],
-      edges: [],
+      nodes: [send, feedback, receive],
+      edges: [virtualEdge],
       sortedNodes: [],
       outputNodeId: null,
       outputOutletIndex: 0,
@@ -128,21 +147,14 @@ describe('send.vdo and recv.vdo routing', () => {
       renderer as never as {
         mergeVirtualEdges: (graph: RenderGraph, edges: RenderGraph['edges']) => RenderGraph;
       }
-    ).mergeVirtualEdges(baseGraph, [
-      {
-        id: 'virtual-video-loop-send-receive',
-        source: 'send',
-        target: 'receive',
-        sourceHandle: 'video-out',
-        targetHandle: 'video-in-0'
-      }
-    ]);
+    ).mergeVirtualEdges(baseGraph, [virtualEdge]);
 
     const state = renderer as unknown as {
       fboNodes: Map<string, unknown>;
       renderGraph: RenderGraph;
       videoTextures: { getDestinationTexture: () => undefined };
     };
+
     state.fboNodes = new Map([
       [
         'feedback',
@@ -153,11 +165,12 @@ describe('send.vdo and recv.vdo routing', () => {
         }
       ]
     ]);
+
     state.renderGraph = mergedGraph;
     state.videoTextures = { getDestinationTexture: () => undefined };
 
     expect(mergedGraph.feedbackNodes).toEqual(new Set(['feedback']));
-    expect(send.backEdgeInlets).toEqual(new Set([0]));
+    expect(mergedGraph.edges).toHaveLength(1);
 
     const textureMap = (
       renderer as never as { getInputTextureMap: (node: RenderNode) => Map<number, unknown> }

--- a/ui/src/workers/rendering/fboRenderer.passthrough.test.ts
+++ b/ui/src/workers/rendering/fboRenderer.passthrough.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type regl from 'regl';
-import type { RenderNode, RenderParams } from '$lib/rendering/types';
+import type { RenderNode } from '$lib/rendering/types';
 import type { FBORenderer } from './fboRenderer';
 
 vi.mock('./hydraRenderer', () => ({ HydraRenderer: class {} }));
@@ -12,8 +11,8 @@ vi.mock('./swglRenderer', () => ({ SwissGLRenderer: class {} }));
 vi.mock('./shaderParkThreeRenderer', () => ({ ShaderParkThreeRenderer: class {} }));
 vi.mock('$lib/projmap/ProjectionMapRenderer', () => ({ ProjectionMapRenderer: class {} }));
 
-describe('send.vdo passthrough', () => {
-  it('copies a directly connected external video texture', async () => {
+describe('send.vdo and recv.vdo routing', () => {
+  it('binds the original external texture after wireless routing', async () => {
     vi.stubGlobal('self', {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
@@ -25,57 +24,44 @@ describe('send.vdo passthrough', () => {
 
     const { FBORenderer } = await import('./fboRenderer');
 
-    const bindFramebuffer = vi.fn();
-    const blitFramebuffer = vi.fn();
-
     const sourceTexture = { width: 640, height: 480 };
-    const sourceFramebuffer = { _framebuffer: { framebuffer: 'webcam-fbo' } };
-    const destinationTexture = { width: 1280, height: 720 };
     const renderer = Object.create(FBORenderer.prototype) as FBORenderer;
 
     const state = renderer as unknown as {
-      fboNodes: Map<string, { texture: typeof destinationTexture; framebuffer: object }>;
+      fboNodes: Map<string, unknown>;
+      renderGraph: { nodes: RenderNode[] };
       videoTextures: {
         getDestinationTexture: (nodeId: string) => typeof sourceTexture | undefined;
-        getDestinationFBO: (nodeId: string) => typeof sourceFramebuffer | undefined;
       };
-      gl: WebGL2RenderingContext;
     };
 
-    state.fboNodes = new Map([
-      [
-        'send',
-        { texture: destinationTexture, framebuffer: { _framebuffer: { framebuffer: 'send-fbo' } } }
-      ]
-    ]);
+    state.fboNodes = new Map();
 
     state.videoTextures = {
-      getDestinationTexture: (nodeId) => (nodeId === 'webcam' ? sourceTexture : undefined),
-      getDestinationFBO: (nodeId) => (nodeId === 'webcam' ? sourceFramebuffer : undefined)
+      getDestinationTexture: (nodeId) => (nodeId === 'webcam' ? sourceTexture : undefined)
     };
 
-    state.gl = {
-      READ_FRAMEBUFFER: 1,
-      DRAW_FRAMEBUFFER: 2,
-      FRAMEBUFFER: 3,
-      COLOR_BUFFER_BIT: 4,
-      LINEAR: 5,
-      bindFramebuffer,
-      blitFramebuffer
-    } as unknown as WebGL2RenderingContext;
-
-    const node = {
+    const send = {
       id: 'send',
+      type: 'send.vdo',
       inletMap: new Map([[0, { sourceNodeId: 'webcam', outletIndex: 0 }]])
     } as RenderNode;
+    const receive = {
+      id: 'receive',
+      type: 'recv.vdo',
+      inletMap: new Map([[0, { sourceNodeId: 'send', outletIndex: 0 }]])
+    } as RenderNode;
+    const consumer = {
+      id: 'consumer',
+      type: 'glsl',
+      inletMap: new Map([[0, { sourceNodeId: 'receive', outletIndex: 0 }]])
+    } as RenderNode;
+    state.renderGraph = { nodes: [send, receive, consumer] };
 
-    renderer
-      .createPassthroughRenderer(node, {
-        _framebuffer: { framebuffer: 'send-fbo' }
-      } as unknown as regl.Framebuffer2D)
-      .render({} as RenderParams);
+    const textureMap = (
+      renderer as never as { getInputTextureMap: (node: RenderNode) => Map<number, unknown> }
+    ).getInputTextureMap(consumer);
 
-    expect(bindFramebuffer).toHaveBeenNthCalledWith(1, 1, 'webcam-fbo');
-    expect(blitFramebuffer).toHaveBeenCalledWith(0, 0, 640, 480, 0, 0, 1280, 720, 4, 5);
+    expect(textureMap.get(0)).toBe(sourceTexture);
   });
 });

--- a/ui/src/workers/rendering/fboRenderer.passthrough.test.ts
+++ b/ui/src/workers/rendering/fboRenderer.passthrough.test.ts
@@ -25,6 +25,7 @@ describe('send.vdo and recv.vdo routing', () => {
     const { FBORenderer } = await import('./fboRenderer');
 
     const sourceTexture = { width: 1080, height: 1920 };
+    const sourceFramebuffer = {};
     const renderer = Object.create(FBORenderer.prototype) as FBORenderer;
 
     const state = renderer as unknown as {
@@ -32,13 +33,15 @@ describe('send.vdo and recv.vdo routing', () => {
       renderGraph: { nodes: RenderNode[] };
       videoTextures: {
         getDestinationTexture: (nodeId: string) => typeof sourceTexture | undefined;
+        getDestinationFBO: (nodeId: string) => typeof sourceFramebuffer | undefined;
       };
     };
 
     state.fboNodes = new Map();
 
     state.videoTextures = {
-      getDestinationTexture: (nodeId) => (nodeId === 'webcam' ? sourceTexture : undefined)
+      getDestinationTexture: (nodeId) => (nodeId === 'webcam' ? sourceTexture : undefined),
+      getDestinationFBO: (nodeId) => (nodeId === 'webcam' ? sourceFramebuffer : undefined)
     };
 
     const send = {
@@ -75,6 +78,20 @@ describe('send.vdo and recv.vdo routing', () => {
 
     expect(source).toEqual({ texture: sourceTexture, width: 1080, height: 1920 });
     expect(textureMap.get(0)).toBe(sourceTexture);
+
+    const captureSource = (
+      renderer as never as {
+        resolveCaptureSource: (
+          nodeId: string
+        ) => { framebuffer: unknown; width: number; height: number } | null;
+      }
+    ).resolveCaptureSource('receive');
+
+    expect(captureSource).toMatchObject({
+      framebuffer: sourceFramebuffer,
+      width: 1080,
+      height: 1920
+    });
   });
 
   it('uses the previous frame when wireless routing closes a feedback loop', async () => {
@@ -177,5 +194,24 @@ describe('send.vdo and recv.vdo routing', () => {
     ).getInputTextureMap(feedback);
 
     expect(textureMap.get(1)).toBe(previousTexture);
+  });
+
+  it('releases obsolete feedback resources', async () => {
+    const { FBORenderer } = await import('./fboRenderer');
+    const renderer = Object.create(FBORenderer.prototype) as FBORenderer;
+    const framebuffer = { destroy: vi.fn() };
+    const texture = { destroy: vi.fn() };
+    const fboNode = { prevFramebuffers: [framebuffer], prevTextures: [texture] };
+
+    (
+      renderer as never as {
+        destroyFeedbackResources: (node: typeof fboNode) => void;
+      }
+    ).destroyFeedbackResources(fboNode);
+
+    expect(framebuffer.destroy).toHaveBeenCalledOnce();
+    expect(texture.destroy).toHaveBeenCalledOnce();
+    expect(fboNode.prevFramebuffers).toBeUndefined();
+    expect(fboNode.prevTextures).toBeUndefined();
   });
 });

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -21,7 +21,7 @@ import {
 } from '$lib/canvas/constants';
 import { PixelReadbackService } from './PixelReadbackService';
 import { PreviewRenderer } from './PreviewRenderer';
-import { CaptureRenderer } from './CaptureRenderer';
+import { CaptureRenderer, type VideoFrameCaptureSource } from './CaptureRenderer';
 import { match, P } from 'ts-pattern';
 import { HydraRenderer } from './hydraRenderer';
 import { CanvasRenderer } from './canvasRenderer';
@@ -686,7 +686,14 @@ export class FBORenderer {
 
     this.shouldProcessPreviews = this.previewRenderer.hasEnabledPreviews();
 
-    // Phase 4 (sync): allocate previous-frame textures for feedback nodes.
+    // Phase 4 (sync): release previous-frame textures no longer needed, then
+    // allocate them for the feedback nodes in the current graph.
+    for (const [nodeId, fboNode] of this.fboNodes) {
+      if (!mergedGraph.feedbackNodes.has(nodeId)) {
+        this.destroyFeedbackResources(fboNode);
+      }
+    }
+
     // Idempotent — skipped if the node already has prevTextures from a prior build.
     // One prev texture + framebuffer is allocated per color attachment so MRT
     // feedback nodes can provide previous-frame data for each outlet independently.
@@ -731,6 +738,14 @@ export class FBORenderer {
       texture.destroy();
     }
 
+    this.destroyFeedbackResources(fboNode);
+
+    if (cleanup) {
+      fboNode.cleanup?.();
+    }
+  }
+
+  private destroyFeedbackResources(fboNode: FBONode): void {
     for (const framebuffer of fboNode.prevFramebuffers ?? []) {
       framebuffer?.destroy();
     }
@@ -739,9 +754,8 @@ export class FBORenderer {
       texture?.destroy();
     }
 
-    if (cleanup) {
-      fboNode.cleanup?.();
-    }
+    fboNode.prevFramebuffers = undefined;
+    fboNode.prevTextures = undefined;
   }
 
   private rebuildCookingPolicies(mergedGraph: RenderGraph) {
@@ -1402,13 +1416,7 @@ export class FBORenderer {
 
   destroyNodes(newNodeIds?: Set<string>) {
     for (const fboNode of this.fboNodes.values()) {
-      fboNode.framebuffer.destroy();
-
-      for (const texture of fboNode.colorAttachments) {
-        texture.destroy();
-      }
-
-      fboNode.cleanup?.();
+      this.destroyFboNode(fboNode);
     }
 
     this.fboNodes.clear();
@@ -2391,6 +2399,7 @@ export class FBORenderer {
    */
   capturePreviewBitmap(nodeId: string, customSize?: [number, number]): ImageBitmap | null {
     const fboNode = this.fboNodes.get(nodeId);
+    const captureSource = this.resolveCaptureSource(nodeId);
 
     const defaultPreview: [number, number] = [
       Math.floor(DEFAULT_OUTPUT_SIZE[0] / PREVIEW_SCALE_FACTOR),
@@ -2398,31 +2407,12 @@ export class FBORenderer {
     ];
 
     const fallbackSize = customSize ?? fboNode?.previewSize ?? defaultPreview;
-
-    const externalTexture = this.videoTextures.getDestinationTexture(nodeId);
-
-    if (externalTexture) {
-      // Use cached FBO to avoid creating/destroying on every capture
-      const sourceFbo = this.videoTextures.getDestinationFBO(nodeId);
-
-      if (sourceFbo) {
-        const bitmap = this.captureRenderer.capturePreviewBitmapSync(
-          sourceFbo,
-          externalTexture.width,
-          externalTexture.height,
-          fallbackSize
-        );
-
-        return bitmap;
-      }
-    }
-
-    if (!fboNode) return null;
+    if (!captureSource) return null;
 
     return this.captureRenderer.capturePreviewBitmapSync(
-      fboNode.framebuffer,
-      fboNode.texture.width,
-      fboNode.texture.height,
+      captureSource.framebuffer,
+      captureSource.width,
+      captureSource.height,
       fallbackSize
     );
   }
@@ -2440,11 +2430,64 @@ export class FBORenderer {
       format?: 'raw' | 'bitmap';
     }>
   ): void {
+    const resolvedSources = new Map<string, VideoFrameCaptureSource>();
+
+    for (const request of requests) {
+      for (const sourceNodeId of request.sourceNodeIds) {
+        if (!sourceNodeId || resolvedSources.has(sourceNodeId)) continue;
+
+        const node = this.renderGraph?.nodes.find((candidate) => candidate.id === sourceNodeId);
+        if (!node || !isPassthroughNodeType(node.type)) continue;
+
+        const source = this.resolveCaptureSource(sourceNodeId);
+        if (source) resolvedSources.set(sourceNodeId, source);
+      }
+    }
+
     this.captureRenderer.initiateVideoFrameBatchAsync(
       requests,
       this.fboNodes,
-      this.videoTextures.destinationTextures
+      this.videoTextures.destinationTextures,
+      resolvedSources
     );
+  }
+
+  private resolveCaptureSource(
+    nodeId: string,
+    visited = new Set<string>()
+  ): VideoFrameCaptureSource | null {
+    if (visited.has(nodeId)) return null;
+    visited.add(nodeId);
+
+    const node = this.renderGraph?.nodes.find((candidate) => candidate.id === nodeId);
+
+    if (node && isPassthroughNodeType(node.type)) {
+      const inlet = node.inletMap.get(0);
+
+      return inlet ? this.resolveCaptureSource(inlet.sourceNodeId, visited) : null;
+    }
+
+    const externalTexture = this.videoTextures.getDestinationTexture(nodeId);
+    const externalFbo = this.videoTextures.getDestinationFBO(nodeId);
+
+    if (externalTexture && externalFbo) {
+      return {
+        framebuffer: externalFbo,
+        width: externalTexture.width,
+        height: externalTexture.height,
+        previewSize: [externalTexture.width, externalTexture.height]
+      };
+    }
+
+    const fboNode = this.fboNodes.get(nodeId);
+    if (!fboNode) return null;
+
+    return {
+      framebuffer: fboNode.framebuffer,
+      width: fboNode.texture.width,
+      height: fboNode.texture.height,
+      previewSize: fboNode.previewSize
+    };
   }
 
   /**

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -2084,6 +2084,7 @@ export class FBORenderer {
     const node = this.renderGraph?.nodes.find((candidate) => candidate.id === nodeId);
 
     if (node && isPassthroughNodeType(node.type)) {
+      // Routing nodes have no texture of their own; preserve the inlet's native texture.
       const inlet = node.inletMap.get(0);
 
       return inlet ? this.resolveVideoSource(inlet.sourceNodeId, inlet.outletIndex, visited) : null;

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -85,6 +85,9 @@ export const FBO_RENDERER_CONTEXT_ATTRIBUTES: WebGLContextAttributes = {
   premultipliedAlpha: false
 };
 
+const isPassthroughNodeType = (nodeType: RenderNode['type']): boolean =>
+  nodeType === 'send.vdo' || nodeType === 'recv.vdo';
+
 export class FBORenderer {
   public outputSize = DEFAULT_OUTPUT_SIZE;
   public backgroundSize: [number, number] = [...DEFAULT_OUTPUT_SIZE];
@@ -512,7 +515,7 @@ export class FBORenderer {
       // Passthrough nodes (send.vdo, recv.vdo) capture inletMap in their closure
       // so they must always be recreated when the graph changes.
       const fingerprint = this.computeNodeFingerprint(node);
-      const isPassthroughNode = node.type === 'send.vdo' || node.type === 'recv.vdo';
+      const isPassthroughNode = isPassthroughNodeType(node.type);
 
       if (
         canReuseFbo &&
@@ -2080,7 +2083,7 @@ export class FBORenderer {
 
     const node = this.renderGraph?.nodes.find((candidate) => candidate.id === nodeId);
 
-    if (node?.type === 'send.vdo' || node?.type === 'recv.vdo') {
+    if (node && isPassthroughNodeType(node.type)) {
       const inlet = node.inletMap.get(0);
 
       return inlet ? this.resolveVideoSource(inlet.sourceNodeId, inlet.outletIndex, visited) : null;

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -65,6 +65,7 @@ import { createRenderNodeCookPolicy } from './cooking/policies';
 import { isSameMouseData, type MouseData } from './mouseData';
 import { getViewportCookRequiredNodeIds, shouldSkipCookForViewport } from './renderEligibility';
 import { createFinalOutputPresentationCommand } from './finalOutputPresentation';
+import { topologicalSort } from '$lib/rendering/graphUtils';
 
 interface MessageCapableRenderer {
   handleMessage(message: Message): void;
@@ -450,13 +451,7 @@ export class FBORenderer {
     // Merge virtual edges from video channels into the render graph
     const virtualEdges = this.videoChannelRegistry.getVirtualEdges();
 
-    const mergedGraph: RenderGraph = {
-      ...renderGraph,
-      edges: [...renderGraph.edges, ...virtualEdges]
-    };
-
-    // Update node relationships with virtual edges
-    this.applyVirtualEdgesToNodes(mergedGraph);
+    const mergedGraph = this.mergeVirtualEdges(renderGraph, virtualEdges);
 
     this.renderGraph = mergedGraph;
     this.outputNodeId = mergedGraph.outputNodeId;
@@ -477,7 +472,7 @@ export class FBORenderer {
 
     const pending: PendingNode[] = [];
 
-    for (const node of renderGraph.nodes) {
+    for (const node of mergedGraph.nodes) {
       const existingFbo = this.fboNodes.get(node.id);
 
       // MRT count: GLSL, REGL, SwissGL, Hydra, and Shader Park
@@ -512,14 +507,10 @@ export class FBORenderer {
       // If both FBO and data are unchanged, skip renderer recreation entirely.
       // This preserves state in JS-based renderers (canvas, three, regl, etc.)
       // that would otherwise lose their scene graphs, animation state, etc.
-      // Passthrough nodes (send.vdo, recv.vdo) capture inletMap in their closure
-      // so they must always be recreated when the graph changes.
       const fingerprint = this.computeNodeFingerprint(node);
-      const isPassthroughNode = isPassthroughNodeType(node.type);
 
       if (
         canReuseFbo &&
-        !isPassthroughNode &&
         existingFbo.nodeType === node.type &&
         existingFbo.dataFingerprint === fingerprint
       ) {
@@ -650,8 +641,8 @@ export class FBORenderer {
           .with({ type: 'float.tex' }, () => this.createEmptyRenderer())
           .with({ type: 'worker' }, () => this.createEmptyRenderer())
           .with({ type: 'bg.out' }, () => this.createEmptyRenderer())
-          .with({ type: 'send.vdo' }, (node) => this.createPassthroughRenderer(node))
-          .with({ type: 'recv.vdo' }, (node) => this.createPassthroughRenderer(node))
+          .with({ type: 'send.vdo' }, () => this.createPassthroughRenderer())
+          .with({ type: 'recv.vdo' }, () => this.createPassthroughRenderer())
           .exhaustive()
       )
     );
@@ -717,13 +708,13 @@ export class FBORenderer {
     // Idempotent — skipped if the node already has prevTextures from a prior build.
     // One prev texture + framebuffer is allocated per color attachment so MRT
     // feedback nodes can provide previous-frame data for each outlet independently.
-    for (const nodeId of renderGraph.feedbackNodes) {
+    for (const nodeId of mergedGraph.feedbackNodes) {
       const fboNode = this.fboNodes.get(nodeId);
       if (!fboNode || fboNode.prevTextures) continue;
 
       // Match the format of the node's color attachments for feedback textures.
       // Read the format from the render graph node data.
-      const feedbackNode = renderGraph.nodes.find((n) => n.id === nodeId);
+      const feedbackNode = mergedGraph.nodes.find((n) => n.id === nodeId);
       const feedbackData = feedbackNode?.data as Record<string, unknown> | undefined;
       const feedbackFormat: FBOFormat = (feedbackData?.fboFormat as FBOFormat) || 'rgba8';
       const feedbackResolution = feedbackData?.resolution as FBOResolution | undefined;
@@ -805,6 +796,41 @@ export class FBORenderer {
   }
 
   /**
+   * Add wireless video-channel edges before graph analysis so a cycle routed
+   * through send.vdo/recv.vdo receives the same previous-frame semantics as a
+   * visible feedback cable.
+   */
+  private mergeVirtualEdges(
+    renderGraph: RenderGraph,
+    virtualEdges: RenderGraph['edges']
+  ): RenderGraph {
+    const mergedGraph: RenderGraph = {
+      ...renderGraph,
+      edges: [...renderGraph.edges, ...virtualEdges]
+    };
+
+    this.applyVirtualEdgesToNodes(mergedGraph);
+
+    // The incoming graph may have been analyzed before virtual edges existed.
+    // Clear that result before recalculating it against the complete graph.
+    for (const node of mergedGraph.nodes) {
+      node.backEdgeInlets.clear();
+    }
+
+    const { sortedNodes, backEdgeIds, feedbackNodeIds } = topologicalSort(
+      mergedGraph.nodes,
+      mergedGraph.edges
+    );
+
+    return {
+      ...mergedGraph,
+      sortedNodes,
+      backEdges: backEdgeIds,
+      feedbackNodes: feedbackNodeIds
+    };
+  }
+
+  /**
    * Create a renderer for video routing nodes (send.vdo, recv.vdo).
    *
    * Routing nodes are texture aliases. They must not draw their inlet into a
@@ -812,16 +838,8 @@ export class FBORenderer {
    * native aspect ratio differs from the patch output. getInputTextureMap()
    * resolves the alias when a downstream node binds its sampler.
    */
-  createPassthroughRenderer(node: RenderNode): { render: RenderFunction; cleanup: () => void } {
-    const nodeId = node.id;
-
-    return {
-      render: () => {},
-      cleanup: () => {
-        // Unsubscribe from video channel when node is destroyed
-        this.videoChannelRegistry.unsubscribeAll(nodeId);
-      }
-    };
+  createPassthroughRenderer(): { render: RenderFunction; cleanup: () => void } {
+    return this.createEmptyRenderer();
   }
 
   async createHydraRenderer(
@@ -2032,28 +2050,14 @@ export class FBORenderer {
 
     // Use inletMap for proper slot-based assignment
     for (const [inletIndex, { sourceNodeId, outletIndex }] of node.inletMap) {
-      const inputFBO = this.fboNodes.get(sourceNodeId);
+      const texture = this.resolveVideoSource(
+        sourceNodeId,
+        outletIndex,
+        node.backEdgeInlets?.has(inletIndex) ?? false
+      )?.texture;
 
-      if (inputFBO) {
-        // For back-edge inlets (feedback loops), read from the previous frame's texture.
-        // This implements the 1-frame delay that prevents the cycle from deadlocking.
-        if (node.backEdgeInlets.has(inletIndex) && inputFBO.prevTextures?.length) {
-          const prevTex = inputFBO.prevTextures[outletIndex] ?? inputFBO.prevTextures[0];
-          textureMap.set(inletIndex, prevTex);
-        } else {
-          // Index into the correct color attachment for MRT sources
-          const texture = this.resolveVideoSource(sourceNodeId, outletIndex)?.texture;
-
-          if (texture) {
-            textureMap.set(inletIndex, texture);
-          }
-        }
-      } else {
-        const texture = this.resolveVideoSource(sourceNodeId, outletIndex)?.texture;
-
-        if (texture) {
-          textureMap.set(inletIndex, texture);
-        }
+      if (texture) {
+        textureMap.set(inletIndex, texture);
       }
     }
 
@@ -2064,6 +2068,7 @@ export class FBORenderer {
   private resolveVideoSource(
     nodeId: string,
     outletIndex = 0,
+    usePreviousFrame = false,
     visited = new Set<string>()
   ): { texture: regl.Texture2D; width: number; height: number } | null {
     if (visited.has(nodeId)) return null;
@@ -2087,11 +2092,19 @@ export class FBORenderer {
       // Routing nodes have no texture of their own; preserve the inlet's native texture.
       const inlet = node.inletMap.get(0);
 
-      return inlet ? this.resolveVideoSource(inlet.sourceNodeId, inlet.outletIndex, visited) : null;
+      return inlet
+        ? this.resolveVideoSource(
+            inlet.sourceNodeId,
+            inlet.outletIndex,
+            usePreviousFrame || (node.backEdgeInlets?.has(0) ?? false),
+            visited
+          )
+        : null;
     }
 
     const fboNode = this.fboNodes.get(nodeId);
-    const texture = fboNode?.colorAttachments[outletIndex] ?? fboNode?.texture;
+    const textures = usePreviousFrame ? fboNode?.prevTextures : fboNode?.colorAttachments;
+    const texture = textures?.[outletIndex] ?? textures?.[0];
     if (!texture) return null;
 
     return { texture, width: texture.width, height: texture.height };

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -406,21 +406,7 @@ export class FBORenderer {
     // since existing FBOs retain their content until overwritten.
     for (const [nodeId, fboNode] of this.fboNodes) {
       if (!newNodeIds.has(nodeId)) {
-        fboNode.framebuffer.destroy();
-
-        for (const texture of fboNode.colorAttachments) {
-          texture.destroy();
-        }
-
-        for (const framebuffer of fboNode.prevFramebuffers ?? []) {
-          framebuffer?.destroy();
-        }
-
-        for (const texture of fboNode.prevTextures ?? []) {
-          texture?.destroy();
-        }
-
-        fboNode.cleanup?.();
+        this.destroyFboNode(fboNode);
 
         this.fboNodes.delete(nodeId);
         this.cookState.removeNode(nodeId);
@@ -474,6 +460,19 @@ export class FBORenderer {
 
     for (const node of mergedGraph.nodes) {
       const existingFbo = this.fboNodes.get(node.id);
+
+      // Routing nodes are texture aliases. They do not render into an FBO, and
+      // their preview would otherwise be a blank readback of that unused FBO.
+      if (isPassthroughNodeType(node.type)) {
+        if (existingFbo) {
+          this.destroyFboNode(existingFbo);
+          this.fboNodes.delete(node.id);
+        }
+
+        this.previewRenderer.setPreviewEnabled(node.id, false);
+
+        continue;
+      }
 
       // MRT count: GLSL, REGL, SwissGL, Hydra, and Shader Park
       // nodes can request multiple color attachments.
@@ -554,23 +553,7 @@ export class FBORenderer {
 
           const isReusableThree = node.type === 'three' && this.threeByNode.has(node.id);
 
-          if (!isHydra && !isShaderPark3D && !isReusableThree) {
-            existingFbo.cleanup?.();
-          }
-
-          existingFbo.framebuffer.destroy();
-
-          for (const texture of existingFbo.colorAttachments) {
-            texture.destroy();
-          }
-
-          for (const framebuffer of existingFbo.prevFramebuffers ?? []) {
-            framebuffer?.destroy();
-          }
-
-          for (const texture of existingFbo.prevTextures ?? []) {
-            texture?.destroy();
-          }
+          this.destroyFboNode(existingFbo, !isHydra && !isShaderPark3D && !isReusableThree);
 
           this.fboNodes.delete(node.id);
         }
@@ -742,6 +725,26 @@ export class FBORenderer {
     return { render: () => {}, cleanup: () => {} };
   }
 
+  private destroyFboNode(fboNode: FBONode, cleanup = true): void {
+    fboNode.framebuffer.destroy();
+
+    for (const texture of fboNode.colorAttachments) {
+      texture.destroy();
+    }
+
+    for (const framebuffer of fboNode.prevFramebuffers ?? []) {
+      framebuffer?.destroy();
+    }
+
+    for (const texture of fboNode.prevTextures ?? []) {
+      texture?.destroy();
+    }
+
+    if (cleanup) {
+      fboNode.cleanup?.();
+    }
+  }
+
   private rebuildCookingPolicies(mergedGraph: RenderGraph) {
     this.cookState.setOutputsByNode(
       new Map(mergedGraph.nodes.map((node) => [node.id, [...node.outputs]]))
@@ -804,9 +807,15 @@ export class FBORenderer {
     renderGraph: RenderGraph,
     virtualEdges: RenderGraph['edges']
   ): RenderGraph {
+    const edgesById = new Map<string, RenderGraph['edges'][number]>();
+
+    for (const edge of [...renderGraph.edges, ...virtualEdges]) {
+      edgesById.set(edge.id, edge);
+    }
+
     const mergedGraph: RenderGraph = {
       ...renderGraph,
-      edges: [...renderGraph.edges, ...virtualEdges]
+      edges: [...edgesById.values()]
     };
 
     this.applyVirtualEdgesToNodes(mergedGraph);
@@ -822,12 +831,41 @@ export class FBORenderer {
       mergedGraph.edges
     );
 
+    // A routing node has no FBO of its own. If it is the source of a
+    // back-edge, preserve the previous frame on the underlying render node.
+    const feedbackStorageNodeIds = new Set<string>();
+
+    for (const nodeId of feedbackNodeIds) {
+      const sourceNodeId = this.resolveFeedbackStorageNodeId(nodeId, mergedGraph);
+
+      if (sourceNodeId) {
+        feedbackStorageNodeIds.add(sourceNodeId);
+      }
+    }
+
     return {
       ...mergedGraph,
       sortedNodes,
       backEdges: backEdgeIds,
-      feedbackNodes: feedbackNodeIds
+      feedbackNodes: feedbackStorageNodeIds
     };
+  }
+
+  private resolveFeedbackStorageNodeId(
+    nodeId: string,
+    graph: RenderGraph,
+    visited = new Set<string>()
+  ): string | null {
+    if (visited.has(nodeId)) return null;
+    visited.add(nodeId);
+
+    const node = graph.nodes.find((candidate) => candidate.id === nodeId);
+    if (!node) return null;
+    if (!isPassthroughNodeType(node.type)) return nodeId;
+
+    const inlet = node.inletMap.get(0);
+
+    return inlet ? this.resolveFeedbackStorageNodeId(inlet.sourceNodeId, graph, visited) : null;
   }
 
   /**
@@ -1455,7 +1493,13 @@ export class FBORenderer {
   }
 
   setPreviewEnabled(nodeId: string, enabled: boolean) {
-    this.previewRenderer.setPreviewEnabled(nodeId, enabled);
+    const node = this.renderGraph?.nodes.find((candidate) => candidate.id === nodeId);
+
+    this.previewRenderer.setPreviewEnabled(
+      nodeId,
+      node ? enabled && !isPassthroughNodeType(node.type) : enabled
+    );
+
     this.shouldProcessPreviews = this.previewRenderer.hasEnabledPreviews();
   }
 
@@ -1829,7 +1873,9 @@ export class FBORenderer {
   }
 
   private hasValidOutputOverride(): boolean {
-    return Boolean(this.overrideOutputNodeId && this.fboNodes.has(this.overrideOutputNodeId));
+    return Boolean(
+      this.overrideOutputNodeId && this.resolveVideoSource(this.overrideOutputNodeId, 0)
+    );
   }
 
   private getEffectiveOutputNodeId(isOverride = this.hasValidOutputOverride()): string | null {

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -2066,14 +2066,8 @@ export class FBORenderer {
     if (visited.has(nodeId)) return null;
     visited.add(nodeId);
 
-    const node = this.renderGraph?.nodes.find((candidate) => candidate.id === nodeId);
-
-    if (node?.type === 'send.vdo' || node?.type === 'recv.vdo') {
-      const inlet = node.inletMap.get(0);
-
-      return inlet ? this.resolveVideoSource(inlet.sourceNodeId, inlet.outletIndex, visited) : null;
-    }
-
+    // External sources are the common direct-input case. Resolve them before
+    // looking up the graph so image/video sampling stays on the fast path.
     const externalTexture = this.videoTextures.getDestinationTexture(nodeId);
 
     if (externalTexture) {
@@ -2082,6 +2076,14 @@ export class FBORenderer {
         width: externalTexture.width,
         height: externalTexture.height
       };
+    }
+
+    const node = this.renderGraph?.nodes.find((candidate) => candidate.id === nodeId);
+
+    if (node?.type === 'send.vdo' || node?.type === 'recv.vdo') {
+      const inlet = node.inletMap.get(0);
+
+      return inlet ? this.resolveVideoSource(inlet.sourceNodeId, inlet.outletIndex, visited) : null;
     }
 
     const fboNode = this.fboNodes.get(nodeId);

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -647,8 +647,8 @@ export class FBORenderer {
           .with({ type: 'float.tex' }, () => this.createEmptyRenderer())
           .with({ type: 'worker' }, () => this.createEmptyRenderer())
           .with({ type: 'bg.out' }, () => this.createEmptyRenderer())
-          .with({ type: 'send.vdo' }, (node) => this.createPassthroughRenderer(node, framebuffer))
-          .with({ type: 'recv.vdo' }, (node) => this.createPassthroughRenderer(node, framebuffer))
+          .with({ type: 'send.vdo' }, (node) => this.createPassthroughRenderer(node))
+          .with({ type: 'recv.vdo' }, (node) => this.createPassthroughRenderer(node))
           .exhaustive()
       )
     );
@@ -802,49 +802,18 @@ export class FBORenderer {
   }
 
   /**
-   * Create a passthrough renderer for video routing nodes (send.vdo, recv.vdo).
-   * Copies input texture from inlet 0 to the output framebuffer.
+   * Create a renderer for video routing nodes (send.vdo, recv.vdo).
+   *
+   * Routing nodes are texture aliases. They must not draw their inlet into a
+   * full-output FBO, because that would resample and stretch sources whose
+   * native aspect ratio differs from the patch output. getInputTextureMap()
+   * resolves the alias when a downstream node binds its sampler.
    */
-  createPassthroughRenderer(
-    node: RenderNode,
-    framebuffer: regl.Framebuffer2D
-  ): { render: RenderFunction; cleanup: () => void } {
+  createPassthroughRenderer(node: RenderNode): { render: RenderFunction; cleanup: () => void } {
     const nodeId = node.id;
 
     return {
-      render: () => {
-        // Get input texture from inlet 0
-        const inlet0 = node.inletMap.get(0);
-        if (!inlet0) return;
-
-        const externalTexture = this.videoTextures.getDestinationTexture(inlet0.sourceNodeId);
-
-        const externalSourceFramebuffer = externalTexture
-          ? this.videoTextures.getDestinationFBO(inlet0.sourceNodeId)
-          : undefined;
-
-        const sourceFbo = this.fboNodes.get(inlet0.sourceNodeId);
-        const sourceFramebuffer = externalSourceFramebuffer ?? sourceFbo?.framebuffer;
-        if (!sourceFramebuffer) return;
-
-        // Blit input FBO to output framebuffer.
-        // Source and destination may differ when the source uses @resolution.
-        const srcW = externalTexture?.width ?? sourceFbo?.texture.width;
-        const srcH = externalTexture?.height ?? sourceFbo?.texture.height;
-        if (!srcW || !srcH) return;
-
-        const dstFbo = this.fboNodes.get(node.id);
-        const dstW = dstFbo?.texture.width ?? srcW;
-        const dstH = dstFbo?.texture.height ?? srcH;
-        const gl = this.gl;
-
-        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, getFramebuffer(sourceFramebuffer));
-        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, getFramebuffer(framebuffer));
-
-        gl.blitFramebuffer(0, 0, srcW, srcH, 0, 0, dstW, dstH, gl.COLOR_BUFFER_BIT, gl.LINEAR);
-
-        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-      },
+      render: () => {},
       cleanup: () => {
         // Unsubscribe from video channel when node is destroyed
         this.videoChannelRegistry.unsubscribeAll(nodeId);
@@ -1637,11 +1606,7 @@ export class FBORenderer {
     if (isOverride) this.outputOutletIndex = 0;
 
     if (effectiveOutputNodeId !== null) {
-      const outputFBONode = this.fboNodes.get(effectiveOutputNodeId);
-
-      if (outputFBONode) {
-        this.profiler.measureOp('blit', () => this.renderNodeToMainOutput(outputFBONode));
-      }
+      this.profiler.measureOp('blit', () => this.renderNodeToMainOutput(effectiveOutputNodeId));
     }
 
     this.outputOutletIndex = savedOutletIndex;
@@ -1957,7 +1922,7 @@ export class FBORenderer {
     return this.profiler.measureOp(op, fn);
   }
 
-  private renderNodeToMainOutput(node: FBONode): void {
+  private renderNodeToMainOutput(nodeId: string): void {
     // outputSize controls the offscreen canvas dimensions (blit destination).
     // backgroundSize is used only for the cover-mode aspect ratio crop.
     const [outputWidth, outputHeight] = this.outputSize;
@@ -1967,35 +1932,15 @@ export class FBORenderer {
       return;
     }
 
-    if (!node) {
+    const source = this.resolveVideoSource(nodeId, this.outputOutletIndex);
+
+    if (!source) {
       console.warn('Could not find source framebuffer for final texture');
       return;
     }
 
     const gl = this.regl._gl as WebGL2RenderingContext;
-
-    let framebuffer: regl.Framebuffer2D | null = null;
-    let texture = node.colorAttachments[this.outputOutletIndex] ?? node.texture;
-
-    // Source size comes from the node's FBO (not the background)
-    let sourceWidth = node.texture.width;
-    let sourceHeight = node.texture.height;
-
-    if (this.videoTextures.has(node.id)) {
-      const tex = this.videoTextures.getDestinationTexture(node.id)!;
-
-      // Use cached FBO instead of creating new one every frame (fixes massive leak)
-      framebuffer = this.videoTextures.getDestinationFBO(node.id) || null;
-      texture = tex;
-      sourceWidth = tex.width;
-      sourceHeight = tex.height;
-    } else {
-      framebuffer = node.framebuffer;
-    }
-
-    if (!framebuffer) {
-      return;
-    }
+    const { texture, width: sourceWidth, height: sourceHeight } = source;
 
     // Cover-mode blit: crop the source to match the background's aspect ratio,
     // so the output fills the screen without stretching (spec 128).
@@ -2086,12 +2031,6 @@ export class FBORenderer {
     for (const [inletIndex, { sourceNodeId, outletIndex }] of node.inletMap) {
       const inputFBO = this.fboNodes.get(sourceNodeId);
 
-      // If there exists an external texture for an input node, use it (always outlet 0).
-      if (this.videoTextures.has(sourceNodeId)) {
-        textureMap.set(inletIndex, this.videoTextures.getDestinationTexture(sourceNodeId)!);
-        continue;
-      }
-
       if (inputFBO) {
         // For back-edge inlets (feedback loops), read from the previous frame's texture.
         // This implements the 1-frame delay that prevents the cycle from deadlocking.
@@ -2100,14 +2039,48 @@ export class FBORenderer {
           textureMap.set(inletIndex, prevTex);
         } else {
           // Index into the correct color attachment for MRT sources
-          const texture = inputFBO.colorAttachments[outletIndex] ?? inputFBO.colorAttachments[0];
-
-          textureMap.set(inletIndex, texture);
+          const texture = this.resolveVideoSource(sourceNodeId, outletIndex)?.texture;
+          if (texture) textureMap.set(inletIndex, texture);
         }
+      } else {
+        const texture = this.resolveVideoSource(sourceNodeId, outletIndex)?.texture;
+        if (texture) textureMap.set(inletIndex, texture);
       }
     }
 
     return textureMap;
+  }
+
+  /** Resolve a node outlet to its underlying texture without resampling routing nodes. */
+  private resolveVideoSource(
+    nodeId: string,
+    outletIndex = 0,
+    visited = new Set<string>()
+  ): { texture: regl.Texture2D; width: number; height: number } | null {
+    if (visited.has(nodeId)) return null;
+    visited.add(nodeId);
+
+    const node = this.renderGraph?.nodes.find((candidate) => candidate.id === nodeId);
+
+    if (node?.type === 'send.vdo' || node?.type === 'recv.vdo') {
+      const inlet = node.inletMap.get(0);
+      return inlet ? this.resolveVideoSource(inlet.sourceNodeId, inlet.outletIndex, visited) : null;
+    }
+
+    const externalTexture = this.videoTextures.getDestinationTexture(nodeId);
+    if (externalTexture) {
+      return {
+        texture: externalTexture,
+        width: externalTexture.width,
+        height: externalTexture.height
+      };
+    }
+
+    const fboNode = this.fboNodes.get(nodeId);
+    const texture = fboNode?.colorAttachments[outletIndex] ?? fboNode?.texture;
+    if (!texture) return null;
+
+    return { texture, width: texture.width, height: texture.height };
   }
 
   /**

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -624,8 +624,7 @@ export class FBORenderer {
           .with({ type: 'float.tex' }, () => this.createEmptyRenderer())
           .with({ type: 'worker' }, () => this.createEmptyRenderer())
           .with({ type: 'bg.out' }, () => this.createEmptyRenderer())
-          .with({ type: 'send.vdo' }, () => this.createPassthroughRenderer())
-          .with({ type: 'recv.vdo' }, () => this.createPassthroughRenderer())
+          .with({ type: P.union('send.vdo', 'recv.vdo') }, () => this.createEmptyRenderer())
           .exhaustive()
       )
     );
@@ -866,18 +865,6 @@ export class FBORenderer {
     const inlet = node.inletMap.get(0);
 
     return inlet ? this.resolveFeedbackStorageNodeId(inlet.sourceNodeId, graph, visited) : null;
-  }
-
-  /**
-   * Create a renderer for video routing nodes (send.vdo, recv.vdo).
-   *
-   * Routing nodes are texture aliases. They must not draw their inlet into a
-   * full-output FBO, because that would resample and stretch sources whose
-   * native aspect ratio differs from the patch output. getInputTextureMap()
-   * resolves the alias when a downstream node binds its sampler.
-   */
-  createPassthroughRenderer(): { render: RenderFunction; cleanup: () => void } {
-    return this.createEmptyRenderer();
   }
 
   async createHydraRenderer(

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -2040,11 +2040,17 @@ export class FBORenderer {
         } else {
           // Index into the correct color attachment for MRT sources
           const texture = this.resolveVideoSource(sourceNodeId, outletIndex)?.texture;
-          if (texture) textureMap.set(inletIndex, texture);
+
+          if (texture) {
+            textureMap.set(inletIndex, texture);
+          }
         }
       } else {
         const texture = this.resolveVideoSource(sourceNodeId, outletIndex)?.texture;
-        if (texture) textureMap.set(inletIndex, texture);
+
+        if (texture) {
+          textureMap.set(inletIndex, texture);
+        }
       }
     }
 
@@ -2064,10 +2070,12 @@ export class FBORenderer {
 
     if (node?.type === 'send.vdo' || node?.type === 'recv.vdo') {
       const inlet = node.inletMap.get(0);
+
       return inlet ? this.resolveVideoSource(inlet.sourceNodeId, inlet.outletIndex, visited) : null;
     }
 
     const externalTexture = this.videoTextures.getDestinationTexture(nodeId);
+
     if (externalTexture) {
       return {
         texture: externalTexture,

--- a/ui/static/content/topics/video-chaining.md
+++ b/ui/static/content/topics/video-chaining.md
@@ -40,12 +40,31 @@ To show a visual, connect the final object to `bg.out`. You can also select **Us
 3. Connect each visual object to an inlet of `sub.hydra`.
 4. Connect `sub.hydra` to `bg.out` to subtract the two visuals.
 
+## Mixed Image Sizes
+
+Video sources keep their own pixel dimensions. Use **Transform** when you want
+to place an image or video with a different aspect ratio into the patch output.
+Choose **Contain** to show the full source without distortion, or **Cover** to
+fill the output and crop its edges. Then use **Over** or **Composite** to place
+the transformed source over a background.
+
+```text
+[img] → [Transform: Contain] ──┐
+                                ├→ [Over] → [bg.out]
+[video / background] ──────────┘
+```
+
+The transparent area around a contained source lets the background show
+through. Use **Stretch** only when you intentionally want the source to fill
+the output regardless of its proportions.
+
 ## Getting Started with Presets
 
 The preset library contains objects for video chaining. Enable them from [Preset Packs](/docs/manage-packs):
 
 - **`hydra>`, `glsl>`, `regl>`, `swgl>`, `three>`** — Pass video through unchanged.
 - **`diff.hydra`, `add.hydra`, `sub.hydra`** — Blend two video inputs with Hydra.
+- **`Fit`, `Transform`, `Over`, `Composite`** — Preserve proportions, place a source, and layer it over another video input.
 - Read the [hydra](/docs/objects/hydra) and [glsl](/docs/objects/glsl) docs for more presets.
 
 ## Sending to output

--- a/ui/static/content/topics/video-chaining.md
+++ b/ui/static/content/topics/video-chaining.md
@@ -50,7 +50,7 @@ the transformed source over a background.
 
 ```text
 [img] → [Transform: Contain] ──┐
-                                ├→ [Over] → [bg.out]
+                               ├→ [Over] → [bg.out]
 [video / background] ──────────┘
 ```
 


### PR DESCRIPTION
## Summary

- derive Fit and Transform aspect ratios from the connected texture
- add contain and cover placement to Transform while retaining Stretch as the compatibility default
- route `send.vdo` and `recv.vdo` as texture aliases so wireless video routing does not resample sources
- document the mixed-aspect compositing workflow

## Why

Normalised GLSL UVs mapped every source across the output FBO. This stretched images and videos whose native aspect ratio differed from the patch output; wireless routing also introduced an unwanted output-sized blit.

## Validation

- `bun run test -- fboRenderer.passthrough.test.ts`
- `bun run check`
- targeted Prettier and ESLint
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added aspect-aware video compositing with contain, cover, and stretch modes.
  * Improved video routing with preserved source dimensions, direct texture handling, and safe feedback-loop behavior.
  * Enhanced compositing for transparent containment and mixed-size source layering.
* **Bug Fixes**
  * Improved texture sizing and transform calculations for mixed image dimensions.
* **Documentation**
  * Added guidance for mixed-size video workflows and expanded Fit, Transform, Over, and Composite preset documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->