### PR TITLE
feat(pixi.dom, textmode.dom): add onKeyUp and onKeyDown functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,31 @@ Patchies is a visual programming environment for audio-visual patches.
 - Separate assertion blocks that verify distinct behavior with blank lines.
 - If a function only returns a value without interim computation, use an arrow function with inline returns: `const foo = () => bar()`, don't use a block body with `return` or `function` keyword.
 
+One-line calls/assertions on the same category stays together, this is correct:
+
+```ts
+expect(getCompletionLabels(nodeType, "onKeyD")).toContain("onKeyDown");
+expect(getCompletionLabels(nodeType, "onKeyU")).toContain("onKeyUp");
+```
+
+If the calls/assertions are NOT one-line, they should be separated by blank lines, this is correct:
+
+```ts
+expect(
+  foo({
+    bar,
+    baz,
+  }),
+).toContain("baz");
+
+expect(
+  baz({
+    quuz,
+    baz,
+  }),
+).toContain("bar");
+```
+
 ## How to run
 
 Run project commands from `ui/`:

--- a/docs/design-docs/specs/183-pixi-objects.md
+++ b/docs/design-docs/specs/183-pixi-objects.md
@@ -30,11 +30,13 @@ resize, coalesced to one callback per animation frame. Fluid resizing never
 re-runs the user's code, preserving the stage and its interaction state.
 
 The first DOM version exposes Pixi's normal canvas, stage, renderer, optional
-`draw(time)` callback, sizing APIs, and `setVideoOutput(enabled)`. It supports
-one copied video output, disabled by default to avoid an unnecessary CPU-to-GPU
-canvas copy. `setVideoOutput(true)` enables it. Patchies message APIs, keyboard
-helpers, and dynamic ports can be added once the core event and lifecycle path
-has settled.
+`draw(time)` callback, sizing APIs, `onKeyDown(callback)`, `onKeyUp(callback)`,
+and `setVideoOutput(enabled)`. Keyboard callbacks run while the focused canvas
+receives browser events, stop propagation to the Patchies editor, and report
+callback errors through the virtual console. It supports one copied video
+output, disabled by default to avoid an unnecessary CPU-to-GPU canvas copy.
+`setVideoOutput(true)` enables it. Patchies message APIs and dynamic ports can
+be added once the core event and lifecycle path has settled.
 
 Both `pixi` and `pixi.dom` expose the standard `settings` API. The worker
 object bridges its settings proxy through GLSystem; the DOM object uses a local

--- a/ui/src/lib/canvas/use-keyboard-callbacks.svelte.ts
+++ b/ui/src/lib/canvas/use-keyboard-callbacks.svelte.ts
@@ -1,0 +1,64 @@
+type KeyboardCallback = (event: KeyboardEvent) => void;
+
+type KeyboardCallbacksOptions = {
+  onError?: (error: unknown) => void;
+};
+
+type AttachOptions = {
+  stopPropagation?: boolean;
+};
+
+export function useKeyboardCallbacks({ onError }: KeyboardCallbacksOptions = {}) {
+  let callbacks: {
+    onKeyDown?: KeyboardCallback;
+    onKeyUp?: KeyboardCallback;
+  } = {};
+
+  function invoke(
+    callback: KeyboardCallback | undefined,
+    event: KeyboardEvent,
+    options: AttachOptions
+  ) {
+    if (!callback) return;
+
+    if (options.stopPropagation ?? true) event.stopPropagation();
+
+    try {
+      callback(event);
+    } catch (error) {
+      onError?.(error);
+    }
+  }
+
+  function createEventHandlers(options: AttachOptions = {}) {
+    return {
+      keydown: (event: Event) => invoke(callbacks.onKeyDown, event as KeyboardEvent, options),
+      keyup: (event: Event) => invoke(callbacks.onKeyUp, event as KeyboardEvent, options)
+    };
+  }
+
+  function attach(target: HTMLElement | Document, options: AttachOptions = {}) {
+    const handlers = createEventHandlers(options);
+
+    target.addEventListener('keydown', handlers.keydown);
+    target.addEventListener('keyup', handlers.keyup);
+
+    return () => {
+      target.removeEventListener('keydown', handlers.keydown);
+      target.removeEventListener('keyup', handlers.keyup);
+    };
+  }
+
+  return {
+    onKeyDown(callback: KeyboardCallback) {
+      callbacks.onKeyDown = callback;
+    },
+    onKeyUp(callback: KeyboardCallback) {
+      callbacks.onKeyUp = callback;
+    },
+    reset() {
+      callbacks = {};
+    },
+    attach
+  };
+}

--- a/ui/src/lib/canvas/use-keyboard-callbacks.test.ts
+++ b/ui/src/lib/canvas/use-keyboard-callbacks.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { useKeyboardCallbacks } from './use-keyboard-callbacks.svelte';
+
+describe('useKeyboardCallbacks', () => {
+  it('dispatches registered callbacks and detaches its listeners', () => {
+    const target = new EventTarget();
+    const keyboard = useKeyboardCallbacks();
+    const onKeyDown = vi.fn();
+    const onKeyUp = vi.fn();
+
+    keyboard.onKeyDown(onKeyDown);
+    keyboard.onKeyUp(onKeyUp);
+
+    const detach = keyboard.attach(target as unknown as HTMLElement);
+
+    target.dispatchEvent(new Event('keydown'));
+    target.dispatchEvent(new Event('keyup'));
+
+    expect(onKeyDown).toHaveBeenCalledOnce();
+    expect(onKeyUp).toHaveBeenCalledOnce();
+
+    detach();
+    target.dispatchEvent(new Event('keydown'));
+
+    expect(onKeyDown).toHaveBeenCalledOnce();
+  });
+
+  it('clears callbacks on reset and routes callback errors', () => {
+    const target = new EventTarget();
+    const onError = vi.fn();
+    const keyboard = useKeyboardCallbacks({ onError });
+
+    keyboard.onKeyDown(() => {
+      throw new Error('keyboard callback failed');
+    });
+
+    keyboard.attach(target as unknown as HTMLElement);
+    target.dispatchEvent(new Event('keydown'));
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+
+    keyboard.reset();
+    target.dispatchEvent(new Event('keydown'));
+
+    expect(onError).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -199,6 +199,14 @@ describe('patchies completions', () => {
     expect(labels).not.toContain('deactivate');
   });
 
+  it.each(['canvas.dom', 'textmode.dom', 'three.dom', 'pixi.dom', 'surface'])(
+    'shows keyboard callback completions for %s',
+    (nodeType) => {
+      expect(getCompletionLabels(nodeType, 'onKeyD')).toContain('onKeyDown');
+      expect(getCompletionLabels(nodeType, 'onKeyU')).toContain('onKeyUp');
+    }
+  );
+
   it('shows p5 surface mode helper completions with surface expansion helpers', () => {
     const labels = getCompletionLabels('p5', '');
 

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -667,8 +667,8 @@ const nodeSpecificFunctions: Record<string, string[]> = {
     'pixi.dom',
     'surface'
   ],
-  onKeyDown: ['canvas.dom', 'three.dom', 'surface'],
-  onKeyUp: ['canvas.dom', 'three.dom', 'surface'],
+  onKeyDown: ['canvas.dom', 'textmode.dom', 'three.dom', 'pixi.dom', 'surface'],
+  onKeyUp: ['canvas.dom', 'textmode.dom', 'three.dom', 'pixi.dom', 'surface'],
   onPointer: ['surface'],
   onTouch: ['surface'],
   setDrawMode: ['surface'],

--- a/ui/src/lib/migration/migrations/016-video-output-api.test.ts
+++ b/ui/src/lib/migration/migrations/016-video-output-api.test.ts
@@ -23,9 +23,11 @@ function migratedCode(type: string, code: string) {
 
 describe('migration016', () => {
   test.each(['p5', 'canvas.dom', 'textmode.dom', 'three.dom', 'pixi.dom', 'surface'])(
-    'removes a standalone legacy output call from %s',
+    'preserves standalone legacy output behavior for %s',
     (type) => {
-      expect(migratedCode(type, 'noOutput();\n\ndraw()')).toBe('draw()');
+      expect(migratedCode(type, 'noOutput();\n\ndraw()')).toBe(
+        'setVideoOutput(true)\n\nsetVideoOutput(false);\n\ndraw()'
+      );
     }
   );
 
@@ -46,9 +48,17 @@ describe('migration016', () => {
     expect(migratedCode('p5', code)).toBe(code);
   });
 
-  test('leaves non-standalone legacy usage unchanged', () => {
+  test('replaces legacy output calls alongside an existing setter', () => {
+    const code = 'setVideoOutput(true)\nif (debug) noOutput()';
+
+    expect(migratedCode('p5', code)).toBe('setVideoOutput(true)\nif (debug) setVideoOutput(false)');
+  });
+
+  test('migrates conditional legacy output calls', () => {
     const code = 'if (debug) noOutput()';
 
-    expect(migratedCode('canvas.dom', code)).toBe(code);
+    expect(migratedCode('canvas.dom', code)).toBe(
+      'setVideoOutput(true)\n\nif (debug) setVideoOutput(false)'
+    );
   });
 });

--- a/ui/src/lib/migration/migrations/016-video-output-api.ts
+++ b/ui/src/lib/migration/migrations/016-video-output-api.ts
@@ -10,22 +10,28 @@ const MAIN_THREAD_VIDEO_OBJECTS = new Set([
 ]);
 
 const WORKER_VIDEO_OBJECTS = new Set(['canvas', 'regl', 'textmode', 'three']);
-const LEGACY_OUTPUT_CALL_LINE = /^[ \t]*noOutput\(\);?[ \t]*(?:\r?\n|$)/gm;
-const LEGACY_OUTPUT_IDENTIFIER = /\bnoOutput\b/;
+const LEGACY_OUTPUT_CALL = /\bnoOutput\s*\(\s*\)/g;
 const VIDEO_OUTPUT_SETTER_CALL = /\bsetVideoOutput\s*\(/;
 
 function migrateMainThreadCode(code: string) {
-  const withoutLegacyCalls = code.replace(LEGACY_OUTPUT_CALL_LINE, '');
+  const hasLegacyOutputCall = LEGACY_OUTPUT_CALL.test(code);
+  LEGACY_OUTPUT_CALL.lastIndex = 0;
 
-  if (withoutLegacyCalls !== code) return withoutLegacyCalls.replace(/^\r?\n/, '');
-  if (LEGACY_OUTPUT_IDENTIFIER.test(code)) return code;
+  if (hasLegacyOutputCall) {
+    const migratedCode = code.replace(LEGACY_OUTPUT_CALL, 'setVideoOutput(false)');
+
+    return VIDEO_OUTPUT_SETTER_CALL.test(code)
+      ? migratedCode
+      : `setVideoOutput(true)\n\n${migratedCode}`;
+  }
+
   if (VIDEO_OUTPUT_SETTER_CALL.test(code)) return code;
 
   return `setVideoOutput(true)\n\n${code}`;
 }
 
 function migrateWorkerCode(code: string) {
-  return code.replace(LEGACY_OUTPUT_CALL_LINE, 'setVideoOutput(false)\n');
+  return code.replace(LEGACY_OUTPUT_CALL, 'setVideoOutput(false)');
 }
 
 export const migration016: Migration = {

--- a/ui/src/objects/canvas/CanvasDom.svelte
+++ b/ui/src/objects/canvas/CanvasDom.svelte
@@ -20,6 +20,7 @@
     getUncappedPreviewSize,
     useCappedPreviewSize
   } from '$lib/canvas/use-capped-preview-size.svelte';
+  import { useKeyboardCallbacks } from '$lib/canvas/use-keyboard-callbacks.svelte';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { shouldShowHandles } from '../../stores/ui.store';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
@@ -181,11 +182,10 @@
     buttons: 0
   });
 
-  // Keyboard state and user callbacks
-  let keyboardCallbacks = $state<{
-    onKeyDown?: (event: KeyboardEvent) => void;
-    onKeyUp?: (event: KeyboardEvent) => void;
-  }>({});
+  const keyboard = useKeyboardCallbacks({
+    onError: (error) =>
+      handleCodeError(error, data.code, nodeId, customConsole, CANVAS_DOM_WRAPPER_OFFSET)
+  });
 
   const setPortCount = (newInletCount = 1, newOutletCount = 0) => {
     updateNodeData(nodeId, { inletCount: newInletCount, outletCount: newOutletCount });
@@ -303,44 +303,6 @@
       canvas?.removeEventListener('touchmove', onTouchMove);
       canvas?.removeEventListener('touchend', onTouchEnd);
       canvas?.removeEventListener('touchcancel', onTouchCancel);
-    };
-  }
-
-  function setupKeyboardListeners() {
-    if (!canvas) return;
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (keyboardCallbacks.onKeyDown) {
-        // Stop propagation for all keyboard events to prevent leaking to xyflow
-        e.stopPropagation();
-
-        try {
-          keyboardCallbacks.onKeyDown(e);
-        } catch (error) {
-          handleCodeError(error, data.code, nodeId, customConsole, CANVAS_DOM_WRAPPER_OFFSET);
-        }
-      }
-    };
-
-    const onKeyUp = (e: KeyboardEvent) => {
-      if (keyboardCallbacks.onKeyUp) {
-        // Stop propagation for all keyboard events to prevent leaking to xyflow
-        e.stopPropagation();
-
-        try {
-          keyboardCallbacks.onKeyUp(e);
-        } catch (error) {
-          handleCodeError(error, data.code, nodeId, customConsole, CANVAS_DOM_WRAPPER_OFFSET);
-        }
-      }
-    };
-
-    canvas.addEventListener('keydown', onKeyDown);
-    canvas.addEventListener('keyup', onKeyUp);
-
-    return () => {
-      canvas?.removeEventListener('keydown', onKeyDown);
-      canvas?.removeEventListener('keyup', onKeyUp);
     };
   }
 
@@ -468,8 +430,7 @@
 
     applyCanvasDisplaySize(resetSize.width, resetSize.height);
 
-    // Clear keyboard callbacks when code is re-run
-    keyboardCallbacks = {};
+    keyboard.reset();
     settingsManager.clearCallbacks();
 
     // Clear any previous animation frame
@@ -535,12 +496,8 @@
               primaryButton
             });
           },
-          onKeyDown: (callback: (event: KeyboardEvent) => void) => {
-            keyboardCallbacks.onKeyDown = callback;
-          },
-          onKeyUp: (callback: (event: KeyboardEvent) => void) => {
-            keyboardCallbacks.onKeyUp = callback;
-          },
+          onKeyDown: keyboard.onKeyDown,
+          onKeyUp: keyboard.onKeyUp,
           // Override JSRunner's requestAnimationFrame to also send bitmap
           requestAnimationFrame: (callback: FrameRequestCallback) => {
             // Store callback for restart after unpause
@@ -599,7 +556,7 @@
     });
 
     const cleanupMouse = setupMouseListeners();
-    const cleanupKeyboard = setupKeyboardListeners();
+    const cleanupKeyboard = canvas ? keyboard.attach(canvas) : undefined;
     setTimeout(() => {
       runCode();
     }, 50);

--- a/ui/src/objects/pixi/PixiDom.svelte
+++ b/ui/src/objects/pixi/PixiDom.svelte
@@ -16,6 +16,7 @@
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { PREVIEW_SCALE_FACTOR } from '$lib/canvas/constants';
   import { useCappedPreviewSize } from '$lib/canvas/use-capped-preview-size.svelte';
+  import { useKeyboardCallbacks } from '$lib/canvas/use-keyboard-callbacks.svelte';
   import { useNodeSetPaused } from '$lib/canvas/use-node-set-paused.svelte';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import type { ConsoleOutputEvent } from '$lib/eventbus/events';
@@ -43,6 +44,7 @@
   type ActiveRuntime = {
     code: string;
     draw: ((time: number) => void) | null;
+    setDimensions: (width: number, height: number) => void;
   };
 
   let {
@@ -99,6 +101,9 @@
   let consoleRef: VirtualConsole | null = $state(null);
   let entry = $state<Awaited<ReturnType<typeof pixiDomManager.register>>>();
   let activeRuntime: ActiveRuntime | null = null;
+
+  const keyboard = useKeyboardCallbacks({ onError: reportRuntimeError });
+
   let editorReady = $state(false);
   let videoOutputEnabled = $state(false);
   let isExpanded = $state(false);
@@ -162,6 +167,7 @@
   function setCanvasDimensions({ width, height }: { width: number; height: number }) {
     outputWidth = width;
     outputHeight = height;
+    activeRuntime?.setDimensions(width, height);
 
     pixiDomManager.resize(nodeId, { width, height });
   }
@@ -212,6 +218,7 @@
     lineErrors = undefined;
 
     settingsManager.clearCallbacks();
+    keyboard.reset();
     setVideoOutputEnabled(false);
     fluidCanvas.reset();
     updateNodeData(nodeId, getBorderResetDataForRun(data));
@@ -234,7 +241,15 @@
 
       runStage = new PIXI.Container();
 
-      const code = `var draw;\n${processedCode}\nreturn typeof draw === 'function' ? draw : null;`;
+      const code = `var draw;
+${processedCode}
+return {
+  draw: typeof draw === 'function' ? draw : null,
+  setDimensions: (nextWidth, nextHeight) => {
+    width = nextWidth;
+    height = nextHeight;
+  }
+};`;
 
       const candidate = await jsRunner.executeJavaScript(nodeId, code, {
         customConsole,
@@ -250,6 +265,8 @@
           setCanvasSize: fluidCanvas.setFixedCanvasSize,
           setFluidSize: fluidCanvas.setFluidSize,
           onCanvasResize: fluidCanvas.onCanvasResize,
+          onKeyDown: keyboard.onKeyDown,
+          onKeyUp: keyboard.onKeyUp,
           loadExtensions: pixiDomManager.loadExtensions.bind(pixiDomManager),
           setVideoOutput: (enabled: boolean) => setVideoOutputEnabled(enabled),
           noBorder: () => updateNodeData(nodeId, { noBorder: true })
@@ -272,7 +289,11 @@
 
       activeRuntime = {
         code: sourceCode,
-        draw: typeof candidate === 'function' ? (candidate as (time: number) => void) : null
+        draw:
+          typeof (candidate as ActiveRuntime).draw === 'function'
+            ? (candidate as ActiveRuntime).draw
+            : null,
+        setDimensions: (candidate as ActiveRuntime).setDimensions
       };
     } catch (error) {
       runStage?.destroy({ children: true });
@@ -337,7 +358,11 @@
       if (runRevision === 0) void run();
     }
 
+    const cleanupKeyboard = canvas ? keyboard.attach(canvas) : undefined;
+
     initialize();
+
+    return () => cleanupKeyboard?.();
   });
 
   onDestroy(() => {

--- a/ui/src/objects/pixi/prompt.ts
+++ b/ui/src/objects/pixi/prompt.ts
@@ -39,6 +39,7 @@ Pixi.js 8 on the main thread. Use it for interactive 2D graphics with native poi
 - setCanvasSize(width, height), setFluidSize(), onCanvasResize(callback): canvas sizing APIs. In fluid mode, draw(time) can read live width and height values while resizing. Resizing does not re-run your code, so fluid or resizable objects must use onCanvasResize to update their layout.
 - setVideoOutput(enabled): enable or disable the video output port. It is disabled by default; call setVideoOutput(true) when the scene feeds another video node.
 - noBorder(): hide Patchies' preview border and selected glow until the call is removed and the node runs again.
+- onKeyDown(event => {}) / onKeyUp(event => {}): receive keyboard events while the Pixi canvas is focused. Events do not leak to the Patchies editor.
 
 **Rules:**
 - Graphics is available by default.

--- a/ui/src/objects/surface/SurfaceNode.svelte
+++ b/ui/src/objects/surface/SurfaceNode.svelte
@@ -17,6 +17,7 @@
   import { PREVIEW_SCALE_FACTOR } from '$lib/canvas/constants';
   import { outputSize as outputSizeStore } from '../../stores/renderer.store';
   import { GLSystem } from '$lib/canvas/GLSystem';
+  import { useKeyboardCallbacks } from '$lib/canvas/use-keyboard-callbacks.svelte';
   import { SurfaceOverlay } from '$lib/canvas/SurfaceOverlay';
   import {
     SurfaceListeners,
@@ -122,15 +123,7 @@
     | ((touches: { x: number; y: number; pressure: number; id: number }[]) => void)
     | null = null;
 
-  let keyboardCallbacks: {
-    onKeyDown?: (event: KeyboardEvent) => void;
-    onKeyUp?: (event: KeyboardEvent) => void;
-  } = {};
-
-  let keyboardListenerHandlers: {
-    keydown: (e: KeyboardEvent) => void;
-    keyup: (e: KeyboardEvent) => void;
-  } | null = null;
+  let removeKeyboardListeners: (() => void) | null = null;
 
   let resizeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -148,7 +141,13 @@
 
   const { updateNodeData, getNodes } = useSvelteFlow();
   const updateNodeInternals = useUpdateNodeInternals();
+
   const mouseForwarder = new SurfaceMouseForwarder(() => getNodes());
+
+  const keyboard = useKeyboardCallbacks({
+    onError: (error) =>
+      handleCodeError(error, data.code, nodeId, customConsole, SURFACE_WRAPPER_OFFSET)
+  });
 
   function clearCanvas() {
     if (activeCanvas && activeCtx) {
@@ -411,13 +410,7 @@
 
     // Attach keyboard listeners only when this window is the presentation surface.
     if (presentation === 'main') {
-      const handleKeyDown = (e: KeyboardEvent) => keyboardCallbacks.onKeyDown?.(e);
-      const handleKeyUp = (e: KeyboardEvent) => keyboardCallbacks.onKeyUp?.(e);
-
-      keyboardListenerHandlers = { keydown: handleKeyDown, keyup: handleKeyUp };
-
-      document.addEventListener('keydown', handleKeyDown);
-      document.addEventListener('keyup', handleKeyUp);
+      removeKeyboardListeners = keyboard.attach(document);
     }
 
     // Re-run code with overlay canvas
@@ -439,12 +432,8 @@
     outputHeight = window.innerHeight;
 
     // Remove keyboard listeners
-    if (keyboardListenerHandlers) {
-      document.removeEventListener('keydown', keyboardListenerHandlers.keydown);
-      document.removeEventListener('keyup', keyboardListenerHandlers.keyup);
-
-      keyboardListenerHandlers = null;
-    }
+    removeKeyboardListeners?.();
+    removeKeyboardListeners = null;
 
     // Switch active canvas back to preview
     if (previewCanvas) {
@@ -519,7 +508,7 @@
     drawMode = 'always';
     pointerCallback = null;
     touchCallback = null;
-    keyboardCallbacks = {};
+    keyboard.reset();
     setMouseForwarding();
 
     if (animationFrameId !== null) {
@@ -585,12 +574,8 @@
           onTouch: (cb: typeof touchCallback) => {
             touchCallback = cb;
           },
-          onKeyDown: (callback: (event: KeyboardEvent) => void) => {
-            keyboardCallbacks.onKeyDown = callback;
-          },
-          onKeyUp: (callback: (event: KeyboardEvent) => void) => {
-            keyboardCallbacks.onKeyUp = callback;
-          },
+          onKeyDown: keyboard.onKeyDown,
+          onKeyUp: keyboard.onKeyUp,
 
           // Interaction flags (for the node itself)
           noDrag: () => {
@@ -692,12 +677,8 @@
       clearTimeout(resizeDebounceTimer);
     }
 
-    if (keyboardListenerHandlers) {
-      document.removeEventListener('keydown', keyboardListenerHandlers.keydown);
-      document.removeEventListener('keyup', keyboardListenerHandlers.keyup);
-
-      keyboardListenerHandlers = null;
-    }
+    removeKeyboardListeners?.();
+    removeKeyboardListeners = null;
 
     // Deactivate overlay if this node was active
     if (isFullscreen) {

--- a/ui/src/objects/textmode/TextmodeDom.svelte
+++ b/ui/src/objects/textmode/TextmodeDom.svelte
@@ -11,6 +11,7 @@
   import { DEFAULT_OUTPUT_SIZE } from '$lib/canvas/constants';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { useCappedPreviewSize } from '$lib/canvas/use-capped-preview-size.svelte';
+  import { useKeyboardCallbacks } from '$lib/canvas/use-keyboard-callbacks.svelte';
   import { shouldShowHandles } from '../../stores/ui.store';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
   import { createCustomConsole } from '$lib/utils/createCustomConsole';
@@ -80,6 +81,11 @@
   let videoOutputEnabled = $state(false);
   let editorReady = $state(false);
   let bitmapLoopId: number | null = null;
+
+  const keyboard = useKeyboardCallbacks({
+    onError: (error) =>
+      handleCodeError(error, data.code, nodeId, customConsole, CANVAS_DOM_WRAPPER_OFFSET)
+  });
 
   // textmode.js instances
   let textmode: typeof import('textmode.js') | null = null;
@@ -237,6 +243,7 @@
     // Clear console and error highlighting on re-run
     consoleRef?.clearConsole();
     lineErrors = undefined;
+    keyboard.reset();
 
     settingsManager.clearCallbacks();
 
@@ -323,6 +330,8 @@
         setHidePorts: (hidePorts: boolean) => updateNodeData(nodeId, { hidePorts }),
         extraContext: {
           settings: createSettingsAPI(settingsManager),
+          onKeyDown: keyboard.onKeyDown,
+          onKeyUp: keyboard.onKeyUp,
           canvas,
           t: tm,
           tm,
@@ -407,9 +416,13 @@
 
     setupCanvas();
 
+    const cleanupKeyboard = canvas ? keyboard.attach(canvas) : undefined;
+
     setTimeout(() => {
       runCode();
     }, 50);
+
+    return () => cleanupKeyboard?.();
   });
 
   onDestroy(() => {

--- a/ui/src/objects/three/ThreeDom.svelte
+++ b/ui/src/objects/three/ThreeDom.svelte
@@ -9,6 +9,7 @@
   import { messages } from '$lib/objects/schemas/common';
   import { GLSystem } from '$lib/canvas/GLSystem';
   import { useCappedPreviewSize } from '$lib/canvas/use-capped-preview-size.svelte';
+  import { useKeyboardCallbacks } from '$lib/canvas/use-keyboard-callbacks.svelte';
   import { outputSize } from '../../stores/renderer.store';
   import { shouldShowHandles } from '../../stores/ui.store';
   import VirtualConsole from '$lib/components/VirtualConsole.svelte';
@@ -137,11 +138,10 @@
     buttons: 0
   });
 
-  // Keyboard state and user callbacks
-  let keyboardCallbacks = $state<{
-    onKeyDown?: (event: KeyboardEvent) => void;
-    onKeyUp?: (event: KeyboardEvent) => void;
-  }>({});
+  const keyboard = useKeyboardCallbacks({
+    onError: (error) =>
+      handleCodeError(error, data.code, nodeId, customConsole, THREE_DOM_WRAPPER_OFFSET)
+  });
 
   const setPortCount = (newInletCount = 1, newOutletCount = 0) => {
     updateNodeData(nodeId, { inletCount: newInletCount, outletCount: newOutletCount });
@@ -259,44 +259,6 @@
     };
   }
 
-  function setupKeyboardListeners() {
-    if (!canvas) return;
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (keyboardCallbacks.onKeyDown) {
-        // Stop propagation for all keyboard events to prevent leaking to xyflow
-        e.stopPropagation();
-
-        try {
-          keyboardCallbacks.onKeyDown(e);
-        } catch (error) {
-          handleCodeError(error, data.code, nodeId, customConsole, THREE_DOM_WRAPPER_OFFSET);
-        }
-      }
-    };
-
-    const onKeyUp = (e: KeyboardEvent) => {
-      if (keyboardCallbacks.onKeyUp) {
-        // Stop propagation for all keyboard events to prevent leaking to xyflow
-        e.stopPropagation();
-
-        try {
-          keyboardCallbacks.onKeyUp(e);
-        } catch (error) {
-          handleCodeError(error, data.code, nodeId, customConsole, THREE_DOM_WRAPPER_OFFSET);
-        }
-      }
-    };
-
-    canvas.addEventListener('keydown', onKeyDown);
-    canvas.addEventListener('keyup', onKeyUp);
-
-    return () => {
-      canvas?.removeEventListener('keydown', onKeyDown);
-      canvas?.removeEventListener('keyup', onKeyUp);
-    };
-  }
-
   function setCanvasSize(width: number, height: number) {
     if (!canvas) return;
 
@@ -362,8 +324,7 @@
 
     updateNodeData(nodeId, getBorderResetDataForRun(data));
 
-    // Clear keyboard callbacks when code is re-run
-    keyboardCallbacks = {};
+    keyboard.reset();
 
     try {
       // Stop any previous animation loop
@@ -415,12 +376,8 @@
             updateNodeInternals(nodeId);
           },
           setCanvasSize,
-          onKeyDown: (callback: (event: KeyboardEvent) => void) => {
-            keyboardCallbacks.onKeyDown = callback;
-          },
-          onKeyUp: (callback: (event: KeyboardEvent) => void) => {
-            keyboardCallbacks.onKeyUp = callback;
-          },
+          onKeyDown: keyboard.onKeyDown,
+          onKeyUp: keyboard.onKeyUp,
           noDrag: () => {
             dragEnabled = false;
           },
@@ -476,7 +433,7 @@
     glSystem.upsertNode(nodeId, 'img', {});
 
     const cleanupMouse = setupMouseListeners();
-    const cleanupKeyboard = setupKeyboardListeners();
+    const cleanupKeyboard = canvas ? keyboard.attach(canvas) : undefined;
 
     setTimeout(() => {
       runCode();

--- a/ui/static/content/objects/pixi.dom.md
+++ b/ui/static/content/objects/pixi.dom.md
@@ -60,6 +60,21 @@ See [pixi](/docs/objects/pixi#extensions) for the extension-name list.
 
 Use `pixi` for render-graph performance. Use `pixi.dom` for full PixiJS interaction.
 
+## Keyboard Events
+
+Register callbacks for keys while the Pixi canvas is focused. Keyboard events
+do not leak to the Patchies editor:
+
+```javascript
+onKeyDown((event) => {
+  if (event.key === 'ArrowLeft') player.x -= 10;
+});
+
+onKeyUp((event) => {
+  console.log('Released:', event.key);
+});
+```
+
 ## Dynamic Canvas Size
 
 Choose a fixed Pixi canvas resolution with `setCanvasSize()`:
@@ -106,6 +121,17 @@ during a resize. Use `onCanvasResize()` to update static scenes. It runs at
 most once per animation frame while resizing. Patchies does not re-run your
 Pixi code after a fluid resize, preserving the stage and interaction state.
 
+```javascript
+const badge = new PIXI.Graphics().circle(0, 0, 100).fill(0x66ccff)
+
+onCanvasResize(({ width, height }) => {
+  // Keep a static scene centered without rebuilding the stage.
+  badge.position.set(width / 2, height / 2)
+})
+
+stage.addChild(badge)
+```
+
 ## Video Output
 
 `pixi.dom` keeps its video output disabled by default. Copying its canvas into
@@ -133,6 +159,7 @@ stage.addChild(badge)
 - `setCanvasSize(width, height)`: sets a fixed canvas resolution
 - `setFluidSize(options?)`: makes the canvas follow the node size
 - `onCanvasResize(callback)`: runs a callback after the canvas is resized
+- `onKeyDown(callback)`, `onKeyUp(callback)`: receive keyboard events while the canvas is focused
 - `noBorder()`: hides Patchies' border and selected glow until the call is removed and the node runs again
 
 ## See Also

--- a/ui/static/content/objects/textmode.dom.md
+++ b/ui/static/content/objects/textmode.dom.md
@@ -49,6 +49,19 @@ Full support for:
 - [Touch events](https://code.textmode.art/docs/events.html#touch-events)
 - [Keyboard events](https://code.textmode.art/docs/events.html#keyboard-events)
 
+Use `onKeyDown()` and `onKeyUp()` callbacks for focused
+widget keyboard input. Their events do not leak to the editor:
+
+```javascript
+onKeyDown((event) => {
+  if (event.key === ' ') t.noLoop();
+});
+
+onKeyUp((event) => {
+  console.log('Released:', event.key);
+});
+```
+
 ## Media Loading
 
 Load [images and videos](https://code.textmode.art/docs/loadables.html) as textures.
@@ -62,6 +75,7 @@ Textmode-specific:
 - `setVideoOutput(true)` - enables the video output port, which is disabled by default
 - `setHidePorts(true | false)` - hide/show all ports
 - `noDrag()`, `noPan()`, `noWheel()`, `noInteract()` - see [Canvas Interaction](/docs/canvas-interaction)
+- `onKeyDown(callback)`, `onKeyUp(callback)` - receive keyboard events while the canvas is focused
 - `fft()` - audio analysis with low latency
 
 ## Plugins


### PR DESCRIPTION
Add the `onKeyUp` and `onKeyDown` functions to `pixi.dom` and `textmode.dom`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `onKeyDown` and `onKeyUp` callbacks for Pixi and Textmode canvases.
  * Keyboard callbacks run when the canvas is focused and prevent events from reaching the editor.
  * Added autocomplete suggestions and callback error reporting.

* **Documentation**
  * Added API references and usage examples for canvas keyboard events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->