### PR TITLE
feat(textmode, textmode.dom): re-evaluate t.setup() block on re-run

### DIFF
--- a/docs/design-docs/specs/105-base-worker-renderer.md
+++ b/docs/design-docs/specs/105-base-worker-renderer.md
@@ -43,7 +43,7 @@ These methods are character-for-character the same across all renderers:
 - **regl**: tracked Proxy wrapper, fallback texture, `getTexture()` → regl.Texture2D
 - **three**: Three.js renderer/renderTarget, blit-to-regl, texture wrapping, `getTexture()` → three.Texture
 - **canvas**: OffscreenCanvas 2D, `drawCanvasToTexture()`, RAF loop, pause/resume
-- **textmode**: OffscreenCanvas 2D + textmode.js, shares `drawCanvasToTexture`/`ensureDrawCommand` with canvas
+- **textmode**: OffscreenCanvas 2D + textmode.js. Code re-evaluations retain the existing `Textmodifier` and replay the newly registered `t.setup()` callback.
 - **hydra**: Hydra synth instance, source/param mapping, code transform, `.out(o0)` injection
 
 ## Design

--- a/docs/design-docs/specs/105-base-worker-renderer.md
+++ b/docs/design-docs/specs/105-base-worker-renderer.md
@@ -43,7 +43,7 @@ These methods are character-for-character the same across all renderers:
 - **regl**: tracked Proxy wrapper, fallback texture, `getTexture()` → regl.Texture2D
 - **three**: Three.js renderer/renderTarget, blit-to-regl, texture wrapping, `getTexture()` → three.Texture
 - **canvas**: OffscreenCanvas 2D, `drawCanvasToTexture()`, RAF loop, pause/resume
-- **textmode**: OffscreenCanvas 2D + textmode.js. Code re-evaluations retain the existing `Textmodifier` and replay the newly registered `t.setup()` callback.
+- **textmode**: textmode.js runs on a WebGL2-backed `OffscreenCanvas`. Code re-evaluations retain the existing `Textmodifier` and replay the newly registered `t.setup()` callback.
 - **hydra**: Hydra synth instance, source/param mapping, code transform, `.out(o0)` injection
 
 ## Design

--- a/ui/src/objects/textmode/TextmodeDom.svelte
+++ b/ui/src/objects/textmode/TextmodeDom.svelte
@@ -21,6 +21,7 @@
   import { useNodeSetPaused } from '$lib/canvas/use-node-set-paused.svelte';
   import { CANVAS_DOM_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
   import type { Textmodifier } from 'textmode.js';
+  import { evaluateTextmodeCode } from '$objects/textmode/re-evaluate-setup';
   import { profiler } from '$lib/profiler';
   import { SettingsManager, createSettingsAPI } from '$lib/settings';
   import { createKVStore } from '$lib/storage';
@@ -239,6 +240,7 @@
     if (!canvas) return;
 
     let hadErrors = !!lineErrors;
+    const shouldReplaySetup = tm !== null;
 
     // Clear console and error highlighting on re-run
     consoleRef?.clearConsole();
@@ -293,6 +295,11 @@
         };
       }
 
+      if (!tm || !textmode) return;
+
+      const textmodifier = tm;
+      const textmodeModule = textmode;
+
       const {
         cellColor,
         char,
@@ -323,65 +330,70 @@
         return;
       }
 
-      await jsRunner.executeJavaScript(nodeId, processedCode, {
-        customConsole,
-        setPortCount,
-        setTitle: (title: string) => updateNodeData(nodeId, { title }),
-        setHidePorts: (hidePorts: boolean) => updateNodeData(nodeId, { hidePorts }),
-        extraContext: {
-          settings: createSettingsAPI(settingsManager),
-          onKeyDown: keyboard.onKeyDown,
-          onKeyUp: keyboard.onKeyUp,
-          canvas,
-          t: tm,
-          tm,
-          textmode: textmode.textmode,
-          cellColor,
-          char,
-          charColor,
-          gradient,
-          noise,
-          plasma,
-          moire,
-          osc,
-          paint,
-          shape,
-          solid,
-          src,
-          voronoi,
-          width: outputWidth,
-          height: outputHeight,
-          noDrag: () => {
-            dragEnabled = false;
-          },
-          noPan: () => {
-            panEnabled = false;
-          },
-          noWheel: () => {
-            wheelEnabled = false;
-          },
-          noInteract: () => {
-            dragEnabled = false;
-            panEnabled = false;
-            wheelEnabled = false;
-          },
-          setVideoOutput: (enabled: boolean) => {
-            videoOutputEnabled = enabled;
-            updateNodeInternals(nodeId);
-          },
-          setCanvasSize: (width: number, height: number) => setCanvasSize(width, height),
-          // Override JSRunner's requestAnimationFrame to also send bitmap
-          requestAnimationFrame: (callback: FrameRequestCallback) => {
-            return requestAnimationFrame((time) => {
-              callback(time);
-              sendBitmap();
-            });
-          },
-          cancelAnimationFrame: (id: number) => {
-            cancelAnimationFrame(id);
-          }
-        }
-      });
+      await evaluateTextmodeCode(
+        textmodifier,
+        () =>
+          jsRunner.executeJavaScript(nodeId, processedCode, {
+            customConsole,
+            setPortCount,
+            setTitle: (title: string) => updateNodeData(nodeId, { title }),
+            setHidePorts: (hidePorts: boolean) => updateNodeData(nodeId, { hidePorts }),
+            extraContext: {
+              settings: createSettingsAPI(settingsManager),
+              onKeyDown: keyboard.onKeyDown,
+              onKeyUp: keyboard.onKeyUp,
+              canvas,
+              t: textmodifier,
+              tm: textmodifier,
+              textmode: textmodeModule.textmode,
+              cellColor,
+              char,
+              charColor,
+              gradient,
+              noise,
+              plasma,
+              moire,
+              osc,
+              paint,
+              shape,
+              solid,
+              src,
+              voronoi,
+              width: outputWidth,
+              height: outputHeight,
+              noDrag: () => {
+                dragEnabled = false;
+              },
+              noPan: () => {
+                panEnabled = false;
+              },
+              noWheel: () => {
+                wheelEnabled = false;
+              },
+              noInteract: () => {
+                dragEnabled = false;
+                panEnabled = false;
+                wheelEnabled = false;
+              },
+              setVideoOutput: (enabled: boolean) => {
+                videoOutputEnabled = enabled;
+                updateNodeInternals(nodeId);
+              },
+              setCanvasSize: (width: number, height: number) => setCanvasSize(width, height),
+              // Override JSRunner's requestAnimationFrame to also send bitmap
+              requestAnimationFrame: (callback: FrameRequestCallback) => {
+                return requestAnimationFrame((time) => {
+                  callback(time);
+                  sendBitmap();
+                });
+              },
+              cancelAnimationFrame: (id: number) => {
+                cancelAnimationFrame(id);
+              }
+            }
+          }),
+        shouldReplaySetup
+      );
 
       // No longer errored!
       if (hadErrors && !tm.isLooping() && !data.paused) {

--- a/ui/src/objects/textmode/re-evaluate-setup.test.ts
+++ b/ui/src/objects/textmode/re-evaluate-setup.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
 import { evaluateTextmodeCode } from './re-evaluate-setup';
 
+function createDeferred() {
+  let resolve: () => void;
+
+  const promise = new Promise<void>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve: resolve! };
+}
+
 describe('evaluateTextmodeCode', () => {
   it('replays the setup callback registered during a re-evaluation', async () => {
     const setup = vi.fn();
@@ -33,5 +43,47 @@ describe('evaluateTextmodeCode', () => {
     );
 
     expect(setupCallback).not.toHaveBeenCalled();
+  });
+
+  it('serializes overlapping evaluations for the same Textmodifier', async () => {
+    const originalSetup = vi.fn();
+    const firstSetupCallback = vi.fn();
+    const secondSetupCallback = vi.fn();
+
+    const firstExecution = createDeferred();
+    const firstStarted = createDeferred();
+
+    const tm = { setup: originalSetup };
+
+    const firstEvaluation = evaluateTextmodeCode(
+      tm as never,
+      async () => {
+        await tm.setup(firstSetupCallback);
+        firstStarted.resolve();
+        await firstExecution.promise;
+      },
+      true
+    );
+
+    await firstStarted.promise;
+
+    const secondEvaluation = evaluateTextmodeCode(
+      tm as never,
+      async () => {
+        await tm.setup(secondSetupCallback);
+      },
+      true
+    );
+
+    expect(originalSetup).toHaveBeenCalledTimes(1);
+
+    firstExecution.resolve();
+    await Promise.all([firstEvaluation, secondEvaluation]);
+
+    expect(originalSetup).toHaveBeenNthCalledWith(1, firstSetupCallback);
+    expect(originalSetup).toHaveBeenNthCalledWith(2, secondSetupCallback);
+    expect(firstSetupCallback).toHaveBeenCalledTimes(1);
+    expect(secondSetupCallback).toHaveBeenCalledTimes(1);
+    expect(tm.setup).toBe(originalSetup);
   });
 });

--- a/ui/src/objects/textmode/re-evaluate-setup.test.ts
+++ b/ui/src/objects/textmode/re-evaluate-setup.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { evaluateTextmodeCode } from './re-evaluate-setup';
+
+describe('evaluateTextmodeCode', () => {
+  it('replays the setup callback registered during a re-evaluation', async () => {
+    const setup = vi.fn();
+    const setupCallback = vi.fn();
+    const tm = { setup };
+
+    await evaluateTextmodeCode(
+      tm as never,
+      async () => {
+        await tm.setup(setupCallback);
+      },
+      true
+    );
+
+    expect(setup).toHaveBeenCalledWith(setupCallback);
+    expect(setupCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves initial setup to the Textmodifier lifecycle', async () => {
+    const setup = vi.fn();
+    const setupCallback = vi.fn();
+    const tm = { setup };
+
+    await evaluateTextmodeCode(
+      tm as never,
+      async () => {
+        await tm.setup(setupCallback);
+      },
+      false
+    );
+
+    expect(setupCallback).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/objects/textmode/re-evaluate-setup.ts
+++ b/ui/src/objects/textmode/re-evaluate-setup.ts
@@ -2,21 +2,48 @@ import type { Textmodifier } from 'textmode.js';
 
 type SetupCallback = () => void | Promise<void>;
 
+const evaluationsByTextmodifier = new WeakMap<Textmodifier, Promise<void>>();
+
 /**
  * Runs code against an existing Textmodifier and replays its newly registered
  * setup callback when the instance has already completed initialization.
  */
-export async function evaluateTextmodeCode(
+export function evaluateTextmodeCode(
+  tm: Textmodifier,
+  executeCode: () => Promise<unknown>,
+  replaySetup: boolean
+): Promise<void> {
+  const previousEvaluation = evaluationsByTextmodifier.get(tm) ?? Promise.resolve();
+
+  const evaluation = previousEvaluation.then(() =>
+    runTextmodeEvaluation(tm, executeCode, replaySetup)
+  );
+
+  const settledEvaluation = evaluation.catch(() => undefined);
+
+  evaluationsByTextmodifier.set(tm, settledEvaluation);
+
+  settledEvaluation.then(() => {
+    if (evaluationsByTextmodifier.get(tm) === settledEvaluation) {
+      evaluationsByTextmodifier.delete(tm);
+    }
+  });
+
+  return evaluation;
+}
+
+async function runTextmodeEvaluation(
   tm: Textmodifier,
   executeCode: () => Promise<unknown>,
   replaySetup: boolean
 ) {
-  const setup = tm.setup.bind(tm);
+  const setup = tm.setup;
   let setupCallback: SetupCallback | undefined;
 
   tm.setup = async (callback) => {
     setupCallback = callback;
-    await setup(callback);
+
+    await setup.call(tm, callback);
   };
 
   try {

--- a/ui/src/objects/textmode/re-evaluate-setup.ts
+++ b/ui/src/objects/textmode/re-evaluate-setup.ts
@@ -1,0 +1,31 @@
+import type { Textmodifier } from 'textmode.js';
+
+type SetupCallback = () => void | Promise<void>;
+
+/**
+ * Runs code against an existing Textmodifier and replays its newly registered
+ * setup callback when the instance has already completed initialization.
+ */
+export async function evaluateTextmodeCode(
+  tm: Textmodifier,
+  executeCode: () => Promise<unknown>,
+  replaySetup: boolean
+) {
+  const setup = tm.setup.bind(tm);
+  let setupCallback: SetupCallback | undefined;
+
+  tm.setup = async (callback) => {
+    setupCallback = callback;
+    await setup(callback);
+  };
+
+  try {
+    await executeCode();
+  } finally {
+    tm.setup = setup;
+  }
+
+  if (replaySetup && setupCallback) {
+    await setupCallback();
+  }
+}

--- a/ui/src/objects/textmode/render-types.ts
+++ b/ui/src/objects/textmode/render-types.ts
@@ -6,5 +6,6 @@ export type TextmodeRenderNode = {
     code: string;
     fboFormat?: FBOFormat;
     resolution?: FBOResolution;
+    _runRevision?: number;
   };
 };

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -1037,6 +1037,7 @@ export class FBORenderer {
         textmodeRenderer.framebuffer = framebuffer;
 
         const runRevision = node.data._runRevision;
+
         const shouldUpdateCode =
           renderer.config.code !== node.data.code || renderer.config.runRevision !== runRevision;
 
@@ -1045,6 +1046,7 @@ export class FBORenderer {
         if (shouldUpdateCode) {
           textmodeRenderer.config.code = node.data.code;
           textmodeRenderer.config.runRevision = runRevision;
+
           await textmodeRenderer.updateCode();
         }
       }

--- a/ui/src/workers/rendering/fboRenderer.ts
+++ b/ui/src/workers/rendering/fboRenderer.ts
@@ -1036,10 +1036,16 @@ export class FBORenderer {
         // Update framebuffer reference (new one is created each buildFBOs call)
         textmodeRenderer.framebuffer = framebuffer;
 
-        // If textmode user code has changed, we update the underlying code
-        if (renderer.config.code !== node.data.code) {
+        const runRevision = node.data._runRevision;
+        const shouldUpdateCode =
+          renderer.config.code !== node.data.code || renderer.config.runRevision !== runRevision;
+
+        // A Run action may retain the same source code, but it must still
+        // re-evaluate it so its registered t.setup() callback can run again.
+        if (shouldUpdateCode) {
           textmodeRenderer.config.code = node.data.code;
-          textmodeRenderer.updateCode();
+          textmodeRenderer.config.runRevision = runRevision;
+          await textmodeRenderer.updateCode();
         }
       }
     }
@@ -1047,7 +1053,7 @@ export class FBORenderer {
     // 2. if there are no renderer to re-use, we create a new one!
     if (!textmodeRenderer) {
       textmodeRenderer = await TextmodeRenderer.create(
-        { code: node.data.code, nodeId: node.id },
+        { code: node.data.code, nodeId: node.id, runRevision: node.data._runRevision },
         framebuffer,
         this
       );

--- a/ui/src/workers/rendering/textmodeRenderer.ts
+++ b/ui/src/workers/rendering/textmodeRenderer.ts
@@ -1,12 +1,17 @@
 import type regl from 'regl';
 import type { FBORenderer } from './fboRenderer';
 import { CANVAS_WRAPPER_OFFSET } from '$lib/constants/error-reporting-offsets';
+import { evaluateTextmodeCode } from '$objects/textmode/re-evaluate-setup';
 import { setupWorkerDOMMocks } from './workerDOMMocks';
 import type { TextmodePlugin, Textmodifier } from 'textmode.js';
 import { BaseWorkerRenderer, type BaseRendererConfig } from './BaseWorkerRenderer';
 import { getFramebuffer } from './utils';
 
-export class TextmodeRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
+export interface TextmodeRendererConfig extends BaseRendererConfig {
+  runRevision?: number;
+}
+
+export class TextmodeRenderer extends BaseWorkerRenderer<TextmodeRendererConfig> {
   // textmode.js text modifier
   public tm: Textmodifier | null = null;
   public textmode: typeof import('textmode.js') | null = null;
@@ -14,7 +19,7 @@ export class TextmodeRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
   private lastRedrawAt: number | undefined;
 
   private constructor(
-    config: BaseRendererConfig,
+    config: TextmodeRendererConfig,
     framebuffer: regl.Framebuffer2D,
     renderer: FBORenderer
   ) {
@@ -22,7 +27,7 @@ export class TextmodeRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
   }
 
   static async create(
-    config: BaseRendererConfig,
+    config: TextmodeRendererConfig,
     framebuffer: regl.Framebuffer2D,
     renderer: FBORenderer
   ): Promise<TextmodeRenderer> {
@@ -61,6 +66,8 @@ export class TextmodeRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
   }
 
   public async updateCode() {
+    const shouldReplaySetup = this.tm !== null;
+
     this.resetState();
     this.lastRedrawAt = undefined;
 
@@ -175,7 +182,11 @@ export class TextmodeRenderer extends BaseWorkerRenderer<BaseRendererConfig> {
         voronoi
       };
 
-      await this.executeUserCode(this.config.code, extraContext);
+      await evaluateTextmodeCode(
+        this.tm,
+        () => this.executeUserCode(this.config.code, extraContext),
+        shouldReplaySetup
+      );
     } catch (error) {
       this.handleCodeError(error, CANVAS_WRAPPER_OFFSET);
     } finally {


### PR DESCRIPTION
Re-evaluates the `t.setup(...)` block on every re-run without re-creating the textmode instance. Should apply to both `textmode` and `textmode.dom` objects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Textmode code re-evaluation now preserves the existing textmodifier state.
  - Registered setup behavior is replayed when code is rerun, improving consistency during live updates.
  - Renderer updates now reliably detect revisions and wait for refreshed code to finish applying.

- **Documentation**
  - Updated textmode renderer documentation to describe state retention and setup replay behavior.

- **Tests**
  - Added coverage for initial evaluation and setup replay during re-evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->