### PR TITLE
Add virtual filesystem browser API

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-08-13T19:24:38+07:00",
+  "generatedAt": "2026-08-18T20:50:26+07:00",
   "title": "Design System: Patchies",
   "extensions": {
     "colorMeta": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@ Patchies is a visual programming environment for audio-visual patches.
 - TailwindCSS 4
 - CodeMirror 6
 
+## Code Style
+
+- Use blank lines to separate distinct steps in a function: declarations, guards, control-flow blocks, and returns.
+- Keep declarations that form one setup step together; add a blank line before the next operation or branch, including a conditional that follows an operation inside a loop.
+
 Run project commands from `ui/`:
 
 ```bash

--- a/docs/design-docs/specs/105-base-worker-renderer.md
+++ b/docs/design-docs/specs/105-base-worker-renderer.md
@@ -174,7 +174,7 @@ export abstract class BaseWorkerRenderer<
       height,
       mouse: this.createMouseObject(),
       fft: this.createFFTFunction(),
-      getVfsUrl: createWorkerGetVfsUrl(this.config.nodeId),
+      vfs: createWorkerVfs(this.config.nodeId),
       onMessage: this.msgContext.createOnMessageFunction(),
       send: this.sendMessage.bind(this),
       noDrag: () => this.setInteraction('drag', false),

--- a/docs/design-docs/specs/52-virtual-filesystem.md
+++ b/docs/design-docs/specs/52-virtual-filesystem.md
@@ -364,8 +364,8 @@ JavaScript-capable objects expose a single asynchronous `vfs` helper. It replace
 ```javascript
 await vfs.getUrl("./foo.png"); // resolves user://foo.png to an object URL
 await vfs.getUrl("user://foo.png"); // explicit VFS path
-await vfs.list("."); // direct children of user://
-await vfs.search("foo", "./assets"); // recursively search user://assets
+await vfs.list("."); // direct entries of user:// as { path, name, kind }
+await vfs.search("foo", "./assets"); // recursively search entries under user://assets
 ```
 
-Relative paths default to `user://`; absolute external URLs passed to `getUrl` pass through unchanged. `list` is non-recursive and returns full VFS paths. `search` is case-insensitive, recursive, and returns matching full VFS paths. Both methods traverse linked local folders after permission has been granted.
+Relative paths default to `user://`; absolute external URLs passed to `getUrl` pass through unchanged. `list` is non-recursive and returns entries with full VFS paths, names, and file or directory kinds. `search` is case-insensitive, recursive, and returns matching entries in the same shape. Both methods traverse linked local folders after permission has been granted.

--- a/docs/design-docs/specs/52-virtual-filesystem.md
+++ b/docs/design-docs/specs/52-virtual-filesystem.md
@@ -81,7 +81,6 @@ I wanted the ability to persist, browse and resolve files in a virtual file syst
 ## Integration Paths
 
 - persist uploaded media in media source objects
-
   - images (`img`)
   - video (`video`)
   - sound (`soundfile~`)
@@ -183,10 +182,10 @@ class VirtualFilesystem {
 
 async function storeHandle(
   path: string,
-  handle: FileSystemFileHandle
+  handle: FileSystemFileHandle,
 ): Promise<void>;
 async function getHandle(
-  path: string
+  path: string,
 ): Promise<FileSystemFileHandle | undefined>;
 async function removeHandle(path: string): Promise<void>;
 async function getAllHandles(): Promise<Map<string, FileSystemFileHandle>>;
@@ -199,7 +198,7 @@ async function clearHandles(): Promise<void>;
 // path-utils.ts
 function generateUserPath(
   filename: string,
-  existingPaths: Set<string>
+  existingPaths: Set<string>,
 ): string {
   // Input: 'photo.jpg'
   // Output: 'user://images/photo.jpg' or 'user://images/photo-1.jpg' if collision
@@ -357,3 +356,16 @@ export const migration002: Migration = {
 - [x] Collision handling → `photo.jpg`, `photo-1.jpg`, `photo-2.jpg`
 - [x] Delete node → VFS entry remains (intentional, for undo support)
 - [x] Clear patch → VFS cleared
+
+## User-Code API
+
+JavaScript-capable objects expose a single asynchronous `vfs` helper. It replaces the former `getVfsUrl` global.
+
+```javascript
+await vfs.getUrl("./foo.png"); // resolves user://foo.png to an object URL
+await vfs.getUrl("user://foo.png"); // explicit VFS path
+await vfs.list("."); // direct children of user://
+await vfs.search("foo", "./assets"); // recursively search user://assets
+```
+
+Relative paths default to `user://`; absolute external URLs passed to `getUrl` pass through unchanged. `list` is non-recursive and returns full VFS paths. `search` is case-insensitive, recursive, and returns matching full VFS paths. Both methods traverse linked local folders after permission has been granted.

--- a/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
+++ b/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
@@ -38,8 +38,8 @@ export const jsRunnerInstructions = `
 - requestAnimationFrame(cb) - Animation frame with auto-cleanup
 - onCleanup(cb) - Register cleanup callback for unmount/re-execution
 - await vfs.getUrl(path) - Resolve a virtual filesystem file to a browser URL. Relative paths use the \`user://\` namespace (e.g. \`await vfs.getUrl('./photo.jpg')\`).
-- await vfs.list(path?) - List a folder's direct children. Relative paths use the \`user://\` namespace (e.g. \`await vfs.list('./samples')\`).
-- await vfs.search(query, path?) - Search matching paths under a folder. Relative paths use the \`user://\` namespace (e.g. \`await vfs.search('kick', './samples')\`).
+- await vfs.list(path?) - List a folder's direct entries as {path, name, kind}. Relative paths use the \`user://\` namespace (e.g. \`await vfs.list('./samples')\`).
+- await vfs.search(query, path?) - Search matching entries as {path, name, kind}. Relative paths use the \`user://\` namespace (e.g. \`await vfs.search('kick', './samples')\`).
 - await llm(prompt, options?) - Call the configured AI provider (requires API key in settings)
   * Options: { model?: string, abortSignal?: AbortSignal, imageNodeId?: string }
 

--- a/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
+++ b/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
@@ -38,6 +38,8 @@ export const jsRunnerInstructions = `
 - requestAnimationFrame(cb) - Animation frame with auto-cleanup
 - onCleanup(cb) - Register cleanup callback for unmount/re-execution
 - await vfs.getUrl(path) - Resolve a virtual filesystem file to a browser URL. Relative paths use the \`user://\` namespace (e.g. \`await vfs.getUrl('./photo.jpg')\`).
+- await vfs.list(path?) - List a folder's direct children. Relative paths use the \`user://\` namespace (e.g. \`await vfs.list('./samples')\`).
+- await vfs.search(query, path?) - Search matching paths under a folder. Relative paths use the \`user://\` namespace (e.g. \`await vfs.search('kick', './samples')\`).
 - await llm(prompt, options?) - Call the configured AI provider (requires API key in settings)
   * Options: { model?: string, abortSignal?: AbortSignal, imageNodeId?: string }
 

--- a/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
+++ b/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
@@ -37,7 +37,7 @@ export const jsRunnerInstructions = `
 - delay(ms) - Promise that resolves after ms (rejects if node stops)
 - requestAnimationFrame(cb) - Animation frame with auto-cleanup
 - onCleanup(cb) - Register cleanup callback for unmount/re-execution
-- await getVfsUrl(path) - Resolve a virtual filesystem file to a browser URL. Paths are usually \`user://...\` (e.g. \`await getVfsUrl('user://photo.jpg')\`).
+- await vfs.getUrl(path) - Resolve a virtual filesystem file to a browser URL. Relative paths use the \`user://\` namespace (e.g. \`await vfs.getUrl('./photo.jpg')\`).
 - await llm(prompt, options?) - Call the configured AI provider (requires API key in settings)
   * Options: { model?: string, abortSignal?: AbortSignal, imageNodeId?: string }
 

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -61,6 +61,7 @@ import { profiler, ProfilerCoordinator, typeFromNodeId } from '$lib/profiler';
 import { VirtualFilesystem } from '$lib/vfs';
 import {
   listVfsEntries,
+  revokeWorkerVfsObjectUrls,
   resolveVfsText,
   resolveVfsUrl,
   searchVfsEntries
@@ -480,7 +481,7 @@ export class GLSystem {
         this.send('vfsUrlResolved', {
           requestId: data.requestId,
           nodeId: data.nodeId,
-          ...(await resolveVfsUrl(data.path))
+          ...(await resolveVfsUrl(data.nodeId, data.path))
         });
       })
       .with({ type: 'listVfs' }, async (data) => {
@@ -851,6 +852,8 @@ export class GLSystem {
   }
 
   removeNode(nodeId: string) {
+    revokeWorkerVfsObjectUrls(nodeId);
+
     const node = this.nodes.find((n) => n.id === nodeId);
     if (!node) return;
 

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -58,7 +58,8 @@ import {
 } from '../../stores/renderer.store';
 import { match, P } from 'ts-pattern';
 import { profiler, ProfilerCoordinator, typeFromNodeId } from '$lib/profiler';
-import { VirtualFilesystem, isVFSPath } from '$lib/vfs';
+import { VirtualFilesystem } from '$lib/vfs';
+import { isExternalUrl, normalizeUserVfsPath } from '$lib/vfs/user-api-paths';
 import { Transport, type TransportState } from '$lib/transport';
 import { FloatTextureUploadBufferPool } from '$lib/float-texture/upload-buffer-pool';
 import type { CapturedVideoFrame, WorkerVideoFrame } from '$lib/js-runner/js-worker-types';
@@ -473,6 +474,12 @@ export class GLSystem {
       .with({ type: 'resolveVfsUrl' }, async (data) => {
         this.handleVfsUrlResolution(data.requestId, data.nodeId, data.path);
       })
+      .with({ type: 'listVfs' }, async (data) => {
+        this.handleVfsPathListing(data.requestId, data.nodeId, data.path);
+      })
+      .with({ type: 'searchVfs' }, async (data) => {
+        this.handleVfsPathSearch(data.requestId, data.nodeId, data.query, data.path);
+      })
       .with({ type: 'resolveVfsText' }, async (data) => {
         this.handleVfsTextResolution(data.requestId, data.nodeId, data.path);
       })
@@ -623,13 +630,13 @@ export class GLSystem {
   private async handleVfsUrlResolution(requestId: string, nodeId: string, path: string) {
     try {
       // If not a VFS path, send back the original path unchanged
-      if (!isVFSPath(path)) {
+      if (isExternalUrl(path)) {
         this.send('vfsUrlResolved', { requestId, nodeId, url: path });
         return;
       }
 
       const vfs = VirtualFilesystem.getInstance();
-      const blob = await vfs.resolve(path);
+      const blob = await vfs.resolve(normalizeUserVfsPath(path));
 
       // Create object URL on main thread - workers can use it (same origin)
       const url = URL.createObjectURL(blob);
@@ -639,6 +646,31 @@ export class GLSystem {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.send('vfsUrlResolved', { requestId, nodeId, error: errorMessage });
+    }
+  }
+
+  private async handleVfsPathListing(requestId: string, nodeId: string, path: string) {
+    try {
+      const paths = await VirtualFilesystem.getInstance().listChildren(normalizeUserVfsPath(path));
+      this.send('vfsPathsResolved', { requestId, nodeId, paths });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.send('vfsPathsResolved', { requestId, nodeId, error: errorMessage });
+    }
+  }
+
+  private async handleVfsPathSearch(
+    requestId: string,
+    nodeId: string,
+    query: string,
+    path: string
+  ) {
+    try {
+      const paths = await VirtualFilesystem.getInstance().search(query, normalizeUserVfsPath(path));
+      this.send('vfsPathsResolved', { requestId, nodeId, paths });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.send('vfsPathsResolved', { requestId, nodeId, error: errorMessage });
     }
   }
 

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -60,11 +60,11 @@ import { match, P } from 'ts-pattern';
 import { profiler, ProfilerCoordinator, typeFromNodeId } from '$lib/profiler';
 import { VirtualFilesystem } from '$lib/vfs';
 import {
-  listVfsPaths,
+  listVfsEntries,
   resolveVfsText,
   resolveVfsUrl,
-  searchVfsPaths
-} from '$lib/vfs/worker-requests';
+  searchVfsEntries
+} from '$lib/vfs/worker-vfs-request-handler';
 import { Transport, type TransportState } from '$lib/transport';
 import { FloatTextureUploadBufferPool } from '$lib/float-texture/upload-buffer-pool';
 import type { CapturedVideoFrame, WorkerVideoFrame } from '$lib/js-runner/js-worker-types';
@@ -487,14 +487,14 @@ export class GLSystem {
         this.send('vfsPathsResolved', {
           requestId: data.requestId,
           nodeId: data.nodeId,
-          ...(await listVfsPaths(data.path))
+          ...(await listVfsEntries(data.path))
         });
       })
       .with({ type: 'searchVfs' }, async (data) => {
         this.send('vfsPathsResolved', {
           requestId: data.requestId,
           nodeId: data.nodeId,
-          ...(await searchVfsPaths(data.query, data.path))
+          ...(await searchVfsEntries(data.query, data.path))
         });
       })
       .with({ type: 'resolveVfsText' }, async (data) => {

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -59,7 +59,12 @@ import {
 import { match, P } from 'ts-pattern';
 import { profiler, ProfilerCoordinator, typeFromNodeId } from '$lib/profiler';
 import { VirtualFilesystem } from '$lib/vfs';
-import { isExternalUrl, normalizeUserVfsPath } from '$lib/vfs/user-api-paths';
+import {
+  listVfsPaths,
+  resolveVfsText,
+  resolveVfsUrl,
+  searchVfsPaths
+} from '$lib/vfs/worker-requests';
 import { Transport, type TransportState } from '$lib/transport';
 import { FloatTextureUploadBufferPool } from '$lib/float-texture/upload-buffer-pool';
 import type { CapturedVideoFrame, WorkerVideoFrame } from '$lib/js-runner/js-worker-types';
@@ -472,16 +477,32 @@ export class GLSystem {
         this.audioAnalysis.handleRenderWorkerMessage(data);
       })
       .with({ type: 'resolveVfsUrl' }, async (data) => {
-        this.handleVfsUrlResolution(data.requestId, data.nodeId, data.path);
+        this.send('vfsUrlResolved', {
+          requestId: data.requestId,
+          nodeId: data.nodeId,
+          ...(await resolveVfsUrl(data.path))
+        });
       })
       .with({ type: 'listVfs' }, async (data) => {
-        this.handleVfsPathListing(data.requestId, data.nodeId, data.path);
+        this.send('vfsPathsResolved', {
+          requestId: data.requestId,
+          nodeId: data.nodeId,
+          ...(await listVfsPaths(data.path))
+        });
       })
       .with({ type: 'searchVfs' }, async (data) => {
-        this.handleVfsPathSearch(data.requestId, data.nodeId, data.query, data.path);
+        this.send('vfsPathsResolved', {
+          requestId: data.requestId,
+          nodeId: data.nodeId,
+          ...(await searchVfsPaths(data.query, data.path))
+        });
       })
       .with({ type: 'resolveVfsText' }, async (data) => {
-        this.handleVfsTextResolution(data.requestId, data.nodeId, data.path);
+        this.send('vfsTextResolved', {
+          requestId: data.requestId,
+          nodeId: data.nodeId,
+          ...(await resolveVfsText(data.path))
+        });
       })
       .with({ type: 'floatTextureBufferReleased' }, (data) => {
         this.floatTextureUploadBuffers.release(data.buffer);
@@ -622,86 +643,6 @@ export class GLSystem {
       })
       .otherwise(() => {});
   };
-
-  /**
-   * Resolves a VFS path from the worker and sends back an object URL.
-   * Object URLs created on main thread are accessible from workers (same origin).
-   */
-  private async handleVfsUrlResolution(requestId: string, nodeId: string, path: string) {
-    try {
-      // If not a VFS path, send back the original path unchanged
-      if (isExternalUrl(path)) {
-        this.send('vfsUrlResolved', { requestId, nodeId, url: path });
-        return;
-      }
-
-      const vfs = VirtualFilesystem.getInstance();
-      const blob = await vfs.resolve(normalizeUserVfsPath(path));
-
-      // Create object URL on main thread - workers can use it (same origin)
-      const url = URL.createObjectURL(blob);
-
-      // TODO: Track for cleanup when node is destroyed
-      this.send('vfsUrlResolved', { requestId, nodeId, url });
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.send('vfsUrlResolved', { requestId, nodeId, error: errorMessage });
-    }
-  }
-
-  private async handleVfsPathListing(requestId: string, nodeId: string, path: string) {
-    try {
-      const paths = await VirtualFilesystem.getInstance().listChildren(normalizeUserVfsPath(path));
-      this.send('vfsPathsResolved', { requestId, nodeId, paths });
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.send('vfsPathsResolved', { requestId, nodeId, error: errorMessage });
-    }
-  }
-
-  private async handleVfsPathSearch(
-    requestId: string,
-    nodeId: string,
-    query: string,
-    path: string
-  ) {
-    try {
-      const paths = await VirtualFilesystem.getInstance().search(query, normalizeUserVfsPath(path));
-      this.send('vfsPathsResolved', { requestId, nodeId, paths });
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.send('vfsPathsResolved', { requestId, nodeId, error: errorMessage });
-    }
-  }
-
-  /**
-   * Resolves a VFS path from the worker and sends back the text content.
-   * Used by the GLSL #include preprocessor to inline VFS shader files.
-   */
-  private async handleVfsTextResolution(requestId: string, nodeId: string, path: string) {
-    if (!path.startsWith('user://')) {
-      this.send('vfsTextResolved', {
-        requestId,
-        nodeId,
-        error: `Invalid VFS path: "${path}". Only user:// paths are supported.`
-      });
-
-      return;
-    }
-
-    try {
-      const vfs = VirtualFilesystem.getInstance();
-
-      const blob = await vfs.resolve(path);
-      const text = await blob.text();
-
-      this.send('vfsTextResolved', { requestId, nodeId, text });
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-
-      this.send('vfsTextResolved', { requestId, nodeId, error: errorMessage });
-    }
-  }
 
   registerSettingsCallbacks(
     nodeId: string,

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -16,6 +16,14 @@ function getCompletionLabels(nodeType: string, doc: string) {
   return result?.options.map((option) => option.label) ?? [];
 }
 
+function getCompletion(nodeType: string, doc: string, label: string) {
+  const state = EditorState.create({ doc });
+  const context = new CompletionContext(state, doc.length, true);
+  return createPatchiesCompletionSource({ nodeType })(context)?.options.find(
+    (option) => option.label === label
+  );
+}
+
 function getShaderParkCompletionLabels(nodeType: string, doc: string) {
   const state = EditorState.create({ doc });
   const context = new CompletionContext(state, doc.length, true);
@@ -122,6 +130,15 @@ describe('patchies completions', () => {
     );
     expect(getCompletionLabels('js', 'vfs.ge')).toEqual(['getUrl']);
     expect(getCompletionLabels('js', 'vfs.se')).toEqual(['search']);
+  });
+
+  it('applies the VFS completion as an object', () => {
+    expect(getCompletion('vue', 'vf', 'vfs')?.apply).toBe('vfs');
+  });
+
+  it('hides member completions when their owning API is unavailable', () => {
+    expect(getCompletionLabels('dsp~', 'vfs.')).toEqual([]);
+    expect(getCompletionLabels('dsp~', 'fft().')).toEqual([]);
   });
 
   it('shows the VFS object completion in nodes with main-thread VFS access', () => {

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -116,6 +116,19 @@ describe('patchies completions', () => {
     expect(getCompletionLabels('hydra', 'fft().get')).toEqual(['getEnergy']);
   });
 
+  it('shows VFS method completions after vfs.', () => {
+    expect(getCompletionLabels('js', 'vfs.')).toEqual(
+      expect.arrayContaining(['getUrl', 'list', 'search'])
+    );
+    expect(getCompletionLabels('js', 'vfs.ge')).toEqual(['getUrl']);
+    expect(getCompletionLabels('js', 'vfs.se')).toEqual(['search']);
+  });
+
+  it('shows the VFS object completion in nodes with main-thread VFS access', () => {
+    expect(getCompletionLabels('dom', 'vf')).toEqual(['vfs']);
+    expect(getCompletionLabels('vue', 'vf')).toEqual(['vfs']);
+  });
+
   it('shows the documented surface JavaScript API completions', () => {
     const labels = getCompletionLabels('surface', '');
 

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -852,15 +852,15 @@ const memberCompletions: Record<string, Completion[]> = {
     {
       label: 'list',
       type: 'method',
-      detail: '(path?: string) => Promise<string[]>',
-      info: 'List a folder’s immediate children. Defaults to the user:// namespace.',
+      detail: '(path?: string) => Promise<VFSListEntry[]>',
+      info: 'List direct entries with path, name, and kind. Defaults to the user:// namespace.',
       apply: "list('.')"
     },
     {
       label: 'search',
       type: 'method',
-      detail: '(query: string, path?: string) => Promise<string[]>',
-      info: 'Search all descendants of a folder. The path defaults to the user:// namespace.',
+      detail: '(query: string, path?: string) => Promise<VFSListEntry[]>',
+      info: 'Search entries with path, name, and kind. The path defaults to the user:// namespace.',
       apply: "search('')"
     }
   ],

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -743,6 +743,8 @@ const nodeSpecificFunctions: Record<string, string[]> = {
     'textmode.dom',
     'three',
     'three.dom',
+    'dom',
+    'vue',
     'tone~',
     'sonic~',
     'elem~'
@@ -836,6 +838,30 @@ const memberCompletions: Record<string, Completion[]> = {
       detail: "(range: 'bass' | 'lowMid' | 'mid' | 'highMid' | 'treble') => number",
       info: 'Get normalized energy for a named frequency range, or pass two frequency values in Hz for a custom range.',
       apply: "getEnergy('bass')"
+    }
+  ],
+
+  vfs: [
+    {
+      label: 'getUrl',
+      type: 'method',
+      detail: '(path: string) => Promise<string>',
+      info: 'Resolve a virtual filesystem file to a browser URL. Relative paths use the user:// namespace.',
+      apply: "getUrl('./file.png')"
+    },
+    {
+      label: 'list',
+      type: 'method',
+      detail: '(path?: string) => Promise<string[]>',
+      info: 'List a folder’s immediate children. Defaults to the user:// namespace.',
+      apply: "list('.')"
+    },
+    {
+      label: 'search',
+      type: 'method',
+      detail: '(query: string, path?: string) => Promise<string[]>',
+      info: 'Search all descendants of a folder. The path defaults to the user:// namespace.',
+      apply: "search('')"
     }
   ],
 

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -423,11 +423,11 @@ const patchiesAPICompletions: Completion[] = [
 
   // VFS
   {
-    label: 'getVfsUrl',
-    type: 'function',
-    detail: '(path: string) => Promise<string>',
-    info: 'Resolve a VFS path (user://, obj://) to an object URL. Regular URLs pass through unchanged.',
-    apply: "getVfsUrl('user://')"
+    label: 'vfs',
+    type: 'variable',
+    detail: '{ getUrl(path), list(path?), search(query, path?) }',
+    info: 'Access VFS files. Relative paths use the user:// namespace.',
+    apply: "vfs.getUrl('./file.png')"
   },
 
   // Console
@@ -591,7 +591,7 @@ const MOUSE_INTERACTION_JS_NODES = [
 // Note on JSRunner defaults (main-thread nodes):
 // JSRunner.executeJavaScript() provides these by default for main-thread nodes:
 //   console, send, onMessage/recv, setInterval, setTimeout, requestAnimationFrame,
-//   fft, llm, setPortCount, setRunOnMount, setTitle, setHidePorts, setTags, getVfsUrl
+//   fft, llm, setPortCount, setRunOnMount, setTitle, setHidePorts, setTags, vfs
 //
 // Worker nodes (hydra, canvas, textmode, three, swgl) must provide their own
 // implementations via extraContext since JSRunner defaults are for main thread.
@@ -731,7 +731,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   onVideoFrame: ['worker'],
   getVideoFrames: ['worker'],
   setVideoFrame: ['worker'],
-  getVfsUrl: [
+  vfs: [
     'js',
     'worker',
     'p5',

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -426,8 +426,8 @@ const patchiesAPICompletions: Completion[] = [
     label: 'vfs',
     type: 'variable',
     detail: '{ getUrl(path), list(path?), search(query, path?) }',
-    info: 'Access VFS files. Relative paths use the user:// namespace.',
-    apply: "vfs.getUrl('./file.png')"
+    info: "Access VFS files. Relative paths use the user:// namespace. Example: await vfs.getUrl('./file.png')",
+    apply: 'vfs'
   },
 
   // Console
@@ -1226,6 +1226,8 @@ export function createPatchiesCompletionSource(patchiesContext?: PatchiesContext
     const fftMemberMatch = context.matchBefore(/fft\(\)\.\w*/);
 
     if (fftMemberMatch) {
+      if (!isCompletionAllowedForNode({ label: 'fft' }, patchiesContext)) return null;
+
       const partial = fftMemberMatch.text.slice('fft().'.length).toLowerCase();
       const methods = memberCompletions.fft;
 
@@ -1245,6 +1247,8 @@ export function createPatchiesCompletionSource(patchiesContext?: PatchiesContext
       const methods = memberCompletions[obj];
 
       if (methods) {
+        if (!isCompletionAllowedForNode({ label: obj }, patchiesContext)) return null;
+
         const partial = memberMatch.text.slice(dotIdx + 1).toLowerCase();
 
         return {

--- a/ui/src/lib/js-runner/JSRunner.ts
+++ b/ui/src/lib/js-runner/JSRunner.ts
@@ -3,7 +3,7 @@ import { opencv } from './opencv';
 import { MessageContext } from '$lib/messages/MessageContext';
 import { profiler, typeFromNodeId } from '$lib/profiler';
 import { debounce } from 'lodash';
-import { createGetVfsUrl, revokeObjectUrls } from '$lib/vfs';
+import { createVfs, revokeObjectUrls } from '$lib/vfs';
 import { handleCodeError } from './handleCodeError';
 import { logger } from '$lib/utils/logger';
 import { createKVStore } from '$lib/storage';
@@ -426,7 +426,7 @@ export class JSRunner {
       'setHidePorts',
       'setTags',
       'onGraphChange',
-      'getVfsUrl',
+      'vfs',
       'clock',
       'opencv',
       ...Object.keys(extraContext)
@@ -539,7 +539,7 @@ export class JSRunner {
       setHidePorts,
       setTags,
       onGraphChange,
-      createGetVfsUrl(nodeId),
+      createVfs(nodeId),
       clock,
       () => opencv((name) => import(/* @vite-ignore */ `${this.moduleProviderUrl}${name}`)),
       ...Object.values(extraContext)

--- a/ui/src/lib/js-runner/WorkerNodeSystem.ts
+++ b/ui/src/lib/js-runner/WorkerNodeSystem.ts
@@ -5,7 +5,11 @@ import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
 import { MessageChannelRegistry } from '$lib/messages/MessageChannelRegistry';
 import { MessageSystem, type MessageCallbackFn } from '$lib/messages/MessageSystem';
 import { DirectChannelService } from '$lib/messages/DirectChannelService';
-import { listVfsPaths, resolveVfsUrl, searchVfsPaths } from '$lib/vfs/worker-requests';
+import {
+  listVfsEntries,
+  resolveVfsUrl,
+  searchVfsEntries
+} from '$lib/vfs/worker-vfs-request-handler';
 import { profiler, ProfilerCoordinator } from '$lib/profiler';
 import { AudioAnalysisSystem } from '$lib/audio/AudioAnalysisSystem';
 import { SuperSonicManager } from '$lib/audio/SuperSonicManager';
@@ -242,7 +246,7 @@ export class WorkerNodeSystem {
           type: 'vfsPathsResolved',
           nodeId,
           requestId: event.requestId,
-          ...(await listVfsPaths(event.path))
+          ...(await listVfsEntries(event.path))
         } satisfies WorkerMessage);
       })
       .with({ type: 'searchVfs' }, async (event) => {
@@ -250,7 +254,7 @@ export class WorkerNodeSystem {
           type: 'vfsPathsResolved',
           nodeId,
           requestId: event.requestId,
-          ...(await searchVfsPaths(event.query, event.path))
+          ...(await searchVfsEntries(event.query, event.path))
         } satisfies WorkerMessage);
       })
       // LLM proxy messages

--- a/ui/src/lib/js-runner/WorkerNodeSystem.ts
+++ b/ui/src/lib/js-runner/WorkerNodeSystem.ts
@@ -5,8 +5,7 @@ import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
 import { MessageChannelRegistry } from '$lib/messages/MessageChannelRegistry';
 import { MessageSystem, type MessageCallbackFn } from '$lib/messages/MessageSystem';
 import { DirectChannelService } from '$lib/messages/DirectChannelService';
-import { VirtualFilesystem } from '$lib/vfs/VirtualFilesystem';
-import { isExternalUrl, normalizeUserVfsPath } from '$lib/vfs/user-api-paths';
+import { listVfsPaths, resolveVfsUrl, searchVfsPaths } from '$lib/vfs/worker-requests';
 import { profiler, ProfilerCoordinator } from '$lib/profiler';
 import { AudioAnalysisSystem } from '$lib/audio/AudioAnalysisSystem';
 import { SuperSonicManager } from '$lib/audio/SuperSonicManager';
@@ -230,14 +229,29 @@ export class WorkerNodeSystem {
         this.audioAnalysis.registerFFTRequest(nodeId, event.analysisType, event.format);
       })
       // VFS proxy messages
-      .with({ type: 'resolveVfsUrl' }, (event) => {
-        this.handleVfsUrlResolution(nodeId, worker, event.requestId, event.path);
+      .with({ type: 'resolveVfsUrl' }, async (event) => {
+        worker.postMessage({
+          type: 'vfsUrlResolved',
+          nodeId,
+          requestId: event.requestId,
+          ...(await resolveVfsUrl(event.path))
+        } satisfies WorkerMessage);
       })
-      .with({ type: 'listVfs' }, (event) => {
-        this.handleVfsPathListing(nodeId, worker, event.requestId, event.path);
+      .with({ type: 'listVfs' }, async (event) => {
+        worker.postMessage({
+          type: 'vfsPathsResolved',
+          nodeId,
+          requestId: event.requestId,
+          ...(await listVfsPaths(event.path))
+        } satisfies WorkerMessage);
       })
-      .with({ type: 'searchVfs' }, (event) => {
-        this.handleVfsPathSearch(nodeId, worker, event.requestId, event.query, event.path);
+      .with({ type: 'searchVfs' }, async (event) => {
+        worker.postMessage({
+          type: 'vfsPathsResolved',
+          nodeId,
+          requestId: event.requestId,
+          ...(await searchVfsPaths(event.query, event.path))
+        } satisfies WorkerMessage);
       })
       // LLM proxy messages
       .with({ type: 'llmRequest' }, (event) => {
@@ -309,95 +323,6 @@ export class WorkerNodeSystem {
         }
       })
       .otherwise(() => {});
-  }
-
-  /**
-   * Resolve VFS path and send URL back to worker.
-   */
-  private async handleVfsUrlResolution(
-    nodeId: string,
-    worker: Worker,
-    requestId: string,
-    path: string
-  ) {
-    try {
-      // If not a VFS path, send back the original path unchanged
-      if (isExternalUrl(path)) {
-        worker.postMessage({
-          type: 'vfsUrlResolved',
-          nodeId,
-          requestId,
-          url: path
-        } satisfies WorkerMessage);
-        return;
-      }
-
-      const vfs = VirtualFilesystem.getInstance();
-      const blob = await vfs.resolve(normalizeUserVfsPath(path));
-      const url = URL.createObjectURL(blob);
-
-      worker.postMessage({
-        type: 'vfsUrlResolved',
-        nodeId,
-        requestId,
-        url
-      } satisfies WorkerMessage);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      worker.postMessage({
-        type: 'vfsUrlResolved',
-        nodeId,
-        requestId,
-        error: errorMessage
-      } satisfies WorkerMessage);
-    }
-  }
-
-  private async handleVfsPathListing(
-    nodeId: string,
-    worker: Worker,
-    requestId: string,
-    path: string
-  ) {
-    try {
-      worker.postMessage({
-        type: 'vfsPathsResolved',
-        nodeId,
-        requestId,
-        paths: await VirtualFilesystem.getInstance().listChildren(normalizeUserVfsPath(path))
-      } satisfies WorkerMessage);
-    } catch (error) {
-      worker.postMessage({
-        type: 'vfsPathsResolved',
-        nodeId,
-        requestId,
-        error: String(error)
-      } satisfies WorkerMessage);
-    }
-  }
-
-  private async handleVfsPathSearch(
-    nodeId: string,
-    worker: Worker,
-    requestId: string,
-    query: string,
-    path: string
-  ) {
-    try {
-      worker.postMessage({
-        type: 'vfsPathsResolved',
-        nodeId,
-        requestId,
-        paths: await VirtualFilesystem.getInstance().search(query, normalizeUserVfsPath(path))
-      } satisfies WorkerMessage);
-    } catch (error) {
-      worker.postMessage({
-        type: 'vfsPathsResolved',
-        nodeId,
-        requestId,
-        error: String(error)
-      } satisfies WorkerMessage);
-    }
   }
 
   /**

--- a/ui/src/lib/js-runner/WorkerNodeSystem.ts
+++ b/ui/src/lib/js-runner/WorkerNodeSystem.ts
@@ -6,7 +6,7 @@ import { MessageChannelRegistry } from '$lib/messages/MessageChannelRegistry';
 import { MessageSystem, type MessageCallbackFn } from '$lib/messages/MessageSystem';
 import { DirectChannelService } from '$lib/messages/DirectChannelService';
 import { VirtualFilesystem } from '$lib/vfs/VirtualFilesystem';
-import { isVFSPath } from '$lib/vfs/types';
+import { isExternalUrl, normalizeUserVfsPath } from '$lib/vfs/user-api-paths';
 import { profiler, ProfilerCoordinator } from '$lib/profiler';
 import { AudioAnalysisSystem } from '$lib/audio/AudioAnalysisSystem';
 import { SuperSonicManager } from '$lib/audio/SuperSonicManager';
@@ -233,6 +233,12 @@ export class WorkerNodeSystem {
       .with({ type: 'resolveVfsUrl' }, (event) => {
         this.handleVfsUrlResolution(nodeId, worker, event.requestId, event.path);
       })
+      .with({ type: 'listVfs' }, (event) => {
+        this.handleVfsPathListing(nodeId, worker, event.requestId, event.path);
+      })
+      .with({ type: 'searchVfs' }, (event) => {
+        this.handleVfsPathSearch(nodeId, worker, event.requestId, event.query, event.path);
+      })
       // LLM proxy messages
       .with({ type: 'llmRequest' }, (event) => {
         this.llmProxy.handle(
@@ -316,7 +322,7 @@ export class WorkerNodeSystem {
   ) {
     try {
       // If not a VFS path, send back the original path unchanged
-      if (!isVFSPath(path)) {
+      if (isExternalUrl(path)) {
         worker.postMessage({
           type: 'vfsUrlResolved',
           nodeId,
@@ -327,7 +333,7 @@ export class WorkerNodeSystem {
       }
 
       const vfs = VirtualFilesystem.getInstance();
-      const blob = await vfs.resolve(path);
+      const blob = await vfs.resolve(normalizeUserVfsPath(path));
       const url = URL.createObjectURL(blob);
 
       worker.postMessage({
@@ -343,6 +349,53 @@ export class WorkerNodeSystem {
         nodeId,
         requestId,
         error: errorMessage
+      } satisfies WorkerMessage);
+    }
+  }
+
+  private async handleVfsPathListing(
+    nodeId: string,
+    worker: Worker,
+    requestId: string,
+    path: string
+  ) {
+    try {
+      worker.postMessage({
+        type: 'vfsPathsResolved',
+        nodeId,
+        requestId,
+        paths: await VirtualFilesystem.getInstance().listChildren(normalizeUserVfsPath(path))
+      } satisfies WorkerMessage);
+    } catch (error) {
+      worker.postMessage({
+        type: 'vfsPathsResolved',
+        nodeId,
+        requestId,
+        error: String(error)
+      } satisfies WorkerMessage);
+    }
+  }
+
+  private async handleVfsPathSearch(
+    nodeId: string,
+    worker: Worker,
+    requestId: string,
+    query: string,
+    path: string
+  ) {
+    try {
+      worker.postMessage({
+        type: 'vfsPathsResolved',
+        nodeId,
+        requestId,
+        paths: await VirtualFilesystem.getInstance().search(query, normalizeUserVfsPath(path))
+      } satisfies WorkerMessage);
+    } catch (error) {
+      worker.postMessage({
+        type: 'vfsPathsResolved',
+        nodeId,
+        requestId,
+        error: String(error)
       } satisfies WorkerMessage);
     }
   }

--- a/ui/src/lib/js-runner/WorkerNodeSystem.ts
+++ b/ui/src/lib/js-runner/WorkerNodeSystem.ts
@@ -7,6 +7,7 @@ import { MessageSystem, type MessageCallbackFn } from '$lib/messages/MessageSyst
 import { DirectChannelService } from '$lib/messages/DirectChannelService';
 import {
   listVfsEntries,
+  revokeWorkerVfsObjectUrls,
   resolveVfsUrl,
   searchVfsEntries
 } from '$lib/vfs/worker-vfs-request-handler';
@@ -238,7 +239,7 @@ export class WorkerNodeSystem {
           type: 'vfsUrlResolved',
           nodeId,
           requestId: event.requestId,
-          ...(await resolveVfsUrl(event.path))
+          ...(await resolveVfsUrl(nodeId, event.path))
         } satisfies WorkerMessage);
       })
       .with({ type: 'listVfs' }, async (event) => {
@@ -744,6 +745,8 @@ export class WorkerNodeSystem {
   }
 
   destroy(nodeId: string): void {
+    revokeWorkerVfsObjectUrls(nodeId);
+
     const instance = this.workers.get(nodeId);
     if (!instance) return;
 

--- a/ui/src/lib/js-runner/js-worker-types.ts
+++ b/ui/src/lib/js-runner/js-worker-types.ts
@@ -3,6 +3,7 @@ import type { PrimaryButton } from '$lib/eventbus/events';
 import type { SendMessageOptions } from '$lib/messages/MessageContext';
 import type { Message } from '$lib/messages/MessageSystem';
 import type { ProfilerCategory, TimingStats } from '$lib/profiler/types';
+import type { VFSListEntry } from '$lib/vfs/types';
 
 /** Render connection for direct worker-to-render messaging. */
 export interface RenderConnection {
@@ -42,7 +43,13 @@ export type WorkerMessage = { nodeId: string } & (
   | { type: 'cleanup' }
   | { type: 'destroy' }
   | { type: 'vfsUrlResolved'; requestId: string; url?: string; error?: string }
-  | { type: 'vfsPathsResolved'; requestId: string; paths?: string[]; error?: string }
+  | {
+      type: 'vfsPathsResolved';
+      requestId: string;
+      paths?: string[];
+      entries?: VFSListEntry[];
+      error?: string;
+    }
   | { type: 'llmConfig'; requestId: string; text?: string; error?: string }
   | { type: 'setFFTData'; analysisType: string; format: string; array: Uint8Array | Float32Array }
   | {

--- a/ui/src/lib/js-runner/js-worker-types.ts
+++ b/ui/src/lib/js-runner/js-worker-types.ts
@@ -42,6 +42,7 @@ export type WorkerMessage = { nodeId: string } & (
   | { type: 'cleanup' }
   | { type: 'destroy' }
   | { type: 'vfsUrlResolved'; requestId: string; url?: string; error?: string }
+  | { type: 'vfsPathsResolved'; requestId: string; paths?: string[]; error?: string }
   | { type: 'llmConfig'; requestId: string; text?: string; error?: string }
   | { type: 'setFFTData'; analysisType: string; format: string; array: Uint8Array | Float32Array }
   | {
@@ -86,6 +87,8 @@ export type WorkerResponse = { nodeId: string } & (
   | { type: 'fftEnabled'; enabled: boolean }
   | { type: 'registerFFTRequest'; analysisType: AudioAnalysisType; format: AudioAnalysisFormat }
   | { type: 'resolveVfsUrl'; requestId: string; path: string }
+  | { type: 'listVfs'; requestId: string; path: string }
+  | { type: 'searchVfs'; requestId: string; query: string; path: string }
   | { type: 'llmRequest'; requestId: string; prompt: string; imageNodeId?: string; model?: string }
   | { type: 'setVideoCount'; inletCount: number; outletCount: number }
   | { type: 'setVideoFrame'; frame: WorkerVideoFrame }

--- a/ui/src/lib/js-runner/js-worker-types.ts
+++ b/ui/src/lib/js-runner/js-worker-types.ts
@@ -43,13 +43,8 @@ export type WorkerMessage = { nodeId: string } & (
   | { type: 'cleanup' }
   | { type: 'destroy' }
   | { type: 'vfsUrlResolved'; requestId: string; url?: string; error?: string }
-  | {
-      type: 'vfsPathsResolved';
-      requestId: string;
-      paths?: string[];
-      entries?: VFSListEntry[];
-      error?: string;
-    }
+  | { type: 'vfsPathsResolved'; requestId: string; entries: VFSListEntry[]; error?: never }
+  | { type: 'vfsPathsResolved'; requestId: string; error: string; entries?: never }
   | { type: 'llmConfig'; requestId: string; text?: string; error?: string }
   | { type: 'setFFTData'; analysisType: string; format: string; array: Uint8Array | Float32Array }
   | {

--- a/ui/src/lib/presets/preset-packs.ts
+++ b/ui/src/lib/presets/preset-packs.ts
@@ -22,6 +22,14 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     presets: ['logger.js', ...OBJECT_PIPE_PRESETS]
   },
   {
+    id: 'vfs-tools',
+    name: 'VFS Tools',
+    description: 'Browse and search files stored with a patch',
+    icon: 'ScanSearch',
+    requiredObjects: ['vue'],
+    presets: ['File Browser']
+  },
+  {
     id: 'canvas-widgets',
     name: 'Canvas Widgets',
     description: 'Interactive widgets you can play with',

--- a/ui/src/lib/presets/preset-packs.ts
+++ b/ui/src/lib/presets/preset-packs.ts
@@ -22,19 +22,11 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
     presets: ['logger.js', ...OBJECT_PIPE_PRESETS]
   },
   {
-    id: 'vfs-tools',
-    name: 'VFS Tools',
-    description: 'Browse and search files stored with a patch',
-    icon: 'ScanSearch',
-    requiredObjects: ['vue'],
-    presets: ['File Browser']
-  },
-  {
     id: 'canvas-widgets',
     name: 'Canvas Widgets',
     description: 'Interactive widgets you can play with',
     icon: 'Layout',
-    requiredObjects: ['canvas.dom', 'dom', 'surface'],
+    requiredObjects: ['canvas.dom', 'dom', 'surface', 'vue'],
     presets: [
       'XY Pad',
       'HSL Picker',
@@ -42,6 +34,7 @@ export const BUILT_IN_PRESET_PACKS: PresetPack[] = [
       'plotter.canvas',
       'particle.canvas',
       'Drawing Surface',
+      'File Browser',
       'MIDI Keyboard',
       'fractal-tree.canvas',
       'bitmaprenderer'

--- a/ui/src/lib/rendering/types.ts
+++ b/ui/src/lib/rendering/types.ts
@@ -18,6 +18,7 @@ import type { TextmodeRenderNode } from '$objects/textmode/render-types';
 import type { ThreeRenderNode } from '$objects/three/render-types';
 import type { WorkerRenderNode } from '$objects/worker/render-types';
 import type { CapturedVideoFrame } from '$lib/js-runner/js-worker-types';
+import type { VFSListEntry } from '$lib/vfs/types';
 
 export type FBOFormat = 'rgba8' | 'rgba16f' | 'rgba32f';
 
@@ -213,6 +214,7 @@ export type WorkerMessage =
       requestId: string;
       nodeId: string;
       paths?: string[];
+      entries?: VFSListEntry[];
       error?: string;
     }
   | { type: 'vfsTextResolved'; requestId: string; nodeId: string; text?: string; error?: string };

--- a/ui/src/lib/rendering/types.ts
+++ b/ui/src/lib/rendering/types.ts
@@ -213,9 +213,15 @@ export type WorkerMessage =
       type: 'vfsPathsResolved';
       requestId: string;
       nodeId: string;
-      paths?: string[];
-      entries?: VFSListEntry[];
-      error?: string;
+      entries: VFSListEntry[];
+      error?: never;
+    }
+  | {
+      type: 'vfsPathsResolved';
+      requestId: string;
+      nodeId: string;
+      error: string;
+      entries?: never;
     }
   | { type: 'vfsTextResolved'; requestId: string; nodeId: string; text?: string; error?: string };
 

--- a/ui/src/lib/rendering/types.ts
+++ b/ui/src/lib/rendering/types.ts
@@ -208,6 +208,13 @@ export type WorkerMessage =
   | { type: 'settingsValueChanged'; nodeId: string; key: string; value: unknown }
   // VFS resolution responses (main → render worker)
   | { type: 'vfsUrlResolved'; requestId: string; nodeId: string; url?: string; error?: string }
+  | {
+      type: 'vfsPathsResolved';
+      requestId: string;
+      nodeId: string;
+      paths?: string[];
+      error?: string;
+    }
   | { type: 'vfsTextResolved'; requestId: string; nodeId: string; text?: string; error?: string };
 
 export type MouseScope = 'local' | 'global';
@@ -283,6 +290,8 @@ export type RenderWorkerMessage =
   | { type: 'renderFrameStats'; stats: RenderFrameStats }
   | { type: 'error'; message: string }
   | { type: 'resolveVfsUrl'; requestId: string; nodeId: string; path: string }
+  | { type: 'listVfs'; requestId: string; nodeId: string; path: string }
+  | { type: 'searchVfs'; requestId: string; nodeId: string; query: string; path: string }
   | { type: 'resolveVfsText'; requestId: string; nodeId: string; path: string }
   | { type: 'floatTextureBufferReleased'; nodeId: string; buffer: ArrayBuffer }
   | {

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -476,6 +476,95 @@ export class VirtualFilesystem {
     return paths.filter((p) => p.startsWith(prefix));
   }
 
+  /** List the immediate children of a VFS directory, including linked local folders. */
+  async listChildren(directory: string): Promise<string[]> {
+    const prefix = directory.endsWith('://') ? directory : `${directory}/`;
+    const children = new Set<string>();
+
+    for (const path of this.entries.keys()) {
+      if (!path.startsWith(prefix)) continue;
+      const child = path.slice(prefix.length).split('/')[0];
+      if (child) children.add(`${prefix}${child}`);
+    }
+
+    const linkedFolderPath = this.getLinkedFolderForPath(directory);
+    if (linkedFolderPath) {
+      const linkedChildren = await this.listLinkedFolderChildren(directory, linkedFolderPath);
+      for (const child of linkedChildren) children.add(child.path);
+    }
+
+    return [...children].sort();
+  }
+
+  /** Recursively find VFS paths whose path includes the query, case-insensitively. */
+  async search(query: string, directory: string): Promise<string[]> {
+    const prefix = directory.endsWith('://') ? directory : `${directory}/`;
+    const normalizedQuery = query.toLocaleLowerCase();
+    const matches = new Set(
+      this.list(prefix).filter((path) => path.toLocaleLowerCase().includes(normalizedQuery))
+    );
+
+    const containingLinkedFolder = this.getLinkedFolderForPath(directory);
+    const linkedFolderPaths = containingLinkedFolder
+      ? [containingLinkedFolder]
+      : [...this.entries]
+          .filter(([path, entry]) => entry.provider === 'local-folder' && path.startsWith(prefix))
+          .map(([path]) => path);
+
+    for (const linkedFolderPath of linkedFolderPaths) {
+      const searchRoot = containingLinkedFolder ? directory : linkedFolderPath;
+      for (const path of await this.searchLinkedFolder(searchRoot, linkedFolderPath)) {
+        if (path.toLocaleLowerCase().includes(normalizedQuery)) matches.add(path);
+      }
+    }
+
+    return [...matches].sort();
+  }
+
+  private getLinkedFolderForPath(path: string): string | null {
+    return this.entries.get(path)?.provider === 'local-folder'
+      ? path
+      : this.findLinkedFolderForPath(path);
+  }
+
+  private async listLinkedFolderChildren(
+    directory: string,
+    linkedFolderPath: string
+  ): Promise<Array<{ path: string; kind: 'file' | 'directory' }>> {
+    const localProvider = this.getLocalProvider();
+    if (!localProvider)
+      throw new Error('VFS: Local provider not available for linked folder listing');
+
+    let handle = await localProvider.getDirHandle(linkedFolderPath);
+    if (!handle) throw new Error(`VFS: No directory handle for linked folder: ${linkedFolderPath}`);
+    if (!(await localProvider.hasDirPermission(linkedFolderPath))) {
+      throw new Error(`VFS: Permission denied for linked folder: ${linkedFolderPath}`);
+    }
+
+    const relativeSegments =
+      directory === linkedFolderPath ? [] : directory.slice(linkedFolderPath.length + 1).split('/');
+    for (const segment of relativeSegments) {
+      handle = await handle.getDirectoryHandle(segment);
+    }
+
+    const entries = await localProvider.listHandleContents(handle);
+    const pathPrefix = directory.endsWith('/') ? directory : `${directory}/`;
+    return entries.map((entry) => ({ path: `${pathPrefix}${entry.name}`, kind: entry.kind }));
+  }
+
+  private async searchLinkedFolder(directory: string, linkedFolderPath: string): Promise<string[]> {
+    const matches: string[] = [];
+
+    for (const child of await this.listLinkedFolderChildren(directory, linkedFolderPath)) {
+      matches.push(child.path);
+      if (child.kind === 'directory') {
+        matches.push(...(await this.searchLinkedFolder(child.path, linkedFolderPath)));
+      }
+    }
+
+    return matches;
+  }
+
   /**
    * Get all entries as a map.
    */

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -7,6 +7,8 @@ import {
   type VFSTree,
   type VFSTreeNode,
   type VFSProvider,
+  type VFSListEntry,
+  isVFSFolder,
   isVFSEntry,
   isVFSPath,
   parseVFSPath,
@@ -477,37 +479,46 @@ export class VirtualFilesystem {
   }
 
   /** List the immediate children of a VFS directory, including linked local folders. */
-  async listChildren(directory: string): Promise<string[]> {
+  async listChildren(directory: string): Promise<VFSListEntry[]> {
     const entry = this.entries.get(directory);
     if (entry && entry.provider !== 'folder' && entry.provider !== 'local-folder') {
       throw new TypeError(`VFS: Path is not a directory: ${directory}`);
     }
 
     const prefix = directory.endsWith('://') ? directory : `${directory}/`;
-    const children = new Set<string>();
+    const children = new Map<string, VFSListEntry>();
 
     for (const path of this.entries.keys()) {
       if (!path.startsWith(prefix)) continue;
       const child = path.slice(prefix.length).split('/')[0];
-      if (child) children.add(`${prefix}${child}`);
+      if (!child) continue;
+
+      const childPath = `${prefix}${child}`;
+      children.set(childPath, this.createListEntry(childPath));
     }
 
     const linkedFolderPath = this.getLinkedFolderForPath(directory);
     if (linkedFolderPath) {
       const linkedChildren = await this.listLinkedFolderChildren(directory, linkedFolderPath);
-      for (const child of linkedChildren) children.add(child.path);
+      for (const child of linkedChildren) {
+        children.set(child.path, this.createListEntry(child.path, child.kind));
+      }
     }
 
-    return [...children].sort();
+    return [...children.values()].sort((a, b) => a.path.localeCompare(b.path));
   }
 
   /** Recursively find VFS paths whose path includes the query, case-insensitively. */
-  async search(query: string, directory: string): Promise<string[]> {
+  async search(query: string, directory: string): Promise<VFSListEntry[]> {
     const prefix = directory.endsWith('://') ? directory : `${directory}/`;
     const normalizedQuery = query.toLowerCase();
-    const matches = new Set(
-      this.list(prefix).filter((path) => path.toLowerCase().includes(normalizedQuery))
-    );
+    const matches = new Map<string, VFSListEntry>();
+
+    for (const path of this.list(prefix)) {
+      if (path.toLowerCase().includes(normalizedQuery)) {
+        matches.set(path, this.createListEntry(path));
+      }
+    }
 
     const containingLinkedFolder = this.getLinkedFolderForPath(directory);
     const linkedFolderPaths = containingLinkedFolder
@@ -518,12 +529,26 @@ export class VirtualFilesystem {
 
     for (const linkedFolderPath of linkedFolderPaths) {
       const searchRoot = containingLinkedFolder ? directory : linkedFolderPath;
-      for (const path of await this.searchLinkedFolder(searchRoot, linkedFolderPath)) {
-        if (path.toLowerCase().includes(normalizedQuery)) matches.add(path);
+      for (const entry of await this.searchLinkedFolder(searchRoot, linkedFolderPath)) {
+        if (entry.path.toLowerCase().includes(normalizedQuery)) matches.set(entry.path, entry);
       }
     }
 
-    return [...matches].sort();
+    return [...matches.values()].sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  private createListEntry(path: string, kind?: VFSListEntry['kind']): VFSListEntry {
+    const name = path.split('/').filter(Boolean).pop() ?? path;
+    return { path, name, kind: kind ?? this.getPathKind(path) };
+  }
+
+  private getPathKind(path: string): VFSListEntry['kind'] {
+    const entry = this.entries.get(path);
+    if (entry && isVFSFolder(entry)) return 'directory';
+
+    return [...this.entries.keys()].some((entryPath) => entryPath.startsWith(`${path}/`))
+      ? 'directory'
+      : 'file';
   }
 
   private getLinkedFolderForPath(path: string): string | null {
@@ -557,11 +582,14 @@ export class VirtualFilesystem {
     return entries.map((entry) => ({ path: `${pathPrefix}${entry.name}`, kind: entry.kind }));
   }
 
-  private async searchLinkedFolder(directory: string, linkedFolderPath: string): Promise<string[]> {
-    const matches: string[] = [];
+  private async searchLinkedFolder(
+    directory: string,
+    linkedFolderPath: string
+  ): Promise<VFSListEntry[]> {
+    const matches: VFSListEntry[] = [];
 
     for (const child of await this.listLinkedFolderChildren(directory, linkedFolderPath)) {
-      matches.push(child.path);
+      matches.push(this.createListEntry(child.path, child.kind));
       if (child.kind === 'directory') {
         matches.push(...(await this.searchLinkedFolder(child.path, linkedFolderPath)));
       }

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -478,6 +478,11 @@ export class VirtualFilesystem {
 
   /** List the immediate children of a VFS directory, including linked local folders. */
   async listChildren(directory: string): Promise<string[]> {
+    const entry = this.entries.get(directory);
+    if (entry && entry.provider !== 'folder' && entry.provider !== 'local-folder') {
+      throw new TypeError(`VFS: Path is not a directory: ${directory}`);
+    }
+
     const prefix = directory.endsWith('://') ? directory : `${directory}/`;
     const children = new Set<string>();
 
@@ -499,9 +504,9 @@ export class VirtualFilesystem {
   /** Recursively find VFS paths whose path includes the query, case-insensitively. */
   async search(query: string, directory: string): Promise<string[]> {
     const prefix = directory.endsWith('://') ? directory : `${directory}/`;
-    const normalizedQuery = query.toLocaleLowerCase();
+    const normalizedQuery = query.toLowerCase();
     const matches = new Set(
-      this.list(prefix).filter((path) => path.toLocaleLowerCase().includes(normalizedQuery))
+      this.list(prefix).filter((path) => path.toLowerCase().includes(normalizedQuery))
     );
 
     const containingLinkedFolder = this.getLinkedFolderForPath(directory);
@@ -514,7 +519,7 @@ export class VirtualFilesystem {
     for (const linkedFolderPath of linkedFolderPaths) {
       const searchRoot = containingLinkedFolder ? directory : linkedFolderPath;
       for (const path of await this.searchLinkedFolder(searchRoot, linkedFolderPath)) {
-        if (path.toLocaleLowerCase().includes(normalizedQuery)) matches.add(path);
+        if (path.toLowerCase().includes(normalizedQuery)) matches.add(path);
       }
     }
 

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -481,6 +481,7 @@ export class VirtualFilesystem {
   /** List the immediate children of a VFS directory, including linked local folders. */
   async listChildren(directory: string): Promise<VFSListEntry[]> {
     const entry = this.entries.get(directory);
+
     if (entry && entry.provider !== 'folder' && entry.provider !== 'local-folder') {
       throw new TypeError(`VFS: Path is not a directory: ${directory}`);
     }
@@ -490,6 +491,7 @@ export class VirtualFilesystem {
 
     for (const path of this.entries.keys()) {
       if (!path.startsWith(prefix)) continue;
+
       const child = path.slice(prefix.length).split('/')[0];
       if (!child) continue;
 
@@ -498,8 +500,10 @@ export class VirtualFilesystem {
     }
 
     const linkedFolderPath = this.getLinkedFolderForPath(directory);
+
     if (linkedFolderPath) {
       const linkedChildren = await this.listLinkedFolderChildren(directory, linkedFolderPath);
+
       for (const child of linkedChildren) {
         children.set(child.path, this.createListEntry(child.path, child.kind));
       }
@@ -521,6 +525,7 @@ export class VirtualFilesystem {
     }
 
     const containingLinkedFolder = this.getLinkedFolderForPath(directory);
+
     const linkedFolderPaths = containingLinkedFolder
       ? [containingLinkedFolder]
       : [...this.entries]
@@ -529,8 +534,11 @@ export class VirtualFilesystem {
 
     for (const linkedFolderPath of linkedFolderPaths) {
       const searchRoot = containingLinkedFolder ? directory : linkedFolderPath;
+
       for (const entry of await this.searchLinkedFolder(searchRoot, linkedFolderPath)) {
-        if (entry.path.toLowerCase().includes(normalizedQuery)) matches.set(entry.path, entry);
+        if (entry.path.toLowerCase().includes(normalizedQuery)) {
+          matches.set(entry.path, entry);
+        }
       }
     }
 
@@ -539,6 +547,7 @@ export class VirtualFilesystem {
 
   private createListEntry(path: string, kind?: VFSListEntry['kind']): VFSListEntry {
     const name = path.split('/').filter(Boolean).pop() ?? path;
+
     return { path, name, kind: kind ?? this.getPathKind(path) };
   }
 
@@ -562,23 +571,33 @@ export class VirtualFilesystem {
     linkedFolderPath: string
   ): Promise<Array<{ path: string; kind: 'file' | 'directory' }>> {
     const localProvider = this.getLocalProvider();
-    if (!localProvider)
+
+    if (!localProvider) {
       throw new Error('VFS: Local provider not available for linked folder listing');
+    }
 
     let handle = await localProvider.getDirHandle(linkedFolderPath);
-    if (!handle) throw new Error(`VFS: No directory handle for linked folder: ${linkedFolderPath}`);
-    if (!(await localProvider.hasDirPermission(linkedFolderPath))) {
+
+    if (!handle) {
+      throw new Error(`VFS: No directory handle for linked folder: ${linkedFolderPath}`);
+    }
+
+    const hasDirectoryPermission = await localProvider.hasDirPermission(linkedFolderPath);
+
+    if (!hasDirectoryPermission) {
       throw new Error(`VFS: Permission denied for linked folder: ${linkedFolderPath}`);
     }
 
     const relativeSegments =
       directory === linkedFolderPath ? [] : directory.slice(linkedFolderPath.length + 1).split('/');
+
     for (const segment of relativeSegments) {
       handle = await handle.getDirectoryHandle(segment);
     }
 
     const entries = await localProvider.listHandleContents(handle);
     const pathPrefix = directory.endsWith('/') ? directory : `${directory}/`;
+
     return entries.map((entry) => ({ path: `${pathPrefix}${entry.name}`, kind: entry.kind }));
   }
 

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -609,6 +609,7 @@ export class VirtualFilesystem {
 
     for (const child of await this.listLinkedFolderChildren(directory, linkedFolderPath)) {
       matches.push(this.createListEntry(child.path, child.kind));
+
       if (child.kind === 'directory') {
         matches.push(...(await this.searchLinkedFolder(child.path, linkedFolderPath)));
       }

--- a/ui/src/lib/vfs/index.ts
+++ b/ui/src/lib/vfs/index.ts
@@ -33,7 +33,8 @@ export {
 } from './path-utils';
 export { UrlProvider } from './providers/UrlProvider';
 export { LocalFilesystemProvider } from './providers/LocalFilesystemProvider';
-export { createGetVfsUrl, revokeObjectUrls } from './vfs-url-helper';
+export { createVfs, revokeObjectUrls } from './vfs-url-helper';
+export type { VfsApi } from './user-api';
 
 // Persistence utilities (for advanced use)
 export {

--- a/ui/src/lib/vfs/index.ts
+++ b/ui/src/lib/vfs/index.ts
@@ -7,6 +7,7 @@ export { useVfsMedia, type UseVfsMediaOptions, type UseVfsMediaReturn } from './
 
 export {
   type VFSEntry,
+  type VFSListEntry,
   type VFSTree,
   type VFSTreeNode,
   type VFSProvider,

--- a/ui/src/lib/vfs/types.ts
+++ b/ui/src/lib/vfs/types.ts
@@ -22,6 +22,13 @@ export interface VFSEntry {
   size?: number;
 }
 
+/** A file or directory returned from the user-facing VFS browsing API. */
+export interface VFSListEntry {
+  path: string;
+  name: string;
+  kind: 'file' | 'directory';
+}
+
 /**
  * Check if a VFSEntry is a folder (regular or linked)
  */
@@ -94,9 +101,8 @@ export const VFS_DEFAULT_EXPANDED = [VFS_PREFIXES.USER, VFS_PREFIXES.OBJECT] as 
 /**
  * Check if a path is a VFS path (has user:// or obj:// prefix)
  */
-export function isVFSPath(path: string): boolean {
-  return path.startsWith(VFS_PREFIXES.USER) || path.startsWith(VFS_PREFIXES.OBJECT);
-}
+export const isVFSPath = (path: string): boolean =>
+  path.startsWith(VFS_PREFIXES.USER) || path.startsWith(VFS_PREFIXES.OBJECT);
 
 /**
  * Parse a VFS path into its components.
@@ -107,11 +113,15 @@ export function parseVFSPath(
 ): { namespace: 'user' | 'obj'; segments: string[] } | null {
   if (path.startsWith(VFS_PREFIXES.USER)) {
     const rest = path.slice(VFS_PREFIXES.USER.length);
+
     return { namespace: 'user', segments: rest.split('/').filter(Boolean) };
   }
+
   if (path.startsWith(VFS_PREFIXES.OBJECT)) {
     const rest = path.slice(VFS_PREFIXES.OBJECT.length);
+
     return { namespace: 'obj', segments: rest.split('/').filter(Boolean) };
   }
+
   return null;
 }

--- a/ui/src/lib/vfs/user-api-paths.test.ts
+++ b/ui/src/lib/vfs/user-api-paths.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { VirtualFilesystem } from './VirtualFilesystem';
+import { normalizeUserVfsPath } from './user-api-paths';
+
+describe('VFS user API paths', () => {
+  beforeEach(() => {
+    VirtualFilesystem.resetInstance();
+  });
+
+  it('defaults relative paths to the user namespace', () => {
+    expect(normalizeUserVfsPath('.')).toBe('user://');
+    expect(normalizeUserVfsPath('./images/cat.png')).toBe('user://images/cat.png');
+    expect(normalizeUserVfsPath('images/cat.png')).toBe('user://images/cat.png');
+    expect(normalizeUserVfsPath('obj://node/file.txt')).toBe('obj://node/file.txt');
+  });
+
+  it('lists direct children and searches descendants', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const entry = { provider: 'url' as const, filename: 'placeholder' };
+    vfs.registerEntry('user://image.png', entry);
+    vfs.registerEntry('user://samples/kick.wav', entry);
+    vfs.registerEntry('user://samples/snares/snare.wav', entry);
+
+    expect(await vfs.listChildren('user://')).toEqual(['user://image.png', 'user://samples']);
+    expect(await vfs.listChildren('user://samples')).toEqual([
+      'user://samples/kick.wav',
+      'user://samples/snares'
+    ]);
+    expect(await vfs.search('snare', 'user://')).toEqual(['user://samples/snares/snare.wav']);
+  });
+
+  it('lists and searches the contents of linked local folders', async () => {
+    const linkedFolder = {
+      name: 'samples',
+      getDirectoryHandle: async () => kicksFolder,
+      async *values() {
+        yield { name: 'kicks', kind: 'directory' };
+        yield { name: 'snare.wav', kind: 'file' };
+      }
+    } as unknown as FileSystemDirectoryHandle;
+    const kicksFolder = {
+      name: 'kicks',
+      async *values() {
+        yield { name: 'kick.wav', kind: 'file' };
+      },
+      getDirectoryHandle: async () => kicksFolder
+    } as unknown as FileSystemDirectoryHandle;
+    const localProvider = {
+      type: 'local' as const,
+      resolve: async () => new Blob(),
+      storeDirHandle: async () => {},
+      getDirHandle: async () => linkedFolder,
+      hasDirPermission: async () => true,
+      listHandleContents: async (handle: FileSystemDirectoryHandle) => {
+        const entries = [] as Array<{
+          name: string;
+          kind: 'file' | 'directory';
+          handle: FileSystemHandle;
+        }>;
+        for await (const handleEntry of handle.values()) {
+          entries.push({ ...handleEntry, handle: handleEntry as FileSystemHandle });
+        }
+        return entries;
+      }
+    };
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.registerProvider(localProvider);
+    vfs.registerEntry('user://samples', { provider: 'local-folder', filename: 'samples' });
+
+    expect(await vfs.listChildren('user://samples')).toEqual([
+      'user://samples/kicks',
+      'user://samples/snare.wav'
+    ]);
+    expect(await vfs.search('kick', 'user://')).toEqual([
+      'user://samples/kicks',
+      'user://samples/kicks/kick.wav'
+    ]);
+  });
+});

--- a/ui/src/lib/vfs/user-api-paths.test.ts
+++ b/ui/src/lib/vfs/user-api-paths.test.ts
@@ -28,15 +28,20 @@ describe('VFS user API paths', () => {
     vfs.registerEntry('user://samples/kick.wav', entry);
     vfs.registerEntry('user://samples/snares/snare.wav', entry);
 
-    expect(await vfs.listChildren('user://')).toEqual(['user://image.png', 'user://samples']);
+    expect(await vfs.listChildren('user://')).toEqual([
+      { path: 'user://image.png', name: 'image.png', kind: 'file' },
+      { path: 'user://samples', name: 'samples', kind: 'directory' }
+    ]);
     expect(await vfs.listChildren('user://samples')).toEqual([
-      'user://samples/kick.wav',
-      'user://samples/snares'
+      { path: 'user://samples/kick.wav', name: 'kick.wav', kind: 'file' },
+      { path: 'user://samples/snares', name: 'snares', kind: 'directory' }
     ]);
     await expect(vfs.listChildren('user://image.png')).rejects.toThrow(
       'VFS: Path is not a directory: user://image.png'
     );
-    expect(await vfs.search('snare', 'user://')).toEqual(['user://samples/snares/snare.wav']);
+    expect(await vfs.search('snare', 'user://')).toEqual([
+      { path: 'user://samples/snares/snare.wav', name: 'snare.wav', kind: 'file' }
+    ]);
   });
 
   it('lists and searches the contents of linked local folders', async () => {
@@ -78,12 +83,12 @@ describe('VFS user API paths', () => {
     vfs.registerEntry('user://samples', { provider: 'local-folder', filename: 'samples' });
 
     expect(await vfs.listChildren('user://samples')).toEqual([
-      'user://samples/kicks',
-      'user://samples/snare.wav'
+      { path: 'user://samples/kicks', name: 'kicks', kind: 'directory' },
+      { path: 'user://samples/snare.wav', name: 'snare.wav', kind: 'file' }
     ]);
     expect(await vfs.search('kick', 'user://')).toEqual([
-      'user://samples/kicks',
-      'user://samples/kicks/kick.wav'
+      { path: 'user://samples/kicks', name: 'kicks', kind: 'directory' },
+      { path: 'user://samples/kicks/kick.wav', name: 'kick.wav', kind: 'file' }
     ]);
   });
 });

--- a/ui/src/lib/vfs/user-api-paths.test.ts
+++ b/ui/src/lib/vfs/user-api-paths.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { VirtualFilesystem } from './VirtualFilesystem';
-import { normalizeUserVfsPath } from './user-api-paths';
+import { isExternalUrl, normalizeUserVfsPath } from './user-api-paths';
 
 describe('VFS user API paths', () => {
   beforeEach(() => {
@@ -13,6 +13,12 @@ describe('VFS user API paths', () => {
     expect(normalizeUserVfsPath('./images/cat.png')).toBe('user://images/cat.png');
     expect(normalizeUserVfsPath('images/cat.png')).toBe('user://images/cat.png');
     expect(normalizeUserVfsPath('obj://node/file.txt')).toBe('obj://node/file.txt');
+  });
+
+  it('recognizes external URLs, including protocol-relative URLs', () => {
+    expect(isExternalUrl('https://example.com/file.png')).toBe(true);
+    expect(isExternalUrl('//cdn.example.com/file.png')).toBe(true);
+    expect(isExternalUrl('user://file.png')).toBe(false);
   });
 
   it('lists direct children and searches descendants', async () => {
@@ -27,6 +33,9 @@ describe('VFS user API paths', () => {
       'user://samples/kick.wav',
       'user://samples/snares'
     ]);
+    await expect(vfs.listChildren('user://image.png')).rejects.toThrow(
+      'VFS: Path is not a directory: user://image.png'
+    );
     expect(await vfs.search('snare', 'user://')).toEqual(['user://samples/snares/snare.wav']);
   });
 

--- a/ui/src/lib/vfs/user-api-paths.ts
+++ b/ui/src/lib/vfs/user-api-paths.ts
@@ -14,6 +14,8 @@ export function normalizeUserVfsPath(path: string): string {
 
 /** True when a path is an external URL that should not be looked up in the VFS. */
 export function isExternalUrl(path: string): boolean {
+  if (path.startsWith('//')) return true;
+
   try {
     return !isVFSPath(path) && new URL(path).protocol !== '';
   } catch {

--- a/ui/src/lib/vfs/user-api-paths.ts
+++ b/ui/src/lib/vfs/user-api-paths.ts
@@ -1,0 +1,22 @@
+import { isVFSPath, VFS_PREFIXES } from './types';
+
+/** Normalize a user-code path to a VFS path. Relative paths live in `user://`. */
+export function normalizeUserVfsPath(path: string): string {
+  if (isVFSPath(path)) {
+    return path.endsWith('/') && !path.endsWith('://') ? path.slice(0, -1) : path;
+  }
+
+  if (path === '.' || path === './') return VFS_PREFIXES.USER;
+  if (path.startsWith('./')) return `${VFS_PREFIXES.USER}${path.slice(2).replace(/\/$/, '')}`;
+
+  return `${VFS_PREFIXES.USER}${path.replace(/\/$/, '')}`;
+}
+
+/** True when a path is an external URL that should not be looked up in the VFS. */
+export function isExternalUrl(path: string): boolean {
+  try {
+    return !isVFSPath(path) && new URL(path).protocol !== '';
+  } catch {
+    return false;
+  }
+}

--- a/ui/src/lib/vfs/user-api.ts
+++ b/ui/src/lib/vfs/user-api.ts
@@ -1,0 +1,28 @@
+import { VirtualFilesystem } from './VirtualFilesystem';
+import { isExternalUrl, normalizeUserVfsPath } from './user-api-paths';
+
+export interface VfsApi {
+  getUrl(path: string): Promise<string>;
+  list(path?: string): Promise<string[]>;
+  search(query: string, path?: string): Promise<string[]>;
+}
+
+/** Create the VFS API exposed to code that runs on the main thread. */
+export function createVfsApi(trackObjectUrl: (url: string) => void): VfsApi {
+  return {
+    async getUrl(path) {
+      if (typeof window === 'undefined' || isExternalUrl(path)) return path;
+
+      const blob = await VirtualFilesystem.getInstance().resolve(normalizeUserVfsPath(path));
+      const url = URL.createObjectURL(blob);
+      trackObjectUrl(url);
+      return url;
+    },
+    async list(path = '.') {
+      return VirtualFilesystem.getInstance().listChildren(normalizeUserVfsPath(path));
+    },
+    async search(query, path = '.') {
+      return VirtualFilesystem.getInstance().search(query, normalizeUserVfsPath(path));
+    }
+  };
+}

--- a/ui/src/lib/vfs/user-api.ts
+++ b/ui/src/lib/vfs/user-api.ts
@@ -1,10 +1,11 @@
 import { VirtualFilesystem } from './VirtualFilesystem';
+import type { VFSListEntry } from './types';
 import { isExternalUrl, normalizeUserVfsPath } from './user-api-paths';
 
 export interface VfsApi {
   getUrl(path: string): Promise<string>;
-  list(path?: string): Promise<string[]>;
-  search(query: string, path?: string): Promise<string[]>;
+  list(path?: string): Promise<VFSListEntry[]>;
+  search(query: string, path?: string): Promise<VFSListEntry[]>;
 }
 
 /** Create the VFS API exposed to code that runs on the main thread. */
@@ -13,16 +14,23 @@ export function createVfsApi(trackObjectUrl: (url: string) => void): VfsApi {
     async getUrl(path) {
       if (typeof window === 'undefined' || isExternalUrl(path)) return path;
 
-      const blob = await VirtualFilesystem.getInstance().resolve(normalizeUserVfsPath(path));
+      const vfs = VirtualFilesystem.getInstance();
+      const blob = await vfs.resolve(normalizeUserVfsPath(path));
+
       const url = URL.createObjectURL(blob);
       trackObjectUrl(url);
+
       return url;
     },
     async list(path = '.') {
-      return VirtualFilesystem.getInstance().listChildren(normalizeUserVfsPath(path));
+      const vfs = VirtualFilesystem.getInstance();
+
+      return vfs.listChildren(normalizeUserVfsPath(path));
     },
     async search(query, path = '.') {
-      return VirtualFilesystem.getInstance().search(query, normalizeUserVfsPath(path));
+      const vfs = VirtualFilesystem.getInstance();
+
+      return vfs.search(query, normalizeUserVfsPath(path));
     }
   };
 }

--- a/ui/src/lib/vfs/vfs-url-helper.ts
+++ b/ui/src/lib/vfs/vfs-url-helper.ts
@@ -5,7 +5,7 @@
  * Usage: loadImage(await vfsUrl('user://images/photo.jpg'))
  */
 
-import { VirtualFilesystem, isVFSPath } from '$lib/vfs';
+import { createVfsApi, type VfsApi } from './user-api';
 
 /** Object URLs created during the node lifecycle - must be revoked on destroy */
 const objectUrls = new Map<string, Set<string>>();
@@ -44,19 +44,6 @@ export function revokeObjectUrls(nodeId: string): void {
  * // Or with regular URLs (passes through unchanged):
  * img = await loadImage(vfsUrl('https://example.com/image.png'));
  */
-export function createGetVfsUrl(nodeId: string): (path: string) => Promise<string> {
-  return async function vfsUrl(path: string): Promise<string> {
-    // VFS is only accessible on the main thread for now
-    if (typeof window === 'undefined') return path;
-
-    if (!isVFSPath(path)) {
-      return path;
-    }
-
-    const vfs = VirtualFilesystem.getInstance();
-    const blob = await vfs.resolve(path);
-    const url = URL.createObjectURL(blob);
-    trackObjectUrl(nodeId, url);
-    return url;
-  };
+export function createVfs(nodeId: string): VfsApi {
+  return createVfsApi((url) => trackObjectUrl(nodeId, url));
 }

--- a/ui/src/lib/vfs/vfs-url-helper.ts
+++ b/ui/src/lib/vfs/vfs-url-helper.ts
@@ -44,6 +44,5 @@ export function revokeObjectUrls(nodeId: string): void {
  * // Or with regular URLs (passes through unchanged):
  * img = await loadImage(vfsUrl('https://example.com/image.png'));
  */
-export function createVfs(nodeId: string): VfsApi {
-  return createVfsApi((url) => trackObjectUrl(nodeId, url));
-}
+export const createVfs = (nodeId: string): VfsApi =>
+  createVfsApi((url) => trackObjectUrl(nodeId, url));

--- a/ui/src/lib/vfs/vfs-url-helper.ts
+++ b/ui/src/lib/vfs/vfs-url-helper.ts
@@ -1,8 +1,8 @@
 /**
- * VFS URL Helper
+ * Per-node VFS API
  *
- * Provides a `vfsUrl()` helper to resolve VFS paths (user://, obj://) to object URLs.
- * Usage: loadImage(await vfsUrl('user://images/photo.jpg'))
+ * Creates the `vfs` object exposed to JavaScript nodes and tracks object URLs
+ * created by `vfs.getUrl()` for cleanup when the node is destroyed.
  */
 
 import { createVfsApi, type VfsApi } from './user-api';
@@ -32,17 +32,14 @@ export function revokeObjectUrls(nodeId: string): void {
 }
 
 /**
- * Create the vfsUrl helper function for a specific node.
+ * Create the `vfs` object for a specific node.
  *
- * Resolves a VFS path to an object URL that can be loaded.
- * If the path is not a VFS path, returns it unchanged.
+ * The object provides `getUrl()`, `list()`, and `search()`. URLs created by
+ * `getUrl()` are tied to the node lifecycle and revoked on destroy.
  *
  * @example
- * // In preload or setup:
- * img = await loadImage(vfsUrl('user://images/photo.jpg'));
- *
- * // Or with regular URLs (passes through unchanged):
- * img = await loadImage(vfsUrl('https://example.com/image.png'));
+ * const files = await vfs.list('.');
+ * const url = await vfs.getUrl(files[0].path);
  */
 export const createVfs = (nodeId: string): VfsApi =>
   createVfsApi((url) => trackObjectUrl(nodeId, url));

--- a/ui/src/lib/vfs/worker-requests.test.ts
+++ b/ui/src/lib/vfs/worker-requests.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { VirtualFilesystem } from './VirtualFilesystem';
+import { listVfsPaths, resolveVfsText, resolveVfsUrl, searchVfsPaths } from './worker-requests';
+
+describe('worker VFS requests', () => {
+  beforeEach(() => {
+    VirtualFilesystem.resetInstance();
+  });
+
+  it('normalizes and resolves VFS path requests', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const entry = { provider: 'url' as const, filename: 'placeholder' };
+    vfs.registerEntry('user://image.png', entry);
+    vfs.registerEntry('user://samples/kick.wav', entry);
+
+    expect(await listVfsPaths('.')).toEqual({ paths: ['user://image.png', 'user://samples'] });
+    expect(await searchVfsPaths('kick', '.')).toEqual({ paths: ['user://samples/kick.wav'] });
+    expect(await listVfsPaths('./image.png')).toEqual({
+      error: 'VFS: Path is not a directory: user://image.png'
+    });
+  });
+
+  it('keeps external URLs external and limits text requests to user paths', async () => {
+    expect(await resolveVfsUrl('//cdn.example.com/file.png')).toEqual({
+      url: '//cdn.example.com/file.png'
+    });
+    expect(await resolveVfsText('obj://node/file.txt')).toEqual({
+      error: 'Invalid VFS path: "obj://node/file.txt". Only user:// paths are supported.'
+    });
+  });
+});

--- a/ui/src/lib/vfs/worker-requests.ts
+++ b/ui/src/lib/vfs/worker-requests.ts
@@ -1,0 +1,67 @@
+import { VirtualFilesystem } from './VirtualFilesystem';
+import { isExternalUrl, normalizeUserVfsPath } from './user-api-paths';
+
+type VfsUrlResponse = { url: string } | { error: string };
+type VfsPathsResponse = { paths: string[] } | { error: string };
+type VfsTextResponse = { text: string } | { error: string };
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+/** Resolve a worker VFS URL request on the main thread. */
+export async function resolveVfsUrl(path: string): Promise<VfsUrlResponse> {
+  try {
+    if (isExternalUrl(path)) return { url: path };
+
+    const vfs = VirtualFilesystem.getInstance();
+    const blob = await vfs.resolve(normalizeUserVfsPath(path));
+
+    return { url: URL.createObjectURL(blob) };
+  } catch (error) {
+    return { error: getErrorMessage(error) };
+  }
+}
+
+/** List a worker VFS directory request on the main thread. */
+export async function listVfsPaths(path: string): Promise<VfsPathsResponse> {
+  try {
+    const vfs = VirtualFilesystem.getInstance();
+
+    return {
+      paths: await vfs.listChildren(normalizeUserVfsPath(path))
+    };
+  } catch (error) {
+    return { error: getErrorMessage(error) };
+  }
+}
+
+/** Search a worker VFS directory request on the main thread. */
+export async function searchVfsPaths(query: string, path: string): Promise<VfsPathsResponse> {
+  try {
+    const vfs = VirtualFilesystem.getInstance();
+
+    return {
+      paths: await vfs.search(query, normalizeUserVfsPath(path))
+    };
+  } catch (error) {
+    return { error: getErrorMessage(error) };
+  }
+}
+
+/** Resolve a text-only VFS request used by render-worker GLSL includes. */
+export async function resolveVfsText(path: string): Promise<VfsTextResponse> {
+  if (!path.startsWith('user://')) {
+    return {
+      error: `Invalid VFS path: "${path}". Only user:// paths are supported.`
+    };
+  }
+
+  try {
+    const vfs = VirtualFilesystem.getInstance();
+    const file = await vfs.resolve(path);
+
+    return { text: await file.text() };
+  } catch (error) {
+    return { error: getErrorMessage(error) };
+  }
+}

--- a/ui/src/lib/vfs/worker-vfs-request-handler.test.ts
+++ b/ui/src/lib/vfs/worker-vfs-request-handler.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { VirtualFilesystem } from './VirtualFilesystem';
-import { listVfsPaths, resolveVfsText, resolveVfsUrl, searchVfsPaths } from './worker-requests';
+import {
+  listVfsEntries,
+  resolveVfsText,
+  resolveVfsUrl,
+  searchVfsEntries
+} from './worker-vfs-request-handler';
 
 describe('worker VFS requests', () => {
   beforeEach(() => {
@@ -11,12 +16,22 @@ describe('worker VFS requests', () => {
   it('normalizes and resolves VFS path requests', async () => {
     const vfs = VirtualFilesystem.getInstance();
     const entry = { provider: 'url' as const, filename: 'placeholder' };
+
     vfs.registerEntry('user://image.png', entry);
     vfs.registerEntry('user://samples/kick.wav', entry);
 
-    expect(await listVfsPaths('.')).toEqual({ paths: ['user://image.png', 'user://samples'] });
-    expect(await searchVfsPaths('kick', '.')).toEqual({ paths: ['user://samples/kick.wav'] });
-    expect(await listVfsPaths('./image.png')).toEqual({
+    expect(await listVfsEntries('.')).toEqual({
+      entries: [
+        { path: 'user://image.png', name: 'image.png', kind: 'file' },
+        { path: 'user://samples', name: 'samples', kind: 'directory' }
+      ]
+    });
+
+    expect(await searchVfsEntries('kick', '.')).toEqual({
+      entries: [{ path: 'user://samples/kick.wav', name: 'kick.wav', kind: 'file' }]
+    });
+
+    expect(await listVfsEntries('./image.png')).toEqual({
       error: 'VFS: Path is not a directory: user://image.png'
     });
   });
@@ -25,6 +40,7 @@ describe('worker VFS requests', () => {
     expect(await resolveVfsUrl('//cdn.example.com/file.png')).toEqual({
       url: '//cdn.example.com/file.png'
     });
+
     expect(await resolveVfsText('obj://node/file.txt')).toEqual({
       error: 'Invalid VFS path: "obj://node/file.txt". Only user:// paths are supported.'
     });

--- a/ui/src/lib/vfs/worker-vfs-request-handler.test.ts
+++ b/ui/src/lib/vfs/worker-vfs-request-handler.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { VirtualFilesystem } from './VirtualFilesystem';
 import {
   listVfsEntries,
+  revokeWorkerVfsObjectUrls,
   resolveVfsText,
   resolveVfsUrl,
   searchVfsEntries
@@ -11,6 +12,10 @@ import {
 describe('worker VFS requests', () => {
   beforeEach(() => {
     VirtualFilesystem.resetInstance();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('normalizes and resolves VFS path requests', async () => {
@@ -37,12 +42,27 @@ describe('worker VFS requests', () => {
   });
 
   it('keeps external URLs external and limits text requests to user paths', async () => {
-    expect(await resolveVfsUrl('//cdn.example.com/file.png')).toEqual({
+    expect(await resolveVfsUrl('node-1', '//cdn.example.com/file.png')).toEqual({
       url: '//cdn.example.com/file.png'
     });
 
     expect(await resolveVfsText('obj://node/file.txt')).toEqual({
       error: 'Invalid VFS path: "obj://node/file.txt". Only user:// paths are supported.'
     });
+  });
+
+  it('revokes Blob URLs when a worker node is destroyed', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.registerProvider({ type: 'url', resolve: async () => new Blob(['file']) });
+    vfs.registerEntry('user://image.png', { provider: 'url', filename: 'image.png' });
+
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:node-1-image');
+
+    const revoke = vi.spyOn(URL, 'revokeObjectURL');
+    await resolveVfsUrl('node-1', './image.png');
+
+    revokeWorkerVfsObjectUrls('node-1');
+
+    expect(revoke).toHaveBeenCalledWith('blob:node-1-image');
   });
 });

--- a/ui/src/lib/vfs/worker-vfs-request-handler.ts
+++ b/ui/src/lib/vfs/worker-vfs-request-handler.ts
@@ -9,18 +9,42 @@ type VfsTextResponse = { text: string } | { error: string };
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
+const objectUrlsByNode = new Map<string, Set<string>>();
+
+function trackObjectUrl(nodeId: string, url: string): void {
+  const urls = objectUrlsByNode.get(nodeId) ?? new Set<string>();
+
+  urls.add(url);
+  objectUrlsByNode.set(nodeId, urls);
+}
+
 /** Resolve a worker VFS URL request on the main thread. */
-export async function resolveVfsUrl(path: string): Promise<VfsUrlResponse> {
+export async function resolveVfsUrl(nodeId: string, path: string): Promise<VfsUrlResponse> {
   try {
     if (isExternalUrl(path)) return { url: path };
 
     const vfs = VirtualFilesystem.getInstance();
     const blob = await vfs.resolve(normalizeUserVfsPath(path));
 
-    return { url: URL.createObjectURL(blob) };
+    const url = URL.createObjectURL(blob);
+    trackObjectUrl(nodeId, url);
+
+    return { url };
   } catch (error) {
     return { error: getErrorMessage(error) };
   }
+}
+
+/** Revoke all Blob URLs created for a worker node. */
+export function revokeWorkerVfsObjectUrls(nodeId: string): void {
+  const urls = objectUrlsByNode.get(nodeId);
+  if (!urls) return;
+
+  for (const url of urls) {
+    URL.revokeObjectURL(url);
+  }
+
+  objectUrlsByNode.delete(nodeId);
 }
 
 /** List a worker VFS directory request on the main thread. */

--- a/ui/src/lib/vfs/worker-vfs-request-handler.ts
+++ b/ui/src/lib/vfs/worker-vfs-request-handler.ts
@@ -1,8 +1,9 @@
 import { VirtualFilesystem } from './VirtualFilesystem';
+import type { VFSListEntry } from './types';
 import { isExternalUrl, normalizeUserVfsPath } from './user-api-paths';
 
 type VfsUrlResponse = { url: string } | { error: string };
-type VfsPathsResponse = { paths: string[] } | { error: string };
+type VfsEntriesResponse = { entries: VFSListEntry[] } | { error: string };
 type VfsTextResponse = { text: string } | { error: string };
 
 const getErrorMessage = (error: unknown): string =>
@@ -23,12 +24,12 @@ export async function resolveVfsUrl(path: string): Promise<VfsUrlResponse> {
 }
 
 /** List a worker VFS directory request on the main thread. */
-export async function listVfsPaths(path: string): Promise<VfsPathsResponse> {
+export async function listVfsEntries(path: string): Promise<VfsEntriesResponse> {
   try {
     const vfs = VirtualFilesystem.getInstance();
 
     return {
-      paths: await vfs.listChildren(normalizeUserVfsPath(path))
+      entries: await vfs.listChildren(normalizeUserVfsPath(path))
     };
   } catch (error) {
     return { error: getErrorMessage(error) };
@@ -36,12 +37,12 @@ export async function listVfsPaths(path: string): Promise<VfsPathsResponse> {
 }
 
 /** Search a worker VFS directory request on the main thread. */
-export async function searchVfsPaths(query: string, path: string): Promise<VfsPathsResponse> {
+export async function searchVfsEntries(query: string, path: string): Promise<VfsEntriesResponse> {
   try {
     const vfs = VirtualFilesystem.getInstance();
 
     return {
-      paths: await vfs.search(query, normalizeUserVfsPath(path))
+      entries: await vfs.search(query, normalizeUserVfsPath(path))
     };
   } catch (error) {
     return { error: getErrorMessage(error) };

--- a/ui/src/presets/index.ts
+++ b/ui/src/presets/index.ts
@@ -32,6 +32,7 @@ import { SURFACE_PRESETS } from './surface.presets';
 import { CHARTS_PRESETS } from './charts.presets';
 import { UXN_DEMO_PRESETS } from './uxn';
 import { OPENCV_PRESETS } from './opencv';
+import { vfsBrowserPreset } from './vfs-browser.vue';
 
 // Re-export individual preset collections
 export {
@@ -106,5 +107,6 @@ export const BUILTIN_PRESETS: Record<
   ...SURFACE_PRESETS,
   ...CHARTS_PRESETS,
   ...UXN_DEMO_PRESETS,
-  ...OPENCV_PRESETS
+  ...OPENCV_PRESETS,
+  'File Browser': vfsBrowserPreset
 };

--- a/ui/src/presets/three.preset.ts
+++ b/ui/src/presets/three.preset.ts
@@ -106,7 +106,7 @@ renderer.outputColorSpace = SRGBColorSpace
 
 const loader = new GLTFLoader()
 
-// Replace this URL with: await getVfsUrl('user://your-model.glb')
+// Replace this URL with: await vfs.getUrl('user://your-model.glb')
 const modelUrl = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb'
 const gltf = await loader.loadAsync(modelUrl)
 

--- a/ui/src/presets/vfs-browser.vue.ts
+++ b/ui/src/presets/vfs-browser.vue.ts
@@ -120,6 +120,37 @@ async function selectFile(path) {
   }
 }
 
+async function navigateRows(event) {
+  if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) return
+
+  event.preventDefault()
+  event.stopPropagation()
+
+  const rows = Array.from(event.currentTarget.querySelectorAll('[data-vfs-browser-row]'))
+  if (rows.length === 0) return
+
+  const focusedRow = event.target.closest('[data-vfs-browser-row]')
+
+  if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+    const path = focusedRow?.dataset.vfsPath
+    const row = visibleRows.value.find((item) => item.node.path === path)
+    const isFolder = row?.node.children && row.node.children.length > 0
+
+    if (isFolder && ((event.key === 'ArrowRight' && !row.node.expanded) || (event.key === 'ArrowLeft' && row.node.expanded))) {
+      await toggle(row.node)
+    }
+    return
+  }
+
+  const currentIndex = rows.indexOf(focusedRow)
+  const direction = event.key === 'ArrowDown' ? 1 : -1
+  const nextIndex = currentIndex === -1
+    ? (direction > 0 ? 0 : rows.length - 1)
+    : Math.max(0, Math.min(rows.length - 1, currentIndex + direction))
+
+  rows[nextIndex].focus()
+}
+
 watch(query, search)
 refresh()
 
@@ -135,11 +166,12 @@ createApp({
       selectedPath,
       selectedUrl,
       toggle,
+      navigateRows,
       visibleRows
     }
   },
   template: \`
-    <main class="flex h-full min-h-0 flex-col overflow-hidden rounded-[10px] border border-zinc-700 bg-[#09090b] font-sans text-sm text-zinc-100 shadow-[0_10px_30px_rgba(0,0,0,0.35)]">
+    <main class="flex h-full min-h-0 flex-col overflow-hidden rounded-[10px] border border-zinc-700 bg-[#09090b] font-sans text-sm text-zinc-100 shadow-[0_10px_30px_rgba(0,0,0,0.35)]" @keydown="navigateRows">
       <section class="border-b border-zinc-800 px-3 py-2.5">
         <div class="flex items-center gap-2">
           <label class="relative min-w-0 flex-1">
@@ -170,6 +202,8 @@ createApp({
             <button
               v-for="path in searchResults"
               :key="path"
+              data-vfs-browser-row
+              :data-vfs-path="path"
               class="nodrag flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left font-mono text-xs text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/70"
               @click="selectFile(path)"
             >
@@ -185,6 +219,8 @@ createApp({
             <button
               v-for="row in visibleRows"
               :key="row.node.path"
+              data-vfs-browser-row
+              :data-vfs-path="row.node.path"
               class="nodrag flex h-7 w-full cursor-pointer items-center gap-1 rounded-md py-1 text-left text-[12px] text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/70"
               :class="selectedPath === row.node.path ? 'bg-orange-400/15 text-zinc-50 ring-1 ring-inset ring-orange-400/30' : ''"
               :style="{ paddingLeft: (row.depth * 16 + 8) + 'px' }"

--- a/ui/src/presets/vfs-browser.vue.ts
+++ b/ui/src/presets/vfs-browser.vue.ts
@@ -10,12 +10,14 @@ const selectedPath = ref('')
 const selectedUrl = ref('')
 const loading = ref(false)
 const error = ref('')
+let searchRequest = 0
 
 function createNode(path) {
   return {
     path,
     name: path.split('/').filter(Boolean).pop() || path,
     children: null,
+    isDirectory: null,
     expanded: false,
     loading: false
   }
@@ -41,19 +43,23 @@ async function loadChildren(node, quiet = false) {
 
   try {
     node.children = (await vfs.list(node.path)).map(createNode)
+    node.isDirectory = true
     await Promise.all(
       node.children.map(async (child) => {
         try {
           child.children = (await vfs.list(child.path)).map(createNode)
+          child.isDirectory = true
         } catch {
           child.children = []
+          child.isDirectory = false
         }
       })
     )
-    return node.children.length > 0
+    return node.isDirectory
   } catch (cause) {
     if (!quiet) error.value = String(cause)
     node.children = []
+    node.isDirectory = false
     return false
   } finally {
     node.loading = false
@@ -71,17 +77,10 @@ async function refresh() {
 }
 
 async function toggle(node) {
-  if (node.expanded) {
-    node.expanded = false
-    return
-  }
+  if (node.isDirectory === null) await loadChildren(node, true)
 
-  const hasChildren = node.children === null ? await loadChildren(node, true) : node.children.length > 0
-  if (hasChildren) {
-    await Promise.all(
-      node.children.filter((child) => child.children === null).map((child) => loadChildren(child, true))
-    )
-    node.expanded = true
+  if (node.isDirectory) {
+    node.expanded = !node.expanded
     return
   }
 
@@ -89,9 +88,11 @@ async function toggle(node) {
 }
 
 async function search() {
+  const request = ++searchRequest
   const trimmed = query.value.trim()
   if (!trimmed) {
     searchResults.value = []
+    loading.value = false
     return
   }
 
@@ -99,11 +100,12 @@ async function search() {
   error.value = ''
 
   try {
-    searchResults.value = await vfs.search(trimmed, '.')
+    const results = await vfs.search(trimmed, '.')
+    if (request === searchRequest) searchResults.value = results
   } catch (cause) {
-    error.value = String(cause)
+    if (request === searchRequest) error.value = String(cause)
   } finally {
-    loading.value = false
+    if (request === searchRequest) loading.value = false
   }
 }
 
@@ -123,18 +125,19 @@ async function selectFile(path) {
 async function navigateRows(event) {
   if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) return
 
+  const focusedRow = event.target.closest('[data-vfs-browser-row]')
+  if (!focusedRow) return
+
   event.preventDefault()
   event.stopPropagation()
 
   const rows = Array.from(event.currentTarget.querySelectorAll('[data-vfs-browser-row]'))
   if (rows.length === 0) return
 
-  const focusedRow = event.target.closest('[data-vfs-browser-row]')
-
   if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
     const path = focusedRow?.dataset.vfsPath
     const row = visibleRows.value.find((item) => item.node.path === path)
-    const isFolder = row?.node.children && row.node.children.length > 0
+    const isFolder = row?.node.isDirectory === true
 
     if (isFolder && ((event.key === 'ArrowRight' && !row.node.expanded) || (event.key === 'ArrowLeft' && row.node.expanded))) {
       await toggle(row.node)
@@ -228,9 +231,9 @@ createApp({
             >
               <span class="flex size-4 shrink-0 items-center justify-center text-zinc-500">
                 <svg v-if="row.node.loading" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-3 animate-spin" aria-hidden="true"><path d="M20 12a8 8 0 1 1-2.3-5.7"/></svg>
-                <svg v-else-if="row.node.children && row.node.children.length" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-3 transition-transform" :class="row.node.expanded ? 'rotate-90' : ''" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
+                <svg v-else-if="row.node.isDirectory" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-3 transition-transform" :class="row.node.expanded ? 'rotate-90' : ''" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
               </span>
-              <svg v-if="row.node.children && row.node.children.length" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="size-3.5 shrink-0 text-orange-400" aria-hidden="true"><path d="M3 6.5A1.5 1.5 0 0 1 4.5 5h5l1.8 2h8.2A1.5 1.5 0 0 1 21 8.5v9A1.5 1.5 0 0 1 19.5 19h-15A1.5 1.5 0 0 1 3 17.5z"/><path d="M3 9h18"/></svg>
+              <svg v-if="row.node.isDirectory" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="size-3.5 shrink-0 text-orange-400" aria-hidden="true"><path d="M3 6.5A1.5 1.5 0 0 1 4.5 5h5l1.8 2h8.2A1.5 1.5 0 0 1 21 8.5v9A1.5 1.5 0 0 1 19.5 19h-15A1.5 1.5 0 0 1 3 17.5z"/><path d="M3 9h18"/></svg>
               <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="size-3.5 shrink-0 text-zinc-500" aria-hidden="true"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/></svg>
               <span class="truncate">{{ row.node.name }}</span>
             </button>

--- a/ui/src/presets/vfs-browser.vue.ts
+++ b/ui/src/presets/vfs-browser.vue.ts
@@ -12,12 +12,12 @@ const loading = ref(false)
 const error = ref('')
 let searchRequest = 0
 
-function createNode(path) {
+function createNode(entry) {
   return {
-    path,
-    name: path.split('/').filter(Boolean).pop() || path,
+    path: entry.path,
+    name: entry.name,
     children: null,
-    isDirectory: null,
+    isDirectory: entry.kind === 'directory',
     expanded: false,
     loading: false
   }
@@ -44,17 +44,6 @@ async function loadChildren(node, quiet = false) {
   try {
     node.children = (await vfs.list(node.path)).map(createNode)
     node.isDirectory = true
-    await Promise.all(
-      node.children.map(async (child) => {
-        try {
-          child.children = (await vfs.list(child.path)).map(createNode)
-          child.isDirectory = true
-        } catch {
-          child.children = []
-          child.isDirectory = false
-        }
-      })
-    )
     return node.isDirectory
   } catch (cause) {
     if (!quiet) error.value = String(cause)
@@ -70,17 +59,18 @@ async function refresh() {
   loading.value = true
   selectedPath.value = ''
   selectedUrl.value = ''
-  const root = createNode('.')
+  const root = createNode({ path: '.', name: '.', kind: 'directory' })
   await loadChildren(root)
   tree.value = root.children
   loading.value = false
 }
 
 async function toggle(node) {
-  if (node.isDirectory === null) await loadChildren(node, true)
-
   if (node.isDirectory) {
+    if (node.children === null) await loadChildren(node, true)
+
     node.expanded = !node.expanded
+
     return
   }
 
@@ -119,6 +109,26 @@ async function selectFile(path) {
   } catch (cause) {
     selectedUrl.value = ''
     error.value = \`Could not resolve \${path}: \${String(cause)}\`
+  }
+}
+
+async function selectSearchResult(entry) {
+  if (entry.kind === 'file') {
+    await selectFile(entry.path)
+    return
+  }
+
+  query.value = ''
+  const segments = entry.path.replace('user://', '').split('/').filter(Boolean)
+  let nodes = tree.value
+  let path = 'user://'
+
+  for (const segment of segments) {
+    path = path.endsWith('://') ? path + segment : path + '/' + segment
+    const node = nodes.find((item) => item.path === path)
+    if (!node || !node.isDirectory) return
+    if (!node.expanded) await toggle(node)
+    nodes = node.children || []
   }
 }
 
@@ -166,6 +176,7 @@ createApp({
       refresh,
       searchResults,
       selectFile,
+      selectSearchResult,
       selectedPath,
       selectedUrl,
       toggle,
@@ -203,15 +214,16 @@ createApp({
           <p v-if="searchResults.length === 0" class="px-2 py-5 text-center text-xs text-zinc-500">No matching files in this patch.</p>
           <div v-else class="space-y-px">
             <button
-              v-for="path in searchResults"
-              :key="path"
+              v-for="entry in searchResults"
+              :key="entry.path"
               data-vfs-browser-row
-              :data-vfs-path="path"
+              :data-vfs-path="entry.path"
               class="nodrag flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left font-mono text-xs text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/70"
-              @click="selectFile(path)"
+              @click="selectSearchResult(entry)"
             >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="size-3.5 shrink-0 text-zinc-500" aria-hidden="true"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/></svg>
-              <code class="truncate">{{ path }}</code>
+              <svg v-if="entry.kind === 'directory'" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="size-3.5 shrink-0 text-orange-400" aria-hidden="true"><path d="M3 6.5A1.5 1.5 0 0 1 4.5 5h5l1.8 2h8.2A1.5 1.5 0 0 1 21 8.5v9A1.5 1.5 0 0 1 19.5 19h-15A1.5 1.5 0 0 1 3 17.5z"/><path d="M3 9h18"/></svg>
+              <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="size-3.5 shrink-0 text-zinc-500" aria-hidden="true"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/></svg>
+              <code class="truncate">{{ entry.path }}</code>
             </button>
           </div>
         </template>

--- a/ui/src/presets/vfs-browser.vue.ts
+++ b/ui/src/presets/vfs-browser.vue.ts
@@ -1,0 +1,226 @@
+export const VFS_BROWSER_VUE = `setTitle('File Browser')
+noBorder()
+setFluidSize({ initialSize: { width: 460, height: 560 } })
+setPortCount(1, 1)
+
+const query = ref('')
+const tree = ref([])
+const searchResults = ref([])
+const selectedPath = ref('')
+const selectedUrl = ref('')
+const loading = ref(false)
+const error = ref('')
+
+function createNode(path) {
+  return {
+    path,
+    name: path.split('/').filter(Boolean).pop() || path,
+    children: null,
+    expanded: false,
+    loading: false
+  }
+}
+
+const visibleRows = computed(() => {
+  const rows = []
+
+  function visit(nodes, depth) {
+    for (const node of nodes) {
+      rows.push({ node, depth })
+      if (node.expanded && node.children) visit(node.children, depth + 1)
+    }
+  }
+
+  visit(tree.value, 0)
+  return rows
+})
+
+async function loadChildren(node, quiet = false) {
+  node.loading = true
+  if (!quiet) error.value = ''
+
+  try {
+    node.children = (await vfs.list(node.path)).map(createNode)
+    await Promise.all(
+      node.children.map(async (child) => {
+        try {
+          child.children = (await vfs.list(child.path)).map(createNode)
+        } catch {
+          child.children = []
+        }
+      })
+    )
+    return node.children.length > 0
+  } catch (cause) {
+    if (!quiet) error.value = String(cause)
+    node.children = []
+    return false
+  } finally {
+    node.loading = false
+  }
+}
+
+async function refresh() {
+  loading.value = true
+  selectedPath.value = ''
+  selectedUrl.value = ''
+  const root = createNode('.')
+  await loadChildren(root)
+  tree.value = root.children
+  loading.value = false
+}
+
+async function toggle(node) {
+  if (node.expanded) {
+    node.expanded = false
+    return
+  }
+
+  const hasChildren = node.children === null ? await loadChildren(node, true) : node.children.length > 0
+  if (hasChildren) {
+    await Promise.all(
+      node.children.filter((child) => child.children === null).map((child) => loadChildren(child, true))
+    )
+    node.expanded = true
+    return
+  }
+
+  await selectFile(node.path)
+}
+
+async function search() {
+  const trimmed = query.value.trim()
+  if (!trimmed) {
+    searchResults.value = []
+    return
+  }
+
+  loading.value = true
+  error.value = ''
+
+  try {
+    searchResults.value = await vfs.search(trimmed, '.')
+  } catch (cause) {
+    error.value = String(cause)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function selectFile(path) {
+  error.value = ''
+  selectedPath.value = path
+  send(path)
+
+  try {
+    selectedUrl.value = await vfs.getUrl(path)
+  } catch (cause) {
+    selectedUrl.value = ''
+    error.value = \`Could not resolve \${path}: \${String(cause)}\`
+  }
+}
+
+watch(query, search)
+refresh()
+
+createApp({
+  setup() {
+    return {
+      error,
+      loading,
+      query,
+      refresh,
+      searchResults,
+      selectFile,
+      selectedPath,
+      selectedUrl,
+      toggle,
+      visibleRows
+    }
+  },
+  template: \`
+    <main class="flex h-full min-h-0 flex-col overflow-hidden rounded-[10px] border border-zinc-700 bg-[#09090b] font-sans text-sm text-zinc-100 shadow-[0_10px_30px_rgba(0,0,0,0.35)]">
+      <section class="border-b border-zinc-800 px-3 py-2.5">
+        <div class="flex items-center gap-2">
+          <label class="relative min-w-0 flex-1">
+            <span class="sr-only">Search files</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-zinc-500" aria-hidden="true"><circle cx="11" cy="11" r="6"/><path d="m16 16 4 4"/></svg>
+            <input
+              v-model="query"
+              class="nodrag h-8 w-full rounded-md border border-zinc-700 bg-zinc-950 py-1.5 pl-8 pr-2.5 font-mono text-xs text-zinc-100 outline-none placeholder:text-zinc-500 focus:border-orange-400 focus:ring-2 focus:ring-orange-400/20"
+              placeholder="Search files and folders"
+            />
+          </label>
+          <button
+            class="nodrag flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-md border border-zinc-700 bg-zinc-950 text-zinc-400 transition-colors hover:border-zinc-600 hover:bg-zinc-800 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/70 disabled:cursor-not-allowed disabled:opacity-50"
+            :disabled="loading"
+            @click="refresh"
+            aria-label="Refresh files"
+          ><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="size-3.5" aria-hidden="true"><path d="M20 11a8 8 0 0 0-14.8-4.2L3 9"/><path d="M3 4v5h5"/><path d="M4 13a8 8 0 0 0 14.8 4.2L21 15"/><path d="M21 20v-5h-5"/></svg></button>
+        </div>
+      </section>
+
+      <section class="nowheel min-h-0 flex-1 overflow-y-auto p-2">
+        <p v-if="loading" class="flex items-center gap-2 px-2 py-3 text-xs text-zinc-400"><span class="size-1.5 animate-pulse rounded-full bg-orange-400"></span> Reading files…</p>
+        <p v-else-if="error" class="mx-1 rounded-md border border-red-900/70 bg-red-950/30 px-2.5 py-2 text-xs leading-5 text-red-200">{{ error }}</p>
+
+        <template v-else-if="query.trim()">
+          <p v-if="searchResults.length === 0" class="px-2 py-5 text-center text-xs text-zinc-500">No matching files in this patch.</p>
+          <div v-else class="space-y-px">
+            <button
+              v-for="path in searchResults"
+              :key="path"
+              class="nodrag flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left font-mono text-xs text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/70"
+              @click="selectFile(path)"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="size-3.5 shrink-0 text-zinc-500" aria-hidden="true"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/></svg>
+              <code class="truncate">{{ path }}</code>
+            </button>
+          </div>
+        </template>
+
+        <template v-else>
+          <p v-if="visibleRows.length === 0" class="px-2 py-5 text-center text-xs text-zinc-500">Drop files into the patch to browse them here.</p>
+          <div v-else class="space-y-px">
+            <button
+              v-for="row in visibleRows"
+              :key="row.node.path"
+              class="nodrag flex h-7 w-full cursor-pointer items-center gap-1 rounded-md py-1 text-left text-[12px] text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/70"
+              :class="selectedPath === row.node.path ? 'bg-orange-400/15 text-zinc-50 ring-1 ring-inset ring-orange-400/30' : ''"
+              :style="{ paddingLeft: (row.depth * 16 + 8) + 'px' }"
+              @click="toggle(row.node)"
+            >
+              <span class="flex size-4 shrink-0 items-center justify-center text-zinc-500">
+                <svg v-if="row.node.loading" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-3 animate-spin" aria-hidden="true"><path d="M20 12a8 8 0 1 1-2.3-5.7"/></svg>
+                <svg v-else-if="row.node.children && row.node.children.length" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="size-3 transition-transform" :class="row.node.expanded ? 'rotate-90' : ''" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
+              </span>
+              <svg v-if="row.node.children && row.node.children.length" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="size-3.5 shrink-0 text-orange-400" aria-hidden="true"><path d="M3 6.5A1.5 1.5 0 0 1 4.5 5h5l1.8 2h8.2A1.5 1.5 0 0 1 21 8.5v9A1.5 1.5 0 0 1 19.5 19h-15A1.5 1.5 0 0 1 3 17.5z"/><path d="M3 9h18"/></svg>
+              <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="size-3.5 shrink-0 text-zinc-500" aria-hidden="true"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/></svg>
+              <span class="truncate">{{ row.node.name }}</span>
+            </button>
+          </div>
+        </template>
+      </section>
+
+      <footer class="border-t border-zinc-800 bg-zinc-900 px-3 py-2 text-xs">
+        <template v-if="selectedPath">
+          <div class="flex min-w-0 items-center gap-2">
+            <code class="min-w-0 flex-1 truncate font-mono text-[11px] text-zinc-300">{{ selectedPath }}</code>
+            <a v-if="selectedUrl" :href="selectedUrl" target="_blank" rel="noreferrer" class="nodrag inline-flex shrink-0 cursor-pointer items-center gap-1 rounded-sm py-0.5 text-zinc-400 transition-colors hover:text-orange-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400/70">Open file <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="size-3" aria-hidden="true"><path d="M7 17 17 7"/><path d="M9 7h8v8"/></svg></a>
+          </div>
+        </template>
+        <p v-else class="text-zinc-500">Select a file to send its <code class="font-mono text-zinc-400">user://</code> path from the outlet.</p>
+      </footer>
+    </main>
+  \`
+}).mount(root)`;
+
+export const vfsBrowserPreset = {
+  type: 'vue' as const,
+  description: 'Explore and search the patch virtual filesystem',
+  data: {
+    code: VFS_BROWSER_VUE,
+    inletCount: 1,
+    outletCount: 1
+  }
+};

--- a/ui/src/workers/js/jsWorker.ts
+++ b/ui/src/workers/js/jsWorker.ts
@@ -23,6 +23,11 @@ import { createKVStore } from '$lib/storage/KVStore';
 
 import { WorkerProfiler } from '../shared/WorkerProfiler';
 import { createWorkerSettingsProxy, type WorkerSettingsProxy } from '../shared/workerSettingsProxy';
+import {
+  createWorkerVfs,
+  handleVfsPathsResolved,
+  handleVfsUrlResolved
+} from '../rendering/vfsWorkerUtils';
 
 import {
   createDirectChannelHandler,
@@ -141,15 +146,6 @@ function getNodeState(nodeId: string): NodeState {
 
   return nodeStates.get(nodeId)!;
 }
-
-// VFS URL resolution (same pattern as vfsWorkerUtils.ts)
-type PendingVfsRequest = {
-  resolve: (url: string) => void;
-  reject: (error: Error) => void;
-};
-
-const pendingVfsRequests = new Map<string, PendingVfsRequest>();
-let vfsRequestIdCounter = 0;
 
 // LLM config proxying (get credentials from main thread, make HTTP call in worker)
 type PendingLLMConfig = {
@@ -355,21 +351,7 @@ function createWorkerContext(nodeId: string) {
     });
   };
 
-  // getVfsUrl - proxied through main thread (same pattern as vfsWorkerUtils.ts)
-  const getVfsUrl = async (path: string): Promise<string> => {
-    const requestId = `vfs-${nodeId}-${++vfsRequestIdCounter}`;
-
-    return new Promise((resolve, reject) => {
-      pendingVfsRequests.set(requestId, { resolve, reject });
-
-      self.postMessage({
-        type: 'resolveVfsUrl',
-        requestId,
-        nodeId,
-        path
-      });
-    });
-  };
+  const vfs = createWorkerVfs(nodeId);
 
   // Video frame APIs
   const setVideoCount = (inletCount = 1, outletCount = 0) => {
@@ -462,7 +444,7 @@ function createWorkerContext(nodeId: string) {
     requestAnimationFrame,
     fft,
     llm,
-    getVfsUrl,
+    vfs,
     flash,
     setVideoCount,
     onVideoFrame,
@@ -578,7 +560,7 @@ async function executeCode(nodeId: string, processedCode: string) {
     'setRunOnMount',
     'setTitle',
     'setPrimaryButton',
-    'getVfsUrl',
+    'vfs',
     'flash',
     'setVideoCount',
     'onVideoFrame',
@@ -605,7 +587,7 @@ async function executeCode(nodeId: string, processedCode: string) {
     ctx.setRunOnMount,
     ctx.setTitle,
     ctx.setPrimaryButton,
-    ctx.getVfsUrl,
+    ctx.vfs,
     ctx.flash,
     ctx.setVideoCount,
     ctx.onVideoFrame,
@@ -695,31 +677,6 @@ function handleCodeError(nodeId: string, code: string, error: unknown): void {
     level: 'error',
     args: [errorMessage]
   });
-}
-
-// Handle VFS URL resolution response from main thread
-function handleVfsUrlResolved(data: {
-  requestId: string;
-  nodeId: string;
-  url?: string;
-  error?: string;
-}) {
-  const pending = pendingVfsRequests.get(data.requestId);
-  if (!pending) return;
-
-  pendingVfsRequests.delete(data.requestId);
-
-  if (data.error) {
-    pending.reject(new Error(data.error));
-    return;
-  }
-
-  if (data.url) {
-    pending.resolve(data.url);
-    return;
-  }
-
-  pending.reject(new Error('Invalid VFS resolution response'));
 }
 
 // Handle LLM response from main thread (main thread made the actual provider call)
@@ -885,6 +842,9 @@ self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
       handleVfsUrlResolved(
         data as { requestId: string; nodeId: string; url?: string; error?: string }
       );
+    })
+    .with({ type: 'vfsPathsResolved' }, (data) => {
+      handleVfsPathsResolved(data as { requestId: string; paths?: string[]; error?: string });
     })
     .with({ type: 'llmConfig' }, (data) => {
       handleLLMConfig(

--- a/ui/src/workers/js/jsWorker.ts
+++ b/ui/src/workers/js/jsWorker.ts
@@ -844,7 +844,7 @@ self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
       );
     })
     .with({ type: 'vfsPathsResolved' }, (data) => {
-      handleVfsPathsResolved(data as { requestId: string; paths?: string[]; error?: string });
+      handleVfsPathsResolved(data);
     })
     .with({ type: 'llmConfig' }, (data) => {
       handleLLMConfig(

--- a/ui/src/workers/rendering/BaseWorkerRenderer.ts
+++ b/ui/src/workers/rendering/BaseWorkerRenderer.ts
@@ -7,7 +7,7 @@ import type { AudioAnalysisPayloadWithType } from '$lib/audio/AudioAnalysisSyste
 import type { SendMessageOptions } from '$lib/messages/MessageContext';
 import { FFTAnalysis } from '$lib/audio/FFTAnalysis';
 import { parseJSError, countLines } from '$lib/js-runner/js-error-parser';
-import { createWorkerGetVfsUrl } from './vfsWorkerUtils';
+import { createWorkerVfs } from './vfsWorkerUtils';
 import { createWorkerSettingsProxy, type WorkerSettingsProxy } from '../shared/workerSettingsProxy';
 import { createWorkerResolver } from '$lib/glsl-include/worker-resolver';
 import { createGlslTag } from '$lib/glsl-include/tagged-template';
@@ -268,7 +268,7 @@ export abstract class BaseWorkerRenderer<TConfig extends BaseRendererConfig = Ba
       height,
       mouse: this.createMouseObject(),
       fft: this.createFFTFunction(),
-      getVfsUrl: createWorkerGetVfsUrl(this.config.nodeId),
+      vfs: createWorkerVfs(this.config.nodeId),
       glsl: createGlslTag(resolver),
       processIncludes: (source: string) => processIncludes(source, resolver),
       onMessage: this.msgContext.createOnMessageFunction(),

--- a/ui/src/workers/rendering/renderWorker.ts
+++ b/ui/src/workers/rendering/renderWorker.ts
@@ -5,7 +5,7 @@ import { handleVfsTextResolved } from '$lib/glsl-include/vfs-resolver';
 import type { AudioAnalysisPayloadWithType } from '$lib/audio/AudioAnalysisSystem';
 
 import { FBORenderer } from './fboRenderer';
-import { handleVfsUrlResolved } from './vfsWorkerUtils';
+import { handleVfsPathsResolved, handleVfsUrlResolved } from './vfsWorkerUtils';
 import { MediaBunnyService } from './MediaBunnyService';
 import { RenderWorkerLifecycle } from './RenderWorkerLifecycle';
 
@@ -157,6 +157,9 @@ export function installRenderWorkerRuntime() {
       })
       .with('vfsUrlResolved', () => {
         handleVfsUrlResolved(data);
+      })
+      .with('vfsPathsResolved', () => {
+        handleVfsPathsResolved(data);
       })
       .with('vfsTextResolved', () => {
         handleVfsTextResolved(data);

--- a/ui/src/workers/rendering/vfsWorkerUtils.ts
+++ b/ui/src/workers/rendering/vfsWorkerUtils.ts
@@ -5,15 +5,16 @@
  * The main thread resolves the path using VirtualFilesystem, creates an object URL,
  * and sends back the URL string. Workers can use it directly (same origin).
  */
+import type { VFSListEntry } from '$lib/vfs/types';
 
 export interface WorkerVfs {
   getUrl(path: string): Promise<string>;
-  list(path?: string): Promise<string[]>;
-  search(query: string, path?: string): Promise<string[]>;
+  list(path?: string): Promise<VFSListEntry[]>;
+  search(query: string, path?: string): Promise<VFSListEntry[]>;
 }
 
 type PendingVfsRequest = {
-  resolve: (value: string | string[]) => void;
+  resolve: (value: string | string[] | VFSListEntry[]) => void;
   reject: (error: Error) => void;
 };
 
@@ -53,6 +54,7 @@ export function handleVfsUrlResolved(data: {
 export function handleVfsPathsResolved(data: {
   requestId: string;
   paths?: string[];
+  entries?: VFSListEntry[];
   error?: string;
 }): void {
   const pending = pendingVfsRequests.get(data.requestId);
@@ -68,6 +70,10 @@ export function handleVfsPathsResolved(data: {
     return pending.resolve(data.paths);
   }
 
+  if (data.entries) {
+    return pending.resolve(data.entries);
+  }
+
   pending.reject(new Error('Invalid VFS listing response'));
 }
 
@@ -75,7 +81,7 @@ export function handleVfsPathsResolved(data: {
  * Create the VFS API for user code. Requests are resolved on the main thread.
  */
 export function createWorkerVfs(nodeId: string): WorkerVfs {
-  const request = <T extends string | string[]>(
+  const request = <T extends string | string[] | VFSListEntry[]>(
     type: 'resolveVfsUrl' | 'listVfs' | 'searchVfs',
     payload: Record<string, string>
   ): Promise<T> => {
@@ -83,7 +89,7 @@ export function createWorkerVfs(nodeId: string): WorkerVfs {
 
     return new Promise((resolve, reject) => {
       pendingVfsRequests.set(requestId, {
-        resolve: resolve as (value: string | string[]) => void,
+        resolve: resolve as (value: string | string[] | VFSListEntry[]) => void,
         reject
       });
 
@@ -98,7 +104,7 @@ export function createWorkerVfs(nodeId: string): WorkerVfs {
 
   return {
     getUrl: (path) => request<string>('resolveVfsUrl', { path }),
-    list: (path = '.') => request<string[]>('listVfs', { path }),
-    search: (query, path = '.') => request<string[]>('searchVfs', { query, path })
+    list: (path = '.') => request<VFSListEntry[]>('listVfs', { path }),
+    search: (query, path = '.') => request<VFSListEntry[]>('searchVfs', { query, path })
   };
 }

--- a/ui/src/workers/rendering/vfsWorkerUtils.ts
+++ b/ui/src/workers/rendering/vfsWorkerUtils.ts
@@ -59,8 +59,15 @@ export function handleVfsPathsResolved(data: {
   if (!pending) return;
 
   pendingVfsRequests.delete(data.requestId);
-  if (data.error) return pending.reject(new Error(data.error));
-  if (data.paths) return pending.resolve(data.paths);
+
+  if (data.error) {
+    return pending.reject(new Error(data.error));
+  }
+
+  if (data.paths) {
+    return pending.resolve(data.paths);
+  }
+
   pending.reject(new Error('Invalid VFS listing response'));
 }
 

--- a/ui/src/workers/rendering/vfsWorkerUtils.ts
+++ b/ui/src/workers/rendering/vfsWorkerUtils.ts
@@ -6,8 +6,14 @@
  * and sends back the URL string. Workers can use it directly (same origin).
  */
 
+export interface WorkerVfs {
+  getUrl(path: string): Promise<string>;
+  list(path?: string): Promise<string[]>;
+  search(query: string, path?: string): Promise<string[]>;
+}
+
 type PendingVfsRequest = {
-  resolve: (url: string) => void;
+  resolve: (value: string | string[]) => void;
   reject: (error: Error) => void;
 };
 
@@ -44,23 +50,48 @@ export function handleVfsUrlResolved(data: {
   pending.reject(new Error('Invalid VFS resolution response'));
 }
 
+export function handleVfsPathsResolved(data: {
+  requestId: string;
+  paths?: string[];
+  error?: string;
+}): void {
+  const pending = pendingVfsRequests.get(data.requestId);
+  if (!pending) return;
+
+  pendingVfsRequests.delete(data.requestId);
+  if (data.error) return pending.reject(new Error(data.error));
+  if (data.paths) return pending.resolve(data.paths);
+  pending.reject(new Error('Invalid VFS listing response'));
+}
+
 /**
- * Create a getVfsUrl function for use in user code.
- * The function requests VFS resolution from the main thread.
+ * Create the VFS API for user code. Requests are resolved on the main thread.
  */
-export function createWorkerGetVfsUrl(nodeId: string): (path: string) => Promise<string> {
-  return async function getVfsUrl(path: string): Promise<string> {
+export function createWorkerVfs(nodeId: string): WorkerVfs {
+  const request = <T extends string | string[]>(
+    type: 'resolveVfsUrl' | 'listVfs' | 'searchVfs',
+    payload: Record<string, string>
+  ): Promise<T> => {
     const requestId = `vfs-${nodeId}-${++requestIdCounter}`;
 
     return new Promise((resolve, reject) => {
-      pendingVfsRequests.set(requestId, { resolve, reject });
+      pendingVfsRequests.set(requestId, {
+        resolve: resolve as (value: string | string[]) => void,
+        reject
+      });
 
       self.postMessage({
-        type: 'resolveVfsUrl',
+        type,
         requestId,
         nodeId,
-        path
+        ...payload
       });
     });
+  };
+
+  return {
+    getUrl: (path) => request<string>('resolveVfsUrl', { path }),
+    list: (path = '.') => request<string[]>('listVfs', { path }),
+    search: (query, path = '.') => request<string[]>('searchVfs', { query, path })
   };
 }

--- a/ui/src/workers/rendering/vfsWorkerUtils.ts
+++ b/ui/src/workers/rendering/vfsWorkerUtils.ts
@@ -14,7 +14,7 @@ export interface WorkerVfs {
 }
 
 type PendingVfsRequest = {
-  resolve: (value: string | string[] | VFSListEntry[]) => void;
+  resolve: (value: string | VFSListEntry[]) => void;
   reject: (error: Error) => void;
 };
 
@@ -53,7 +53,6 @@ export function handleVfsUrlResolved(data: {
 
 export function handleVfsPathsResolved(data: {
   requestId: string;
-  paths?: string[];
   entries?: VFSListEntry[];
   error?: string;
 }): void {
@@ -64,10 +63,6 @@ export function handleVfsPathsResolved(data: {
 
   if (data.error) {
     return pending.reject(new Error(data.error));
-  }
-
-  if (data.paths) {
-    return pending.resolve(data.paths);
   }
 
   if (data.entries) {
@@ -81,7 +76,7 @@ export function handleVfsPathsResolved(data: {
  * Create the VFS API for user code. Requests are resolved on the main thread.
  */
 export function createWorkerVfs(nodeId: string): WorkerVfs {
-  const request = <T extends string | string[] | VFSListEntry[]>(
+  const request = <T extends string | VFSListEntry[]>(
     type: 'resolveVfsUrl' | 'listVfs' | 'searchVfs',
     payload: Record<string, string>
   ): Promise<T> => {
@@ -89,7 +84,7 @@ export function createWorkerVfs(nodeId: string): WorkerVfs {
 
     return new Promise((resolve, reject) => {
       pendingVfsRequests.set(requestId, {
-        resolve: resolve as (value: string | string[] | VFSListEntry[]) => void,
+        resolve: resolve as (value: string | VFSListEntry[]) => void,
         reject
       });
 

--- a/ui/static/content/objects/vue.md
+++ b/ui/static/content/objects/vue.md
@@ -85,6 +85,10 @@ canvas or GLSL layers. See [HTML in Canvas](/docs/html-in-canvas) for
 `htmlCanvas.videoOutput()`, `htmlCanvas.canvasLayer()`, and
 `htmlCanvas.glslLayer()`.
 
+## Presets
+
+- `File Browser` — a resizable file explorer that demonstrates `vfs.list()`, `vfs.search()`, and `vfs.getUrl()`.
+
 ## See Also
 
 - [dom](/docs/objects/dom) - vanilla JS interfaces

--- a/ui/static/content/topics/js-integrations.md
+++ b/ui/static/content/topics/js-integrations.md
@@ -7,8 +7,15 @@ Use JavaScript to call an AI provider, control object presentation, and set GPU 
 Load images, videos, fonts, and other files from the patch virtual filesystem:
 
 ```javascript
-const url = await getVfsUrl("my-image.png");
+const url = await vfs.getUrl("./my-image.png");
 const img = loadImage(url); // works in p5, for example
+```
+
+List one folder level or search recursively:
+
+```javascript
+const files = await vfs.list(".");
+const samples = await vfs.search("kick", "./samples");
 ```
 
 See [Virtual Filesystem](/docs/virtual-filesystem) to add files to a patch.

--- a/ui/static/content/topics/js-integrations.md
+++ b/ui/static/content/topics/js-integrations.md
@@ -16,6 +16,7 @@ List one folder level or search recursively:
 ```javascript
 const files = await vfs.list(".");
 const samples = await vfs.search("kick", "./samples");
+const folders = files.filter((entry) => entry.kind === "directory");
 ```
 
 See [Virtual Filesystem](/docs/virtual-filesystem) to add files to a patch.

--- a/ui/static/content/topics/manage-files.md
+++ b/ui/static/content/topics/manage-files.md
@@ -33,7 +33,7 @@ Click the **add link** button to store a URL as a virtual file.
 
 ## Use Files in Code
 
-Use `getVfsUrl()` to load files in an object. See [Virtual Filesystem](/docs/virtual-filesystem) for details.
+Use `vfs.getUrl()` to load files in an object. See [Virtual Filesystem](/docs/virtual-filesystem) for details.
 
 ## See Also
 

--- a/ui/static/content/topics/virtual-filesystem.md
+++ b/ui/static/content/topics/virtual-filesystem.md
@@ -34,11 +34,11 @@ VFS paths use the `user://` prefix for uploaded files. Patchies clears object UR
 
 ## Browsing Files in Code
 
-Use `vfs.list()` to inspect one folder level at a time. Use `vfs.search()` to find matching paths anywhere below a folder:
+Use `vfs.list()` to inspect one folder level at a time. Use `vfs.search()` to find matching entries anywhere below a folder. Both return objects with `path`, `name`, and `kind` (`file` or `directory`):
 
 ```javascript
 // Direct children of the user:// root, including folders.
-const rootFiles = await vfs.list(".");
+const rootEntries = await vfs.list(".");
 
 // Every matching path under user://samples.
 const kicks = await vfs.search("kick", "./samples");

--- a/ui/static/content/topics/virtual-filesystem.md
+++ b/ui/static/content/topics/virtual-filesystem.md
@@ -34,7 +34,7 @@ VFS paths use the `user://` prefix for uploaded files. Patchies clears object UR
 
 ## Browsing Files in Code
 
-Use `vfs.list()` to inspect one folder level at a time. Use `vfs.search()` to find matching files anywhere below a folder:
+Use `vfs.list()` to inspect one folder level at a time. Use `vfs.search()` to find matching paths anywhere below a folder:
 
 ```javascript
 // Direct children of the user:// root, including folders.

--- a/ui/static/content/topics/virtual-filesystem.md
+++ b/ui/static/content/topics/virtual-filesystem.md
@@ -14,23 +14,37 @@ See [Files](/docs/manage-files) for file management details.
 
 ## Loading Files in Code
 
-Use `await getVfsUrl(path)` to get the URL for a VFS file:
+Use `await vfs.getUrl(path)` to get the URL for a VFS file. Relative paths use the `user://` namespace:
 
 ```javascript
 // In p5:
 let img;
 
 async function setup() {
-  let url = await getVfsUrl("user://photo.jpg");
+  let url = await vfs.getUrl("./photo.jpg");
   img = await loadImage(url);
 }
 
 // In js or canvas.dom:
-const url = await getVfsUrl("user://data.json");
+const url = await vfs.getUrl("user://data.json");
 const data = await fetch(url).then(r => r.json());
 ```
 
 VFS paths use the `user://` prefix for uploaded files. Patchies clears object URLs when it destroys the object.
+
+## Browsing Files in Code
+
+Use `vfs.list()` to inspect one folder level at a time. Use `vfs.search()` to find matching files anywhere below a folder:
+
+```javascript
+// Direct children of the user:// root, including folders.
+const rootFiles = await vfs.list(".");
+
+// Every matching path under user://samples.
+const kicks = await vfs.search("kick", "./samples");
+```
+
+Both methods also browse linked local folders after you grant Patchies permission.
 
 ## Getting File Content
 
@@ -38,18 +52,18 @@ Get the underlying Blob or raw data:
 
 ```javascript
 // Get as Blob
-const blob = await fetch(await getVfsUrl("user://image.png")).then(r => r.blob());
+const blob = await fetch(await vfs.getUrl("user://image.png")).then(r => r.blob());
 
 // Get as ArrayBuffer (for binary data)
-const buffer = await fetch(await getVfsUrl("user://audio.wav")).then(r => r.arrayBuffer());
+const buffer = await fetch(await vfs.getUrl("user://audio.wav")).then(r => r.arrayBuffer());
 
 // Get as text
-const text = await fetch(await getVfsUrl("user://data.csv")).then(r => r.text());
+const text = await fetch(await vfs.getUrl("user://data.csv")).then(r => r.text());
 ```
 
 ## Supported Objects
 
-Use `getVfsUrl()` in all [JavaScript Runner](/docs/javascript-runner) objects.
+Use `vfs` in all [JavaScript Runner](/docs/javascript-runner)-based objects.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

- Replace `getVfsUrl` with the `vfs` API: `getUrl`, `list`, and `search`.
- Support listing and searching linked local folders across main-thread and worker runtimes.
- Add a File Browser Vue preset with a searchable, expandable file tree, outlet output, and keyboard navigation.
- Add CodeMirror completions for the `vfs` object and its methods.

## Why

JavaScript nodes need a complete virtual filesystem API, including the ability to browse linked local folders. The File Browser preset demonstrates that API in a practical patch.

## Validation

- `bun run test:unit -- src/lib/vfs/user-api-paths.test.ts`
- `bun run test:unit -- src/lib/presets/preset-packs.test.ts`
- `bun run test:unit -- src/lib/codemirror/patchies-completions.test.ts`
- Prettier, ESLint, and `git diff --check` for changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `vfs` API for resolving file URLs, listing directories, and searching files.
  - Added support for browsing and searching linked local folders.
  - Added the built-in **File Browser** preset with navigation, search, refresh, and file selection.
  - Added VFS support to DOM and Vue code nodes.

- **Documentation**
  - Updated examples and guidance to use `vfs.getUrl()`, `vfs.list()`, and `vfs.search()`.
  - Documented relative paths, external URLs, and linked-folder browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->