### PR TITLE
feat(p5): add setFluidSize fluid resizer api

### DIFF
--- a/docs/design-docs/specs/100-p5-surface-mode.md
+++ b/docs/design-docs/specs/100-p5-surface-mode.md
@@ -27,6 +27,30 @@ Surface-mode p5 also exposes:
 - `hideExitButton()` to hide the overlay exit badge.
 - `setMouseForwarding({ enabled, only, except })` to forward p5 mouse and wheel interaction to mouse-aware render nodes while expanded.
 
+## Resizable Inline Canvases
+
+Inline p5 sketches can call `setFluidSize()` to make their canvas follow a
+user-resized Patchies node:
+
+```javascript
+function setup() {
+  setFluidSize({ keepAspectRatio: true });
+  createCanvas(400, 240);
+}
+```
+
+`createCanvas()` is the single source of the initial size. When the node has
+not been resized before, Patchies adopts the dimensions of the canvas p5
+actually created. When a persisted node size exists, Patchies calls
+`resizeCanvas()` after `createCanvas()` so the sketch starts at that size.
+Subsequent node resizing also calls `resizeCanvas()`.
+
+The fluid options are `showResizer`, `resize`, and `keepAspectRatio`.
+`initialSize` is intentionally not supported for p5 because it would conflict
+with `createCanvas()`. `createSurfaceCanvas()` and `setFluidSize()` are also
+mutually exclusive: surface canvases follow the renderer output instead of a
+node size.
+
 ## Preview And Expand Behavior
 
 - Before expansion, the node shows a scaled preview of the surface-sized p5 canvas.

--- a/docs/design-docs/specs/100-p5-surface-mode.md
+++ b/docs/design-docs/specs/100-p5-surface-mode.md
@@ -44,6 +44,9 @@ not been resized before, Patchies adopts the dimensions of the canvas p5
 actually created. When a persisted node size exists, Patchies calls
 `resizeCanvas()` after `createCanvas()` so the sketch starts at that size.
 Subsequent node resizing also calls `resizeCanvas()`.
+Patchies waits for p5 user setup to finish before deciding whether to clear a
+previously saved node size, so top-level dynamic imports do not discard a
+fluid sketch's resize state.
 
 The fluid options are `showResizer`, `resize`, and `keepAspectRatio`.
 `initialSize` is intentionally not supported for p5 because it would conflict

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -189,6 +189,7 @@ describe('patchies completions', () => {
   it('shows p5 surface mode helper completions inside setup', () => {
     expect(getCompletionLabels('p5', 'function setup() { setM')).toContain('setMouseForwarding');
     expect(getCompletionLabels('p5', 'function setup() { hide')).toContain('hideExitButton');
+    expect(getCompletionLabels('p5', 'function setup() { setF')).toContain('setFluidSize');
   });
 
   it('shows surface expansion helper completions inside callbacks', () => {
@@ -216,6 +217,15 @@ describe('patchies completions', () => {
     expect(getCompletionLabels('canvas', 'setF')).not.toContain('setFluidSize');
     expect(getCompletionLabels('canvas', 'onCanvasR')).not.toContain('onCanvasResize');
     expect(getCompletionLabels('canvas.dom', 'onR')).not.toContain('onResize');
+  });
+
+  it('omits initialSize from the p5 fluid-size completion', () => {
+    const p5Completion = getCompletion('p5', 'setF', 'setFluidSize');
+    const canvasCompletion = getCompletion('canvas.dom', 'setF', 'setFluidSize');
+
+    expect(p5Completion?.detail).not.toContain('initialSize');
+    expect(p5Completion?.apply).toBe('setFluidSize()');
+    expect(canvasCompletion?.detail).toContain('initialSize');
   });
 
   it('shows noBorder completions only for native UI nodes', () => {

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -521,6 +521,15 @@ const patchiesAPICompletions: Completion[] = [
   }
 ];
 
+const p5FluidSizeCompletion: Completion = {
+  label: 'setFluidSize',
+  type: 'function',
+  detail:
+    "(options?: { showResizer?: boolean; resize?: 'horizontal' | 'vertical' | 'both'; keepAspectRatio?: boolean }) => void",
+  info: 'Make this p5 canvas follow its node size. createCanvas() sets the initial size; limit resizing to an axis or preserve its aspect ratio.',
+  apply: 'setFluidSize()'
+};
+
 // Setup functions that should only appear at top-level (not in function bodies)
 const topLevelOnlyFunctions = new Set([
   'noDrag',
@@ -565,7 +574,11 @@ const topLevelOnlyFunctions = new Set([
   'setVideoCount'
 ]);
 
-const p5FunctionBodySurfaceHelpers = new Set(['hideExitButton', 'setMouseForwarding']);
+const p5FunctionBodySurfaceHelpers = new Set([
+  'hideExitButton',
+  'setMouseForwarding',
+  'setFluidSize'
+]);
 
 function isAllowedInFunctionBody(completion: Completion, patchiesContext?: PatchiesContext) {
   if (!topLevelOnlyFunctions.has(completion.label)) return true;
@@ -659,7 +672,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
   setAudioPortCount: ['dsp~'],
   showAudioInput: ['tone~', 'sonic~', 'elem~'],
   setCanvasSize: ['canvas.dom', 'textmode.dom', 'three.dom'],
-  setFluidSize: ['canvas.dom', 'dom', 'vue'],
+  setFluidSize: ['canvas.dom', 'dom', 'vue', 'p5'],
   onCanvasResize: ['canvas.dom'],
   onResize: ['dom', 'vue'],
   setSize: ['dom', 'vue'],
@@ -1162,6 +1175,14 @@ function isCompletionAllowedForNode(completion: Completion, context?: PatchiesCo
   return true;
 }
 
+function getCompletionOptions(context?: PatchiesContext): Completion[] {
+  if (context?.nodeType !== 'p5') return patchiesAPICompletions;
+
+  return patchiesAPICompletions.map((completion) =>
+    completion.label === 'setFluidSize' ? p5FluidSizeCompletion : completion
+  );
+}
+
 export function getPatchiesCompletionByLabel(
   label: string,
   context?: PatchiesContext
@@ -1170,7 +1191,7 @@ export function getPatchiesCompletionByLabel(
   if (context?.nodeType === 'expr') return;
   if (context?.nodeType === 'msg') return;
 
-  const completion = patchiesAPICompletions.find((option) => option.label === label);
+  const completion = getCompletionOptions(context).find((option) => option.label === label);
   if (!completion) return;
 
   return isCompletionAllowedForNode(completion, context) ? completion : undefined;
@@ -1290,7 +1311,7 @@ export function createPatchiesCompletionSource(patchiesContext?: PatchiesContext
     const insideFunction = isInsideFunctionBody(allTextBefore);
 
     // Filter completions based on context
-    let options = patchiesAPICompletions;
+    let options = getCompletionOptions(patchiesContext);
 
     // Filter out top-level only functions when inside a function body
     if (insideFunction) {

--- a/ui/src/lib/p5/P5Manager.test.ts
+++ b/ui/src/lib/p5/P5Manager.test.ts
@@ -60,6 +60,23 @@ describe('P5Manager', () => {
     ]);
   });
 
+  it('exposes setFluidSize to p5 user code', async () => {
+    vi.stubGlobal('window', {});
+
+    const setFluidSize = vi.fn();
+
+    executeJavaScript.mockImplementationOnce((_nodeId, _code, options) => {
+      options.extraContext.setFluidSize({ keepAspectRatio: true });
+      return {};
+    });
+
+    const manager = new P5Manager('p5-node', {} as HTMLElement);
+
+    await manager['executeUserCode']({} as never, { code: '', setFluidSize }, {});
+
+    expect(setFluidSize).toHaveBeenCalledWith({ keepAspectRatio: true });
+  });
+
   it('keeps mouse and previous-mouse coordinates in canvas space across scaled pointer events', () => {
     const canvas = {
       scrollWidth: 400,

--- a/ui/src/lib/p5/P5Manager.ts
+++ b/ui/src/lib/p5/P5Manager.ts
@@ -10,6 +10,13 @@ import type { SurfaceMouseForwardingRules } from '$lib/canvas/surfaceMouseForwar
 import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
 import type { PrimaryButton } from '$lib/eventbus/events';
 
+type P5FluidCanvasOptions = {
+  showResizer?: boolean;
+  resize?: 'horizontal' | 'vertical' | 'both';
+  keepAspectRatio?: boolean;
+  initialSize?: { width: number; height: number };
+};
+
 interface P5SketchConfig {
   code: string;
   messageContext?: UserFnRunContext;
@@ -68,6 +75,7 @@ interface P5SketchConfig {
   setMouseForwarding?: (rules?: SurfaceMouseForwardingRules) => void;
   expandSurface?: () => void;
   collapseSurface?: () => void;
+  setFluidSize?: (options?: P5FluidCanvasOptions) => void;
   normalizeInlineMouseCoordinates?: boolean;
 }
 
@@ -220,6 +228,15 @@ export class P5Manager {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let userCode: any;
+
+        const notifyCanvasCreated = () => {
+          const canvas = (p as unknown as { canvas?: unknown }).canvas;
+
+          if (canvas instanceof HTMLCanvasElement) {
+            config.onCanvasCreated?.(canvas, { width: p.width, height: p.height });
+          }
+        };
+
         try {
           userCode = await this.executeUserCode(p, sketchConfig, P5);
         } catch (error) {
@@ -233,6 +250,7 @@ export class P5Manager {
         try {
           await userCode?.preload?.call(p);
           await userCode?.setup?.call(p);
+          notifyCanvasCreated();
 
           if (!userCode?.draw) {
             requestAnimationFrame(signalFrameReady);
@@ -250,11 +268,7 @@ export class P5Manager {
           try {
             userCode?.setup?.call(p);
 
-            const canvas = (p as unknown as { canvas?: unknown }).canvas;
-
-            if (canvas instanceof HTMLCanvasElement) {
-              config.onCanvasCreated?.(canvas, { width: p.width, height: p.height });
-            }
+            notifyCanvasCreated();
 
             if (!userCode?.draw) {
               requestAnimationFrame(signalFrameReady);
@@ -490,6 +504,7 @@ export class P5Manager {
         setMouseForwarding: config.setMouseForwarding,
         expandSurface: config.expandSurface,
         collapseSurface: config.collapseSurface,
+        setFluidSize: config.setFluidSize,
         setPrimaryButton: (primaryButton: PrimaryButton) => {
           PatchiesEventBus.getInstance().dispatch({
             type: 'nodePrimaryButtonUpdate',

--- a/ui/src/objects/canvas/useFluidCanvas.svelte.ts
+++ b/ui/src/objects/canvas/useFluidCanvas.svelte.ts
@@ -27,6 +27,7 @@ type UseFluidCanvasOptions = {
   warn: (message: string) => void;
   onResizeCallback: (callback: (size: CanvasSize) => void) => void;
   previewScaleFactor: number;
+  deferInitialSize?: boolean;
 };
 
 const usesFluidCanvas = (code: string) =>
@@ -81,6 +82,14 @@ export function useFluidCanvas(options: UseFluidCanvasOptions) {
     resizeAxis = resolvedOptions.resize;
     keepAspectRatio = resolvedOptions.keepAspectRatio;
 
+    if (options.deferInitialSize) {
+      if (data.fluidCanvasResizerVisible === undefined) {
+        options.updateNodeData(options.getNodeId(), { fluidCanvasResizerVisible: showResizer });
+      }
+
+      return;
+    }
+
     if (
       resolvedOptions.initialSize &&
       nodeSize.width === undefined &&
@@ -106,6 +115,29 @@ export function useFluidCanvas(options: UseFluidCanvasOptions) {
     if (data.fluidCanvasResizerVisible === undefined) {
       options.updateNodeData(options.getNodeId(), { fluidCanvasResizerVisible: showResizer });
     }
+  }
+
+  function initializeSize(initialSize: CanvasSize) {
+    if (!isFluid) return;
+
+    const nodeSize = options.getNodeSize();
+
+    if (nodeSize.width === undefined && nodeSize.height === undefined) {
+      options.updateNode(options.getNodeId(), {
+        width: initialSize.width / options.previewScaleFactor,
+        height: initialSize.height / options.previewScaleFactor
+      });
+
+      options.setCanvasSize(initialSize);
+      return;
+    }
+
+    const previewSize = options.getPreviewSize();
+
+    options.setCanvasSize({
+      width: Math.round((nodeSize.width ?? previewSize.width) * options.previewScaleFactor),
+      height: Math.round((nodeSize.height ?? previewSize.height) * options.previewScaleFactor)
+    });
   }
 
   function setFixedCanvasSize(width: number, height: number) {
@@ -190,6 +222,7 @@ export function useFluidCanvas(options: UseFluidCanvasOptions) {
         : options.getCanvasSize(),
     reset,
     setFluidSize,
+    initializeSize,
     setFixedCanvasSize,
     onCanvasResize,
     handleResize

--- a/ui/src/objects/canvas/useFluidCanvas.svelte.ts
+++ b/ui/src/objects/canvas/useFluidCanvas.svelte.ts
@@ -75,7 +75,6 @@ export function useFluidCanvas(options: UseFluidCanvasOptions) {
 
     const resolvedOptions = resolveFluidCanvasOptions(fluidOptions);
     const data = options.getData();
-    const nodeSize = options.getNodeSize();
     const showResizer = data.fluidCanvasResizerVisible ?? resolvedOptions.showResizer;
 
     defaultResizerVisible = showResizer;
@@ -90,39 +89,19 @@ export function useFluidCanvas(options: UseFluidCanvasOptions) {
       return;
     }
 
-    if (
-      resolvedOptions.initialSize &&
-      nodeSize.width === undefined &&
-      nodeSize.height === undefined
-    ) {
-      const { width, height } = resolvedOptions.initialSize;
-
-      options.updateNode(options.getNodeId(), {
-        width: width / options.previewScaleFactor,
-        height: height / options.previewScaleFactor
-      });
-
-      options.setCanvasSize({ width, height });
-    } else {
-      const previewSize = options.getPreviewSize();
-
-      options.setCanvasSize({
-        width: Math.round((nodeSize.width ?? previewSize.width) * options.previewScaleFactor),
-        height: Math.round((nodeSize.height ?? previewSize.height) * options.previewScaleFactor)
-      });
-    }
+    initializeSize(resolvedOptions.initialSize);
 
     if (data.fluidCanvasResizerVisible === undefined) {
       options.updateNodeData(options.getNodeId(), { fluidCanvasResizerVisible: showResizer });
     }
   }
 
-  function initializeSize(initialSize: CanvasSize) {
+  function initializeSize(initialSize?: CanvasSize) {
     if (!isFluid) return;
 
     const nodeSize = options.getNodeSize();
 
-    if (nodeSize.width === undefined && nodeSize.height === undefined) {
+    if (initialSize && nodeSize.width === undefined && nodeSize.height === undefined) {
       options.updateNode(options.getNodeId(), {
         width: initialSize.width / options.previewScaleFactor,
         height: initialSize.height / options.previewScaleFactor

--- a/ui/src/objects/p5/P5CanvasNode.svelte
+++ b/ui/src/objects/p5/P5CanvasNode.svelte
@@ -404,6 +404,10 @@
           },
           getSurfaceCanvasSize: surfaceMode.getCanvasSize,
           onCanvasCreated: (canvas, dimensions) => {
+            if (!fluidCanvas.isFluid && (width !== undefined || height !== undefined)) {
+              updateNode(nodeId, { width: undefined, height: undefined });
+            }
+
             if (fluidCanvas.isFluid) {
               if (nextSurfaceModeEnabled) {
                 if (!warnedAboutFluidSurfaceMode) {
@@ -452,10 +456,6 @@
 
         if (!nextSurfaceModeEnabled && surfaceMode.isSurfaceCanvasExpanded) {
           surfaceMode.exit();
-        }
-
-        if (!fluidCanvas.isFluid && (width !== undefined || height !== undefined)) {
-          updateNode(nodeId, { width: undefined, height: undefined });
         }
 
         measureWidth(100);

--- a/ui/src/objects/p5/P5CanvasNode.svelte
+++ b/ui/src/objects/p5/P5CanvasNode.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { useSvelteFlow, useUpdateNodeInternals } from '@xyflow/svelte';
+  import {
+    NodeResizer,
+    NodeResizeControl,
+    ResizeControlVariant,
+    useSvelteFlow,
+    useUpdateNodeInternals
+  } from '@xyflow/svelte';
   import { onMount, onDestroy } from 'svelte';
   import { P5Manager } from '$lib/p5/P5Manager';
   import CodeEditor from '$lib/components/CodeEditor.svelte';
@@ -21,13 +27,18 @@
   import type { SettingsSchema } from '$lib/settings';
   import { getBorderChromeClass, getBorderResetDataForRun } from '$lib/components/border-chrome';
   import { getP5PreviewDimensions } from './preview-dimensions';
+  import { useNodeDataTracker } from '$lib/history';
+  import { useFluidCanvas } from '$objects/canvas/useFluidCanvas.svelte';
+  import type { FluidCanvasOptions } from '$objects/canvas/fluid-canvas-options';
 
   let consoleRef: VirtualConsole | null = $state(null);
 
   let {
     id: nodeId,
     data,
-    selected
+    selected,
+    width,
+    height
   }: {
     id: string;
     data: {
@@ -43,16 +54,20 @@
       settingsSchema?: SettingsSchema;
       settings?: Record<string, unknown>;
       noBorder?: boolean;
+      fluidCanvasResizerVisible?: boolean;
     };
     selected: boolean;
+    width?: number;
+    height?: number;
   } = $props();
 
   function initialNodeId() {
     return nodeId;
   }
 
-  const { getNodes, updateNodeData } = useSvelteFlow();
+  const { getNodes, updateNode, updateNodeData } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
+  const tracker = $derived.by(() => useNodeDataTracker(nodeId));
 
   // Settings manager — persists across code re-runs
   const settingsManager = new SettingsManager(
@@ -64,6 +79,7 @@
 
   let containerElement: HTMLDivElement;
   let measureElement: HTMLDivElement;
+
   let p5Manager: P5Manager | null = null;
   let glSystem = GLSystem.getInstance();
   let messageContext: MessageContext;
@@ -80,12 +96,68 @@
   let outletCount = $derived(data.outletCount ?? 1);
   let isSurfaceModeAvailable = $derived((data.surfaceMode ?? false) || usesP5SurfaceCanvas(code));
   let previousExecuteCode = $state<number | undefined>(undefined);
+  let warnedAboutFluidSurfaceMode = false;
+  let warnedAboutFluidInitialSize = false;
 
   // Local state for pre-parsed canvas dimensions (not persisted)
   // These prevent layout shift by setting min-width/height before P5.js loads
   let preloadCanvasWidth = $state<number | undefined>(0);
   let preloadCanvasHeight = $state<number | undefined>(0);
   let preservedFrameCanvas: HTMLCanvasElement | null = null;
+
+  function setP5CanvasSize({
+    width: nextWidth,
+    height: nextHeight
+  }: {
+    width: number;
+    height: number;
+  }) {
+    const p5 = p5Manager?.p5;
+    if (!p5) return;
+
+    p5.resizeCanvas(nextWidth, nextHeight);
+
+    preloadCanvasWidth = nextWidth;
+    preloadCanvasHeight = nextHeight;
+
+    measureWidth(0);
+    p5Manager?.sendBitmap();
+  }
+
+  const fluidCanvas = useFluidCanvas({
+    getNodeId: () => nodeId,
+    getData: () => data,
+    getNodeSize: () => ({ width, height }),
+    getPreviewSize: () => ({
+      width: preloadCanvasWidth ?? 1,
+      height: preloadCanvasHeight ?? 1
+    }),
+    getCanvasSize: () => {
+      const p5 = p5Manager?.p5;
+
+      return p5 ? { width: p5.width, height: p5.height } : { width: 1, height: 1 };
+    },
+    setCanvasSize: setP5CanvasSize,
+    updateNode,
+    updateNodeData,
+    commitNodeData: (key, oldValue, newValue) => tracker.commit(key, oldValue, newValue),
+    warn: (message) => customConsole.warn(message),
+    onResizeCallback: () => {},
+    previewScaleFactor: 1,
+    deferInitialSize: true
+  });
+
+  function setFluidSize(fluidOptions: FluidCanvasOptions = {}) {
+    if (fluidOptions.initialSize && !warnedAboutFluidInitialSize) {
+      customConsole.warn(
+        'p5 setFluidSize() infers its initial size from createCanvas(); initialSize is ignored.'
+      );
+
+      warnedAboutFluidInitialSize = true;
+    }
+
+    fluidCanvas.setFluidSize({ ...fluidOptions, initialSize: undefined });
+  }
 
   const surfaceMode = createP5SurfaceMode({
     nodeId: initialNodeId(),
@@ -185,6 +257,7 @@
 
   onDestroy(() => {
     clearPreservedFrameCanvas();
+    fluidCanvas.reset();
     surfaceMode.cleanup();
     p5Manager?.destroy();
     glSystem.removeNode(nodeId);
@@ -250,8 +323,14 @@
     enableDrag = true;
     enablePan = true;
     enableWheel = true;
+
+    fluidCanvas.reset();
+
     let nextVideoOutputEnabled = true;
     let nextSurfaceModeEnabled = false;
+
+    warnedAboutFluidSurfaceMode = false;
+    warnedAboutFluidInitialSize = false;
 
     // Clear previous error state at the start of each run
     // If an error occurs during updateCode, it will be set again
@@ -325,6 +404,23 @@
           },
           getSurfaceCanvasSize: surfaceMode.getCanvasSize,
           onCanvasCreated: (canvas, dimensions) => {
+            if (fluidCanvas.isFluid) {
+              if (nextSurfaceModeEnabled) {
+                if (!warnedAboutFluidSurfaceMode) {
+                  customConsole.warn(
+                    'setFluidSize() is ignored when createSurfaceCanvas() is active.'
+                  );
+                  warnedAboutFluidSurfaceMode = true;
+                }
+
+                fluidCanvas.reset();
+              } else {
+                requestAnimationFrame(() => {
+                  fluidCanvas.initializeSize(dimensions);
+                });
+              }
+            }
+
             if (surfaceMode.isExpanded) {
               surfaceMode.styleCanvas(canvas, dimensions);
             }
@@ -337,6 +433,7 @@
               setVideoOutputEnabled(false);
             }
           },
+          setFluidSize,
           onSurfaceCanvasCreated: surfaceMode.styleCanvas,
           onSurfaceFrame: surfaceMode.requestMirrorFrame,
           onSurfacePointer: surfaceMode.forwardPointer,
@@ -357,9 +454,14 @@
           surfaceMode.exit();
         }
 
+        if (!fluidCanvas.isFluid && (width !== undefined || height !== undefined)) {
+          updateNode(nodeId, { width: undefined, height: undefined });
+        }
+
         measureWidth(100);
       } catch (error) {
         errorMessage = error instanceof Error ? error.message : String(error);
+
         handleCodeError(error, nextCode, nodeId, customConsole);
         setCanvasDimensionsFromCode(nextCode);
       }
@@ -383,116 +485,151 @@
 
     return `z-1 transition-opacity ${selected ? '' : 'sm:opacity-0 opacity-30 group-hover:opacity-100'}`;
   });
+
+  const resizeControlsVisible = $derived(
+    selected && fluidCanvas.isFluid && fluidCanvas.resizerVisible
+  );
+
+  const displayExtraMenuItems = $derived(fluidCanvas.displayExtraMenuItems ?? []);
 </script>
 
-<ObjectPreviewLayout
-  title={data.title ?? 'p5'}
-  objectType="p5"
-  {nodeId}
-  onCodeChange={handleCodeChange}
-  onrun={updateSketch}
-  previewWidth={previewContainerWidth}
-  showPauseButton
-  paused={data.paused}
-  onPlaybackToggle={togglePlayback}
-  {editorReady}
-  settingsSchema={data.settingsSchema}
-  settingsValues={data.settings ?? {}}
-  onSettingsValueChange={(key, value) => settingsManager.setValue(key, value)}
-  onSettingsRevertAll={() => settingsManager.revertAll()}
-  displayExtraMenuItems={surfaceMode.menuItems}
->
-  {#snippet topHandle()}
-    {#each Array.from({ length: inletCount }) as _, index (index)}
-      <TypedHandle
-        port="inlet"
-        spec={{ handleId: index }}
-        title={`Inlet ${index}`}
-        total={inletCount}
-        {index}
-        class={handleClass}
-        {nodeId}
+<div class="relative">
+  {#if resizeControlsVisible}
+    {#if fluidCanvas.resizeAxis === 'both' || fluidCanvas.keepAspectRatio}
+      <NodeResizer
+        class="z-1"
+        minWidth={100}
+        minHeight={80}
+        keepAspectRatio={fluidCanvas.keepAspectRatio}
+        onResize={fluidCanvas.handleResize}
       />
-    {/each}
-  {/snippet}
-
-  {#snippet preview()}
-    <div class="relative" bind:this={measureElement}>
-      <div
-        bind:this={containerElement}
-        class={[
-          'rounded-md border bg-transparent',
-          'relative overflow-hidden',
-          enableDrag && enablePan && enableWheel
-            ? 'cursor-grab'
-            : [
-                'cursor-default',
-                !enableDrag && 'nodrag',
-                !enablePan && 'nopan',
-                !enableWheel && 'nowheel'
-              ],
-          getBorderChromeClass({
-            hasError: Boolean(errorMessage),
-            selected,
-            noBorder: data.noBorder,
-            errorClass: 'border-red-500 [&>canvas]:rounded-[7px]',
-            selectedClass: 'shadow-glow-md border-zinc-200 [&>canvas]:rounded-[7px]',
-            idleClass: 'hover:shadow-glow-sm border-transparent [&>canvas]:rounded-md',
-            borderlessClass: 'border-transparent shadow-none [&>canvas]:rounded-md'
-          })
-        ]}
-        style={preloadCanvasWidth && preloadCanvasHeight
-          ? `min-width: ${preloadCanvasWidth}px; min-height: ${preloadCanvasHeight}px;`
-          : ''}
-      ></div>
-    </div>
-  {/snippet}
-
-  {#snippet bottomHandle()}
-    {#if videoOutputEnabled}
-      <TypedHandle
-        port="outlet"
-        spec={{ handleType: 'video', handleId: '0' }}
-        title="Video output"
-        total={outletCount + 1}
-        index={0}
-        class={handleClass}
-        {nodeId}
-      />
+    {:else}
+      {#each fluidCanvas.resizeControlPositions as position (position)}
+        <NodeResizeControl
+          class="z-1"
+          {position}
+          variant={ResizeControlVariant.Line}
+          minWidth={100}
+          minHeight={80}
+          onResize={fluidCanvas.handleResize}
+        />
+      {/each}
     {/if}
+  {/if}
 
-    {#each Array.from({ length: outletCount }) as _, index (index)}
-      <TypedHandle
-        port="outlet"
-        spec={{ handleId: index }}
-        title={`Outlet ${index}`}
-        total={videoOutputEnabled ? outletCount + 1 : outletCount}
-        index={videoOutputEnabled ? index + 1 : index}
-        class={handleClass}
+  <ObjectPreviewLayout
+    title={data.title ?? 'p5'}
+    objectType="p5"
+    {nodeId}
+    onCodeChange={handleCodeChange}
+    onrun={updateSketch}
+    previewWidth={previewContainerWidth}
+    showPauseButton
+    paused={data.paused}
+    onPlaybackToggle={togglePlayback}
+    {editorReady}
+    showExpandOption
+    onCustomExpandToggle={() => (surfaceMode.isExpanded ? surfaceMode.exit() : surfaceMode.enter())}
+    customExpanded={surfaceMode.isExpanded}
+    settingsSchema={data.settingsSchema}
+    settingsValues={data.settings ?? {}}
+    onSettingsValueChange={(key, value) => settingsManager.setValue(key, value)}
+    onSettingsRevertAll={() => settingsManager.revertAll()}
+    {displayExtraMenuItems}
+  >
+    {#snippet topHandle()}
+      {#each Array.from({ length: inletCount }) as _, index (index)}
+        <TypedHandle
+          port="inlet"
+          spec={{ handleId: index }}
+          title={`Inlet ${index}`}
+          total={inletCount}
+          {index}
+          class={handleClass}
+          {nodeId}
+        />
+      {/each}
+    {/snippet}
+
+    {#snippet preview()}
+      <div class="relative" bind:this={measureElement}>
+        <div
+          bind:this={containerElement}
+          class={[
+            'rounded-md border bg-transparent',
+            'relative overflow-hidden',
+            enableDrag && enablePan && enableWheel
+              ? 'cursor-grab'
+              : [
+                  'cursor-default',
+                  !enableDrag && 'nodrag',
+                  !enablePan && 'nopan',
+                  !enableWheel && 'nowheel'
+                ],
+            getBorderChromeClass({
+              hasError: Boolean(errorMessage),
+              selected,
+              noBorder: data.noBorder,
+              hideBorder: resizeControlsVisible,
+              errorClass: 'border-red-500 [&>canvas]:rounded-[7px]',
+              selectedClass: 'shadow-glow-md border-zinc-200 [&>canvas]:rounded-[7px]',
+              idleClass: 'hover:shadow-glow-sm border-transparent [&>canvas]:rounded-md',
+              borderlessClass: 'border-transparent shadow-none [&>canvas]:rounded-md'
+            })
+          ]}
+          style={preloadCanvasWidth && preloadCanvasHeight
+            ? `min-width: ${preloadCanvasWidth}px; min-height: ${preloadCanvasHeight}px;`
+            : ''}
+        ></div>
+      </div>
+    {/snippet}
+
+    {#snippet bottomHandle()}
+      {#if videoOutputEnabled}
+        <TypedHandle
+          port="outlet"
+          spec={{ handleType: 'video', handleId: '0' }}
+          title="Video output"
+          total={outletCount + 1}
+          index={0}
+          class={handleClass}
+          {nodeId}
+        />
+      {/if}
+
+      {#each Array.from({ length: outletCount }) as _, index (index)}
+        <TypedHandle
+          port="outlet"
+          spec={{ handleId: index }}
+          title={`Outlet ${index}`}
+          total={videoOutputEnabled ? outletCount + 1 : outletCount}
+          index={videoOutputEnabled ? index + 1 : index}
+          class={handleClass}
+          {nodeId}
+        />
+      {/each}
+    {/snippet}
+
+    {#snippet codeEditor()}
+      <CodeEditor
+        value={code}
+        onchange={handleCodeChange}
+        language="javascript"
+        nodeType="p5"
+        placeholder="Write your p5.js code here..."
+        class="nodrag h-64 w-full resize-none"
+        onrun={updateSketch}
+        onready={() => (editorReady = true)}
+        {lineErrors}
         {nodeId}
       />
-    {/each}
-  {/snippet}
+    {/snippet}
 
-  {#snippet codeEditor()}
-    <CodeEditor
-      value={code}
-      onchange={handleCodeChange}
-      language="javascript"
-      nodeType="p5"
-      placeholder="Write your p5.js code here..."
-      class="nodrag h-64 w-full resize-none"
-      onrun={updateSketch}
-      onready={() => (editorReady = true)}
-      {lineErrors}
-      {nodeId}
-    />
-  {/snippet}
-
-  {#snippet console()}
-    <!-- Always render VirtualConsole so it receives events even when hidden -->
-    <div class="mt-3" class:hidden={!data.showConsole}>
-      <VirtualConsole bind:this={consoleRef} {nodeId} onrun={updateSketch} />
-    </div>
-  {/snippet}
-</ObjectPreviewLayout>
+    {#snippet console()}
+      <!-- Always render VirtualConsole so it receives events even when hidden -->
+      <div class="mt-3" class:hidden={!data.showConsole}>
+        <VirtualConsole bind:this={consoleRef} {nodeId} onrun={updateSketch} />
+      </div>
+    {/snippet}
+  </ObjectPreviewLayout>
+</div>

--- a/ui/src/objects/p5/prompt.ts
+++ b/ui/src/objects/p5/prompt.ts
@@ -20,6 +20,7 @@ ${esmInstructions}
 - noInteract() - Disable all XYFlow canvas interactions (drag, pan, wheel)
 - noBorder() - Hide Patchies border and selected glow
 - noOutput() - Hide video output port (call this when the sketch is self-contained and does not need to feed video to other nodes)
+- setFluidSize({ showResizer?, resize?, keepAspectRatio? }) - Make the canvas follow a user-resized node. createCanvas() supplies the initial size; do not pass initialSize.
 - createSurfaceCanvas(renderer?) - Create a transparent renderer-output-sized canvas and enable Expand so the p5 sketch can run as a fullscreen surface overlay. Do NOT also call createCanvas() when using this.
 - expandSurface() / collapseSurface() - In p5 surface mode, enter or exit fullscreen surface mode from code.
 - hideExitButton() - In expanded p5 surface mode, hide the "Exit surface" badge.
@@ -29,6 +30,7 @@ ${esmInstructions}
 **Default behaviors to apply unless there's a reason not to:**
 - Call noOutput() by default unless the sketch is explicitly meant to output video to another node.
 - For fullscreen transparent overlays over Hydra/GLSL/video output, call createSurfaceCanvas() in setup() instead of createCanvas(), and use clear() in draw() so visuals underneath show through.
+- For a resizable inline sketch, call setFluidSize() and createCanvas(width, height) in setup(). Do not combine setFluidSize() with createSurfaceCanvas().
 - In p5 surface mode, use setMouseForwarding() when only some render nodes should receive mouse/wheel interaction, and setMouseForwarding({ enabled: false }) when p5 should consume interaction without driving Hydra/GLSL/Three.
 - Call noDrag() if the sketch uses mousePressed, mouseDragged, mouseX/mouseY interaction.
 - Call noWheel() if the sketch uses scroll or mouseWheel interaction.

--- a/ui/src/presets/p5.presets.ts
+++ b/ui/src/presets/p5.presets.ts
@@ -21,6 +21,7 @@ recv(m => {
 })
 
 function setup() {
+  setFluidSize({ showResizer: false })
   createCanvas(W, 200)
   pixelDensity(3)
   noStroke()
@@ -38,6 +39,7 @@ function draw() {
 }`;
 
 const AUDIO_FFT_SMALL_P5 = `function setup() {
+  setFluidSize({ showResizer: false })
   createCanvas(${defaultWidth}, ${defaultHeight})
   pixelDensity(${PREVIEW_SCALE_FACTOR})
   strokeWeight(1)
@@ -71,6 +73,7 @@ function draw() {
 }`;
 
 const AUDIO_FFT_FULL_P5 = `function setup() {
+  setFluidSize({ showResizer: false })
   createCanvas(${defaultWidth}, ${defaultHeight})
   pixelDensity(${PREVIEW_SCALE_FACTOR})
 }
@@ -105,6 +108,7 @@ function draw() {
 }`;
 
 const AUDIO_FFT_RMS_WIDE_P5 = `function setup() {
+  setFluidSize({ showResizer: false })
   createCanvas(${defaultWidth}, ${defaultHeight})
   pixelDensity(${PREVIEW_SCALE_FACTOR})
   strokeWeight(3)
@@ -131,6 +135,7 @@ let vy;
 let size = 40;
 
 function setup() {
+  setFluidSize({ showResizer: false })
   createCanvas(${defaultWidth}, ${defaultHeight})
   pixelDensity(${PREVIEW_SCALE_FACTOR})
   noStroke()
@@ -162,6 +167,7 @@ function draw() {
 }`;
 
 const AUDIO_FFT_RMS_NARROW_P5 = `function setup() {
+  setFluidSize({ showResizer: false })
   createCanvas(200, 150)
   pixelDensity(4)
   strokeWeight(3)
@@ -183,6 +189,7 @@ function draw() {
 const TEXT_BANNER_P5 = `const txt = "hello, world!"
 
 function setup() {
+  setFluidSize({ showResizer: false })
   createCanvas(500, 100)
   pixelDensity(4)
   setHidePorts(true)

--- a/ui/static/content/objects/p5.md
+++ b/ui/static/content/objects/p5.md
@@ -25,6 +25,26 @@ function draw() {
 
 By default, mouse interactions are passed through to the canvas for panning/dragging. To enable interactivity in your sketch (sliders, mousePressed, etc.), call `noInteract()` in `setup()`. See [Canvas Interaction](/docs/canvas-interaction) for details.
 
+## Resizable Canvases
+
+Call `setFluidSize()` to let people resize an inline sketch from its Patchies node:
+
+```javascript
+function setup() {
+  setFluidSize({ keepAspectRatio: true });
+  createCanvas(400, 240);
+}
+```
+
+`createCanvas()` supplies the initial size. After someone resizes the node, p5's
+`width` and `height` update with the canvas, so draw code continues to use the
+current dimensions. Use `resize: 'horizontal'` or `resize: 'vertical'` to limit
+the resize direction, or `showResizer: false` to hide the handles initially.
+
+Do not pass `initialSize` to `setFluidSize()` in p5: it would duplicate the size
+already declared by `createCanvas()`. Fluid sizing is for inline canvases; use
+`createSurfaceCanvas()` instead for a fullscreen surface overlay.
+
 ## Focused Interactive View
 
 Open the node overflow menu and choose **Expand** to focus any p5 canvas.


### PR DESCRIPTION
Adds the `setFluidSize` API to P5.js object, so we can create resizable objects with P5.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added resizable inline p5 canvases with `setFluidSize()`.
  * Added controls for resize direction, aspect-ratio preservation, and resizer visibility.
  * Added support for persisted canvas dimensions and interactive resizing.
  * Added editor autocomplete and p5 prompt guidance for fluid canvas sizing.
  * Updated embedded p5 presets to use the new sizing behavior.

* **Documentation**
  * Documented fluid canvas sizing, supported options, limitations, and recommended usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->