### PR TITLE
feat(midi, smplr): add CC 64 sustain pedal support

### DIFF
--- a/docs/design-docs/specs/165-smplr-sampled-instruments.md
+++ b/docs/design-docs/specs/165-smplr-sampled-instruments.md
@@ -70,6 +70,13 @@ channel for notes and treat `programChange` as a change to the one active
 instrument. `gm~` is the multi-channel object for Standard MIDI file playback:
 it preserves independent channel state and routes notes by MIDI channel.
 
+Melodic smplr instruments support MIDI CC 64 sustain pedal behavior. Patchies
+uses `1` for pedal down and `0` for pedal up; any positive CC 64 value holds
+subsequent `noteOff` messages, while `0` releases every held note. Normalized
+pedal-on values are sent to smplr as MIDI value `127` so CC-conditioned sample
+regions remain available. `drums~` and `gm~` channel 10 percussion do not use
+sustain-pedal handling.
+
 ## Shared Descriptor Architecture
 
 Each object is described by a smplr instrument descriptor. The Svelte component
@@ -394,6 +401,8 @@ Focused tests should cover:
 - velocity `0` note-on becomes note-off;
 - `noteOff` calls targeted stop with scheduled time;
 - `controlChange` calls `setCC`;
+- melodic smplr instruments defer note-offs while CC 64 is on, then release
+  held notes when the pedal turns off; `drums~` does not;
 - `programChange` updates settings for `soundfont~` and `soundfont2~` mappings;
 - `gm~` keeps program changes scoped to their MIDI channel;
 - `gm~` queues first notes while the target channel's instrument is loading

--- a/ui/src/objects/smplr/GmAudioNode.test.ts
+++ b/ui/src/objects/smplr/GmAudioNode.test.ts
@@ -120,6 +120,34 @@ describe('GmAudioNode', () => {
     });
   });
 
+  it('sustains melodic channels independently while leaving channel 10 unaffected', async () => {
+    const piano = createInstrument();
+    const drums = createInstrument();
+    const module = {
+      Soundfont: () => piano,
+      DrumMachine: () => drums
+    } as unknown as SmplrModule;
+    const node = new GmAudioNode('gm-1', createFakeAudioContext(), async () => module);
+
+    await node.create([{ source: 'soundfont', kit: 'MusyngKite', volume: 100, velocity: 100 }]);
+    await node.send('message', { type: 'noteOn', note: 64, velocity: 90, channel: 2 });
+    await node.send('message', { type: 'controlChange', control: 64, value: 1, channel: 2 });
+    await node.send('message', { type: 'noteOff', note: 64, channel: 2 });
+
+    expect(piano.stop).not.toHaveBeenCalled();
+    expect(piano.setCC).toHaveBeenCalledWith(64, 127);
+
+    await node.send('message', { type: 'controlChange', control: 64, value: 0, channel: 2 });
+
+    expect(piano.stop).toHaveBeenCalledWith({ stopId: 64 });
+
+    await node.send('message', { type: 'noteOn', note: 36, velocity: 90, channel: 10 });
+    await node.send('message', { type: 'controlChange', control: 64, value: 1, channel: 10 });
+    await node.send('message', { type: 'noteOff', note: 36, channel: 10 });
+
+    expect(drums.stop).toHaveBeenCalledWith({ stopId: 36 });
+  });
+
   it('maps soundfont2 programs by parsed instrument order', async () => {
     const loadInstrument = vi.fn(async () => {});
 

--- a/ui/src/objects/smplr/GmAudioNode.test.ts
+++ b/ui/src/objects/smplr/GmAudioNode.test.ts
@@ -148,6 +148,29 @@ describe('GmAudioNode', () => {
     expect(drums.stop).toHaveBeenCalledWith({ stopId: 36 });
   });
 
+  it('releases a sustained note on its original instrument after a program change', async () => {
+    const instruments = new Map<string, SmplrInstrument>();
+    const module = {
+      Soundfont: (_context: AudioContext, options: Record<string, unknown>) => {
+        const instrument = createInstrument();
+        instruments.set(String(options.instrument), instrument);
+        return instrument;
+      }
+    } as unknown as SmplrModule;
+    const node = new GmAudioNode('gm-1', createFakeAudioContext(), async () => module);
+
+    await node.create([{ source: 'soundfont', kit: 'MusyngKite', volume: 100, velocity: 100 }]);
+    await node.send('message', { type: 'noteOn', note: 64, velocity: 90, channel: 2 });
+    await node.send('message', { type: 'controlChange', control: 64, value: 1, channel: 2 });
+    await node.send('message', { type: 'noteOff', note: 64, channel: 2 });
+    await node.send('message', { type: 'programChange', program: 40, channel: 2 });
+    await node.send('message', { type: 'noteOn', note: 65, velocity: 90, channel: 2 });
+    await node.send('message', { type: 'controlChange', control: 64, value: 0, channel: 2 });
+
+    expect(instruments.get('acoustic_grand_piano')?.stop).toHaveBeenCalledWith({ stopId: 64 });
+    expect(instruments.get('violin')?.stop).not.toHaveBeenCalled();
+  });
+
   it('maps soundfont2 programs by parsed instrument order', async () => {
     const loadInstrument = vi.fn(async () => {});
 

--- a/ui/src/objects/smplr/GmAudioNode.ts
+++ b/ui/src/objects/smplr/GmAudioNode.ts
@@ -17,6 +17,7 @@ import {
   getSoundfont2ProgramName
 } from './programs';
 import { DRUM_MACHINE_INSTRUMENTS } from './descriptors';
+import { normalizeSustainPedalValue, SustainPedal } from './SustainPedal';
 
 type Soundfont2Constructor = (typeof import('soundfont2'))['SoundFont2'];
 const CUSTOM_SOUNDFONT_KIT = 'Custom';
@@ -106,6 +107,10 @@ export class GmAudioNode implements AudioNodeV2 {
   private instrumentCache = new Map<string, SmplrInstrument>();
   private loads = new Map<string, Promise<SmplrInstrument | null>>();
   private activeNotes = new Map<number, Set<string>>();
+  private sustainPedals = new Map<
+    number,
+    SustainPedal<{ stopId?: number | string; time?: number }>
+  >();
   private programChannels = new Set<number>();
   private preloadRequests = new Map<string, ProgramRequest>();
   private monitorChannels = createInitialMonitorChannels();
@@ -203,8 +208,12 @@ export class GmAudioNode implements AudioNodeV2 {
       })
       .with({ type: 'stop' }, (stopCommand) => {
         const loaded = this.channels.get(channel);
-        loaded?.instrument.stop(stopCommand.target);
-        this.removeActiveNote(channel, stopCommand.target.stopId);
+
+        if (!this.getSustainPedal(channel).hold(stopCommand.target)) {
+          loaded?.instrument.stop(stopCommand.target);
+          this.removeActiveNote(channel, stopCommand.target.stopId);
+        }
+
         this.updateMonitorChannel(channel, {
           activeNotes: this.getActiveNoteCount(channel),
           lastNote: stopCommand.target.stopId
@@ -212,11 +221,12 @@ export class GmAudioNode implements AudioNodeV2 {
       })
       .with({ type: 'stopAll' }, (stopAllCommand) => {
         this.stopAll(stopAllCommand.time);
+        this.clearSustainPedals();
         this.clearActiveNotes();
       })
       .with({ type: 'cc' }, (ccCommand) => {
         const loaded = this.channels.get(channel);
-        loaded?.instrument.setCC(ccCommand.control, ccCommand.value);
+        this.applyControlChange(channel, loaded?.instrument, ccCommand.control, ccCommand.value);
         this.updateMonitorChannel(channel, { lastControl: ccCommand.control });
       })
       .with({ type: 'program' }, (programCommand) => {
@@ -260,6 +270,9 @@ export class GmAudioNode implements AudioNodeV2 {
 
     this.channels.set(channel, { key, instrument });
     this.applyLiveSettingsTo(instrument);
+    if (!this.isPercussionChannel(channel)) {
+      instrument.setCC(64, this.getSustainPedal(channel).isDown ? 127 : 0);
+    }
     this.updateMonitorChannel(channel, {
       program,
       instrumentName: this.getMonitorInstrumentName(channel, program),
@@ -546,6 +559,57 @@ export class GmAudioNode implements AudioNodeV2 {
     instrument.output.volume = readNumber(this.settings.volume, 100);
   }
 
+  private applyControlChange(
+    channel: number,
+    instrument: SmplrInstrument | undefined,
+    control: number,
+    value: number
+  ): void {
+    const controlValue =
+      this.isPercussionChannel(channel) || control !== 64
+        ? value
+        : normalizeSustainPedalValue(value);
+    instrument?.setCC(control, controlValue);
+
+    if (this.isPercussionChannel(channel) || control !== 64) return;
+
+    this.releaseSustainedNotes(
+      channel,
+      instrument,
+      this.getSustainPedal(channel).set(controlValue)
+    );
+  }
+
+  private getSustainPedal(
+    channel: number
+  ): SustainPedal<{ stopId?: number | string; time?: number }> {
+    const pedal = this.sustainPedals.get(channel) ?? new SustainPedal();
+    this.sustainPedals.set(channel, pedal);
+
+    return pedal;
+  }
+
+  private releaseSustainedNotes(
+    channel: number,
+    instrument: SmplrInstrument | undefined,
+    noteOffs: Array<{ stopId?: number | string; time?: number }>
+  ): void {
+    for (const target of noteOffs) {
+      instrument?.stop(target);
+      this.removeActiveNote(channel, target.stopId);
+    }
+
+    if (noteOffs.length === 0) return;
+
+    this.updateMonitorChannel(channel, { activeNotes: this.getActiveNoteCount(channel) });
+  }
+
+  private clearSustainPedals(): void {
+    for (const pedal of this.sustainPedals.values()) {
+      pedal.clear();
+    }
+  }
+
   private stopAll(time?: number): void {
     for (const { instrument } of this.channels.values()) {
       instrument.stop(time === undefined ? undefined : { time });
@@ -615,6 +679,7 @@ export class GmAudioNode implements AudioNodeV2 {
     this.channels.clear();
     this.instrumentCache.clear();
     this.loads.clear();
+    this.sustainPedals.clear();
   }
 }
 

--- a/ui/src/objects/smplr/GmAudioNode.ts
+++ b/ui/src/objects/smplr/GmAudioNode.ts
@@ -17,7 +17,7 @@ import {
   getSoundfont2ProgramName
 } from './programs';
 import { DRUM_MACHINE_INSTRUMENTS } from './descriptors';
-import { normalizeSustainPedalValue, SustainPedal } from './SustainPedal';
+import { ChannelSustainPedals, normalizeSustainPedalValue } from './SustainPedal';
 
 type Soundfont2Constructor = (typeof import('soundfont2'))['SoundFont2'];
 const CUSTOM_SOUNDFONT_KIT = 'Custom';
@@ -72,6 +72,11 @@ type LoadedProgramMetadata = {
   preloadPrograms: ProgramRequest[];
 };
 
+type SustainedNoteOff = {
+  instrument: SmplrInstrument | undefined;
+  target: { stopId?: number | string; time?: number };
+};
+
 const GM_PERCUSSION_CHANNEL = 10;
 
 export class GmAudioNode implements AudioNodeV2 {
@@ -107,10 +112,7 @@ export class GmAudioNode implements AudioNodeV2 {
   private instrumentCache = new Map<string, SmplrInstrument>();
   private loads = new Map<string, Promise<SmplrInstrument | null>>();
   private activeNotes = new Map<number, Set<string>>();
-  private sustainPedals = new Map<
-    number,
-    SustainPedal<{ stopId?: number | string; time?: number }>
-  >();
+  private sustainPedals = new ChannelSustainPedals<SustainedNoteOff>();
   private programChannels = new Set<number>();
   private preloadRequests = new Map<string, ProgramRequest>();
   private monitorChannels = createInitialMonitorChannels();
@@ -209,7 +211,12 @@ export class GmAudioNode implements AudioNodeV2 {
       .with({ type: 'stop' }, (stopCommand) => {
         const loaded = this.channels.get(channel);
 
-        if (!this.getSustainPedal(channel).hold(stopCommand.target)) {
+        if (
+          !this.sustainPedals.hold(channel, {
+            instrument: loaded?.instrument,
+            target: stopCommand.target
+          })
+        ) {
           loaded?.instrument.stop(stopCommand.target);
           this.removeActiveNote(channel, stopCommand.target.stopId);
         }
@@ -221,7 +228,7 @@ export class GmAudioNode implements AudioNodeV2 {
       })
       .with({ type: 'stopAll' }, (stopAllCommand) => {
         this.stopAll(stopAllCommand.time);
-        this.clearSustainPedals();
+        this.sustainPedals.clearHeld();
         this.clearActiveNotes();
       })
       .with({ type: 'cc' }, (ccCommand) => {
@@ -271,7 +278,7 @@ export class GmAudioNode implements AudioNodeV2 {
     this.channels.set(channel, { key, instrument });
     this.applyLiveSettingsTo(instrument);
     if (!this.isPercussionChannel(channel)) {
-      instrument.setCC(64, this.getSustainPedal(channel).isDown ? 127 : 0);
+      instrument.setCC(64, this.sustainPedals.isDown(channel) ? 127 : 0);
     }
     this.updateMonitorChannel(channel, {
       program,
@@ -573,41 +580,16 @@ export class GmAudioNode implements AudioNodeV2 {
 
     if (this.isPercussionChannel(channel) || control !== 64) return;
 
-    this.releaseSustainedNotes(
-      channel,
-      instrument,
-      this.getSustainPedal(channel).set(controlValue)
-    );
-  }
+    const noteOffs = this.sustainPedals.set(channel, controlValue);
 
-  private getSustainPedal(
-    channel: number
-  ): SustainPedal<{ stopId?: number | string; time?: number }> {
-    const pedal = this.sustainPedals.get(channel) ?? new SustainPedal();
-    this.sustainPedals.set(channel, pedal);
-
-    return pedal;
-  }
-
-  private releaseSustainedNotes(
-    channel: number,
-    instrument: SmplrInstrument | undefined,
-    noteOffs: Array<{ stopId?: number | string; time?: number }>
-  ): void {
-    for (const target of noteOffs) {
-      instrument?.stop(target);
+    for (const { instrument: noteInstrument, target } of noteOffs) {
+      noteInstrument?.stop(target);
       this.removeActiveNote(channel, target.stopId);
     }
 
     if (noteOffs.length === 0) return;
 
     this.updateMonitorChannel(channel, { activeNotes: this.getActiveNoteCount(channel) });
-  }
-
-  private clearSustainPedals(): void {
-    for (const pedal of this.sustainPedals.values()) {
-      pedal.clear();
-    }
   }
 
   private stopAll(time?: number): void {

--- a/ui/src/objects/smplr/SmplrInstrumentAudioNode.test.ts
+++ b/ui/src/objects/smplr/SmplrInstrumentAudioNode.test.ts
@@ -32,7 +32,8 @@ function createInstrument() {
 }
 
 function createDescriptor(
-  loadInstrument: SmplrInstrumentDescriptor['loadInstrument']
+  loadInstrument: SmplrInstrumentDescriptor['loadInstrument'],
+  supportsSustainPedal = false
 ): SmplrInstrumentDescriptor {
   return {
     type: 'soundfont~',
@@ -43,6 +44,7 @@ function createDescriptor(
     reloadsOnSettings: ['instrument'],
     defaultBangNote: '60',
     defaultVelocity: 100,
+    supportsSustainPedal,
     getDisplayName: (settings) => String(settings.instrument ?? 'piano'),
     loadInstrument
   };
@@ -110,6 +112,28 @@ describe('SmplrInstrumentAudioNode', () => {
 
     expect(load).toHaveBeenCalledTimes(2);
     expect(first.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('holds piano note-offs until a released sustain pedal', async () => {
+    const instrument = createInstrument();
+    const node = new SmplrInstrumentAudioNode(
+      'smplr-1',
+      createFakeAudioContext(),
+      createDescriptor(async () => instrument, true)
+    );
+
+    await node.create([{ instrument: 'piano', volume: 100, velocity: 100, defaultNote: '60' }]);
+    instrument.stop.mockClear();
+
+    node.send('message', { type: 'controlChange', control: 64, value: 1 });
+    node.send('message', { type: 'noteOff', note: 64 });
+
+    expect(instrument.stop).not.toHaveBeenCalled();
+    expect(instrument.setCC).toHaveBeenCalledWith(64, 127);
+
+    node.send('message', { type: 'controlChange', control: 64, value: 0 });
+
+    expect(instrument.stop).toHaveBeenCalledWith({ stopId: 64 });
   });
 
   it('ignores stale async loads when a newer load wins', async () => {

--- a/ui/src/objects/smplr/SmplrInstrumentAudioNode.ts
+++ b/ui/src/objects/smplr/SmplrInstrumentAudioNode.ts
@@ -1,5 +1,6 @@
 import type { AudioNodeGroup, AudioNodeV2 } from '$lib/audio/v2/interfaces/audio-nodes';
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
+import { match } from 'ts-pattern';
 import { normalizeSmplrMessage } from './messages';
 import type { SmplrInstrument, SmplrInstrumentDescriptor, SmplrModule } from './descriptors';
 import { normalizeSustainPedalValue, SustainPedal } from './SustainPedal';
@@ -34,6 +35,7 @@ export class SmplrInstrumentAudioNode implements AudioNodeV2 {
   ];
 
   readonly nodeId: string;
+
   audioNode: GainNode;
   instrument: SmplrInstrument | null = null;
   onStatusChange?: (status: SmplrRuntimeStatus) => void;
@@ -125,9 +127,11 @@ export class SmplrInstrumentAudioNode implements AudioNodeV2 {
 
       this.disposeInstrument(this.instrument);
       this.instrument = instrument;
+
       this.sustainPedal.clear();
       this.applyLiveSettings(settings);
       this.applySustainPedalState();
+
       this.onStatusChange?.({
         state: 'ready',
         instrumentName: this.descriptor.getDisplayName(settings),
@@ -147,35 +151,23 @@ export class SmplrInstrumentAudioNode implements AudioNodeV2 {
     const instrument = this.instrument;
     if (!instrument) return;
 
-    switch (command.type) {
-      case 'start':
-        instrument.start(command.event);
-        break;
-      case 'stop':
-        this.stopNote(instrument, command.target);
-        break;
-      case 'stopAll':
+    match(command)
+      .with({ type: 'start' }, ({ event }) => instrument.start(event))
+      .with({ type: 'stop' }, ({ target }) => this.stopNote(instrument, target))
+      .with({ type: 'stopAll' }, ({ time }) => {
         this.sustainPedal.clear();
-        instrument.stop(command.time === undefined ? undefined : { time: command.time });
-        break;
-      case 'cc':
-        this.applyControlChange(instrument, command.control, command.value);
-        break;
-      case 'program':
-        this.applyProgramChange(command.program);
-        break;
-      case 'volume':
-        instrument.output.volume = command.value;
-        break;
-      case 'detune':
-        instrument.setDetune(command.value);
-        break;
-      case 'reverse':
-        instrument.setReverse(command.value);
-        break;
-      case 'ignored':
-        break;
-    }
+
+        instrument.stop(time === undefined ? undefined : { time });
+      })
+      .with({ type: 'cc' }, ({ control, value }) =>
+        this.applyControlChange(instrument, control, value)
+      )
+      .with({ type: 'program' }, ({ program }) => this.applyProgramChange(program))
+      .with({ type: 'volume' }, ({ value }) => (instrument.output.volume = value))
+      .with({ type: 'detune' }, ({ value }) => instrument.setDetune(value))
+      .with({ type: 'reverse' }, ({ value }) => instrument.setReverse(value))
+      .with({ type: 'ignored' }, () => {})
+      .exhaustive();
   }
 
   private applyProgramChange(program: number): void {

--- a/ui/src/objects/smplr/SmplrInstrumentAudioNode.ts
+++ b/ui/src/objects/smplr/SmplrInstrumentAudioNode.ts
@@ -2,6 +2,7 @@ import type { AudioNodeGroup, AudioNodeV2 } from '$lib/audio/v2/interfaces/audio
 import type { ObjectInlet, ObjectOutlet } from '$lib/objects/v2/object-metadata';
 import { normalizeSmplrMessage } from './messages';
 import type { SmplrInstrument, SmplrInstrumentDescriptor, SmplrModule } from './descriptors';
+import { normalizeSustainPedalValue, SustainPedal } from './SustainPedal';
 
 export type SmplrRuntimeStatus =
   | { state: 'idle' }
@@ -38,8 +39,10 @@ export class SmplrInstrumentAudioNode implements AudioNodeV2 {
   onStatusChange?: (status: SmplrRuntimeStatus) => void;
   onSettingsPatch?: (patch: Record<string, unknown>) => void;
 
-  private settings: Record<string, unknown> = {};
   private loadToken = 0;
+  private settings: Record<string, unknown> = {};
+
+  private sustainPedal = new SustainPedal<{ stopId?: number | string; time?: number }>();
 
   constructor(
     nodeId: string,
@@ -53,12 +56,14 @@ export class SmplrInstrumentAudioNode implements AudioNodeV2 {
 
   async create(params: unknown[]): Promise<void> {
     const settings = params.length === 1 ? params[0] : params[1];
+
     await this.reload(asSettings(settings));
   }
 
   async send(key: string, message: unknown): Promise<void> {
     if (key === 'settings') {
       await this.applySettings(asSettings(message));
+
       return;
     }
 
@@ -95,6 +100,7 @@ export class SmplrInstrumentAudioNode implements AudioNodeV2 {
 
   private async reload(settings: Record<string, unknown>): Promise<void> {
     const token = ++this.loadToken;
+
     this.settings = { ...settings };
     this.onStatusChange?.({ state: 'loading', loaded: 0, total: 0 });
 
@@ -119,7 +125,9 @@ export class SmplrInstrumentAudioNode implements AudioNodeV2 {
 
       this.disposeInstrument(this.instrument);
       this.instrument = instrument;
+      this.sustainPedal.clear();
       this.applyLiveSettings(settings);
+      this.applySustainPedalState();
       this.onStatusChange?.({
         state: 'ready',
         instrumentName: this.descriptor.getDisplayName(settings),
@@ -144,13 +152,14 @@ export class SmplrInstrumentAudioNode implements AudioNodeV2 {
         instrument.start(command.event);
         break;
       case 'stop':
-        instrument.stop(command.target);
+        this.stopNote(instrument, command.target);
         break;
       case 'stopAll':
+        this.sustainPedal.clear();
         instrument.stop(command.time === undefined ? undefined : { time: command.time });
         break;
       case 'cc':
-        instrument.setCC(command.control, command.value);
+        this.applyControlChange(instrument, command.control, command.value);
         break;
       case 'program':
         this.applyProgramChange(command.program);
@@ -178,16 +187,48 @@ export class SmplrInstrumentAudioNode implements AudioNodeV2 {
     if (!patch) return;
 
     this.onSettingsPatch?.(patch);
-    void this.applySettings({ ...this.settings, ...patch });
+    this.applySettings({ ...this.settings, ...patch });
+  }
+
+  private stopNote(
+    instrument: SmplrInstrument,
+    target: { stopId?: number | string; time?: number }
+  ): void {
+    if (this.descriptor.supportsSustainPedal && this.sustainPedal.hold(target)) return;
+
+    instrument.stop(target);
+  }
+
+  private applyControlChange(instrument: SmplrInstrument, control: number, value: number): void {
+    const controlValue =
+      this.descriptor.supportsSustainPedal && control === 64
+        ? normalizeSustainPedalValue(value)
+        : value;
+
+    instrument.setCC(control, controlValue);
+
+    if (!this.descriptor.supportsSustainPedal || control !== 64) return;
+
+    for (const target of this.sustainPedal.set(controlValue)) {
+      instrument.stop(target);
+    }
+  }
+
+  private applySustainPedalState(): void {
+    if (this.descriptor.supportsSustainPedal) {
+      this.instrument?.setCC(64, this.sustainPedal.isDown ? 127 : 0);
+    }
   }
 
   private applyLiveSettings(settings: Record<string, unknown>): void {
     if (!this.instrument) return;
 
     this.instrument.output.volume = readNumber(settings.volume, 100);
+
     if (typeof this.instrument.output.pan === 'number') {
       this.instrument.output.pan = readNumber(settings.pan, 0);
     }
+
     this.instrument.setDetune(readNumber(settings.detune, 0));
     this.instrument.setReverse(Boolean(settings.reverse));
   }
@@ -203,8 +244,8 @@ export class SmplrInstrumentAudioNode implements AudioNodeV2 {
   }
 }
 
-export function createSmplrAudioNodeClass(descriptor: SmplrInstrumentDescriptor) {
-  return class DescriptorSmplrAudioNode extends SmplrInstrumentAudioNode {
+export const createSmplrAudioNodeClass = (descriptor: SmplrInstrumentDescriptor) =>
+  class DescriptorSmplrAudioNode extends SmplrInstrumentAudioNode {
     static type = descriptor.type;
     static group: AudioNodeGroup = 'processors';
     static description = descriptor.description;
@@ -216,18 +257,12 @@ export function createSmplrAudioNodeClass(descriptor: SmplrInstrumentDescriptor)
       super(nodeId, audioContext, descriptor);
     }
   };
-}
 
-function asSettings(value: unknown): Record<string, unknown> {
-  return typeof value === 'object' && value !== null
-    ? { ...(value as Record<string, unknown>) }
-    : {};
-}
+const asSettings = (value: unknown): Record<string, unknown> =>
+  typeof value === 'object' && value !== null ? { ...(value as Record<string, unknown>) } : {};
 
-function readNumber(value: unknown, fallback: number): number {
-  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
-}
+const readNumber = (value: unknown, fallback: number): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback;
 
-function readNote(value: unknown, fallback: number | string): number | string {
-  return typeof value === 'number' || typeof value === 'string' ? value : fallback;
-}
+const readNote = (value: unknown, fallback: number | string): number | string =>
+  typeof value === 'number' || typeof value === 'string' ? value : fallback;

--- a/ui/src/objects/smplr/SustainPedal.test.ts
+++ b/ui/src/objects/smplr/SustainPedal.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeSustainPedalValue, SustainPedal } from './SustainPedal';
+import { ChannelSustainPedals, normalizeSustainPedalValue, SustainPedal } from './SustainPedal';
 
 describe('SustainPedal', () => {
   it('holds note-offs until the pedal is released', () => {
@@ -19,5 +19,18 @@ describe('SustainPedal', () => {
     expect(normalizeSustainPedalValue(1)).toBe(127);
     expect(normalizeSustainPedalValue(64)).toBe(64);
     expect(normalizeSustainPedalValue(0)).toBe(0);
+  });
+
+  it('keeps pedal state independent for each channel', () => {
+    const pedals = new ChannelSustainPedals<string>();
+
+    pedals.set(1, 1);
+    pedals.hold(1, 'C4');
+    pedals.hold(2, 'D4');
+
+    expect(pedals.isDown(1)).toBe(true);
+    expect(pedals.isDown(2)).toBe(false);
+    expect(pedals.set(2, 0)).toEqual([]);
+    expect(pedals.set(1, 0)).toEqual(['C4']);
   });
 });

--- a/ui/src/objects/smplr/SustainPedal.test.ts
+++ b/ui/src/objects/smplr/SustainPedal.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeSustainPedalValue, SustainPedal } from './SustainPedal';
+
+describe('SustainPedal', () => {
+  it('holds note-offs until the pedal is released', () => {
+    const pedal = new SustainPedal<string>();
+
+    expect(pedal.hold('C4')).toBe(false);
+    expect(pedal.set(1)).toEqual([]);
+    expect(pedal.isDown).toBe(true);
+    expect(pedal.hold('C4')).toBe(true);
+    expect(pedal.hold('E4')).toBe(true);
+    expect(pedal.set(0)).toEqual(['C4', 'E4']);
+    expect(pedal.isDown).toBe(false);
+  });
+
+  it('normalizes Patchies pedal-on values for raw MIDI consumers', () => {
+    expect(normalizeSustainPedalValue(1)).toBe(127);
+    expect(normalizeSustainPedalValue(64)).toBe(64);
+    expect(normalizeSustainPedalValue(0)).toBe(0);
+  });
+});

--- a/ui/src/objects/smplr/SustainPedal.ts
+++ b/ui/src/objects/smplr/SustainPedal.ts
@@ -1,0 +1,44 @@
+/**
+ * Holds note-off targets while MIDI CC 64 is down, then returns them together
+ * when the pedal is released. Callers own the instrument-specific stop action.
+ */
+export class SustainPedal<T> {
+  private pedalDown = false;
+  private heldNoteOffs: T[] = [];
+
+  get isDown(): boolean {
+    return this.pedalDown;
+  }
+
+  hold(noteOff: T): boolean {
+    if (!this.pedalDown) return false;
+
+    this.heldNoteOffs.push(noteOff);
+    return true;
+  }
+
+  set(value: number): T[] {
+    const wasDown = this.pedalDown;
+    this.pedalDown = value > 0;
+
+    if (wasDown && !this.pedalDown) {
+      return this.takeHeldNoteOffs();
+    }
+
+    return [];
+  }
+
+  clear(): void {
+    this.heldNoteOffs = [];
+  }
+
+  private takeHeldNoteOffs(): T[] {
+    const heldNoteOffs = this.heldNoteOffs;
+    this.heldNoteOffs = [];
+
+    return heldNoteOffs;
+  }
+}
+
+export const normalizeSustainPedalValue = (value: number): number =>
+  value > 0 && value <= 1 ? 127 : value;

--- a/ui/src/objects/smplr/SustainPedal.ts
+++ b/ui/src/objects/smplr/SustainPedal.ts
@@ -40,5 +40,38 @@ export class SustainPedal<T> {
   }
 }
 
+export class ChannelSustainPedals<T> {
+  private pedals = new Map<number, SustainPedal<T>>();
+
+  isDown(channel: number): boolean {
+    return this.get(channel).isDown;
+  }
+
+  hold(channel: number, noteOff: T): boolean {
+    return this.get(channel).hold(noteOff);
+  }
+
+  set(channel: number, value: number): T[] {
+    return this.get(channel).set(value);
+  }
+
+  clearHeld(): void {
+    for (const pedal of this.pedals.values()) {
+      pedal.clear();
+    }
+  }
+
+  clear(): void {
+    this.pedals.clear();
+  }
+
+  private get(channel: number): SustainPedal<T> {
+    const pedal = this.pedals.get(channel) ?? new SustainPedal<T>();
+    this.pedals.set(channel, pedal);
+
+    return pedal;
+  }
+}
+
 export const normalizeSustainPedalValue = (value: number): number =>
   value > 0 && value <= 1 ? 127 : value;

--- a/ui/src/objects/smplr/descriptors.test.ts
+++ b/ui/src/objects/smplr/descriptors.test.ts
@@ -37,6 +37,18 @@ describe('smplr descriptors', () => {
     expect(descriptor.handleProgramChange?.(40, { kit: 'Custom' })).toBeNull();
   });
 
+  it('enables sustain-pedal handling for melodic instruments but not drums', () => {
+    expect(getSmplrDescriptor('piano~').supportsSustainPedal).toBe(true);
+    expect(getSmplrDescriptor('epiano~').supportsSustainPedal).toBe(true);
+    expect(getSmplrDescriptor('soundfont~').supportsSustainPedal).toBe(true);
+    expect(getSmplrDescriptor('soundfont2~').supportsSustainPedal).toBe(true);
+    expect(getSmplrDescriptor('mallet~').supportsSustainPedal).toBe(true);
+    expect(getSmplrDescriptor('mellotron~').supportsSustainPedal).toBe(true);
+    expect(getSmplrDescriptor('versilian~').supportsSustainPedal).toBe(true);
+    expect(getSmplrDescriptor('smolken~').supportsSustainPedal).toBe(true);
+    expect(getSmplrDescriptor('drums~').supportsSustainPedal).toBe(false);
+  });
+
   it('exposes FatBoy as a built-in MIDI.js soundfont kit', () => {
     const soundfontKitField = getSmplrDescriptor('soundfont~').settingsSchema.find(
       (field) => field.key === 'kit'

--- a/ui/src/objects/smplr/descriptors.ts
+++ b/ui/src/objects/smplr/descriptors.ts
@@ -57,6 +57,7 @@ export type SmplrInstrumentDescriptor = {
   reloadsOnSettings: string[];
   defaultBangNote: number | string;
   defaultVelocity: number;
+  supportsSustainPedal?: boolean;
   getDisplayName(settings: Record<string, unknown>): string;
   loadInstrument(args: {
     module: SmplrModule;
@@ -165,6 +166,7 @@ export const smplrDescriptors: Record<SmplrObjectType, SmplrInstrumentDescriptor
     title: 'soundfont~',
     description: 'General MIDI Soundfont instrument for MIDI note messages',
     defaultBangNote: '60',
+    supportsSustainPedal: true,
     defaultSettings: {
       instrument: 'acoustic_grand_piano',
       kit: 'MusyngKite',
@@ -237,6 +239,7 @@ export const smplrDescriptors: Record<SmplrObjectType, SmplrInstrumentDescriptor
     title: 'soundfont2~',
     description: 'Load a SoundFont2 SF2 file and play its instruments from MIDI messages',
     defaultBangNote: '60',
+    supportsSustainPedal: true,
     defaultSettings: {
       url: '',
       instrument: '',
@@ -310,6 +313,7 @@ export const smplrDescriptors: Record<SmplrObjectType, SmplrInstrumentDescriptor
       detune: 0,
       reverse: false
     },
+    supportsSustainPedal: true,
     settingsSchema: [
       { key: 'decayTime', label: 'Decay Time', type: 'number', min: 0, step: 0.05, default: 0.5 },
       ...commonSettings
@@ -332,7 +336,10 @@ export const smplrDescriptors: Record<SmplrObjectType, SmplrInstrumentDescriptor
     'Electric piano sampled instrument',
     electricPianos,
     'CP80',
-    (module, context, options) => module.ElectricPiano(context, options)
+    (module, context, options) => module.ElectricPiano(context, options),
+    '60',
+    undefined,
+    true
   ),
   'drums~': selectableInstrumentDescriptor(
     'drums~',
@@ -389,13 +396,15 @@ function selectableInstrumentDescriptor(
     options: SelectableInstrumentOptions
   ) => SmplrInstrument,
   defaultBangNote: number | string = '60',
-  getInstrumentNames?: (module: SmplrModule) => Promise<string[]>
+  getInstrumentNames?: (module: SmplrModule) => Promise<string[]>,
+  supportsSustainPedal = type !== 'drums~'
 ): SmplrInstrumentDescriptor {
   return descriptor({
     type,
     title: type,
     description,
     defaultBangNote,
+    supportsSustainPedal,
     defaultSettings: {
       instrument: defaultInstrument,
       volume: 100,

--- a/ui/src/presets/tone.preset.test.ts
+++ b/ui/src/presets/tone.preset.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { TONE_JS_PRESETS } from './tone.preset';
+
+describe('poly-synth-midi.tone preset', () => {
+  it('releases every overlapping same-pitch note when the sustain pedal is released', () => {
+    let receive: (message: Record<string, number | string>) => void = () => {};
+    const triggerRelease = vi.fn();
+    const synth = {
+      connect: () => synth,
+      triggerAttack: vi.fn(),
+      triggerRelease,
+      set: vi.fn()
+    };
+    const reverb = {
+      connect: () => reverb,
+      generate: vi.fn()
+    };
+    function Reverb() {
+      return reverb;
+    }
+
+    function PolySynth() {
+      return synth;
+    }
+
+    const Tone = {
+      Reverb,
+      PolySynth,
+      Synth: class {},
+      Frequency: (note: number) => ({ toNote: () => `note-${note}` }),
+      now: () => 0
+    };
+    const code = TONE_JS_PRESETS['poly-synth-midi.tone'].data.code;
+    const runPreset = new Function('Tone', 'outputNode', 'recv', 'setPortCount', 'setTitle', code);
+
+    runPreset(
+      Tone,
+      {},
+      (handler: typeof receive) => (receive = handler),
+      () => {},
+      () => {}
+    );
+    receive({ type: 'noteOn', note: 60, velocity: 100 });
+    receive({ type: 'noteOn', note: 60, velocity: 100 });
+    receive({ type: 'controlChange', control: 64, value: 1 });
+    receive({ type: 'noteOff', note: 60 });
+    receive({ type: 'noteOff', note: 60 });
+    receive({ type: 'controlChange', control: 64, value: 0 });
+
+    expect(triggerRelease).toHaveBeenCalledTimes(2);
+    expect(triggerRelease).toHaveBeenNthCalledWith(1, 'note-60', 0);
+    expect(triggerRelease).toHaveBeenNthCalledWith(2, 'note-60', 0);
+  });
+});

--- a/ui/src/presets/tone.preset.ts
+++ b/ui/src/presets/tone.preset.ts
@@ -20,6 +20,13 @@ const synth = new Tone.PolySynth(Tone.Synth, {
 
 reverb.generate();
 
+let sustainPedalDown = false;
+const sustainedNotes = new Set();
+
+const release = (note, time) => {
+  synth.triggerRelease(Tone.Frequency(note, "midi").toNote(), time);
+};
+
 recv(m => {
   const now = Tone.now();
 
@@ -29,9 +36,22 @@ recv(m => {
 
     synth.triggerAttack(freq, now, velocity);
   } else if (m.type === 'noteOff') {
-    const freq = Tone.Frequency(m.note, "midi").toNote();
+    if (sustainPedalDown) {
+      sustainedNotes.add(m.note);
+    } else {
+      release(m.note, now);
+    }
+  } else if (m.type === 'controlChange' && m.control === 64) {
+    const wasDown = sustainPedalDown;
+    sustainPedalDown = m.value > 0;
 
-    synth.triggerRelease(freq, now);
+    if (wasDown && !sustainPedalDown) {
+      for (const note of sustainedNotes) {
+        release(note, now);
+      }
+
+      sustainedNotes.clear();
+    }
   } else if (m.type === 'pitchBend') {
     synth.set({ detune: m.value * 200 });
   }

--- a/ui/src/presets/tone.preset.ts
+++ b/ui/src/presets/tone.preset.ts
@@ -21,7 +21,7 @@ const synth = new Tone.PolySynth(Tone.Synth, {
 reverb.generate();
 
 let sustainPedalDown = false;
-const sustainedNotes = new Set();
+const sustainedNotes = [];
 
 const release = (note, time) => {
   synth.triggerRelease(Tone.Frequency(note, "midi").toNote(), time);
@@ -37,7 +37,7 @@ recv(m => {
     synth.triggerAttack(freq, now, velocity);
   } else if (m.type === 'noteOff') {
     if (sustainPedalDown) {
-      sustainedNotes.add(m.note);
+      sustainedNotes.push(m.note);
     } else {
       release(m.note, now);
     }
@@ -50,7 +50,7 @@ recv(m => {
         release(note, now);
       }
 
-      sustainedNotes.clear();
+      sustainedNotes.length = 0;
     }
   } else if (m.type === 'pitchBend') {
     synth.set({ detune: m.value * 200 });

--- a/ui/static/content/objects/epiano~.md
+++ b/ui/static/content/objects/epiano~.md
@@ -13,9 +13,13 @@ velocity, pan, default note, detune, and reverse playback.
 ```text
 { type: "noteOn", note: 64, velocity: 100 }
 { type: "noteOff", note: 64 }
-{ type: "controlChange", control: 64, value: 127 }
+{ type: "controlChange", control: 64, value: 1 }
 { type: "bang", value: 1, duration: 0.25 }
 ```
+
+CC 64 controls the sustain pedal. Patchies sends `1` while the pedal is down
+and `0` when it is released. Any positive value holds notes after their
+`noteOff`; `0` releases those held notes.
 
 ## See Also
 

--- a/ui/static/content/objects/gm~.md
+++ b/ui/static/content/objects/gm~.md
@@ -40,10 +40,14 @@ Built-in Soundfont kits include `MusyngKite`, `FluidR3_GM`, and `FatBoy`.
 { type: "programChange", program: 40, channel: 2 }
 { type: "noteOn", note: 64, velocity: 90, channel: 2, time: audioTime }
 { type: "noteOff", note: 64, channel: 2, time: audioTime }
-{ type: "controlChange", control: 64, value: 127, channel: 2 }
+{ type: "controlChange", control: 64, value: 1, channel: 2 }
 ```
 
 Channels are 1-based. If `channel` is omitted, `gm~` uses channel 1.
+
+CC 64 sustains notes independently on each melodic channel. Patchies sends `1`
+while the pedal is down and `0` when it is released. Channel 10 percussion
+does not use sustain-pedal handling.
 
 For built-in Soundfont mode, `programChange` uses the General MIDI program
 list on melodic channels. Program `0` selects `acoustic_grand_piano`, program

--- a/ui/static/content/objects/piano~.md
+++ b/ui/static/content/objects/piano~.md
@@ -14,10 +14,15 @@ note, detune, and reverse playback.
 ```text
 { type: "noteOn", note: 60, velocity: 100, time: audioTime }
 { type: "noteOff", note: 60, time: audioTime }
+{ type: "controlChange", control: 64, value: 1 }
 { type: "bang", value: 1, duration: 0.5 }
 ```
 
 A number triggers the configured default note with that gain multiplier.
+
+Send MIDI CC 64 to use a sustain pedal. Patchies sends `1` while the pedal is
+down and `0` when it is released. Any positive value holds notes after their
+`noteOff`; `0` releases those held notes.
 
 ## See Also
 


### PR DESCRIPTION
Adds the CC64 sustain pedal support to `smplr` and other objects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sustain-pedal support to melodic sampled instruments and the poly synth.
  * Pressing the pedal holds released notes until it is lifted.
  * Sustain control values are normalized consistently across MIDI inputs.
  * Newly loaded instruments preserve the current sustain-pedal state.

* **Bug Fixes**
  * Drum and channel 10 percussion sounds remain unaffected by sustain-pedal messages.

* **Documentation**
  * Updated piano, electric piano, and General MIDI guidance with sustain-pedal usage and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->