### PR TITLE
feat(pixi, pixi.dom): dynamically load pixi extensions

### DIFF
--- a/docs/design-docs/specs/183-pixi-objects.md
+++ b/docs/design-docs/specs/183-pixi-objects.md
@@ -47,3 +47,26 @@ recreate a WebGL context as part of a code rerun.
 
 The initial worker object has one video output and no video-texture input.
 Resource cleanup must destroy the Pixi renderer, stage, and RenderTexture.
+
+## Runtime extension loading
+
+The worker `pixi` object exposes `await loadExtensions(...extensions)` to load
+Pixi extension entrypoints on demand. It accepts every worker-safe Pixi 8
+extension name and the `'all'` shorthand. When newly loaded extensions change
+the renderer configuration, Patchies recreates the node's Pixi renderer on the
+same shared WebGL context and replaces its RenderTexture. The user-visible
+`renderer` object remains a stable proxy to the current Pixi renderer.
+
+`accessibility`, `dom`, `events`, and `text-html` are browser-only and must fail
+with a clear error in the worker object rather than attempting to construct DOM
+systems in the render worker. `pixi.dom` remains their interactive counterpart.
+
+`pixi.dom` exposes the same asynchronous helper and accepts every Pixi 8
+extension name, including `accessibility`, `dom`, and `events`. Its PixiJS
+runtime is dynamically imported when the first DOM object registers, rather
+than when Patchies loads the node component. When an extension changes renderer
+configuration, the manager recreates its one shared application while retaining
+every registered stage, canvas, and event binding. Its `renderer` user-code
+value is a stable proxy to the replacement renderer. Ordinary code reruns still
+reuse the application and do not recreate a WebGL context. Concurrent extension
+requests are serialized so each caller observes a fully initialized application.

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -69,6 +69,13 @@ const patchiesAPICompletions: Completion[] = [
     apply: 'getTexture(0)'
   },
   {
+    label: 'loadExtensions',
+    type: 'function',
+    detail: '(...extensions: string[]) => Promise<void>',
+    info: "Load Pixi extensions. Await loadExtensions('filters', 'text') or loadExtensions('all').",
+    apply: "await loadExtensions('filters')"
+  },
+  {
     label: 'OrbitControls',
     type: 'class',
     detail: 'new OrbitControls(camera)',
@@ -556,6 +563,7 @@ const topLevelOnlyFunctions = new Set([
   'redraw',
   'setAudioPortCount',
   'setCanvasSize',
+  'loadExtensions',
   'setFluidSize',
   'onCanvasResize',
   'setDrawMode',
@@ -642,6 +650,7 @@ const nodeSpecificFunctions: Record<string, string[]> = {
     'tone~'
   ],
   opencv: ['js', 'worker', 'canvas', 'canvas.dom'],
+  loadExtensions: ['pixi', 'pixi.dom'],
   noDrag: MOUSE_INTERACTION_JS_NODES,
   noPan: MOUSE_INTERACTION_JS_NODES,
   noWheel: MOUSE_INTERACTION_JS_NODES,

--- a/ui/src/objects/pixi/PixiDom.svelte
+++ b/ui/src/objects/pixi/PixiDom.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
 
+  import type { Container } from 'pixi.js';
   import {
     NodeResizer,
     NodeResizeControl,
@@ -25,6 +26,12 @@
     outputHeight as globalOutputHeight,
     outputWidth as globalOutputWidth
   } from '../../stores/renderer.store';
+
+  type AsyncUserCode = (...args: unknown[]) => Promise<unknown>;
+  type AsyncFunctionConstructor = new (...args: string[]) => AsyncUserCode;
+
+  const AsyncFunction = Object.getPrototypeOf(async () => {})
+    .constructor as AsyncFunctionConstructor;
 
   let {
     id: nodeId,
@@ -97,9 +104,6 @@
     pixiDomManager.resize(nodeId, { width, height });
   }
 
-  const clearStage = () =>
-    entry?.stage.removeChildren().forEach((child) => child.destroy({ children: true }));
-
   function togglePlayback() {
     const wasPaused = !!data.paused;
     const paused = !wasPaused;
@@ -132,6 +136,7 @@
     if (!canvas || !entry) return;
 
     const revision = ++runRevision;
+    let runStage: Container | null = null;
 
     draw = null;
     fluidCanvas.reset();
@@ -142,16 +147,16 @@
     });
 
     try {
-      const app = await pixiDomManager.getApplication();
-      const PIXI = await import('pixi.js');
+      await pixiDomManager.getApplication();
+
+      const PIXI = await pixiDomManager.getPixiRuntime();
 
       if (revision !== runRevision) return;
 
-      clearStage();
-
       const dimensions = fluidCanvas.getExecutionDimensions(data.code);
+      runStage = new PIXI.Container();
 
-      const execute = new Function(
+      const execute = new AsyncFunction(
         'PIXI',
         'renderer',
         'stage',
@@ -161,25 +166,39 @@
         'setCanvasSize',
         'setFluidSize',
         'onCanvasResize',
+        'loadExtensions',
         `${data.code}\nreturn typeof draw === 'function' ? draw : null;`
       );
 
-      const candidate = execute(
+      const candidate = await execute(
         PIXI,
-        app.renderer,
-        entry.stage,
+        pixiDomManager.getRenderer(),
+        runStage,
         canvas,
         dimensions.width,
         dimensions.height,
         fluidCanvas.setFixedCanvasSize,
         fluidCanvas.setFluidSize,
-        fluidCanvas.onCanvasResize
+        fluidCanvas.onCanvasResize,
+        pixiDomManager.loadExtensions.bind(pixiDomManager)
       );
 
-      if (revision !== runRevision) return;
+      if (revision !== runRevision) {
+        runStage.destroy({ children: true });
+        return;
+      }
 
-      draw = typeof candidate === 'function' ? candidate : null;
+      if (!pixiDomManager.replaceStage(nodeId, runStage)) {
+        runStage.destroy({ children: true });
+        return;
+      }
+
+      runStage = null;
+
+      draw = typeof candidate === 'function' ? (candidate as (time: number) => void) : null;
     } catch (error) {
+      runStage?.destroy({ children: true });
+
       if (revision !== runRevision) return;
 
       console.error('[pixi.dom] code error', error);

--- a/ui/src/objects/pixi/PixiDomManager.test.ts
+++ b/ui/src/objects/pixi/PixiDomManager.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const pixiMocks = vi.hoisted(() => ({
+  applications: [] as Array<{ destroy: ReturnType<typeof vi.fn> }>,
+  extensionVersion: 0,
+  initWaiters: [] as Promise<void>[],
+  loadExtensions: vi.fn(async () => {
+    pixiMocks.extensionVersion += 1;
+  })
+}));
+
+vi.mock('$objects/pixi/extensions', () => ({
+  getPixiExtensionVersion: () => pixiMocks.extensionVersion,
+  loadPixiDomExtensions: pixiMocks.loadExtensions
+}));
+
+vi.mock('pixi.js', () => ({
+  Application: class {
+    renderer = {
+      extensionVersion: -1,
+      events: {
+        rootBoundary: { rootTarget: null },
+        setTargetElement: vi.fn()
+      }
+    };
+    ticker = {
+      add: vi.fn(),
+      remove: vi.fn(),
+      start: vi.fn()
+    };
+    destroy = vi.fn();
+
+    constructor() {
+      pixiMocks.applications.push(this);
+    }
+
+    async init() {
+      this.renderer.extensionVersion = pixiMocks.extensionVersion;
+
+      await pixiMocks.initWaiters.shift();
+    }
+  },
+  Container: class {}
+}));
+
+import { pixiDomManager } from './PixiDomManager';
+
+const deferred = () => {
+  let resolve!: () => void;
+
+  const promise = new Promise<void>((next) => {
+    resolve = next;
+  });
+
+  return { promise, resolve };
+};
+
+describe('PixiDomManager', () => {
+  afterEach(() => {
+    pixiDomManager.destroy();
+    vi.unstubAllGlobals();
+  });
+
+  it('serializes concurrent extension loads through application recreation', async () => {
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    });
+
+    await pixiDomManager.getApplication();
+
+    const recreation = deferred();
+    pixiMocks.initWaiters.push(recreation.promise);
+
+    const firstLoad = pixiDomManager.loadExtensions('filters');
+    await vi.waitFor(() => expect(pixiMocks.applications).toHaveLength(2));
+
+    const secondLoad = pixiDomManager.loadExtensions('text');
+    expect(pixiMocks.loadExtensions).toHaveBeenCalledTimes(1);
+
+    recreation.resolve();
+    await Promise.all([firstLoad, secondLoad]);
+
+    expect(pixiMocks.loadExtensions.mock.calls).toEqual([['filters'], ['text']]);
+
+    expect(
+      (pixiDomManager.getRenderer() as unknown as { extensionVersion: number }).extensionVersion
+    ).toBe(2);
+  });
+});

--- a/ui/src/objects/pixi/PixiDomManager.ts
+++ b/ui/src/objects/pixi/PixiDomManager.ts
@@ -1,4 +1,16 @@
-import { Application, Container, type WebGLRenderer } from 'pixi.js';
+import type { Application, Container, WebGLRenderer } from 'pixi.js';
+
+import { getPixiExtensionVersion, loadPixiDomExtensions } from '$objects/pixi/extensions';
+
+type PixiRuntime = typeof import('pixi.js');
+
+let pixiRuntimePromise: Promise<PixiRuntime> | null = null;
+
+const loadPixiRuntime = () => {
+  pixiRuntimePromise ??= import('pixi.js');
+
+  return pixiRuntimePromise;
+};
 
 type PixiHandler =
   | '_onPointerDown'
@@ -38,6 +50,11 @@ class PixiDomManager {
   private applicationInit: Promise<Application> | null = null;
   private entries = new Map<string, PixiDomEntry>();
   private activePointers = new Map<number, PixiDomEntry>();
+  private extensionLoadQueue = Promise.resolve();
+  private pixiRuntime: PixiRuntime | null = null;
+  private rendererProxy: WebGLRenderer | null = null;
+  private extensionVersion = 0;
+  private windowEventsBound = false;
   private destroyed = false;
 
   async register(
@@ -47,6 +64,8 @@ class PixiDomManager {
     draw: (time: number) => void,
     onRendered: () => void
   ) {
+    const PIXI = await this.getPixiRuntime();
+
     await this.getApplication();
 
     const entry: PixiDomEntry = {
@@ -55,7 +74,7 @@ class PixiDomManager {
       height: size.height,
       onRendered,
       paused: false,
-      stage: new Container(),
+      stage: new PIXI.Container(),
       width: size.width
     };
 
@@ -68,7 +87,6 @@ class PixiDomManager {
 
   unregister(nodeId: string) {
     const entry = this.entries.get(nodeId);
-
     if (!entry) return;
 
     this.unbindEvents(entry);
@@ -83,15 +101,25 @@ class PixiDomManager {
 
   resize(nodeId: string, size: { width: number; height: number }) {
     const entry = this.entries.get(nodeId);
-
     if (!entry) return;
 
     this.resizeEntry(entry, size);
   }
 
+  replaceStage(nodeId: string, nextStage: Container) {
+    const entry = this.entries.get(nodeId);
+    if (!entry) return false;
+
+    const previousStage = entry.stage;
+
+    entry.stage = nextStage;
+    previousStage.destroy({ children: true });
+
+    return true;
+  }
+
   setPaused(nodeId: string, paused: boolean) {
     const entry = this.entries.get(nodeId);
-
     if (!entry) return;
 
     entry.paused = paused;
@@ -101,52 +129,123 @@ class PixiDomManager {
     if (this.app) return this.app;
     if (this.applicationInit) return this.applicationInit;
 
-    const nextApp = new Application();
+    this.applicationInit = this.initializeApplication();
 
-    this.applicationInit = nextApp
-      .init({
+    return this.applicationInit;
+  }
+
+  async getPixiRuntime() {
+    this.pixiRuntime ??= await loadPixiRuntime();
+
+    return this.pixiRuntime;
+  }
+
+  loadExtensions(...extensions: string[]) {
+    const request = this.extensionLoadQueue.then(() =>
+      this.loadExtensionsAndRecreate(...extensions)
+    );
+
+    this.extensionLoadQueue = request.catch(() => {});
+
+    return request;
+  }
+
+  private async loadExtensionsAndRecreate(...extensions: string[]) {
+    await loadPixiDomExtensions(...extensions);
+    await this.getApplication();
+
+    if (this.extensionVersion === getPixiExtensionVersion()) return;
+
+    await this.recreateApplication();
+  }
+
+  getRenderer() {
+    this.rendererProxy ??= new Proxy({} as WebGLRenderer, {
+      get: (_target, property) => {
+        const renderer = this.app?.renderer as WebGLRenderer | undefined;
+        if (!renderer) return undefined;
+
+        const value = Reflect.get(renderer, property, renderer);
+
+        return typeof value === 'function' ? value.bind(renderer) : value;
+      },
+      set: (_target, property, value) => {
+        const renderer = this.app?.renderer as WebGLRenderer | undefined;
+        if (!renderer) return false;
+
+        return Reflect.set(renderer, property, value, renderer);
+      }
+    });
+
+    return this.rendererProxy;
+  }
+
+  private async initializeApplication() {
+    const PIXI = await this.getPixiRuntime();
+    const nextApp = new PIXI.Application();
+
+    try {
+      await nextApp.init({
         autoStart: false,
         backgroundAlpha: 0,
         multiView: true,
         antialias: true
-      })
-      .then(() => {
-        if (this.destroyed) {
-          nextApp.destroy({ removeView: false }, { children: true });
+      });
 
-          throw new Error('Pixi DOM manager was destroyed during initialization.');
-        }
+      if (this.destroyed) {
+        nextApp.destroy({ removeView: false }, { children: true });
 
-        nextApp.ticker.remove(nextApp.render, nextApp);
-        nextApp.ticker.add((ticker) => this.render(ticker.lastTime / 1000));
-        nextApp.ticker.start();
+        throw new Error('Pixi DOM manager was destroyed during initialization.');
+      }
 
-        const events = nextApp.renderer.events as PixiDomEvents;
-        events.setTargetElement(null as never);
+      nextApp.ticker.remove(nextApp.render, nextApp);
+      nextApp.ticker.add((ticker) => this.render(ticker.lastTime / 1000));
+      nextApp.ticker.start();
 
+      const events = nextApp.renderer.events as PixiDomEvents;
+      events.setTargetElement(null as never);
+
+      if (!this.windowEventsBound) {
         window.addEventListener('pointermove', this.handleWindowPointerMove);
         window.addEventListener('pointerup', this.handleWindowPointerUp);
 
-        this.app = nextApp;
+        this.windowEventsBound = true;
+      }
 
-        return nextApp;
-      })
-      .finally(() => {
-        this.applicationInit = null;
-      });
+      this.app = nextApp;
+      this.extensionVersion = getPixiExtensionVersion();
 
-    return this.applicationInit;
+      return nextApp;
+    } finally {
+      this.applicationInit = null;
+    }
+  }
+
+  private async recreateApplication() {
+    const app = this.app;
+    if (!app) return;
+
+    this.app = null;
+    app.destroy({ removeView: false }, { children: false });
+
+    await this.getApplication();
   }
 
   destroy() {
     this.destroyed = true;
     this.entries.forEach((_, nodeId) => this.unregister(nodeId));
 
-    window.removeEventListener('pointermove', this.handleWindowPointerMove);
-    window.removeEventListener('pointerup', this.handleWindowPointerUp);
+    if (this.windowEventsBound) {
+      window.removeEventListener('pointermove', this.handleWindowPointerMove);
+      window.removeEventListener('pointerup', this.handleWindowPointerUp);
+
+      this.windowEventsBound = false;
+    }
 
     this.app?.destroy({ removeView: false }, { children: true });
     this.app = null;
+    this.pixiRuntime = null;
+    this.rendererProxy = null;
   }
 
   private bindEvents(entry: PixiDomEntry) {

--- a/ui/src/objects/pixi/extensions.ts
+++ b/ui/src/objects/pixi/extensions.ts
@@ -1,0 +1,117 @@
+const PIXI_EXTENSION_NAMES = [
+  'accessibility',
+  'advanced-blend-modes',
+  'app',
+  'basis',
+  'dds',
+  'dom',
+  'events',
+  'filters',
+  'gif',
+  'graphics',
+  'ktx',
+  'ktx2',
+  'math-extras',
+  'mesh',
+  'particle-container',
+  'prepare',
+  'sprite-nine-slice',
+  'sprite-tiling',
+  'text',
+  'text-bitmap',
+  'text-html',
+  'unsafe-eval'
+] as const;
+
+const PIXI_DOM_ONLY_EXTENSION_NAMES = ['accessibility', 'dom', 'events', 'text-html'];
+
+const PIXI_WORKER_EXTENSION_NAMES = PIXI_EXTENSION_NAMES.filter(
+  (extension) => !PIXI_DOM_ONLY_EXTENSION_NAMES.includes(extension)
+);
+
+type PixiExtensionName = (typeof PIXI_EXTENSION_NAMES)[number];
+
+type PixiEnvironment = 'dom' | 'worker';
+
+const extensionLoaders: Record<PixiExtensionName, () => Promise<unknown>> = {
+  accessibility: () => import('pixi.js/accessibility'),
+  'advanced-blend-modes': () => import('pixi.js/advanced-blend-modes'),
+  app: () => import('pixi.js/app'),
+  basis: () => import('pixi.js/basis'),
+  dds: () => import('pixi.js/dds'),
+  dom: () => import('pixi.js/dom'),
+  events: () => import('pixi.js/events'),
+  filters: () => import('pixi.js/filters'),
+  gif: () => import('pixi.js/gif'),
+  graphics: () => import('pixi.js/graphics'),
+  ktx: () => import('pixi.js/ktx'),
+  ktx2: () => import('pixi.js/ktx2'),
+  'math-extras': () => import('pixi.js/math-extras'),
+  mesh: () => import('pixi.js/mesh'),
+  'particle-container': () => import('pixi.js/particle-container'),
+  prepare: () => import('pixi.js/prepare'),
+  'sprite-nine-slice': () => import('pixi.js/sprite-nine-slice'),
+  'sprite-tiling': () => import('pixi.js/sprite-tiling'),
+  text: () => import('pixi.js/text'),
+  'text-bitmap': () => import('pixi.js/text-bitmap'),
+  'text-html': () => import('pixi.js/text-html'),
+  'unsafe-eval': () => import('pixi.js/unsafe-eval')
+};
+
+const enabledExtensions = new Set<PixiExtensionName>();
+const extensionPromises = new Map<PixiExtensionName, Promise<unknown>>();
+
+export const getPixiExtensionVersion = () => enabledExtensions.size;
+
+export const loadPixiDomExtensions = (...extensions: string[]) =>
+  loadPixiExtensions('dom', ...extensions);
+
+export const loadPixiWorkerExtensions = (...extensions: string[]) =>
+  loadPixiExtensions('worker', ...extensions);
+
+async function loadPixiExtensions(environment: PixiEnvironment, ...extensions: string[]) {
+  const availableExtensions =
+    environment === 'dom' ? PIXI_EXTENSION_NAMES : PIXI_WORKER_EXTENSION_NAMES;
+  const requestedExtensions = extensions.includes('all') ? availableExtensions : extensions;
+
+  const browserOnlyExtension = requestedExtensions.find(
+    (extension) => environment === 'worker' && PIXI_DOM_ONLY_EXTENSION_NAMES.includes(extension)
+  );
+
+  if (browserOnlyExtension) {
+    throw new Error(
+      `[pixi] "${browserOnlyExtension}" requires browser DOM infrastructure and is only available in pixi.dom.`
+    );
+  }
+
+  const unknownExtension = requestedExtensions.find(
+    (extension) => !Object.hasOwn(extensionLoaders, extension)
+  );
+
+  if (unknownExtension) {
+    throw new Error(
+      `[pixi] Unknown extension "${unknownExtension}". Use "all" or one of: ${availableExtensions.join(', ')}.`
+    );
+  }
+
+  for (const extension of requestedExtensions as PixiExtensionName[]) {
+    if (enabledExtensions.has(extension)) {
+      continue;
+    }
+
+    let load = extensionPromises.get(extension);
+
+    if (!load) {
+      load = extensionLoaders[extension]();
+      extensionPromises.set(extension, load);
+    }
+
+    try {
+      await load;
+      enabledExtensions.add(extension);
+    } catch (error) {
+      extensionPromises.delete(extension);
+      throw error;
+    }
+  }
+}

--- a/ui/src/objects/pixi/schema.ts
+++ b/ui/src/objects/pixi/schema.ts
@@ -4,7 +4,7 @@ import { Run, SetCode } from '$lib/objects/schemas/common';
 export const pixiSchema: ObjectSchema = {
   type: 'pixi',
   category: 'video',
-  description: 'Creates PixiJS 8 graphics in the worker render pipeline',
+  description: 'Creates Pixi.js graphics in the rendering pipeline',
   inlets: [
     {
       id: 'message',
@@ -22,6 +22,6 @@ export const pixiSchema: ObjectSchema = {
 export const pixiDomSchema: ObjectSchema = {
   ...pixiSchema,
   type: 'pixi.dom',
-  description: 'Creates interactive PixiJS 8 graphics on the main thread',
+  description: 'Creates interactive Pixi.js graphics on the main thread',
   inlets: []
 };

--- a/ui/src/objects/pixi/worker-extensions.test.ts
+++ b/ui/src/objects/pixi/worker-extensions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  loadPixiDomExtensions,
+  loadPixiWorkerExtensions,
+  getPixiExtensionVersion
+} from './extensions';
+
+describe('loadPixiWorkerExtensions', () => {
+  it('loads every worker-safe Pixi extension with the all shorthand', async () => {
+    await expect(loadPixiWorkerExtensions('all')).resolves.toBeUndefined();
+
+    expect(getPixiExtensionVersion()).toBe(18);
+  });
+
+  it('loads browser-only extensions for pixi.dom', async () => {
+    await expect(loadPixiDomExtensions('all')).resolves.toBeUndefined();
+
+    expect(getPixiExtensionVersion()).toBe(22);
+  });
+
+  it('rejects browser-only Pixi extensions before loading them', async () => {
+    await expect(loadPixiWorkerExtensions('dom')).rejects.toThrow('pixi.dom');
+    await expect(loadPixiWorkerExtensions('text-html')).rejects.toThrow('pixi.dom');
+  });
+
+  it('rejects inherited object property names as unknown extensions', async () => {
+    await expect(loadPixiDomExtensions('constructor')).rejects.toThrow(
+      'Unknown extension "constructor"'
+    );
+  });
+});

--- a/ui/src/objects/pixi/worker-extensions.ts
+++ b/ui/src/objects/pixi/worker-extensions.ts
@@ -1,0 +1,4 @@
+export {
+  loadPixiWorkerExtensions,
+  getPixiExtensionVersion as getPixiWorkerExtensionVersion
+} from './extensions';

--- a/ui/src/types/pixi.d.ts
+++ b/ui/src/types/pixi.d.ts
@@ -1,1 +1,1 @@
-declare module 'pixi.js/graphics';
+declare module 'pixi.js/*';

--- a/ui/src/workers/rendering/pixiRenderer.ts
+++ b/ui/src/workers/rendering/pixiRenderer.ts
@@ -2,6 +2,10 @@ import type regl from 'regl';
 import type { Container, RenderTexture, WebGLRenderer } from 'pixi.js';
 
 import type { RenderParams } from '$lib/rendering/types';
+import {
+  loadPixiWorkerExtensions,
+  getPixiWorkerExtensionVersion
+} from '$objects/pixi/worker-extensions';
 import { getFramebuffer } from './utils';
 import { BaseWorkerRenderer, type BaseRendererConfig } from './BaseWorkerRenderer';
 import type { FBORenderer } from './fboRenderer';
@@ -37,8 +41,10 @@ export class PixiRenderer extends BaseWorkerRenderer<PixiRendererConfig> {
   private pixiRuntime: PixiRuntime | null = null;
   private stage: Container | null = null;
   private target: RenderTexture | null = null;
+  private rendererProxy: WebGLRenderer | null = null;
   private draw: ((time: number) => void) | null = null;
   private codeRevision = 0;
+  private extensionVersion = 0;
 
   private constructor(
     config: PixiRendererConfig,
@@ -57,27 +63,11 @@ export class PixiRenderer extends BaseWorkerRenderer<PixiRendererConfig> {
     const PIXI = await loadPixiRuntime();
 
     PIXI.DOMAdapter.set(PIXI.WebWorkerAdapter);
-
-    const sizedFramebuffer = framebuffer as SizedFramebuffer;
-    const [outputWidth, outputHeight] = renderer.outputSize;
-    const canvas = renderer.offscreenCanvas;
+    await loadPixiWorkerExtensions('graphics');
 
     instance.pixiRuntime = PIXI;
     instance.stage = new PIXI.Container();
-    instance.pixi = new PIXI.WebGLRenderer();
-
-    await instance.pixi.init({
-      canvas,
-      context: renderer.gl!,
-      width: outputWidth,
-      height: outputHeight,
-      antialias: true
-    });
-
-    instance.target = PIXI.RenderTexture.create({
-      width: sizedFramebuffer.width,
-      height: sizedFramebuffer.height
-    });
+    await instance.initializePixiRenderer();
 
     await instance.updateCode();
 
@@ -121,8 +111,9 @@ export class PixiRenderer extends BaseWorkerRenderer<PixiRendererConfig> {
       const result = await this.executeUserCode(code, {
         ...this.buildBaseExtraContext(),
         PIXI: this.pixiRuntime,
-        renderer: this.pixi,
+        renderer: this.getRendererProxy(),
         stage: nextStage,
+        loadExtensions: this.loadExtensions.bind(this),
         width: framebuffer?.width ?? 0,
         height: framebuffer?.height ?? 0,
         mouse: { x: this.mouseX, y: this.mouseY }
@@ -177,8 +168,55 @@ export class PixiRenderer extends BaseWorkerRenderer<PixiRendererConfig> {
 
   destroy() {
     this.codeRevision += 1;
-    this.target?.destroy(true);
     this.stage?.destroy({ children: true });
+    this.destroyPixiRenderer();
+
+    super.destroy();
+
+    this.target = null;
+    this.pixi = null;
+    this.pixiRuntime = null;
+    this.rendererProxy = null;
+    this.stage = null;
+    this.draw = null;
+  }
+
+  private async loadExtensions(...extensions: string[]) {
+    await loadPixiWorkerExtensions(...extensions);
+
+    if (this.extensionVersion !== getPixiWorkerExtensionVersion()) {
+      await this.recreatePixiRenderer();
+    }
+  }
+
+  private async initializePixiRenderer() {
+    if (!this.pixiRuntime || !this.framebuffer) return;
+
+    const [outputWidth, outputHeight] = this.renderer.outputSize;
+    const { width, height } = this.framebuffer as SizedFramebuffer;
+
+    this.pixiRuntime.DOMAdapter.set(this.pixiRuntime.WebWorkerAdapter);
+    this.pixi = new this.pixiRuntime.WebGLRenderer();
+
+    await this.pixi.init({
+      canvas: this.renderer.offscreenCanvas,
+      context: this.renderer.gl!,
+      width: outputWidth,
+      height: outputHeight,
+      antialias: true
+    });
+
+    this.target = this.pixiRuntime.RenderTexture.create({ width, height });
+    this.extensionVersion = getPixiWorkerExtensionVersion();
+  }
+
+  private async recreatePixiRenderer() {
+    this.destroyPixiRenderer();
+    await this.initializePixiRenderer();
+  }
+
+  private destroyPixiRenderer() {
+    this.target?.destroy(true);
 
     if (this.pixi) {
       // Pixi assumes it owns its WebGL context and loses it during destroy().
@@ -187,13 +225,28 @@ export class PixiRenderer extends BaseWorkerRenderer<PixiRendererConfig> {
       this.pixi.destroy();
     }
 
-    super.destroy();
-
     this.target = null;
     this.pixi = null;
-    this.pixiRuntime = null;
-    this.stage = null;
-    this.draw = null;
+  }
+
+  private getRendererProxy() {
+    this.rendererProxy ??= new Proxy({} as WebGLRenderer, {
+      get: (_target, property) => {
+        const renderer = this.pixi;
+        if (!renderer) return undefined;
+
+        const value = Reflect.get(renderer, property, renderer);
+
+        return typeof value === 'function' ? value.bind(renderer) : value;
+      },
+      set: (_target, property, value) => {
+        if (!this.pixi) return false;
+
+        return Reflect.set(this.pixi, property, value, this.pixi);
+      }
+    });
+
+    return this.rendererProxy;
   }
 
   private blitTarget() {

--- a/ui/static/content/objects/pixi.dom.md
+++ b/ui/static/content/objects/pixi.dom.md
@@ -1,4 +1,4 @@
-The `pixi.dom` object creates interactive [PixiJS 8](https://pixijs.com/8.x) graphics on a main-thread canvas. Use it when your scene needs native pointer events.
+The `pixi.dom` object creates interactive [PixiJS v8.x](https://pixijs.com/8.x/guides/getting-started/intro) graphics on a main-thread canvas. Use it when your scene needs native pointer events.
 
 ## Getting Started
 
@@ -19,6 +19,33 @@ button.on('pointertap', () => button.tint = Math.random() * 0xffffff);
 
 stage.addChild(button);
 ```
+
+## Extensions
+
+`pixi.dom` lazily loads PixiJS when the first object is added. You can then
+load any PixiJS 8 extension, including browser-only extensions, before using
+its APIs:
+
+```javascript
+await loadExtensions('events', 'accessibility')
+
+const { Graphics } = PIXI
+
+const button = new Graphics()
+  .circle(width / 2, height / 2, 80)
+  .fill(0x66ccff)
+
+button.eventMode = 'static'
+button.on('pointertap', () => button.tint = Math.random() * 0xffffff)
+stage.addChild(button)
+```
+
+Use `await loadExtensions('all')` to load every PixiJS extension. The first call
+for a new extension recreates the shared Pixi renderer while keeping every
+`pixi.dom` stage and canvas in place. Group extension names in one call to do
+that once.
+
+See [pixi](/docs/objects/pixi#extensions) for the extension-name list.
 
 ## Comparison with pixi
 

--- a/ui/static/content/objects/pixi.md
+++ b/ui/static/content/objects/pixi.md
@@ -1,4 +1,4 @@
-The `pixi` object creates 2D graphics with [PixiJS 8](https://pixijs.com/8.x). It runs in Patchies' web-worker render pipeline, so its output chains efficiently to other visual objects.
+The `pixi` object creates 2D graphics with [PixiJS v8.x](https://pixijs.com/8.x/guides/getting-started/intro). It runs in Patchies' web-worker render pipeline, so its output chains efficiently to other visual objects.
 
 ## Getting Started
 
@@ -20,6 +20,39 @@ function draw(time) {
 ```
 
 The Patchies renderer schedules frames. Do not create a second animation loop or call `renderer.render()` yourself.
+
+## Extensions
+
+`pixi` includes graphics support. Call and await `loadExtensions()` before using an optional extension's APIs:
+
+```javascript
+await loadExtensions('filters')
+
+const { Graphics, BlurFilter } = PIXI
+
+const circle = new Graphics()
+  .circle(width / 2, height / 2, 100)
+  .fill(0x66ccff)
+
+circle.filters = [new BlurFilter({ strength: 8 })]
+stage.addChild(circle)
+```
+
+Pass several names together to rebuild the shared worker renderer once, or use `'all'` to enable every worker-safe extension:
+
+```javascript
+await loadExtensions('advanced-blend-modes', 'text-bitmap', 'prepare')
+// await loadExtensions('all')
+```
+
+Available names are `advanced-blend-modes`, `app`, `basis`, `dds`, `filters`,
+`gif`, `graphics`, `ktx`, `ktx2`, `math-extras`, `mesh`,
+`particle-container`, `prepare`, `sprite-nine-slice`, `sprite-tiling`, `text`,
+`text-bitmap`, and `unsafe-eval`.
+
+`accessibility`, `dom`, `events`, and `text-html` require browser DOM APIs and
+cannot run in the render worker. Use [pixi.dom](/docs/objects/pixi.dom) for
+native pointer, keyboard, HTML text, and DOM behavior.
 
 ## How It Works
 


### PR DESCRIPTION
Adds `enablePixi` function to `pixi` and `pixi.dom` so we can enable Pixi.js extensions at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `loadExtensions()` to load PixiJS extensions on demand in worker and DOM environments.
  * Supports individual extensions, multiple extensions, or all compatible extensions.
  * Provides clear errors for unknown or environment-incompatible extensions.
  * Preserves drawing resources and WebGL contexts when updating renderers where possible.
  * Added editor completions for `loadExtensions()`.

* **Documentation**
  * Added extension usage guidance, compatibility details, extension lists, and interactive examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->