### PR TITLE
feat(p5, canvas.dom): stop culling when video output is connected

### DIFF
--- a/docs/design-docs/specs/134-viewport-pause-culling-for-main-thread-nodes.md
+++ b/docs/design-docs/specs/134-viewport-pause-culling-for-main-thread-nodes.md
@@ -45,6 +45,27 @@ The manager computes separate FBO and DOM viewport bounds, builds both visible s
 - a `pausedByViewport` set so nodes paused by the viewport are resumed on re-entry, while user-paused nodes stay paused;
 - `nodeDataCommit` and `nodeDataBatchCommit` handling so manual pause/unpause changes keep the viewport ownership ledger consistent.
 
+### Active DOM Video Output Exception
+
+Offscreen `p5`, `canvas.dom`, `pixi.dom`, `three.dom`, and `textmode.dom` nodes
+remain live when all of the following are true:
+
+- their `video-out-*` handle is connected;
+- global output is enabled, either through a `bg.out` connection or a background-output override. This remains true when output is routed to the secondary screen rather than the background canvas.
+
+A supported DOM renderer that is directly selected as the output override also
+remains live without an outgoing video edge.
+
+`getViewportPersistentDomNodeIds()` supplies those IDs to
+`ViewportCullingManager`; persistent IDs are treated as DOM-viewport-visible so
+the existing pause-ownership rules resume them when output becomes active and
+pause them again when it becomes inactive. Changes to the persistent ID set
+bypass the normal viewport-update throttle so an output activation takes effect
+immediately. The active override store also counts immediately, before the
+renderer has finished synchronizing its output state. The policy builds its set
+of video-edge sources once, then checks p5 membership against that set; it does
+not parse p5 code.
+
 ## DOM Renderer Contract
 
 DOM-backed renderers that opt into viewport pause culling must:
@@ -109,6 +130,7 @@ Before enabling that optimization broadly:
 ## Success Criteria
 
 - Offscreen `p5`, `canvas.dom`, `textmode.dom`, and `three.dom` nodes stop their main-thread render loops.
+- A DOM renderer with a connected video output remains running while global output is enabled.
 - Returning those nodes to the viewport resumes only nodes that the viewport paused.
 - User-paused nodes stay paused when moved offscreen and back onscreen.
 - Manual pause/unpause while offscreen does not leave expensive render loops running invisibly.

--- a/docs/design-docs/specs/183-pixi-objects.md
+++ b/docs/design-docs/specs/183-pixi-objects.md
@@ -25,9 +25,11 @@ the copied video-output bitmap. Its preview uses the shared capped preview
 dimensions so main-thread and render-worker nodes have the same default size.
 
 The first DOM version exposes Pixi's normal canvas, stage, renderer, optional
-`draw(time)` callback, and sizing APIs. It supports one copied video output;
-Patchies message APIs, settings, keyboard helpers, and dynamic ports can be
-added once the core event and lifecycle path has settled.
+`draw(time)` callback, sizing APIs, and `noOutput()`. It supports one copied
+video output. `noOutput()` hides that output, and the default program calls it
+to avoid an unnecessary CPU-to-GPU canvas copy. Patchies message APIs,
+settings, keyboard helpers, and dynamic ports can be added once the core event
+and lifecycle path has settled.
 
 `pixi.dom` uses a shared Pixi application with Pixi's `multiView` renderer
 option. The application owns one off-DOM WebGL context; every `pixi.dom` node

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -26,7 +26,11 @@ import {
   feedbackEdgeIds
 } from '../../stores/renderer.store';
 import { get } from 'svelte/store';
-import { isBackgroundOutputCanvasEnabled, outputTarget } from '../../stores/canvas.store';
+import {
+  isBackgroundOutputCanvasEnabled,
+  isGlobalOutputEnabled,
+  outputTarget
+} from '../../stores/canvas.store';
 import { currentPatchId } from '../../stores/ui.store';
 import { renderFpsCap, showCookStats } from '../../stores/renderer.store';
 import { IpcSystem } from './IpcSystem';
@@ -769,6 +773,7 @@ export class GLSystem {
     const useBackground =
       this._outputTarget === 'background' || this.ipcSystem.outputWindow === null;
 
+    isGlobalOutputEnabled.set(outputEnabled);
     isBackgroundOutputCanvasEnabled.set(useBackground && outputEnabled);
 
     this.setOutputEnabled(outputEnabled);

--- a/ui/src/lib/canvas/ViewportCullingManager.ts
+++ b/ui/src/lib/canvas/ViewportCullingManager.ts
@@ -43,6 +43,7 @@ export class ViewportCullingManager {
 
   private cachedVisibleFboNodes: Set<string> = new Set();
   private cachedVisibleDomNodes: Set<string> = new Set();
+  private cachedPersistentDomNodeIds: Set<string> = new Set();
 
   public onVisibleFboNodesChange?: (nodeIds: Set<string>) => void;
 
@@ -112,7 +113,8 @@ export class ViewportCullingManager {
     viewport: { x: number; y: number; zoom: number },
     nodes: Node[],
     screenWidth: number,
-    screenHeight: number
+    screenHeight: number,
+    persistentDomNodeIds: ReadonlySet<string> = new Set()
   ): Set<string> | null {
     const now = performance.now();
 
@@ -121,13 +123,22 @@ export class ViewportCullingManager {
       viewport.x !== this.lastViewport.x ||
       viewport.y !== this.lastViewport.y ||
       viewport.zoom !== this.lastViewport.zoom;
+    const persistentDomNodesChanged = !this.setsEqual(
+      persistentDomNodeIds,
+      this.cachedPersistentDomNodeIds
+    );
 
-    if (!viewportMoved && now - this.lastUpdateTime < this.config.throttleMs) {
+    if (
+      !viewportMoved &&
+      !persistentDomNodesChanged &&
+      now - this.lastUpdateTime < this.config.throttleMs
+    ) {
       return null;
     }
 
     this.lastUpdateTime = now;
     this.lastViewport = { x: viewport.x, y: viewport.y, zoom: viewport.zoom };
+    this.cachedPersistentDomNodeIds = new Set(persistentDomNodeIds);
 
     const fboBounds = this.calculateViewportBounds(
       viewport,
@@ -163,7 +174,7 @@ export class ViewportCullingManager {
       if (isDom) {
         liveDomIds.add(node.id);
 
-        if (this.isNodeVisible(node, domBounds)) {
+        if (persistentDomNodeIds.has(node.id) || this.isNodeVisible(node, domBounds)) {
           visibleDomNodes.add(node.id);
         }
       }
@@ -182,7 +193,7 @@ export class ViewportCullingManager {
     return visibleFboNodes;
   }
 
-  private setsEqual(a: Set<string>, b: Set<string>): boolean {
+  private setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
     if (a.size !== b.size) return false;
 
     for (const item of a) {
@@ -197,11 +208,18 @@ export class ViewportCullingManager {
     viewport: { x: number; y: number; zoom: number },
     nodes: Node[],
     screenWidth: number,
-    screenHeight: number
+    screenHeight: number,
+    persistentDomNodeIds: ReadonlySet<string> = new Set()
   ): Set<string> | null {
     this.lastUpdateTime = -Infinity;
 
-    return this.updateVisibleNodes(viewport, nodes, screenWidth, screenHeight);
+    return this.updateVisibleNodes(
+      viewport,
+      nodes,
+      screenWidth,
+      screenHeight,
+      persistentDomNodeIds
+    );
   }
 
   getVisibleNodes(): Set<string> {
@@ -217,5 +235,6 @@ export class ViewportCullingManager {
     this.onVisibleDomNodesChange = undefined;
     this.cachedVisibleFboNodes.clear();
     this.cachedVisibleDomNodes.clear();
+    this.cachedPersistentDomNodeIds.clear();
   }
 }

--- a/ui/src/lib/canvas/viewport-culling-policy.test.ts
+++ b/ui/src/lib/canvas/viewport-culling-policy.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import type { Edge, Node } from '@xyflow/svelte';
+import { ViewportCullingManager } from './ViewportCullingManager';
+import { getViewportPersistentDomNodeIds } from './viewport-culling-policy';
+
+const p5Node = (): Node => ({
+  id: 'p5-1',
+  type: 'p5',
+  position: { x: 0, y: 0 },
+  data: {}
+});
+
+const domVideoNode = (id: string, type: string): Node => ({
+  id,
+  type,
+  position: { x: 0, y: 0 },
+  data: {}
+});
+
+const videoEdge: Edge = {
+  id: 'p5-to-glsl',
+  source: 'p5-1',
+  target: 'glsl-1',
+  sourceHandle: 'video-out-0',
+  targetHandle: 'video-in-0'
+};
+
+const domVideoEdge = (source: string): Edge => ({
+  id: `${source}-to-glsl`,
+  source,
+  target: 'glsl-1',
+  sourceHandle: 'video-out-0',
+  targetHandle: 'video-in-0'
+});
+
+describe('getViewportPersistentDomNodeIds', () => {
+  it('keeps a connected p5 node live while global output or an output override is enabled', () => {
+    expect(getViewportPersistentDomNodeIds([p5Node()], [videoEdge], true)).toEqual(
+      new Set(['p5-1'])
+    );
+  });
+
+  it('does not keep p5 live without an active output or video connection', () => {
+    expect(getViewportPersistentDomNodeIds([p5Node()], [videoEdge], false)).toEqual(new Set());
+    expect(getViewportPersistentDomNodeIds([p5Node()], [], true)).toEqual(new Set());
+  });
+
+  it('uses the video edge rather than inspecting p5 code', () => {
+    const node = { ...p5Node(), data: { code: 'noOutput()' } };
+
+    expect(getViewportPersistentDomNodeIds([node], [videoEdge], true)).toEqual(new Set(['p5-1']));
+  });
+
+  it.each(['canvas.dom', 'pixi.dom', 'three.dom', 'textmode.dom'])(
+    'keeps %s live when its video output is connected',
+    (type) => {
+      const node = domVideoNode(`${type}-1`, type);
+
+      expect(getViewportPersistentDomNodeIds([node], [domVideoEdge(node.id)], true)).toEqual(
+        new Set([node.id])
+      );
+    }
+  );
+
+  it('keeps a directly overridden DOM renderer live without a video edge', () => {
+    const node = domVideoNode('canvas-dom-1', 'canvas.dom');
+
+    expect(getViewportPersistentDomNodeIds([node], [], true, node.id)).toEqual(new Set([node.id]));
+  });
+
+  it('does not keep an unsupported directly overridden node live', () => {
+    const node = domVideoNode('glsl-1', 'glsl');
+
+    expect(getViewportPersistentDomNodeIds([node], [], true, node.id)).toEqual(new Set());
+  });
+
+  it('updates DOM visibility immediately when a p5 becomes persistent', () => {
+    const manager = new ViewportCullingManager({ throttleMs: 1_000 });
+    const viewport = { x: 0, y: 0, zoom: 1 };
+    const offscreenP5 = { ...p5Node(), position: { x: 2_000, y: 2_000 } };
+
+    manager.updateVisibleNodes(viewport, [offscreenP5], 1_000, 1_000);
+    manager.updateVisibleNodes(viewport, [offscreenP5], 1_000, 1_000, new Set(['p5-1']));
+
+    expect(manager.getVisibleDomNodes()).toEqual(new Set(['p5-1']));
+  });
+});

--- a/ui/src/lib/canvas/viewport-culling-policy.ts
+++ b/ui/src/lib/canvas/viewport-culling-policy.ts
@@ -1,0 +1,41 @@
+import type { Edge, Node } from '@xyflow/svelte';
+
+const OUTPUT_PERSISTENT_DOM_TYPES = new Set([
+  'p5',
+  'canvas.dom',
+  'pixi.dom',
+  'three.dom',
+  'textmode.dom'
+]);
+
+/**
+ * Returns DOM renderer IDs that must keep running while offscreen because they
+ * provide frames to an active global output.
+ */
+export function getViewportPersistentDomNodeIds(
+  nodes: Node[],
+  edges: Edge[],
+  isGlobalOutputEnabled: boolean,
+  overrideOutputNodeId: string | null = null
+): Set<string> {
+  if (!isGlobalOutputEnabled) return new Set();
+
+  const connectedVideoSourceIds = new Set<string>();
+
+  for (const edge of edges) {
+    if (edge.sourceHandle?.startsWith('video-out') === true) {
+      connectedVideoSourceIds.add(edge.source);
+    }
+  }
+
+  const persistentNodeIds = new Set<string>();
+
+  for (const node of nodes) {
+    if (!node.type || !OUTPUT_PERSISTENT_DOM_TYPES.has(node.type)) continue;
+    if (node.id !== overrideOutputNodeId && !connectedVideoSourceIds.has(node.id)) continue;
+
+    persistentNodeIds.add(node.id);
+  }
+
+  return persistentNodeIds;
+}

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -215,6 +215,7 @@ describe('patchies completions', () => {
     expect(getCompletionLabels('pixi.dom', 'setF')).toContain('setFluidSize');
 
     expect(getCompletionLabels('pixi.dom', 'onCanvasR')).toContain('onCanvasResize');
+    expect(getCompletionLabels('pixi.dom', 'noO')).toContain('noOutput');
     expect(getCompletionLabels('dom', 'setF')).toContain('setFluidSize');
     expect(getCompletionLabels('vue', 'setF')).toContain('setFluidSize');
     expect(getCompletionLabels('dom', 'onR')).toContain('onResize');

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -666,6 +666,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
     'textmode.dom',
     'three',
     'three.dom',
+    'pixi.dom',
     'surface'
   ],
   onKeyDown: ['canvas.dom', 'three.dom', 'surface'],

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -56,6 +56,7 @@
   import {
     hasSomeAudioNode,
     isBackgroundOutputCanvasEnabled,
+    isGlobalOutputEnabled,
     snapGridSize
   } from '../../stores/canvas.store';
 
@@ -70,6 +71,7 @@
     isValidConnectionBetweenHandles
   } from '$lib/utils/connection-validation';
   import { ViewportCullingManager } from '$lib/canvas/ViewportCullingManager';
+  import { getViewportPersistentDomNodeIds } from '$lib/canvas/viewport-culling-policy';
   import { CULLABLE_DOM_TYPES } from '$lib/rendering/types';
   import { useFocusNode, useNodeLabels } from '$lib/canvas/use-focus-node.svelte';
   import AIProviderSettingsDialog from './dialogs/AIProviderSettingsDialog.svelte';
@@ -107,7 +109,7 @@
   import { toast } from 'svelte-sonner';
   import { Transport } from '$lib/transport';
   import { transportStore } from '../../stores/transport.store';
-  import { allPreviewsDisabled } from '../../stores/renderer.store';
+  import { allPreviewsDisabled, overrideOutputNodeId } from '../../stores/renderer.store';
   import { cullObjects } from '../../stores/debug.store';
   import {
     activeCodeEditorTarget,
@@ -579,7 +581,20 @@
     const screenWidth = typeof window !== 'undefined' ? window.innerWidth : 1920;
     const screenHeight = typeof window !== 'undefined' ? window.innerHeight : 1080;
 
-    viewportCullingManager.updateVisibleNodes(currentViewport, nodes, screenWidth, screenHeight);
+    const persistentDomNodeIds = getViewportPersistentDomNodeIds(
+      nodes,
+      edges,
+      $isGlobalOutputEnabled || $overrideOutputNodeId !== null,
+      $overrideOutputNodeId
+    );
+
+    viewportCullingManager.updateVisibleNodes(
+      currentViewport,
+      nodes,
+      screenWidth,
+      screenHeight,
+      persistentDomNodeIds
+    );
   });
 
   // Keyboard shortcuts delegated to KeyboardShortcutManager (created in onMount)

--- a/ui/src/lib/services/PatchManager.ts
+++ b/ui/src/lib/services/PatchManager.ts
@@ -13,7 +13,7 @@ import {
   helpModeObject,
   isCablesVisible
 } from '../../stores/ui.store';
-import { isBackgroundOutputCanvasEnabled } from '../../stores/canvas.store';
+import { isBackgroundOutputCanvasEnabled, isGlobalOutputEnabled } from '../../stores/canvas.store';
 import { transportStore } from '../../stores/transport.store';
 import { DEFAULT_BPM, DEFAULT_TIME_SIGNATURE } from '$lib/transport/constants';
 import { GLSystem } from '$lib/canvas/GLSystem';
@@ -386,6 +386,7 @@ export class PatchManager {
 
     // Reset stores
     isBackgroundOutputCanvasEnabled.set(false);
+    isGlobalOutputEnabled.set(false);
     currentPatchName.set(null);
 
     // Restore default settings

--- a/ui/src/objects/pixi/PixiDom.svelte
+++ b/ui/src/objects/pixi/PixiDom.svelte
@@ -6,7 +6,8 @@
     NodeResizer,
     NodeResizeControl,
     ResizeControlVariant,
-    useSvelteFlow
+    useSvelteFlow,
+    useUpdateNodeInternals
   } from '@xyflow/svelte';
 
   import CanvasPreviewLayout from '$lib/components/CanvasPreviewLayout.svelte';
@@ -53,6 +54,7 @@
   } = $props();
 
   const { updateNode, updateNodeData } = useSvelteFlow();
+  const updateNodeInternals = useUpdateNodeInternals();
 
   const glSystem = GLSystem.getInstance();
   const eventBus = PatchiesEventBus.getInstance();
@@ -68,6 +70,7 @@
   let entry = $state<Awaited<ReturnType<typeof pixiDomManager.register>>>();
   let draw: ((time: number) => void) | null = null;
   let editorReady = $state(false);
+  let videoOutputEnabled = $state(true);
   let runRevision = 0;
   let destroyed = false;
   let outputWidth = $state($globalOutputWidth);
@@ -102,6 +105,13 @@
     outputHeight = height;
 
     pixiDomManager.resize(nodeId, { width, height });
+  }
+
+  function setVideoOutputEnabled(enabled: boolean) {
+    if (videoOutputEnabled === enabled) return;
+
+    videoOutputEnabled = enabled;
+    updateNodeInternals(nodeId);
   }
 
   function togglePlayback() {
@@ -139,6 +149,7 @@
     let runStage: Container | null = null;
 
     draw = null;
+    setVideoOutputEnabled(true);
     fluidCanvas.reset();
 
     setCanvasDimensions({
@@ -167,6 +178,7 @@
         'setFluidSize',
         'onCanvasResize',
         'loadExtensions',
+        'noOutput',
         `${data.code}\nreturn typeof draw === 'function' ? draw : null;`
       );
 
@@ -180,7 +192,8 @@
         fluidCanvas.setFixedCanvasSize,
         fluidCanvas.setFluidSize,
         fluidCanvas.onCanvasResize,
-        pixiDomManager.loadExtensions.bind(pixiDomManager)
+        pixiDomManager.loadExtensions.bind(pixiDomManager),
+        () => setVideoOutputEnabled(false)
       );
 
       if (revision !== runRevision) {
@@ -297,14 +310,16 @@
     displayExtraMenuItems={fluidCanvas.displayExtraMenuItems}
   >
     {#snippet bottomHandle()}
-      <TypedHandle
-        port="outlet"
-        spec={{ handleType: 'video', handleId: '0' }}
-        title="Video output"
-        total={1}
-        index={0}
-        {nodeId}
-      />
+      {#if videoOutputEnabled}
+        <TypedHandle
+          port="outlet"
+          spec={{ handleType: 'video', handleId: '0' }}
+          title="Video output"
+          total={1}
+          index={0}
+          {nodeId}
+        />
+      {/if}
     {/snippet}
 
     {#snippet codeEditor()}

--- a/ui/src/objects/pixi/constants.ts
+++ b/ui/src/objects/pixi/constants.ts
@@ -20,7 +20,9 @@ function draw(t) {
   })
 }`;
 
-export const DEFAULT_PIXI_DOM_CODE = `const { Graphics } = PIXI
+export const DEFAULT_PIXI_DOM_CODE = `noOutput()
+
+const { Graphics } = PIXI
 
 const colors = [0xff5ea0, 0x66ccff, 0xa78bfa]
 

--- a/ui/src/objects/pixi/prompt.ts
+++ b/ui/src/objects/pixi/prompt.ts
@@ -37,19 +37,21 @@ PixiJS 8 on the main thread. Use it for interactive 2D graphics with native poin
 - renderer: managed Pixi renderer; do not call renderer.render()
 - loadExtensions(...names): await before using optional Pixi APIs, for example await loadExtensions('events', 'accessibility'). Use loadExtensions('all') for every extension.
 - setCanvasSize(width, height), setFluidSize(), onCanvasResize(callback): canvas sizing APIs
+- noOutput(): hide the video output port when the scene does not feed another video node
 
 **Rules:**
 - Graphics is available by default.
 - Draw a shape before calling fill() or stroke(). For paths, chain moveTo()/lineTo()/arcTo() directly on Graphics; never call Graphics.path() without a GraphicsPath argument.
 - Define draw(time) for animation. Do not use requestAnimationFrame.
 - Use await loadExtensions('events') before adding Pixi pointer handlers.
+- Call noOutput() by default unless the scene explicitly outputs video to another node.
 
 Example:
 \`\`\`json
 {
   "type": "pixi.dom",
   "data": {
-    "code": "await loadExtensions('events')\n\nconst { Graphics } = PIXI\n\nconst button = new Graphics().circle(width / 2, height / 2, 72).fill(0x66ccff)\nbutton.eventMode = 'static'\nbutton.cursor = 'pointer'\nbutton.on('pointertap', () => button.tint = Math.random() * 0xffffff)\nstage.addChild(button)"
+    "code": "noOutput()\nawait loadExtensions('events')\n\nconst { Graphics } = PIXI\n\nconst button = new Graphics().circle(width / 2, height / 2, 72).fill(0x66ccff)\nbutton.eventMode = 'static'\nbutton.cursor = 'pointer'\nbutton.on('pointertap', () => button.tint = Math.random() * 0xffffff)\nstage.addChild(button)"
   }
 }
 \`\`\``;

--- a/ui/src/stores/canvas.store.ts
+++ b/ui/src/stores/canvas.store.ts
@@ -1,6 +1,10 @@
 import { writable } from 'svelte/store';
 
 export const isBackgroundOutputCanvasEnabled = writable(false);
+
+/** Whether any global output route is active, including a secondary output screen. */
+export const isGlobalOutputEnabled = writable(false);
+
 export const hasSomeAudioNode = writable(false);
 
 /** Where rendered output frames are routed: background canvas or secondary output screen. */

--- a/ui/static/content/objects/pixi.dom.md
+++ b/ui/static/content/objects/pixi.dom.md
@@ -98,6 +98,32 @@ onCanvasResize(({ width, height }) => {
 the same behavior as [canvas.dom](/docs/objects/canvas.dom#resizable-widgets).
 While fluid mode is active, `setCanvasSize()` is ignored.
 
+## Video Output
+
+`pixi.dom` copies its canvas into the video pipeline only when it feeds another
+video node. The copy is slower than worker-side [pixi](/docs/objects/pixi), so
+the default program calls `noOutput()` and hides the video output port.
+
+Remove `noOutput()` when you want to chain the scene into another visual:
+
+```javascript
+const { Graphics } = PIXI
+
+const badge = new Graphics()
+  .circle(width / 2, height / 2, 100)
+  .fill(0x66ccff)
+
+stage.addChild(badge)
+```
+
+## Special Functions
+
+- `noOutput()` — hides the video output port
+- `setCanvasSize(width, height)` — sets a fixed canvas resolution
+- `setFluidSize(options?)` — makes the canvas follow the node size
+- `onCanvasResize(callback)` — runs a callback after the canvas is resized
+- `loadExtensions(...names)` — loads optional PixiJS extensions
+
 ## See Also
 
 - [pixi](/docs/objects/pixi) — worker-side PixiJS


### PR DESCRIPTION
Stops culling `p5` and `canvas.dom` objects whenever its video output is connected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offscreen video-rendering nodes now remain active when global output or secondary-screen routing is enabled.
  * Output-connected nodes are preserved immediately when routing changes, ensuring uninterrupted video output.

* **Bug Fixes**
  * Corrected viewport culling behavior for connected `p5` and `canvas.dom` video nodes.
  * Reset output state when creating a new patch.

* **Tests**
  * Added coverage for output routing, node connections, and immediate visibility updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->