### PR TITLE
feat(vfs): add patch-persisted storage namespace for vfs

### DIFF
--- a/docs/design-docs/specs/52-virtual-filesystem.md
+++ b/docs/design-docs/specs/52-virtual-filesystem.md
@@ -475,6 +475,16 @@ IndexedDB remains a fallback for browsers without filesystem handles and a persi
 
 The existing user-code VFS API keeps its current defaults: `vfs.getUrl("./foo")`, `vfs.list(".")`, and similar relative paths resolve under `user://`. The `patch://` shorthand applies only to JavaScript imports and GLSL includes.
 
+### Internal Architecture
+
+`VirtualFilesystem` is the stable public facade. Its implementation composes internal modules so provider, persistence, history, and Patch-import rules do not accumulate in the facade:
+
+- `VfsEntryIndex` owns the in-memory entry map, snapshots, and path-tree queries.
+- `PatchImportPlanner` turns browser files or recursive copy sources into a validated atomic Patch import plan. It owns text validation, path normalization, collision allocation, and embedded-content budgets.
+- `VfsMutationCoordinator` records entry-map transitions and their provider effects as one global history operation.
+
+The Files panel continues to own user interaction such as asking whether to Replace, Keep Both, or Cancel. Browser `DataTransfer` traversal stays in a separate adapter. These modules report plans and outcomes; they do not depend on Svelte UI state.
+
 ## Delivery Plan
 
 Ship the feature in exactly three pull requests. Each pull request is a complete release point with its own user outcome and focused verification. Tests stay in the same commit as the behavior they verify; do not create preparatory commits containing only types or unused helpers.

--- a/docs/design-docs/specs/52-virtual-filesystem.md
+++ b/docs/design-docs/specs/52-virtual-filesystem.md
@@ -51,7 +51,7 @@ I wanted the ability to persist, browse and resolve files in a virtual file syst
     - example: `obj://csound~-42` contains filesystem for a Csound object
     - only some node will have a virtual node filesystem, such as `chuck~` and `elem~` and `csound~`
   - the prefixes helps us to check if it is a virtual filesystem path, or an already resolved path.
-- In the saved patches, we should also store a `files` mapping as well, with top-level namespaces `user` (`user://`) and `objects` (`obj://`):
+- Saved patches store a `files` mapping for persistent namespaces such as `user://`. The `obj://` tree is runtime-only and is rebuilt from the objects in the patch; serializing it would create a second source of truth.
 
 ```ts
 {
@@ -68,11 +68,6 @@ I wanted the ability to persist, browse and resolve files in a virtual file syst
                     provider: "local",
                 },
             }
-        },
-        "objects": {
-           "csound~-24": {},
-           "elem~-36": {},
-           "chuck~-48": {}
         }
     }
 }
@@ -131,7 +126,6 @@ export interface VFSProvider {
 // Tree structure for serialization (matches patch format)
 export interface VFSTree {
   user?: Record<string, VFSEntry | VFSTree>;
-  objects?: Record<string, VFSTree>;
 }
 ```
 
@@ -330,7 +324,7 @@ export const migration002: Migration = {
   migrate(patch: RawPatchData): RawPatchData {
     return {
       ...patch,
-      files: patch.files ?? { user: {}, objects: {} },
+      files: patch.files ?? { user: {} },
     };
   },
 };
@@ -384,7 +378,7 @@ The VFS has three namespaces:
 | --- | --- | --- | --- |
 | `patch://` | Embedded in the current patch | Serialized under `files.patch` | Supported text files are editable |
 | `user://` | External or browser-local user resource | Handle, URL, or patch-scoped IndexedDB fallback | Read-only in the first editor release |
-| `obj://` | Object-owned resource | Existing object VFS behavior | Not editable independently |
+| `obj://` | Object-owned resource | Runtime-only; rebuilt from object state | Not editable independently |
 
 An embedded entry uses the `embedded` provider and stores UTF-8 text directly:
 
@@ -401,9 +395,10 @@ interface EmbeddedVFSEntry extends VFSEntry {
 interface VFSTree {
   patch?: Record<string, VFSTreeNode>;
   user?: Record<string, VFSTreeNode>;
-  objects?: Record<string, VFSTreeNode>;
 }
 ```
+
+`obj://` is deliberately excluded from `VFSTree`. Object-owned entries are a virtual runtime view of each object's own state. Serialization and hydration ignore that namespace so patch files never contain a competing copy.
 
 The serialized text is a normal JSON string, not base64. Limits use UTF-8 byte length:
 
@@ -479,11 +474,14 @@ The existing user-code VFS API keeps its current defaults: `vfs.getUrl("./foo")`
 
 ### Internal Architecture
 
-`VirtualFilesystem` is the stable public facade. Its implementation composes internal modules so provider, persistence, history, and Patch-import rules do not accumulate in the facade:
+`VirtualFilesystem` is the stable public facade. Its implementation composes internal modules so provider, persistence, history, browsing, and Patch-file rules do not accumulate in the facade:
 
-- `VfsEntryIndex` owns the in-memory entry map, snapshots, and path-tree queries.
-- `PatchImportPlanner` turns browser files or recursive copy sources into a validated atomic Patch import plan. It owns text validation, path normalization, collision allocation, and embedded-content budgets.
-- `VfsMutationCoordinator` records entry-map transitions and their provider effects as one global history operation.
+- `VfsEntryIndex` owns the in-memory entry map and all path-tree calculations, including rename and deletion plans.
+- `VfsDirectoryReader` owns directory listing, pagination, recursive search, and traversal of linked local folders.
+- `VfsTreeCodec` converts between the flat entry index and the serialized patch tree without accessing providers or UI state.
+- `VfsPermissionTracker` owns paths that need file or directory permission and scans hydrated entries against the local provider.
+- `PatchFileOperations` owns the complete `patch://` lifecycle. It delegates atomic import staging to `PatchImportPlanner` and applies the same embedded-content policy to create, write, read, export, import, and recovery hydration.
+- `VfsMutationCoordinator` records complete VFS state transitions as one global history operation and serializes asynchronous provider effects from undo and redo.
 
 The Files panel continues to own user interaction such as asking whether to Replace, Keep Both, or Cancel. Browser `DataTransfer` traversal stays in a separate adapter. These modules report plans and outcomes; they do not depend on Svelte UI state.
 

--- a/docs/design-docs/specs/52-virtual-filesystem.md
+++ b/docs/design-docs/specs/52-virtual-filesystem.md
@@ -362,13 +362,15 @@ export const migration002: Migration = {
 JavaScript-capable objects expose a single asynchronous `vfs` helper. It replaces the former `getVfsUrl` global.
 
 ```javascript
+await vfs.get("./data.json").json(); // read and parse file contents
+await vfs.get("./notes.txt").text(); // read file contents as text
 await vfs.getUrl("./foo.png"); // resolves user://foo.png to an object URL
 await vfs.getUrl("user://foo.png"); // explicit VFS path
 await vfs.list("."); // direct entries of user:// as { path, name, kind }
 await vfs.search("foo", "./assets"); // recursively search entries under user://assets
 ```
 
-Relative paths default to `user://`; absolute external URLs passed to `getUrl` pass through unchanged. `list` is non-recursive and returns entries with full VFS paths, names, and file or directory kinds. `search` is case-insensitive, recursive, and returns matching entries in the same shape. Both methods traverse linked local folders after permission has been granted.
+`vfs.get(path)` returns a lazy reader with `json()`, `text()`, `blob()`, and `arrayBuffer()` methods. Each method resolves and fetches the file, then returns the requested representation. Relative paths default to `user://`; absolute external URLs passed to `get` or `getUrl` remain external. `list` is non-recursive and returns entries with full VFS paths, names, and file or directory kinds. `search` is case-insensitive, recursive, and returns matching entries in the same shape. Both methods traverse linked local folders after permission has been granted.
 
 ## Patch-Local Text Files and Editing
 

--- a/docs/reflections/2026-09-03-vfs-boundary-refactor.md
+++ b/docs/reflections/2026-09-03-vfs-boundary-refactor.md
@@ -1,0 +1,36 @@
+# VFS Boundary Refactor
+
+## Objective
+
+Reduce `VirtualFilesystem` responsibility without changing its public interface or
+Stage 1 Patch-file behavior.
+
+## Key Challenges & Solutions
+
+- Patch imports had grown beyond content validation into recursive copy,
+  collision allocation, replacement-tree removal, and byte-budget planning.
+  `PatchImportPlanner` now owns that complete atomic planning workflow against
+  an immutable entry snapshot.
+- Entry-map snapshots and global history commands were interleaved with VFS
+  behavior. `VfsMutationCoordinator` now records those reversible transitions
+  while the facade retains its existing provider-side effects.
+- Tree lookup and snapshots were coupled to the facade's raw `Map`.
+  `VfsEntryIndex` now owns the entry index, snapshots, and tree-path lookup.
+
+## What Could Be Better
+
+- Rename and delete still contain provider-specific effect orchestration in
+  `VirtualFilesystem`. Moving those effects into typed mutation plans is the
+  next useful extraction.
+- Linked-folder traversal, permission handling, and hydration remain together
+  in the facade because they share the Local Filesystem Access API lifecycle.
+  Extract them only when their interface can be tested without exposing provider
+  internals.
+
+## Action Items
+
+- Keep browser `DataTransfer` traversal in `drop-import.ts` and Files-panel
+  collision prompts in the sidebar UI.
+- Add new Patch import rules to `PatchImportPlanner`, not `VirtualFilesystem`.
+- Extract linked-folder access and serialization only with a behavior-driven
+  test seam.

--- a/docs/reflections/2026-09-04-vfs-decomposition.md
+++ b/docs/reflections/2026-09-04-vfs-decomposition.md
@@ -1,0 +1,42 @@
+# VFS Decomposition
+
+## Objective
+
+Turn `VirtualFilesystem` into a stable public facade whose collaborators own the
+major VFS policies and state transitions, without changing observable behavior.
+
+## Key Challenges & Solutions
+
+- Directory traversal combined indexed entries with live linked-folder handles.
+  `VfsDirectoryReader` now presents one listing, paging, search, metadata, and
+  linked-file resolution boundary while keeping provider access injectable.
+- Patch-file rules were split between direct writes, hydration quarantine, and
+  import planning. `PatchFileOperations` now owns that lifecycle and continues to
+  use `PatchImportPlanner` for immutable atomic import plans.
+- Path mutations need complete collision checks before touching state.
+  `VfsEntryIndex` now creates rename and deletion plans before applying them.
+- Hydration mixed tree encoding with provider permission checks. `VfsTreeCodec`
+  now handles only shape conversion, while `VfsPermissionTracker` owns local
+  permission state and scanning.
+- Synchronous history callbacks can start asynchronous provider writes.
+  `VfsMutationCoordinator` now serializes those effects so rapid undo and redo do
+  not reorder persisted changes.
+
+## What Could Be Better
+
+- The facade still coordinates local-file storage, replacement, and linked-folder
+  lifecycle. This is intentional for now because these methods combine public API
+  semantics, provider effects, history, and events; a future extraction should
+  start from a typed local-resource operation rather than another pass-through
+  wrapper.
+- Provider capabilities are discovered with structural checks and casts. Typed
+  provider capability interfaces would make those dependencies more explicit.
+
+## Action Items
+
+- Add new Patch-file validation and budget rules to `PatchFileOperations` or
+  `PatchImportPlanner`, depending on whether they apply before or during staging.
+- Add new tree calculations to `VfsEntryIndex`; keep the facade free of path-map
+  scans.
+- Keep tests at the `VirtualFilesystem` public API boundary unless a collaborator
+  gains independently meaningful behavior that cannot be exercised there.

--- a/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
+++ b/ui/src/lib/ai/object-prompts/shared-jsrunner.ts
@@ -39,6 +39,7 @@ export const jsRunnerInstructions = `
 - delay(ms) - Promise that resolves after ms (rejects if node stops)
 - requestAnimationFrame(cb) - Animation frame with auto-cleanup
 - onCleanup(cb) - Register cleanup callback for unmount/re-execution
+- await vfs.get(path).json() / .text() / .blob() / .arrayBuffer() - Read a virtual filesystem file in the requested format (e.g. \`await vfs.get('./data.json').json()\`).
 - await vfs.getUrl(path) - Resolve a virtual filesystem file to a browser URL. Relative paths use the \`user://\` namespace (e.g. \`await vfs.getUrl('./photo.jpg')\`).
 - await vfs.list(path?) - List a folder's direct entries as {path, name, kind}. Relative paths use the \`user://\` namespace (e.g. \`await vfs.list('./samples')\`).
 - await vfs.search(query, path?) - Search matching entries as {path, name, kind}. Relative paths use the \`user://\` namespace (e.g. \`await vfs.search('kick', './samples')\`).

--- a/ui/src/lib/ai/patch-to-prompt/patch-transformer.ts
+++ b/ui/src/lib/ai/patch-to-prompt/patch-transformer.ts
@@ -175,22 +175,6 @@ function filterVfsTreeForUrls(tree: VFSTree): VFSTree | null {
     }
   }
 
-  if (tree.objects) {
-    const filteredObjects: VFSTree['objects'] = {};
-
-    for (const [nodeId, nodeFiles] of Object.entries(tree.objects)) {
-      const filtered = filterUrlEntries(nodeFiles);
-
-      if (filtered && !isVFSEntry(filtered)) {
-        filteredObjects[nodeId] = filtered;
-      }
-    }
-
-    if (Object.keys(filteredObjects).length > 0) {
-      result.objects = filteredObjects;
-    }
-  }
-
   return Object.keys(result).length > 0 ? result : null;
 }
 

--- a/ui/src/lib/codemirror/patchies-completions.test.ts
+++ b/ui/src/lib/codemirror/patchies-completions.test.ts
@@ -151,10 +151,17 @@ describe('patchies completions', () => {
 
   it('shows VFS method completions after vfs.', () => {
     expect(getCompletionLabels('js', 'vfs.')).toEqual(
-      expect.arrayContaining(['getUrl', 'list', 'search'])
+      expect.arrayContaining(['get', 'getUrl', 'list', 'search'])
     );
-    expect(getCompletionLabels('js', 'vfs.ge')).toEqual(['getUrl']);
+    expect(getCompletionLabels('js', 'vfs.ge')).toEqual(['get', 'getUrl']);
     expect(getCompletionLabels('js', 'vfs.se')).toEqual(['search']);
+  });
+
+  it('shows file reader completions after vfs.get()', () => {
+    expect(getCompletionLabels('js', "vfs.get('./file.json').")).toEqual(
+      expect.arrayContaining(['arrayBuffer', 'blob', 'json', 'text'])
+    );
+    expect(getCompletionLabels('js', "vfs.get('./file.json').j")).toEqual(['json']);
   });
 
   it('shows settings completions for Pixi nodes', () => {

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -432,8 +432,8 @@ const PATCHIES_API_COMPLETIONS: Completion[] = [
   {
     label: 'vfs',
     type: 'variable',
-    detail: '{ getUrl(path), list(path?), search(query, path?) }',
-    info: "Access VFS files. Relative paths use the user:// namespace. Example: await vfs.getUrl('./file.png')",
+    detail: '{ get(path), getUrl(path), list(path?), search(query, path?) }',
+    info: "Access VFS files. Relative paths use the user:// namespace. Example: await vfs.get('./file.json').json()",
     apply: 'vfs'
   },
 
@@ -888,6 +888,13 @@ const memberCompletions: Record<string, Completion[]> = {
 
   vfs: [
     {
+      label: 'get',
+      type: 'method',
+      detail: '(path: string) => VfsFileReader',
+      info: 'Read a virtual filesystem file as JSON, text, a Blob, or an ArrayBuffer.',
+      apply: "get('./file.json')"
+    },
+    {
       label: 'getUrl',
       type: 'method',
       detail: '(path: string) => Promise<string>',
@@ -907,6 +914,37 @@ const memberCompletions: Record<string, Completion[]> = {
       detail: '(query: string, path?: string) => Promise<VFSListEntry[]>',
       info: 'Search entries with path, name, and kind. The path defaults to the user:// namespace.',
       apply: "search('')"
+    }
+  ],
+
+  vfsFile: [
+    {
+      label: 'arrayBuffer',
+      type: 'method',
+      detail: '() => Promise<ArrayBuffer>',
+      info: 'Read the file as binary data.',
+      apply: 'arrayBuffer()'
+    },
+    {
+      label: 'blob',
+      type: 'method',
+      detail: '() => Promise<Blob>',
+      info: 'Read the file as a Blob.',
+      apply: 'blob()'
+    },
+    {
+      label: 'json',
+      type: 'method',
+      detail: '<T = unknown>() => Promise<T>',
+      info: 'Read and parse the file as JSON.',
+      apply: 'json()'
+    },
+    {
+      label: 'text',
+      type: 'method',
+      detail: '() => Promise<string>',
+      info: 'Read the file as text.',
+      apply: 'text()'
     }
   ],
 
@@ -1275,7 +1313,7 @@ export function createPatchiesCompletionSource(patchiesContext?: PatchiesContext
     if (patchiesContext?.nodeType === 'expr') return null;
     if (patchiesContext?.nodeType === 'msg') return null;
 
-    // Check for member completions (fft()., kv., clock., settings.)
+    // Check for member completions (fft()., vfs.get()., kv., clock., settings.)
     const fftMemberMatch = context.matchBefore(/fft\(\)\.\w*/);
 
     if (fftMemberMatch) {
@@ -1286,6 +1324,23 @@ export function createPatchiesCompletionSource(patchiesContext?: PatchiesContext
 
       return {
         from: fftMemberMatch.from + 'fft().'.length,
+        options: partial
+          ? methods.filter((method) => method.label.toLowerCase().startsWith(partial))
+          : methods
+      };
+    }
+
+    const vfsFileMemberMatch = context.matchBefore(/vfs\.get\([^)]*\)\.\w*/);
+
+    if (vfsFileMemberMatch) {
+      if (!isCompletionAllowedForNode({ label: 'vfs' }, patchiesContext)) return null;
+
+      const dotIndex = vfsFileMemberMatch.text.lastIndexOf('.');
+      const partial = vfsFileMemberMatch.text.slice(dotIndex + 1).toLowerCase();
+      const methods = memberCompletions.vfsFile;
+
+      return {
+        from: vfsFileMemberMatch.from + dotIndex + 1,
         options: partial
           ? methods.filter((method) => method.label.toLowerCase().startsWith(partial))
           : methods

--- a/ui/src/lib/components/sidebar/FileTreeView.svelte
+++ b/ui/src/lib/components/sidebar/FileTreeView.svelte
@@ -668,7 +668,12 @@
       return;
     }
 
-    vfs.renamePath(oldPath, newBasePath);
+    try {
+      vfs.renamePath(oldPath, newBasePath);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message.replace('VFS: ', '') : 'Move failed');
+      return;
+    }
 
     // Update selection if moved item was selected
     if (selectedPaths.has(oldPath)) {
@@ -809,7 +814,14 @@
         const entry = vfs.getEntry(oldPath);
 
         if (entry) {
-          vfs.renamePath(oldPath, newPath);
+          try {
+            vfs.renamePath(oldPath, newPath);
+          } catch (error) {
+            toast.error(
+              error instanceof Error ? error.message.replace('VFS: ', '') : 'Rename failed'
+            );
+            return;
+          }
 
           // Update selection if renamed item was selected
           if (selectedPaths.has(oldPath)) {

--- a/ui/src/lib/components/sidebar/FileTreeView.svelte
+++ b/ui/src/lib/components/sidebar/FileTreeView.svelte
@@ -400,10 +400,16 @@
   async function deleteSelectedFiles() {
     if (selectedPaths.size === 0) return;
 
-    vfs.deletePaths(selectedPaths);
+    const paths = [...selectedPaths].filter((path) => vfs.has(path));
 
-    selectedPaths.clear();
-    lastSelectedPath = null;
+    try {
+      if (paths.length > 0) vfs.deletePaths(paths);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message.replace('VFS: ', '') : 'Delete failed');
+    } finally {
+      selectedPaths.clear();
+      lastSelectedPath = null;
+    }
   }
 
   function handleKeydown(event: KeyboardEvent) {

--- a/ui/src/lib/components/sidebar/FileTreeView.svelte
+++ b/ui/src/lib/components/sidebar/FileTreeView.svelte
@@ -44,6 +44,7 @@
   import * as ContextMenu from '$lib/components/ui/context-menu';
   import * as Popover from '$lib/components/ui/popover';
   import { toast } from 'svelte-sonner';
+  import { match } from 'ts-pattern';
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import { isMobile, isSidebarOpen } from '../../../stores/ui.store';
   import FolderPickerDialog, { type FolderNode } from './FolderPickerDialog.svelte';
@@ -186,10 +187,13 @@
   // Get the currently selected file path (for mobile toolbar)
   const selectedFilePath = $derived.by(() => {
     if (selectedPaths.size !== 1) return null;
+
     const path = [...selectedPaths][0];
     const entry = vfs.getEntry(path);
+
     // Only return if it's a file (not a folder)
     if (entry && !isVFSFolder(entry)) return path;
+
     return null;
   });
 
@@ -203,9 +207,16 @@
   const moveFolderTree = $derived.by((): FolderNode[] => {
     const entries = $vfsEntries;
 
+    const selectedNamespace = selectedFilePath
+      ? parseVFSPath(selectedFilePath)?.namespace
+      : undefined;
+
+    const namespace = selectedNamespace === 'patch' ? 'patch' : 'user';
+    const namespacePath = namespace === 'patch' ? 'patch://' : 'user://';
+
     // Collect all folder paths
     const folderPaths = new SvelteSet<string>();
-    folderPaths.add('user://');
+    folderPaths.add(namespacePath);
 
     for (const [path, entry] of entries) {
       if (isVFSFolder(entry) && !isLocalFolder(entry)) {
@@ -215,9 +226,9 @@
       // Also add parent paths of all files as potential folders
       const parsed = parseVFSPath(path);
 
-      if (parsed && parsed.namespace === 'user' && parsed.segments.length > 1) {
+      if (parsed && parsed.namespace === namespace && parsed.segments.length > 1) {
         for (let i = 1; i < parsed.segments.length; i++) {
-          const parentPath = `user://${parsed.segments.slice(0, i).join('/')}`;
+          const parentPath = `${namespacePath}${parsed.segments.slice(0, i).join('/')}`;
           folderPaths.add(parentPath);
         }
       }
@@ -226,13 +237,14 @@
     // Build tree structure
     function buildChildren(parentPath: string): FolderNode[] {
       const children: FolderNode[] = [];
-      const prefix = parentPath === 'user://' ? 'user://' : `${parentPath}/`;
+      const prefix = parentPath === namespacePath ? namespacePath : `${parentPath}/`;
 
       for (const folderPath of folderPaths) {
         if (!folderPath.startsWith(prefix) || folderPath === parentPath) continue;
 
         // Check if this is a direct child
         const relativePath = folderPath.slice(prefix.length);
+
         if (!relativePath.includes('/')) {
           // Check if this folder is the current file's parent (disable it)
           const isCurrentParent = !!(
@@ -255,11 +267,11 @@
 
     return [
       {
-        id: 'user://',
-        name: 'user',
-        icon: User,
-        iconClass: 'text-yellow-400',
-        children: buildChildren('user://')
+        id: namespacePath,
+        name: namespace,
+        icon: namespace === 'patch' ? Package : User,
+        iconClass: namespace === 'patch' ? 'text-emerald-400' : 'text-yellow-400',
+        children: buildChildren(namespacePath)
       }
     ];
   });
@@ -313,11 +325,15 @@
       }
       if (node.path) paths.push(node.path);
       if (node.children === undefined) return;
+
       const isExpanded = node.path ? expandedPaths.has(node.path) : true;
       if (!isExpanded) return;
+
       const isLinkedFolderNode = node.entry && isLocalFolder(node.entry);
       if (!isLinkedFolderNode) {
-        for (const child of getSortedChildren(node)) traverseNode(child);
+        for (const child of getSortedChildren(node)) {
+          traverseNode(child);
+        }
       }
     }
 
@@ -344,24 +360,8 @@
   async function deleteSelectedFiles() {
     if (selectedPaths.size === 0) return;
 
-    const localProvider = getLocalProvider();
-
     for (const path of selectedPaths) {
-      // If it's a folder, also delete all children
-      const allPaths = vfs.list();
-      const pathsToDelete = allPaths.filter(
-        (p) => p === path || p.startsWith(path.endsWith('/') ? path : path + '/')
-      );
-
-      for (const pathToDelete of pathsToDelete) {
-        // Remove from VFS in-memory entries
-        vfs.remove(pathToDelete);
-
-        // Clean up persisted data (handle + file data from IndexedDB)
-        if (localProvider) {
-          await localProvider.remove(pathToDelete);
-        }
-      }
+      vfs.deletePath(path);
     }
 
     selectedPaths.clear();
@@ -374,6 +374,7 @@
 
     if (event.key === 'Delete' || event.key === 'Backspace') {
       event.preventDefault();
+
       deleteSelectedFiles();
     }
   }
@@ -410,7 +411,7 @@
       children: new Map()
     };
 
-    // Create namespace roots
+    // Namespace roots
     const patchRoot: TreeNode = { name: 'Patch', path: 'patch://', children: new Map() };
     const userRoot: TreeNode = { name: 'User', path: 'user://', children: new Map() };
     const objRoot: TreeNode = { name: 'objects', path: 'obj://', children: new Map() };
@@ -419,8 +420,11 @@
       const parsed = parseVFSPath(path);
       if (!parsed) continue;
 
-      const targetRoot =
-        parsed.namespace === 'patch' ? patchRoot : parsed.namespace === 'user' ? userRoot : objRoot;
+      const targetRoot = match(parsed.namespace)
+        .with('patch', () => patchRoot)
+        .with('user', () => userRoot)
+        .otherwise(() => objRoot);
+
       let current = targetRoot;
 
       // Build nested structure
@@ -433,17 +437,18 @@
         }
 
         if (!current.children.has(segment)) {
-          const prefix =
-            parsed.namespace === 'patch'
-              ? 'patch://'
-              : parsed.namespace === 'user'
-                ? 'user://'
-                : 'obj://';
+          const prefix = match(parsed.namespace)
+            .with('patch', () => 'patch://')
+            .with('user', () => 'user://')
+            .otherwise(() => 'obj://');
+
           const nodePath = `${prefix}${parsed.segments.slice(0, i + 1).join('/')}`;
           const isFolder = isLast && isVFSFolder(entry);
+
           current.children.set(segment, {
             name: segment,
             path: nodePath,
+
             // Folders always have children map (even if empty), files don't
             children: isLast && !isFolder ? undefined : new Map(),
             entry: isLast ? entry : undefined
@@ -485,6 +490,7 @@
       // Folders come before files
       const aIsFolder = a.children !== undefined;
       const bIsFolder = b.children !== undefined;
+
       if (aIsFolder && !bIsFolder) return -1;
       if (!aIsFolder && bIsFolder) return 1;
 
@@ -526,6 +532,7 @@
   // Check if a path is within the drop target folder
   function isInDropTarget(nodePath: string | undefined): boolean {
     if (!dropTargetPath || !nodePath) return false;
+
     return (
       nodePath === dropTargetPath || nodePath.startsWith(dropTargetPath.replace(/\/$/, '') + '/')
     );
@@ -542,9 +549,11 @@
     if (hasFiles || hasVfsPath) {
       event.preventDefault();
       event.stopPropagation();
+
       if (event.dataTransfer) {
         event.dataTransfer.dropEffect = hasVfsPath ? 'move' : 'copy';
       }
+
       dropTargetPath = folderPath;
     }
   }
@@ -556,9 +565,11 @@
 
     if (hasFiles || hasVfsPath) {
       event.preventDefault();
+
       if (event.dataTransfer) {
         event.dataTransfer.dropEffect = hasVfsPath ? 'move' : 'copy';
       }
+
       // Only set to user:// if we're not already targeting a folder
       if (dropTargetPath === null) {
         dropTargetPath = 'user://';
@@ -569,6 +580,7 @@
   function handleFolderDragLeave(event: DragEvent) {
     // Only clear if leaving the tree entirely
     const relatedTarget = event.relatedTarget as HTMLElement | null;
+
     if (!relatedTarget?.closest('[role="tree"]')) {
       dropTargetPath = null;
     }
@@ -585,6 +597,7 @@
     const vfsPath = event.dataTransfer?.getData('application/x-vfs-path');
     if (vfsPath && targetFolder) {
       await moveVfsFile(vfsPath, targetFolder);
+
       return;
     }
 
@@ -593,7 +606,12 @@
     if (!files || files.length === 0) return;
 
     if (targetFolder?.startsWith('patch://')) {
-      await vfs.importToPatch(Array.from(files), targetFolder);
+      try {
+        await vfs.importToPatch(Array.from(files), targetFolder);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message.replace('VFS: ', '') : 'Import failed');
+      }
+
       return;
     }
 
@@ -608,7 +626,15 @@
     if (!parsed) return;
 
     if (parsed.namespace === 'user' && targetFolder.startsWith('patch://')) {
+      const source = vfs.getEntry(oldPath);
+
+      if (source && isVFSFolder(source)) {
+        toast.error('Folder import to Patch is not supported yet');
+        return;
+      }
+
       await vfs.copyToPatch(oldPath, targetFolder, 'keep-both');
+
       return;
     }
 
@@ -619,6 +645,7 @@
 
     // Get the entry to access the real filename
     const rootEntry = vfs.getEntry(oldPath);
+
     // Use entry.filename (the real name) or fall back to path segment
     const filename = rootEntry?.filename || parsed.segments[parsed.segments.length - 1];
 
@@ -641,19 +668,7 @@
       return;
     }
 
-    // Get all paths that need to be moved (the item and all its children)
-    const allPaths = vfs.list();
-    const pathsToMove = allPaths.filter((p) => p === oldPath || p.startsWith(oldPathPrefix));
-
-    const localProvider = getLocalProvider();
-
     vfs.renamePath(oldPath, newBasePath);
-
-    for (const pathToMove of pathsToMove) {
-      const newPath =
-        newBasePath + (pathToMove === oldPath ? '' : pathToMove.slice(oldPath.length));
-      await localProvider?.rename(pathToMove, newPath);
-    }
 
     // Update selection if moved item was selected
     if (selectedPaths.has(oldPath)) {
@@ -668,6 +683,7 @@
 
   function handleUploadClick(folderPath: string, event: MouseEvent) {
     event.stopPropagation();
+
     pendingUploadFolder = folderPath;
 
     if (folderPath.startsWith('patch://')) {
@@ -707,6 +723,7 @@
 
   function handleAddUrlClick(folderPath: string, event: MouseEvent) {
     event.stopPropagation();
+
     showUrlInput = folderPath;
     urlInputValue = '';
   }
@@ -714,9 +731,11 @@
   async function handleUrlSubmit(event: KeyboardEvent) {
     if (event.key === 'Enter' && urlInputValue.trim()) {
       event.preventDefault();
+
       // For now, registerUrl doesn't support target folder, so we just register at root
       // TODO: Add folder support to registerUrl
       await vfs.registerUrl(urlInputValue.trim());
+
       showUrlInput = null;
       urlInputValue = '';
     } else if (isDismissKey(event)) {
@@ -731,6 +750,7 @@
 
   function handleCreateFolderClick(folderPath: string, event: MouseEvent) {
     event.stopPropagation();
+
     showFolderInput = folderPath;
     folderInputValue = '';
   }
@@ -738,7 +758,9 @@
   function handleFolderInputSubmit(event: KeyboardEvent) {
     if (event.key === 'Enter' && folderInputValue.trim()) {
       event.preventDefault();
+
       const parentPath = showFolderInput;
+
       if (parentPath) {
         // Create the folder in VFS
         const newFolderPath = vfs.createFolder(parentPath, folderInputValue.trim());
@@ -747,6 +769,7 @@
         expandedPaths.add(parentPath);
         expandedPaths.add(newFolderPath);
       }
+
       showFolderInput = null;
       folderInputValue = '';
     } else if (isDismissKey(event)) {
@@ -767,13 +790,16 @@
   async function handleRenameSubmit(event: KeyboardEvent) {
     if (event.key === 'Enter' && renameInputValue.trim() && renamingPath) {
       event.preventDefault();
+
       const newName = renameInputValue.trim();
       const oldPath = renamingPath;
 
       // Get the parent path and construct new path
       const parsed = parseVFSPath(oldPath);
+
       if (parsed) {
         const parentSegments = parsed.segments.slice(0, -1);
+
         const newPath =
           parentSegments.length > 0
             ? `${parsed.namespace}://${parentSegments.join('/')}/${newName}`
@@ -781,14 +807,9 @@
 
         // Rename through the VFS so this mutation has global undo/redo support.
         const entry = vfs.getEntry(oldPath);
+
         if (entry) {
           vfs.renamePath(oldPath, newPath);
-
-          // Also rename in LocalProvider to persist the change
-          const localProvider = getLocalProvider();
-          if (localProvider) {
-            await localProvider.rename(oldPath, newPath);
-          }
 
           // Update selection if renamed item was selected
           if (selectedPaths.has(oldPath)) {
@@ -813,22 +834,21 @@
 
   async function handleSaveToDisk(path: string) {
     const entry = vfs.getEntry(path);
-    if (!entry) return;
+    if (!entry || isVFSFolder(entry)) return;
 
-    const url = URL.createObjectURL(await vfs.resolve(path));
+    const vfsPath = await vfs.resolve(path);
+    const url = URL.createObjectURL(vfsPath);
+
     const link = document.createElement('a');
     link.href = url;
     link.download = entry.filename;
     link.click();
+
     URL.revokeObjectURL(url);
   }
 
   async function handleDeleteFromContextMenu(path: string) {
-    const localProvider = getLocalProvider();
-
-    const pathsToDelete = vfs.list().filter((p) => p === path || p.startsWith(`${path}/`));
     vfs.deletePath(path);
-    for (const pathToDelete of pathsToDelete) await localProvider?.remove(pathToDelete);
 
     selectedPaths.clear();
     lastSelectedPath = null;
@@ -872,6 +892,7 @@
 
         const file = await handle.getFile();
         await vfs.replaceFile(path, file, handle);
+
         return;
       } catch (err) {
         // User cancelled or error - fall back to input
@@ -914,7 +935,7 @@
 
   // Cache for directory handles within linked folders (for expanding subdirs)
   let subdirHandleCache = new SvelteMap<string, FileSystemDirectoryHandle>();
-  const loadingLocalFolderPaths = new Set<string>();
+  const loadingLocalFolderPaths = new SvelteSet<string>();
 
   async function handleLinkFolderClick(event: MouseEvent) {
     event.stopPropagation();
@@ -994,7 +1015,7 @@
   function queueLocalFolderContentsLoad(path: string) {
     loadingLocalFolderPaths.add(path);
 
-    void loadLocalFolderContents(path).finally(() => {
+    loadLocalFolderContents(path).finally(() => {
       loadingLocalFolderPaths.delete(path);
     });
   }
@@ -1013,14 +1034,12 @@
     }
   });
 
-  // Load contents when a local folder is expanded (always refresh to pick up filesystem changes)
-  async function handleLocalFolderExpand(path: string) {
-    await loadLocalFolderContents(path);
-  }
-
   async function handleRefreshLinkedFolder(path: string, event: MouseEvent) {
     event.stopPropagation();
-    await loadLocalFolderContents(path, undefined, { refreshExpandedDescendants: true });
+
+    await loadLocalFolderContents(path, undefined, {
+      refreshExpandedDescendants: true
+    });
   }
 
   async function handleRelinkFolderClick(path: string, event: MouseEvent) {
@@ -1053,6 +1072,7 @@
 
     // Toggle expansion
     const willExpand = !expandedPaths.has(subdirPath);
+
     if (willExpand) {
       expandedPaths.add(subdirPath);
     } else {
@@ -1204,7 +1224,7 @@
 
                 // Load local folder contents when expanding
                 if (isLinkedFolder && willExpand) {
-                  await handleLocalFolderExpand(node.path);
+                  await loadLocalFolderContents(node.path);
                 }
               } else if (isFolder && node.path) {
                 // For namespace roots: just expand/collapse
@@ -1394,7 +1414,7 @@
             <Copy class="mr-2 h-4 w-4" />
             Copy Path
           </ContextMenu.Item>
-          {#if node.path?.startsWith('patch://')}
+          {#if isFile && node.path?.startsWith('patch://')}
             <ContextMenu.Item onclick={() => handleSaveToDisk(node.path!)}>
               <File class="mr-2 h-4 w-4" />
               Save to Disk…

--- a/ui/src/lib/components/sidebar/FileTreeView.svelte
+++ b/ui/src/lib/components/sidebar/FileTreeView.svelte
@@ -793,6 +793,8 @@
   }
 
   async function handleRenameSubmit(event: KeyboardEvent) {
+    event.stopPropagation();
+
     if (event.key === 'Enter' && renameInputValue.trim() && renamingPath) {
       event.preventDefault();
 

--- a/ui/src/lib/components/sidebar/FileTreeView.svelte
+++ b/ui/src/lib/components/sidebar/FileTreeView.svelte
@@ -30,8 +30,11 @@
   import {
     PATCH_TEXT_FILE_ACCEPT,
     VirtualFilesystem,
+    collectDroppedPatchItems,
     getLocalProvider,
-    guessMimeType
+    guessMimeType,
+    type PatchImportItem,
+    type VfsCollisionStrategy
   } from '$lib/vfs';
   import {
     parseVFSPath,
@@ -48,6 +51,7 @@
   import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
   import { isMobile, isSidebarOpen } from '../../../stores/ui.store';
   import FolderPickerDialog, { type FolderNode } from './FolderPickerDialog.svelte';
+  import VfsCollisionDialog from './VfsCollisionDialog.svelte';
   import {
     getExpandedChildDirectories,
     getExpandedLinkedFolderPathsToLoad,
@@ -93,6 +97,42 @@
 
   let expandedPaths = new SvelteSet(loadExpandedPaths());
   let searchQuery = $state('');
+  let collisionDialogOpen = $state(false);
+  let collisionPaths = $state<string[]>([]);
+  let collisionResolver: ((strategy: VfsCollisionStrategy) => void) | null = null;
+
+  function handleCollisionChoice(strategy: VfsCollisionStrategy) {
+    const resolve = collisionResolver;
+    collisionResolver = null;
+    collisionPaths = [];
+    collisionDialogOpen = false;
+
+    resolve?.(strategy);
+  }
+
+  function requestCollisionChoice(paths: string[]): Promise<VfsCollisionStrategy> {
+    if (paths.length === 0) return Promise.resolve('keep-both');
+    if (collisionResolver) return Promise.resolve('cancel');
+
+    collisionPaths = paths;
+    collisionDialogOpen = true;
+
+    return new Promise((resolve) => {
+      collisionResolver = resolve;
+    });
+  }
+
+  async function importPatchItems(
+    items: Iterable<globalThis.File | PatchImportItem>,
+    targetFolder: string
+  ): Promise<string[]> {
+    const importItems = [...items];
+    const collisions = vfs.getPatchImportCollisions(importItems, targetFolder);
+    const strategy = await requestCollisionChoice(collisions);
+    if (strategy === 'cancel') return [];
+
+    return vfs.importToPatch(importItems, targetFolder, strategy);
+  }
 
   // Search result type for flat display
   type FileSearchResult = {
@@ -600,12 +640,15 @@
     }
 
     // Handle external file drops
-    const files = event.dataTransfer?.files;
-    if (!files || files.length === 0) return;
+    const dataTransfer = event.dataTransfer;
+    if (!dataTransfer) return;
 
     if (targetFolder?.startsWith('patch://')) {
       try {
-        await vfs.importToPatch(Array.from(files), targetFolder);
+        const items = await collectDroppedPatchItems(dataTransfer);
+        if (items.length === 0) return;
+
+        await importPatchItems(items, targetFolder);
       } catch (error) {
         toast.error(error instanceof Error ? error.message.replace('VFS: ', '') : 'Import failed');
       }
@@ -614,7 +657,7 @@
     }
 
     // Store each dropped file in User with linked-file behavior.
-    for (const file of Array.from(files)) {
+    for (const file of Array.from(dataTransfer.files)) {
       await vfs.storeFile(file, undefined, targetFolder ?? undefined);
     }
   }
@@ -624,14 +667,12 @@
     if (!parsed) return;
 
     if (parsed.namespace === 'user' && targetFolder.startsWith('patch://')) {
-      const source = vfs.getEntry(oldPath);
-
-      if (source && isVFSFolder(source)) {
-        toast.error('Folder import to Patch is not supported yet');
-        return;
+      try {
+        const items = await vfs.preparePatchCopy(oldPath);
+        await importPatchItems(items, targetFolder);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message.replace('VFS: ', '') : 'Import failed');
       }
-
-      await vfs.copyToPatch(oldPath, targetFolder, 'keep-both');
 
       return;
     }
@@ -705,7 +746,7 @@
 
     try {
       if (pendingUploadFolder?.startsWith('patch://')) {
-        await vfs.importToPatch(Array.from(files), pendingUploadFolder);
+        await importPatchItems(Array.from(files), pendingUploadFolder);
       } else {
         for (const file of Array.from(files)) {
           await vfs.storeFile(file, undefined, pendingUploadFolder ?? undefined);
@@ -1682,4 +1723,10 @@
   confirmText="Move here"
   folders={moveFolderTree}
   onSelect={handleMoveFile}
+/>
+
+<VfsCollisionDialog
+  bind:open={collisionDialogOpen}
+  paths={collisionPaths}
+  onChoose={handleCollisionChoice}
 />

--- a/ui/src/lib/components/sidebar/FileTreeView.svelte
+++ b/ui/src/lib/components/sidebar/FileTreeView.svelte
@@ -360,9 +360,7 @@
   async function deleteSelectedFiles() {
     if (selectedPaths.size === 0) return;
 
-    for (const path of selectedPaths) {
-      vfs.deletePath(path);
-    }
+    vfs.deletePaths(selectedPaths);
 
     selectedPaths.clear();
     lastSelectedPath = null;
@@ -850,7 +848,7 @@
     const entry = vfs.getEntry(path);
     if (!entry || isVFSFolder(entry)) return;
 
-    const vfsPath = await vfs.resolve(path);
+    const vfsPath = vfs.exportEmbeddedFile(path);
     const url = URL.createObjectURL(vfsPath);
 
     const link = document.createElement('a');

--- a/ui/src/lib/components/sidebar/FileTreeView.svelte
+++ b/ui/src/lib/components/sidebar/FileTreeView.svelte
@@ -13,6 +13,7 @@
     FolderSymlink,
     Image,
     Music,
+    Package,
     User,
     Box,
     Upload,
@@ -26,7 +27,12 @@
     Ellipsis
   } from '@lucide/svelte/icons';
   import SearchBar from './SearchBar.svelte';
-  import { VirtualFilesystem, getLocalProvider, guessMimeType } from '$lib/vfs';
+  import {
+    PATCH_TEXT_FILE_ACCEPT,
+    VirtualFilesystem,
+    getLocalProvider,
+    guessMimeType
+  } from '$lib/vfs';
   import {
     parseVFSPath,
     isVFSFolder,
@@ -405,6 +411,7 @@
     };
 
     // Create namespace roots
+    const patchRoot: TreeNode = { name: 'Patch', path: 'patch://', children: new Map() };
     const userRoot: TreeNode = { name: 'User', path: 'user://', children: new Map() };
     const objRoot: TreeNode = { name: 'objects', path: 'obj://', children: new Map() };
 
@@ -412,7 +419,8 @@
       const parsed = parseVFSPath(path);
       if (!parsed) continue;
 
-      const targetRoot = parsed.namespace === 'user' ? userRoot : objRoot;
+      const targetRoot =
+        parsed.namespace === 'patch' ? patchRoot : parsed.namespace === 'user' ? userRoot : objRoot;
       let current = targetRoot;
 
       // Build nested structure
@@ -425,7 +433,13 @@
         }
 
         if (!current.children.has(segment)) {
-          const nodePath = `${parsed.namespace === 'user' ? 'user://' : 'obj://'}${parsed.segments.slice(0, i + 1).join('/')}`;
+          const prefix =
+            parsed.namespace === 'patch'
+              ? 'patch://'
+              : parsed.namespace === 'user'
+                ? 'user://'
+                : 'obj://';
+          const nodePath = `${prefix}${parsed.segments.slice(0, i + 1).join('/')}`;
           const isFolder = isLast && isVFSFolder(entry);
           current.children.set(segment, {
             name: segment,
@@ -444,7 +458,8 @@
       }
     }
 
-    // Always show user namespace (so users can upload/create folders)
+    // Patch and User are always visible; Objects only appears when populated.
+    root.children!.set('patch', patchRoot);
     root.children!.set('user', userRoot);
 
     // Only add objects namespace if it has children
@@ -517,8 +532,8 @@
   }
 
   function handleFolderDragOver(event: DragEvent, folderPath: string) {
-    // Only allow drops into user:// or obj:// namespace
-    if (!folderPath.startsWith('user://') && !folderPath.startsWith('obj://')) return;
+    // The drop root declares whether the bytes remain linked or are embedded.
+    if (!folderPath.startsWith('patch://') && !folderPath.startsWith('user://')) return;
 
     const hasFiles = event.dataTransfer?.types.includes('Files');
     const hasVfsPath = event.dataTransfer?.types.includes('application/x-vfs-path');
@@ -577,7 +592,12 @@
     const files = event.dataTransfer?.files;
     if (!files || files.length === 0) return;
 
-    // Store each dropped file in VFS with the target folder
+    if (targetFolder?.startsWith('patch://')) {
+      await vfs.importToPatch(Array.from(files), targetFolder);
+      return;
+    }
+
+    // Store each dropped file in User with linked-file behavior.
     for (const file of Array.from(files)) {
       await vfs.storeFile(file, undefined, targetFolder ?? undefined);
     }
@@ -586,6 +606,16 @@
   async function moveVfsFile(oldPath: string, targetFolder: string) {
     const parsed = parseVFSPath(oldPath);
     if (!parsed) return;
+
+    if (parsed.namespace === 'user' && targetFolder.startsWith('patch://')) {
+      await vfs.copyToPatch(oldPath, targetFolder, 'keep-both');
+      return;
+    }
+
+    if (parsed.namespace === 'patch' && targetFolder.startsWith('user://')) {
+      toast.error('Use Save to Disk to export a Patch file');
+      return;
+    }
 
     // Get the entry to access the real filename
     const rootEntry = vfs.getEntry(oldPath);
@@ -617,30 +647,12 @@
 
     const localProvider = getLocalProvider();
 
-    // Move each path
+    vfs.renamePath(oldPath, newBasePath);
+
     for (const pathToMove of pathsToMove) {
-      const entry = vfs.getEntry(pathToMove);
-      if (!entry) continue;
-
-      // Calculate new path by replacing the old base with the new base
-      const relativePath = pathToMove === oldPath ? '' : pathToMove.slice(oldPath.length);
-      const newPath = newBasePath + relativePath;
-
-      // Move in VFS - preserve the original filename from the entry
-      vfs.registerEntry(newPath, entry);
-      vfs.remove(pathToMove);
-
-      // Move in LocalProvider
-      if (localProvider) {
-        await localProvider.rename(pathToMove, newPath);
-      }
-
-      // Dispatch event to update vfsPath in nodes
-      eventBus.dispatch({
-        type: 'vfsPathRenamed',
-        oldPath: pathToMove,
-        newPath
-      });
+      const newPath =
+        newBasePath + (pathToMove === oldPath ? '' : pathToMove.slice(oldPath.length));
+      await localProvider?.rename(pathToMove, newPath);
     }
 
     // Update selection if moved item was selected
@@ -657,6 +669,13 @@
   function handleUploadClick(folderPath: string, event: MouseEvent) {
     event.stopPropagation();
     pendingUploadFolder = folderPath;
+
+    if (folderPath.startsWith('patch://')) {
+      fileInputRef?.setAttribute('accept', PATCH_TEXT_FILE_ACCEPT);
+    } else {
+      fileInputRef?.removeAttribute('accept');
+    }
+
     fileInputRef?.click();
   }
 
@@ -665,8 +684,16 @@
     const files = input.files;
     if (!files || files.length === 0) return;
 
-    for (const file of Array.from(files)) {
-      await vfs.storeFile(file, undefined, pendingUploadFolder ?? undefined);
+    try {
+      if (pendingUploadFolder?.startsWith('patch://')) {
+        await vfs.importToPatch(Array.from(files), pendingUploadFolder);
+      } else {
+        for (const file of Array.from(files)) {
+          await vfs.storeFile(file, undefined, pendingUploadFolder ?? undefined);
+        }
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message.replace('VFS: ', '') : 'Import failed');
     }
 
     // Reset input so same file can be selected again
@@ -752,22 +779,16 @@
             ? `${parsed.namespace}://${parentSegments.join('/')}/${newName}`
             : `${parsed.namespace}://${newName}`;
 
-        // Get entry, register at new path, remove old path
+        // Rename through the VFS so this mutation has global undo/redo support.
         const entry = vfs.getEntry(oldPath);
         if (entry) {
-          // Update the filename in the entry
-          const updatedEntry = { ...entry, filename: newName };
-          vfs.registerEntry(newPath, updatedEntry);
-          vfs.remove(oldPath);
+          vfs.renamePath(oldPath, newPath);
 
           // Also rename in LocalProvider to persist the change
           const localProvider = getLocalProvider();
           if (localProvider) {
             await localProvider.rename(oldPath, newPath);
           }
-
-          // Dispatch event to update vfsPath in nodes
-          eventBus.dispatch({ type: 'vfsPathRenamed', oldPath, newPath });
 
           // Update selection if renamed item was selected
           if (selectedPaths.has(oldPath)) {
@@ -790,21 +811,24 @@
     toast.success('Path copied to clipboard');
   }
 
+  async function handleSaveToDisk(path: string) {
+    const entry = vfs.getEntry(path);
+    if (!entry) return;
+
+    const url = URL.createObjectURL(await vfs.resolve(path));
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = entry.filename;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
   async function handleDeleteFromContextMenu(path: string) {
     const localProvider = getLocalProvider();
 
-    // If it's a folder, also delete all children
-    const allPaths = vfs.list();
-    const pathsToDelete = allPaths.filter(
-      (p) => p === path || p.startsWith(path.endsWith('/') ? path : path + '/')
-    );
-
-    for (const pathToDelete of pathsToDelete) {
-      vfs.remove(pathToDelete);
-      if (localProvider) {
-        await localProvider.remove(pathToDelete);
-      }
-    }
+    const pathsToDelete = vfs.list().filter((p) => p === path || p.startsWith(`${path}/`));
+    vfs.deletePath(path);
+    for (const pathToDelete of pathsToDelete) await localProvider?.remove(pathToDelete);
 
     selectedPaths.clear();
     lastSelectedPath = null;
@@ -1106,6 +1130,7 @@
   bind:this={fileInputRef}
   type="file"
   multiple
+  accept={pendingUploadFolder?.startsWith('patch://') ? PATCH_TEXT_FILE_ACCEPT : undefined}
   class="hidden"
   onchange={handleFileInputChange}
 />
@@ -1125,13 +1150,18 @@
   {@const isExpanded = node.path ? expandedPaths.has(node.path) : true}
   {@const isSelected = node.path ? selectedPaths.has(node.path) : false}
   {@const paddingLeft = depth * 12 + 8}
+  {@const isPatchNamespace = node.path === 'patch://'}
   {@const isUserNamespace = node.path === 'user://'}
   {@const isObjectNamespace = node.path === 'obj://'}
   {@const isDropTarget = isInDropTarget(node.path)}
-  {@const isNamespace = isUserNamespace || isObjectNamespace}
+  {@const isNamespace = isPatchNamespace || isUserNamespace || isObjectNamespace}
   {@const isLinkedFolder = node.entry && isLocalFolder(node.entry)}
   {@const canHaveChildren =
-    isNamespace || (isFolder && node.path?.startsWith('user://') && !isLinkedFolder)}
+    isPatchNamespace ||
+    isUserNamespace ||
+    (isFolder &&
+      (node.path?.startsWith('patch://') || node.path?.startsWith('user://')) &&
+      !isLinkedFolder)}
   {@const needsReselectFlag = needsReselect(node.path)}
 
   {@const isRenaming = renamingPath === node.path}
@@ -1190,7 +1220,9 @@
               {:else}
                 <ChevronRight class="h-3 w-3 shrink-0 text-zinc-500" />
               {/if}
-              {#if isUserNamespace}
+              {#if isPatchNamespace}
+                <Package class="h-3.5 w-3.5 shrink-0 text-emerald-400" />
+              {:else if isUserNamespace}
                 <User class="h-3.5 w-3.5 shrink-0 text-blue-400" />
               {:else if isObjectNamespace}
                 <Box class="h-3.5 w-3.5 shrink-0 text-blue-400" />
@@ -1263,31 +1295,35 @@
                 </Tooltip.Root>
               {/if}
 
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  <button
-                    class="rounded p-0.5 text-zinc-500 hover:bg-zinc-700 hover:text-zinc-300"
-                    onclick={(e) => handleUploadClick(node.path!, e)}
-                    title="Upload file"
-                  >
-                    <Upload class="h-3.5 w-3.5" />
-                  </button>
-                </Tooltip.Trigger>
-                <Tooltip.Content side="bottom">Upload file</Tooltip.Content>
-              </Tooltip.Root>
+              {#if !isObjectNamespace}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <button
+                      class="rounded p-0.5 text-zinc-500 hover:bg-zinc-700 hover:text-zinc-300"
+                      onclick={(e) => handleUploadClick(node.path!, e)}
+                      title="Upload file"
+                    >
+                      <Upload class="h-3.5 w-3.5" />
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content side="bottom">Upload file</Tooltip.Content>
+                </Tooltip.Root>
+              {/if}
 
-              <Tooltip.Root>
-                <Tooltip.Trigger>
-                  <button
-                    class="rounded p-0.5 text-zinc-500 hover:bg-zinc-700 hover:text-zinc-300"
-                    onclick={(e) => handleAddUrlClick(node.path!, e)}
-                    title="Add from URL"
-                  >
-                    <Link class="h-3.5 w-3.5" />
-                  </button>
-                </Tooltip.Trigger>
-                <Tooltip.Content side="bottom">Add from URL</Tooltip.Content>
-              </Tooltip.Root>
+              {#if isUserNamespace}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <button
+                      class="rounded p-0.5 text-zinc-500 hover:bg-zinc-700 hover:text-zinc-300"
+                      onclick={(e) => handleAddUrlClick(node.path!, e)}
+                      title="Add from URL"
+                    >
+                      <Link class="h-3.5 w-3.5" />
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content side="bottom">Add from URL</Tooltip.Content>
+                </Tooltip.Root>
+              {/if}
             </div>
           {/if}
 
@@ -1358,6 +1394,12 @@
             <Copy class="mr-2 h-4 w-4" />
             Copy Path
           </ContextMenu.Item>
+          {#if node.path?.startsWith('patch://')}
+            <ContextMenu.Item onclick={() => handleSaveToDisk(node.path!)}>
+              <File class="mr-2 h-4 w-4" />
+              Save to Disk…
+            </ContextMenu.Item>
+          {/if}
           <ContextMenu.Separator />
           <ContextMenu.Item
             variant="destructive"

--- a/ui/src/lib/components/sidebar/VfsCollisionDialog.svelte
+++ b/ui/src/lib/components/sidebar/VfsCollisionDialog.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import * as Dialog from '$lib/components/ui/dialog';
+  import type { VfsCollisionStrategy } from '$lib/vfs/VirtualFilesystem';
+
+  let {
+    open = $bindable(false),
+    paths,
+    onChoose
+  }: {
+    open: boolean;
+    paths: string[];
+    onChoose: (strategy: VfsCollisionStrategy) => void;
+  } = $props();
+
+  function choose(strategy: VfsCollisionStrategy) {
+    onChoose(strategy);
+    open = false;
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && open) onChoose('cancel');
+
+    open = nextOpen;
+  }
+</script>
+
+<Dialog.Root bind:open onOpenChange={handleOpenChange}>
+  <Dialog.Content class="max-w-md border-zinc-700 bg-zinc-900">
+    <Dialog.Header>
+      <Dialog.Title>Files already exist</Dialog.Title>
+      <Dialog.Description class="text-left text-zinc-400">
+        Choose how to handle {paths.length === 1
+          ? 'this collision'
+          : `these ${paths.length} collisions`}.
+      </Dialog.Description>
+    </Dialog.Header>
+
+    <div class="max-h-40 overflow-y-auto rounded border border-zinc-800 bg-zinc-950/50 p-2">
+      {#each paths as path (path)}
+        <div class="truncate font-mono text-xs text-zinc-300">{path}</div>
+      {/each}
+    </div>
+
+    <Dialog.Footer class="flex gap-2">
+      <button
+        class="modal-action modal-action--secondary cursor-pointer"
+        onclick={() => choose('cancel')}
+      >
+        Cancel
+      </button>
+      <button
+        class="modal-action modal-action--secondary cursor-pointer"
+        onclick={() => choose('keep-both')}
+      >
+        Keep Both
+      </button>
+      <button
+        class="modal-action modal-action--primary cursor-pointer"
+        onclick={() => choose('replace')}
+      >
+        Replace
+      </button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/ui/src/lib/eventbus/events.ts
+++ b/ui/src/lib/eventbus/events.ts
@@ -21,6 +21,7 @@ export type PatchiesEvent =
   | NodeReplaceEvent
   | IframePostMessageEvent
   | FileRelinkedEvent
+  | VfsContentModifiedEvent
   | VfsPathRenamedEvent
   | InsertVfsFileToCanvasEvent
   | InsertPresetToCanvasEvent
@@ -200,6 +201,12 @@ export interface FileRelinkedEvent {
 
   /** The VFS path that was relinked */
   path: string;
+}
+
+export interface VfsContentModifiedEvent {
+  type: 'vfsContentModified';
+  path: string;
+  revision: number;
 }
 
 export interface VfsPathRenamedEvent {

--- a/ui/src/lib/migration/migrate-patch.ts
+++ b/ui/src/lib/migration/migrate-patch.ts
@@ -15,6 +15,7 @@ import { migration013 } from './migrations/013-expr-multi-outlet-handles';
 import { migration014 } from './migrations/014-tap-to-ui-node';
 import { migration015 } from './migrations/015-toggle-legacy-value';
 import { migration016 } from './migrations/016-video-output-api';
+import { migration017 } from './migrations/017-add-patch-vfs-namespace';
 
 /**
  * All migrations in order. Each migration upgrades from version N-1 to N.
@@ -36,7 +37,8 @@ const migrations: Migration[] = [
   migration013,
   migration014,
   migration015,
-  migration016
+  migration016,
+  migration017
 ];
 
 /**

--- a/ui/src/lib/migration/migrations/002-add-vfs-files-field.ts
+++ b/ui/src/lib/migration/migrations/002-add-vfs-files-field.ts
@@ -22,7 +22,7 @@ export const migration002: Migration = {
     // Add empty files structure if not present
     const migratedPatch = {
       ...patch,
-      files: { user: {}, objects: {}, ...(patch.files ?? {}), patch: patch.files?.patch ?? {} }
+      files: { user: {}, ...(patch.files ?? {}), patch: patch.files?.patch ?? {} }
     };
 
     // Strip file and fileName from `img` node

--- a/ui/src/lib/migration/migrations/002-add-vfs-files-field.ts
+++ b/ui/src/lib/migration/migrations/002-add-vfs-files-field.ts
@@ -22,7 +22,7 @@ export const migration002: Migration = {
     // Add empty files structure if not present
     const migratedPatch = {
       ...patch,
-      files: patch.files ?? { user: {}, objects: {} }
+      files: { user: {}, objects: {}, ...(patch.files ?? {}), patch: patch.files?.patch ?? {} }
     };
 
     // Strip file and fileName from `img` node

--- a/ui/src/lib/migration/migrations/004-soundfile-vfs-migration.ts
+++ b/ui/src/lib/migration/migrations/004-soundfile-vfs-migration.ts
@@ -64,7 +64,7 @@ export const migration004: Migration = {
     if (!patch.nodes) return patch;
 
     // Ensure files structure exists
-    const files: VFSTree = patch.files ?? { user: {}, objects: {} };
+    const files: VFSTree = patch.files ?? { user: {} };
     if (!files.user) files.user = {};
 
     const migratedNodes = patch.nodes.map((node) => {

--- a/ui/src/lib/migration/migrations/017-add-patch-vfs-namespace.test.ts
+++ b/ui/src/lib/migration/migrations/017-add-patch-vfs-namespace.test.ts
@@ -12,8 +12,7 @@ describe('migration017', () => {
 
     expect(migrated.files).toEqual({
       patch: {},
-      user: { 'shared.js': { provider: 'url', filename: 'shared.js', url: '/shared.js' } },
-      objects: {}
+      user: { 'shared.js': { provider: 'url', filename: 'shared.js', url: '/shared.js' } }
     });
   });
 });

--- a/ui/src/lib/migration/migrations/017-add-patch-vfs-namespace.test.ts
+++ b/ui/src/lib/migration/migrations/017-add-patch-vfs-namespace.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { migration017 } from './017-add-patch-vfs-namespace';
+
+describe('migration017', () => {
+  it('adds an empty Patch namespace without converting user files', () => {
+    const migrated = migration017.migrate({
+      files: {
+        user: { 'shared.js': { provider: 'url', filename: 'shared.js', url: '/shared.js' } }
+      }
+    });
+
+    expect(migrated.files).toEqual({
+      patch: {},
+      user: { 'shared.js': { provider: 'url', filename: 'shared.js', url: '/shared.js' } },
+      objects: {}
+    });
+  });
+});

--- a/ui/src/lib/migration/migrations/017-add-patch-vfs-namespace.ts
+++ b/ui/src/lib/migration/migrations/017-add-patch-vfs-namespace.ts
@@ -10,7 +10,6 @@ export const migration017: Migration = {
       ...patch,
       files: {
         user: {},
-        objects: {},
         ...(patch.files ?? {}),
         patch: patch.files?.patch ?? {}
       }

--- a/ui/src/lib/migration/migrations/017-add-patch-vfs-namespace.ts
+++ b/ui/src/lib/migration/migrations/017-add-patch-vfs-namespace.ts
@@ -1,0 +1,19 @@
+import type { Migration } from '../types';
+
+/** Adds the portable patch:// namespace without changing existing user:// entries. */
+export const migration017: Migration = {
+  version: 17,
+  name: 'add-patch-vfs-namespace',
+
+  migrate(patch) {
+    return {
+      ...patch,
+      files: {
+        user: {},
+        objects: {},
+        ...(patch.files ?? {}),
+        patch: patch.files?.patch ?? {}
+      }
+    };
+  }
+};

--- a/ui/src/lib/save-load/serialize-patch.ts
+++ b/ui/src/lib/save-load/serialize-patch.ts
@@ -69,7 +69,9 @@ export function serializePatch({
     patchId,
     settings,
     // Only include files if there are any entries
-    ...(Object.keys(files.user || {}).length > 0 || Object.keys(files.objects || {}).length > 0
+    ...(Object.keys(files.patch || {}).length > 0 ||
+    Object.keys(files.user || {}).length > 0 ||
+    Object.keys(files.objects || {}).length > 0
       ? { files }
       : {})
   };

--- a/ui/src/lib/save-load/serialize-patch.ts
+++ b/ui/src/lib/save-load/serialize-patch.ts
@@ -69,9 +69,7 @@ export function serializePatch({
     patchId,
     settings,
     // Only include files if there are any entries
-    ...(Object.keys(files.patch || {}).length > 0 ||
-    Object.keys(files.user || {}).length > 0 ||
-    Object.keys(files.objects || {}).length > 0
+    ...(Object.keys(files.patch || {}).length > 0 || Object.keys(files.user || {}).length > 0
       ? { files }
       : {})
   };

--- a/ui/src/lib/services/PatchManager.ts
+++ b/ui/src/lib/services/PatchManager.ts
@@ -287,6 +287,13 @@ export class PatchManager {
     this.ctx.nodes = [];
     this.ctx.edges = [];
 
+    // Scope browser-local VFS resources before hydration looks them up.
+    if (migrated.patchId) {
+      currentPatchId.set(migrated.patchId);
+    } else {
+      generateNewPatchId();
+    }
+
     // Hydrate VFS from saved files
     const vfs = VirtualFilesystem.getInstance();
     vfs.clear();
@@ -308,13 +315,6 @@ export class PatchManager {
     // Update node counter based on loaded nodes
     if (migrated.nodes.length > 0) {
       this.ctx.setNodeIdCounterFromNodes(migrated.nodes);
-    }
-
-    // Restore or generate patchId for KV storage scoping
-    if (migrated.patchId) {
-      currentPatchId.set(migrated.patchId);
-    } else {
-      generateNewPatchId();
     }
 
     // Restore patch settings

--- a/ui/src/lib/vfs/PatchFileOperations.ts
+++ b/ui/src/lib/vfs/PatchFileOperations.ts
@@ -1,0 +1,269 @@
+import {
+  MAX_EMBEDDED_FILE_BYTES,
+  MAX_EMBEDDED_PATCH_BYTES,
+  PatchImportPlanner,
+  type PatchImportSource,
+  type VfsCollisionStrategy
+} from './PatchImportPlanner';
+
+import { getBasename, getExtension, getFilename, guessMimeType } from './path-utils';
+
+import {
+  type EmbeddedVFSEntry,
+  type PatchImportItem,
+  type VFSEntry,
+  isEmbeddedVFSEntry,
+  parseVFSPath,
+  VFS_PREFIXES
+} from './types';
+
+import type { VfsEntryIndex } from './VfsEntryIndex';
+
+type MutationCallbacks = { redo?: () => void; undo?: () => void };
+
+type PatchFileAccess = {
+  entries: VfsEntryIndex;
+  recordMutation: (description: string, mutate: () => void, callbacks?: MutationCallbacks) => void;
+  notifyChange: () => void;
+  emitContentModified: (path: string, revision: number) => void;
+};
+
+/** Owns validation, budgets, content changes, and atomic patch-file imports. */
+export class PatchFileOperations {
+  private invalidPaths = new Map<string, string>();
+
+  constructor(private access: PatchFileAccess) {}
+
+  validateEntry(path: string, entry: VFSEntry, enforceLimits = true): void {
+    const parsed = parseVFSPath(path);
+
+    if (!parsed || parsed.segments.length === 0) {
+      throw new Error(`VFS: Invalid path: ${path}`);
+    }
+
+    if (parsed.namespace === 'patch') {
+      if (entry.provider !== 'embedded' && entry.provider !== 'folder') {
+        throw new Error(`VFS: patch:// entries must use the embedded provider: ${path}`);
+      }
+    } else if (entry.provider === 'embedded') {
+      throw new Error(`VFS: embedded entries are only valid under patch://: ${path}`);
+    }
+
+    if (entry.provider === 'embedded' && !isEmbeddedVFSEntry(entry)) {
+      throw new Error(`VFS: embedded file content must be UTF-8 text: ${path}`);
+    }
+
+    if (enforceLimits && isEmbeddedVFSEntry(entry)) {
+      this.assertContentWithinBudget(entry.content, path);
+    }
+  }
+
+  refreshValidation(): void {
+    const invalidPaths = new Map<string, string>();
+    let totalBytes = 0;
+
+    for (const [path, entry] of this.access.entries) {
+      if (!isEmbeddedVFSEntry(entry)) continue;
+
+      const size = byteLength(entry.content);
+      totalBytes += size;
+
+      if (size > MAX_EMBEDDED_FILE_BYTES) {
+        invalidPaths.set(path, `VFS: Embedded file exceeds 256 KiB: ${path}`);
+      }
+    }
+
+    if (totalBytes > MAX_EMBEDDED_PATCH_BYTES) {
+      for (const [path, entry] of this.access.entries) {
+        if (isEmbeddedVFSEntry(entry) && !invalidPaths.has(path)) {
+          invalidPaths.set(path, 'VFS: Embedded patch files exceed 1 MiB');
+        }
+      }
+    }
+
+    this.invalidPaths = invalidPaths;
+  }
+
+  assertReadable(path: string): void {
+    const validationError = this.invalidPaths.get(path);
+
+    if (validationError) {
+      throw new Error(validationError);
+    }
+  }
+
+  create(path: string, content = '', collision: VfsCollisionStrategy = 'cancel'): string | null {
+    const parsed = parseVFSPath(path);
+
+    if (parsed?.namespace !== 'patch') {
+      throw new Error(`VFS: Embedded files must use patch:// paths: ${path}`);
+    }
+
+    const destination = this.resolveCollision(path, collision);
+    if (!destination) return null;
+
+    const filename = getFilename(destination);
+
+    const entry: EmbeddedVFSEntry = {
+      provider: 'embedded',
+      filename,
+      mimeType: guessMimeType(filename) ?? 'text/plain;charset=utf-8',
+      content,
+      size: byteLength(content),
+      revision: 1
+    };
+
+    this.validateEntry(destination, entry);
+
+    this.access.recordMutation(`Create ${filename}`, () => {
+      this.access.entries.set(destination, entry);
+      this.access.notifyChange();
+      this.access.emitContentModified(destination, entry.revision ?? 1);
+    });
+
+    return destination;
+  }
+
+  write(path: string, content: string): void {
+    const entry = this.access.entries.get(path);
+
+    if (!entry || !isEmbeddedVFSEntry(entry)) {
+      throw new Error(`VFS: Embedded file not found: ${path}`);
+    }
+
+    this.assertContentWithinBudget(content, path);
+
+    const updated: EmbeddedVFSEntry = {
+      ...entry,
+      content,
+      size: byteLength(content),
+      revision: (entry.revision ?? 0) + 1
+    };
+
+    this.access.recordMutation(`Write ${entry.filename}`, () => {
+      this.access.entries.set(path, updated);
+      this.access.notifyChange();
+      this.access.emitContentModified(path, updated.revision ?? 1);
+    });
+  }
+
+  read(path: string): string {
+    const entry = this.access.entries.get(path);
+
+    if (!entry || !isEmbeddedVFSEntry(entry)) {
+      throw new Error(`VFS: Embedded file not found: ${path}`);
+    }
+
+    this.assertReadable(path);
+
+    return entry.content;
+  }
+
+  export(path: string): File {
+    const entry = this.access.entries.get(path);
+
+    if (!entry || !isEmbeddedVFSEntry(entry)) {
+      throw new Error(`VFS: Embedded file not found: ${path}`);
+    }
+
+    return new File([entry.content], entry.filename, {
+      type: entry.mimeType || 'text/plain;charset=utf-8'
+    });
+  }
+
+  async prepareCopy(sourcePath: string, source: PatchImportSource): Promise<PatchImportItem[]> {
+    return this.createImportPlanner().prepareCopy(sourcePath, source);
+  }
+
+  getImportCollisions(
+    files: Iterable<File | PatchImportItem>,
+    targetFolder: string = VFS_PREFIXES.PATCH
+  ): string[] {
+    return this.createImportPlanner().getCollisions(files, targetFolder);
+  }
+
+  async import(
+    files: Iterable<File | PatchImportItem>,
+    targetFolder: string = VFS_PREFIXES.PATCH,
+    collision: VfsCollisionStrategy = 'keep-both'
+  ): Promise<string[]> {
+    const plan = await this.createImportPlanner().plan(files, targetFolder, collision);
+
+    this.access.recordMutation(
+      `Import ${plan.importedPaths.length} patch file${plan.importedPaths.length === 1 ? '' : 's'}`,
+      () => {
+        for (const path of plan.removedExistingPaths) {
+          this.access.entries.delete(path);
+        }
+
+        for (const [path, entry] of plan.stagedEntries) {
+          this.access.entries.set(path, entry);
+
+          if (isEmbeddedVFSEntry(entry)) {
+            this.access.emitContentModified(path, entry.revision ?? 1);
+          }
+        }
+
+        this.access.notifyChange();
+      }
+    );
+
+    return plan.importedPaths;
+  }
+
+  private resolveCollision(path: string, collision: VfsCollisionStrategy): string | null {
+    const occupied = new Set(this.access.entries.keys());
+
+    const hasCollision = (candidate: string) =>
+      occupied.has(candidate) || [...occupied].some((item) => item.startsWith(`${candidate}/`));
+
+    if (!hasCollision(path)) return path;
+    if (collision === 'replace') return path;
+    if (collision === 'cancel') return null;
+
+    const filename = getFilename(path);
+    const extension = getExtension(filename);
+    const basename = getBasename(filename);
+    const parent = path.slice(0, -filename.length);
+
+    let counter = 1;
+    let candidate = `${parent}${basename}-${counter}${extension}`;
+
+    while (hasCollision(candidate)) {
+      counter += 1;
+      candidate = `${parent}${basename}-${counter}${extension}`;
+    }
+
+    return candidate;
+  }
+
+  private assertContentWithinBudget(content: string, path: string): void {
+    const size = byteLength(content);
+
+    if (size > MAX_EMBEDDED_FILE_BYTES) {
+      throw new Error(`VFS: Embedded file exceeds 256 KiB: ${path}`);
+    }
+
+    if (this.getEmbeddedByteLength(path) + size > MAX_EMBEDDED_PATCH_BYTES) {
+      throw new Error('VFS: Embedded patch files exceed 1 MiB');
+    }
+  }
+
+  private getEmbeddedByteLength(excludingPath?: string): number {
+    let total = 0;
+
+    for (const [path, entry] of this.access.entries) {
+      if (path !== excludingPath && isEmbeddedVFSEntry(entry)) {
+        total += byteLength(entry.content);
+      }
+    }
+
+    return total;
+  }
+
+  private createImportPlanner(): PatchImportPlanner {
+    return new PatchImportPlanner(this.access.entries.snapshot());
+  }
+}
+
+const byteLength = (content: string) => new TextEncoder().encode(content).byteLength;

--- a/ui/src/lib/vfs/PatchImportPlanner.ts
+++ b/ui/src/lib/vfs/PatchImportPlanner.ts
@@ -1,0 +1,360 @@
+import {
+  type EmbeddedVFSEntry,
+  type PatchImportItem,
+  type VFSEntry,
+  type VFSListEntry,
+  isEmbeddedVFSEntry,
+  isVFSFolder,
+  VFS_PREFIXES
+} from './types';
+import { getBasename, getExtension, getFilename, guessMimeType } from './path-utils';
+
+export const MAX_EMBEDDED_FILE_BYTES = 256 * 1024;
+export const MAX_EMBEDDED_PATCH_BYTES = 1024 * 1024;
+
+export const PATCH_TEXT_FILE_ACCEPT =
+  'text/*,.js,.mjs,.gl,.glsl,.frag,.vert,.glslf,.glslv,.json,.jsonc,.css,.html,.htm,.svg,.xml,.yaml,.yml,.md,.txt,.csv';
+
+const PATCH_TEXT_EXTENSIONS = new Set([
+  '.js',
+  '.mjs',
+  '.gl',
+  '.glsl',
+  '.frag',
+  '.vert',
+  '.glslf',
+  '.glslv',
+  '.json',
+  '.jsonc',
+  '.css',
+  '.html',
+  '.htm',
+  '.svg',
+  '.xml',
+  '.yaml',
+  '.yml',
+  '.md',
+  '.txt',
+  '.csv'
+]);
+
+export type VfsCollisionStrategy = 'replace' | 'keep-both' | 'cancel';
+
+export type PatchImportPlan = {
+  stagedEntries: Map<string, VFSEntry>;
+  removedExistingPaths: Set<string>;
+  importedPaths: string[];
+};
+
+export type PatchImportSource = {
+  getEntry: (path: string) => VFSEntry | undefined;
+  listChildren: (path: string) => Promise<VFSListEntry[]>;
+  resolve: (path: string) => Promise<File | Blob>;
+};
+
+export function getPatchImportError(file: File): string | null {
+  if (file.size > MAX_EMBEDDED_FILE_BYTES) {
+    return `${file.name} exceeds 256 KiB Patch-file limit`;
+  }
+
+  const extension = getExtension(file.name).toLowerCase();
+  const isTextMimeType =
+    file.type.startsWith('text/') ||
+    file.type === 'application/javascript' ||
+    file.type === 'application/json' ||
+    file.type === 'application/xml' ||
+    file.type === 'image/svg+xml';
+
+  if (!isTextMimeType && !PATCH_TEXT_EXTENSIONS.has(extension)) {
+    return `${file.name} is not a supported text file`;
+  }
+
+  return null;
+}
+
+/** Validates and stages atomic Patch imports against an immutable entry snapshot. */
+export class PatchImportPlanner {
+  constructor(private entries: ReadonlyMap<string, VFSEntry>) {}
+
+  async prepareCopy(sourcePath: string, source: PatchImportSource): Promise<PatchImportItem[]> {
+    const sourceEntry = source.getEntry(sourcePath);
+    if (!sourceEntry) throw new Error(`VFS: Path not found: ${sourcePath}`);
+
+    if (!isVFSFolder(sourceEntry)) {
+      const file = await this.resolveSourceFile(sourcePath, sourceEntry, source);
+      return [{ kind: 'file', file, relativePath: sourceEntry.filename }];
+    }
+
+    const rootName = sourceEntry.filename;
+    const items: PatchImportItem[] = [{ kind: 'directory', relativePath: rootName }];
+    const collectChildren = async (directory: string, relativeDirectory: string): Promise<void> => {
+      for (const child of await source.listChildren(directory)) {
+        const relativePath = `${relativeDirectory}/${child.name}`;
+
+        if (child.kind === 'directory') {
+          items.push({ kind: 'directory', relativePath });
+          await collectChildren(child.path, relativePath);
+          continue;
+        }
+
+        const entry = source.getEntry(child.path);
+        if (!entry) throw new Error(`VFS: File not found: ${child.path}`);
+
+        const file = await this.resolveSourceFile(child.path, entry, source);
+        items.push({ kind: 'file', file, relativePath });
+      }
+    };
+
+    await collectChildren(sourcePath, rootName);
+    return items;
+  }
+
+  getCollisions(
+    files: Iterable<File | PatchImportItem>,
+    targetFolder: string = VFS_PREFIXES.PATCH
+  ): string[] {
+    const items = this.normalizeItems(files);
+    const collisions = items
+      .map((item) => this.joinPath(targetFolder, item.relativePath))
+      .filter((path) =>
+        [...this.entries.keys()].some(
+          (existing) => existing === path || existing.startsWith(`${path}/`)
+        )
+      );
+
+    return [...new Set(collisions)].filter(
+      (path, _, all) => !all.some((other) => other !== path && path.startsWith(`${other}/`))
+    );
+  }
+
+  async plan(
+    files: Iterable<File | PatchImportItem>,
+    targetFolder: string = VFS_PREFIXES.PATCH,
+    collision: VfsCollisionStrategy = 'keep-both'
+  ): Promise<PatchImportPlan> {
+    if (!targetFolder.startsWith(VFS_PREFIXES.PATCH)) {
+      throw new Error(`VFS: Patch destination required: ${targetFolder}`);
+    }
+
+    const items = this.normalizeItems(files);
+    const decodedContent = new Map<PatchImportItem, string>();
+    const errors: string[] = [];
+
+    for (const item of items) {
+      if (item.kind === 'directory') continue;
+
+      const importError = getPatchImportError(item.file);
+      if (importError) {
+        errors.push(importError);
+        continue;
+      }
+
+      try {
+        decodedContent.set(item, await this.decodeUtf8(item.file, item.relativePath));
+      } catch (error) {
+        errors.push(
+          error instanceof Error ? error.message.replace('VFS: ', '') : item.relativePath
+        );
+      }
+    }
+
+    if (errors.length > 0) throw new Error(`VFS: ${errors.join('; ')}`);
+
+    const stagedEntries = new Map<string, VFSEntry>();
+    const occupied = new Set(this.entries.keys());
+    const removedExistingPaths = new Set<string>();
+    const resolvedDirectories = new Map<string, string>();
+    let totalBytes = this.getEmbeddedByteLength();
+
+    const removeExistingTree = (path: string) => {
+      for (const [existingPath, entry] of this.entries) {
+        if (existingPath !== path && !existingPath.startsWith(`${path}/`)) continue;
+        if (removedExistingPaths.has(existingPath)) continue;
+
+        removedExistingPaths.add(existingPath);
+        occupied.delete(existingPath);
+        if (isEmbeddedVFSEntry(entry)) totalBytes -= this.byteLength(entry.content);
+      }
+    };
+    const removeStagedTree = (path: string) => {
+      for (const [stagedPath, entry] of stagedEntries) {
+        if (stagedPath !== path && !stagedPath.startsWith(`${path}/`)) continue;
+
+        stagedEntries.delete(stagedPath);
+        occupied.delete(stagedPath);
+        if (isEmbeddedVFSEntry(entry)) totalBytes -= this.byteLength(entry.content);
+      }
+    };
+
+    for (const item of items) {
+      const parent = this.resolveParent(item.relativePath, targetFolder, resolvedDirectories);
+      if (!parent) throw new Error(`VFS: Invalid import path: ${item.relativePath}`);
+
+      const name = getFilename(item.relativePath);
+      const rawPath = this.joinPath(parent, name);
+      const priorEntry = stagedEntries.get(rawPath) ?? this.entries.get(rawPath);
+      const path = this.resolveCollision(rawPath, collision, occupied, item.kind === 'directory');
+      if (!path) throw new Error(`VFS: Import cancelled because ${name} already exists`);
+
+      if (collision === 'replace' && path === rawPath) {
+        removeStagedTree(path);
+        removeExistingTree(path);
+      }
+
+      if (item.kind === 'directory') {
+        resolvedDirectories.set(item.relativePath, path);
+        stagedEntries.set(path, { provider: 'folder', filename: getFilename(path) });
+        occupied.add(path);
+        continue;
+      }
+
+      const content = decodedContent.get(item)!;
+      const size = this.byteLength(content);
+      totalBytes += size;
+      if (totalBytes > MAX_EMBEDDED_PATCH_BYTES) {
+        throw new Error('VFS: Embedded patch files exceed 1 MiB');
+      }
+
+      occupied.add(path);
+      const entry: EmbeddedVFSEntry = {
+        provider: 'embedded',
+        filename: getFilename(path),
+        mimeType: item.file.type || guessMimeType(item.file.name) || 'text/plain;charset=utf-8',
+        content,
+        size,
+        revision: priorEntry && isEmbeddedVFSEntry(priorEntry) ? (priorEntry.revision ?? 0) + 1 : 1
+      };
+      stagedEntries.set(path, entry);
+    }
+
+    return {
+      stagedEntries,
+      removedExistingPaths,
+      importedPaths: [...stagedEntries]
+        .filter(([, entry]) => isEmbeddedVFSEntry(entry))
+        .map(([path]) => path)
+    };
+  }
+
+  private async resolveSourceFile(
+    path: string,
+    entry: VFSEntry,
+    source: PatchImportSource
+  ): Promise<File> {
+    if (entry.size && entry.size > MAX_EMBEDDED_FILE_BYTES) {
+      throw new Error(`VFS: ${entry.filename} exceeds 256 KiB Patch-file limit`);
+    }
+
+    const blob = await source.resolve(path);
+    return blob instanceof File
+      ? blob
+      : new File([blob], entry.filename, { type: entry.mimeType ?? blob.type });
+  }
+
+  private normalizeItems(files: Iterable<File | PatchImportItem>): PatchImportItem[] {
+    const directories = new Set<string>();
+    const fileItems: PatchImportItem[] = [];
+
+    for (const input of files) {
+      const item: PatchImportItem =
+        input instanceof File
+          ? { kind: 'file', file: input, relativePath: this.getImportRelativePath(input) }
+          : { ...input, relativePath: this.normalizeRelativePath(input.relativePath) };
+      const segments = item.relativePath.split('/');
+
+      for (let index = 1; index < segments.length; index += 1) {
+        directories.add(segments.slice(0, index).join('/'));
+      }
+
+      if (item.kind === 'directory') directories.add(item.relativePath);
+      else fileItems.push(item);
+    }
+
+    const directoryItems: PatchImportItem[] = [...directories]
+      .sort((a, b) => a.split('/').length - b.split('/').length || a.localeCompare(b))
+      .map((relativePath) => ({ kind: 'directory', relativePath }));
+
+    return [...directoryItems, ...fileItems];
+  }
+
+  private resolveCollision(
+    path: string,
+    collision: VfsCollisionStrategy,
+    occupied: Set<string>,
+    directory: boolean
+  ): string | null {
+    const hasCollision = (candidate: string) =>
+      occupied.has(candidate) || [...occupied].some((item) => item.startsWith(`${candidate}/`));
+
+    if (!hasCollision(path)) return path;
+    if (collision === 'replace') return path;
+    if (collision === 'cancel') return null;
+
+    const filename = getFilename(path);
+    const extension = directory ? '' : getExtension(filename);
+    const basename = directory ? filename : getBasename(filename);
+    const parent = path.slice(0, -filename.length);
+    let counter = 1;
+    let candidate = `${parent}${basename}-${counter}${extension}`;
+
+    while (hasCollision(candidate)) {
+      counter += 1;
+      candidate = `${parent}${basename}-${counter}${extension}`;
+    }
+
+    return candidate;
+  }
+
+  private getEmbeddedByteLength(): number {
+    let total = 0;
+    for (const entry of this.entries.values()) {
+      if (isEmbeddedVFSEntry(entry)) total += this.byteLength(entry.content);
+    }
+    return total;
+  }
+
+  private async decodeUtf8(blob: Blob, path: string): Promise<string> {
+    try {
+      return new TextDecoder('utf-8', { fatal: true }).decode(await blob.arrayBuffer());
+    } catch {
+      throw new Error(`VFS: Only UTF-8 text can be embedded: ${path}`);
+    }
+  }
+
+  private getImportRelativePath(file: File): string {
+    const relativePath = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+    return this.normalizeRelativePath(relativePath || file.name);
+  }
+
+  private normalizeRelativePath(relativePath: string): string {
+    const normalized = relativePath.replaceAll('\\', '/');
+    const segments = normalized.split('/').filter(Boolean);
+
+    if (segments.length === 0 || segments.some((segment) => segment === '.' || segment === '..')) {
+      throw new Error(`VFS: Invalid import path: ${normalized}`);
+    }
+
+    return segments.join('/');
+  }
+
+  private resolveParent(
+    relativePath: string,
+    targetFolder: string,
+    resolvedDirectories: ReadonlyMap<string, string>
+  ): string | undefined {
+    const separator = relativePath.lastIndexOf('/');
+    return separator === -1
+      ? targetFolder
+      : resolvedDirectories.get(relativePath.slice(0, separator));
+  }
+
+  private joinPath(parent: string, child: string): string {
+    return parent.endsWith('://') || parent.endsWith('/')
+      ? `${parent}${child}`
+      : `${parent}/${child}`;
+  }
+
+  private byteLength(content: string): number {
+    return new TextEncoder().encode(content).byteLength;
+  }
+}

--- a/ui/src/lib/vfs/VfsDirectoryReader.ts
+++ b/ui/src/lib/vfs/VfsDirectoryReader.ts
@@ -1,0 +1,250 @@
+import type { LocalFilesystemProvider } from './providers/LocalFilesystemProvider';
+import { guessMimeType } from './path-utils';
+import {
+  type VFSEntry,
+  type VFSListEntry,
+  type VFSListPage,
+  type VFSSearchPage,
+  isVFSFolder,
+  VFS_PREFIXES
+} from './types';
+import type { VfsEntryIndex } from './VfsEntryIndex';
+
+type PageOptions = { offset?: number; limit?: number };
+
+/** Reads virtual and linked-folder directory trees through one interface. */
+export class VfsDirectoryReader {
+  constructor(
+    private entries: VfsEntryIndex,
+    private getLocalProvider: () => LocalFilesystemProvider | undefined
+  ) {}
+
+  findLinkedFolder(path: string): string | null {
+    if (this.entries.get(path)?.provider === 'local-folder') return path;
+
+    const segments = path.split('/');
+    for (let index = 3; index < segments.length; index += 1) {
+      const potentialFolderPath = segments.slice(0, index).join('/');
+      if (this.entries.get(potentialFolderPath)?.provider === 'local-folder') {
+        return potentialFolderPath;
+      }
+    }
+
+    return null;
+  }
+
+  getEntry(path: string): VFSEntry | undefined {
+    const entry = this.entries.get(path);
+    if (entry) {
+      return entry.mimeType ? entry : { ...entry, mimeType: guessMimeType(entry.filename) };
+    }
+
+    if (!this.findLinkedFolder(path)) return undefined;
+
+    const filename = path.split('/').pop() || '';
+    return { provider: 'local', filename, mimeType: guessMimeType(filename) };
+  }
+
+  async resolveLinkedFile(path: string): Promise<File | undefined> {
+    const linkedFolderPath = this.findLinkedFolder(path);
+    if (!linkedFolderPath || linkedFolderPath === path) return undefined;
+
+    const provider = this.getLocalProvider();
+    if (!provider) {
+      throw new Error('VFS: Local provider not available for linked folder resolution');
+    }
+
+    const relativePath = path.slice(linkedFolderPath.length + 1).split('/');
+    return provider.resolveFileInDir(linkedFolderPath, relativePath);
+  }
+
+  async listChildren(directory: string): Promise<VFSListEntry[]> {
+    const entry = this.entries.get(directory);
+    const linkedFolderPath = this.findLinkedFolder(directory);
+    const hasChildren = this.entries.hasDescendant(directory);
+    const isNamespaceRoot =
+      directory === VFS_PREFIXES.PATCH ||
+      directory === VFS_PREFIXES.USER ||
+      directory === VFS_PREFIXES.OBJECT;
+
+    if (entry && !isVFSFolder(entry)) {
+      throw new TypeError(`VFS: Path is not a directory: ${directory}`);
+    }
+
+    if (!entry && !linkedFolderPath && !hasChildren && !isNamespaceRoot) {
+      throw new Error(`VFS: Directory not found: ${directory}`);
+    }
+
+    const children = new Map<string, VFSListEntry>();
+    for (const childPath of this.entries.immediateChildPaths(directory)) {
+      children.set(childPath, this.createListEntry(childPath));
+    }
+
+    if (linkedFolderPath) {
+      for (const child of await this.listLinkedFolderChildren(directory, linkedFolderPath)) {
+        children.set(child.path, this.createListEntry(child.path, child.kind));
+      }
+    }
+
+    return [...children.values()].sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  async listChildrenPage(directory: string, options: PageOptions = {}): Promise<VFSListPage> {
+    const offset = Math.max(0, Math.floor(options.offset ?? 0));
+    const limit = Math.max(1, Math.floor(options.limit ?? 50));
+    const linkedFolderPath = this.findLinkedFolder(directory);
+
+    if (linkedFolderPath) {
+      const children = await this.listLinkedFolderChildren(directory, linkedFolderPath, {
+        offset,
+        limit: limit + 1
+      });
+      const truncated = children.length > limit;
+      const entries = children
+        .slice(0, limit)
+        .map((child) => this.createListEntry(child.path, child.kind));
+
+      return {
+        entries,
+        offset,
+        limit,
+        truncated,
+        ...(truncated ? { nextOffset: offset + entries.length } : {})
+      };
+    }
+
+    const children = await this.listChildren(directory);
+    const entries = children.slice(offset, offset + limit);
+    const truncated = offset + entries.length < children.length;
+
+    return {
+      entries,
+      offset,
+      limit,
+      truncated,
+      ...(truncated ? { nextOffset: offset + entries.length } : {})
+    };
+  }
+
+  async search(query: string, directory: string): Promise<VFSListEntry[]> {
+    const prefix = directory.endsWith('://') ? directory : `${directory}/`;
+    const normalizedQuery = query.toLowerCase();
+    const matches = new Map<string, VFSListEntry>();
+
+    for (const path of this.entries.paths(prefix)) {
+      if (path.toLowerCase().includes(normalizedQuery)) {
+        matches.set(path, this.createListEntry(path));
+      }
+    }
+
+    const containingLinkedFolder = this.findLinkedFolder(directory);
+    const linkedFolderPaths = containingLinkedFolder
+      ? [containingLinkedFolder]
+      : [...this.entries]
+          .filter(([path, entry]) => entry.provider === 'local-folder' && path.startsWith(prefix))
+          .map(([path]) => path);
+
+    for (const linkedFolderPath of linkedFolderPaths) {
+      const searchRoot = containingLinkedFolder ? directory : linkedFolderPath;
+
+      for (const entry of await this.searchLinkedFolder(searchRoot, linkedFolderPath)) {
+        if (entry.path.toLowerCase().includes(normalizedQuery)) matches.set(entry.path, entry);
+      }
+    }
+
+    return [...matches.values()].sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  async searchPage(
+    query: string,
+    directory: string,
+    options: PageOptions = {}
+  ): Promise<VFSSearchPage> {
+    const offset = Math.max(0, Math.floor(options.offset ?? 0));
+    const limit = Math.max(1, Math.floor(options.limit ?? 50));
+    const normalizedQuery = query.toLowerCase();
+    const entries: VFSListEntry[] = [];
+    let skipped = 0;
+
+    const visit = async (currentDirectory: string): Promise<boolean> => {
+      for (const child of await this.listChildren(currentDirectory)) {
+        if (child.path.toLowerCase().includes(normalizedQuery)) {
+          if (skipped < offset) skipped += 1;
+          else if (entries.length < limit) entries.push(child);
+          else return true;
+        }
+
+        if (child.kind === 'directory' && (await visit(child.path))) return true;
+      }
+
+      return false;
+    };
+
+    const truncated = await visit(directory);
+
+    return {
+      entries,
+      offset,
+      limit,
+      truncated,
+      ...(truncated ? { nextOffset: offset + entries.length } : {})
+    };
+  }
+
+  private createListEntry(path: string, kind?: VFSListEntry['kind']): VFSListEntry {
+    const name = path.split('/').filter(Boolean).pop() ?? path;
+    return { path, name, kind: kind ?? this.getPathKind(path) };
+  }
+
+  private getPathKind(path: string): VFSListEntry['kind'] {
+    const entry = this.entries.get(path);
+    if (entry && isVFSFolder(entry)) return 'directory';
+
+    return this.entries.hasDescendant(path) ? 'directory' : 'file';
+  }
+
+  private async listLinkedFolderChildren(
+    directory: string,
+    linkedFolderPath: string,
+    options?: PageOptions
+  ): Promise<Array<{ path: string; kind: 'file' | 'directory' }>> {
+    const provider = this.getLocalProvider();
+    if (!provider) {
+      throw new Error('VFS: Local provider not available for linked folder listing');
+    }
+
+    let handle = await provider.getDirHandle(linkedFolderPath);
+    if (!handle) {
+      throw new Error(`VFS: No directory handle for linked folder: ${linkedFolderPath}`);
+    }
+    if (!(await provider.hasDirPermission(linkedFolderPath))) {
+      throw new Error(`VFS: Permission denied for linked folder: ${linkedFolderPath}`);
+    }
+
+    const relativeSegments =
+      directory === linkedFolderPath ? [] : directory.slice(linkedFolderPath.length + 1).split('/');
+    for (const segment of relativeSegments) {
+      handle = await handle.getDirectoryHandle(segment);
+    }
+
+    const entries = await provider.listHandleContents(handle, options);
+    const pathPrefix = directory.endsWith('/') ? directory : `${directory}/`;
+    return entries.map((entry) => ({ path: `${pathPrefix}${entry.name}`, kind: entry.kind }));
+  }
+
+  private async searchLinkedFolder(
+    directory: string,
+    linkedFolderPath: string
+  ): Promise<VFSListEntry[]> {
+    const matches: VFSListEntry[] = [];
+
+    for (const child of await this.listLinkedFolderChildren(directory, linkedFolderPath)) {
+      matches.push(this.createListEntry(child.path, child.kind));
+      if (child.kind === 'directory') {
+        matches.push(...(await this.searchLinkedFolder(child.path, linkedFolderPath)));
+      }
+    }
+
+    return matches;
+  }
+}

--- a/ui/src/lib/vfs/VfsEntryIndex.ts
+++ b/ui/src/lib/vfs/VfsEntryIndex.ts
@@ -59,7 +59,13 @@ export class VfsEntryIndex implements Iterable<[string, VFSEntry]> {
 
   paths(prefix?: string): string[] {
     const paths = [...this.entries.keys()];
-    return prefix ? paths.filter((path) => path.startsWith(prefix)) : paths;
+    if (!prefix) return paths;
+    if (prefix.endsWith('://')) return paths.filter((path) => path.startsWith(prefix));
+
+    const normalizedPrefix = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+    return paths.filter(
+      (path) => path === normalizedPrefix || path.startsWith(`${normalizedPrefix}/`)
+    );
   }
 
   treePaths(path: string): string[] {

--- a/ui/src/lib/vfs/VfsEntryIndex.ts
+++ b/ui/src/lib/vfs/VfsEntryIndex.ts
@@ -1,0 +1,70 @@
+import type { VFSEntry } from './types';
+
+/** In-memory index for VFS entries and complete path trees. */
+export class VfsEntryIndex implements Iterable<[string, VFSEntry]> {
+  private entries: Map<string, VFSEntry>;
+
+  constructor(entries: Iterable<[string, VFSEntry]> = []) {
+    this.entries = new Map(entries);
+  }
+
+  [Symbol.iterator](): MapIterator<[string, VFSEntry]> {
+    return this.entries[Symbol.iterator]();
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  get(path: string): VFSEntry | undefined {
+    return this.entries.get(path);
+  }
+
+  set(path: string, entry: VFSEntry): this {
+    this.entries.set(path, entry);
+    return this;
+  }
+
+  has(path: string): boolean {
+    return this.entries.has(path);
+  }
+
+  delete(path: string): boolean {
+    return this.entries.delete(path);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  keys(): MapIterator<string> {
+    return this.entries.keys();
+  }
+
+  values(): MapIterator<VFSEntry> {
+    return this.entries.values();
+  }
+
+  snapshot(): Map<string, VFSEntry> {
+    return new Map(
+      [...this.entries].map(([path, entry]) => [path, { ...entry }] as [string, VFSEntry])
+    );
+  }
+
+  replace(entries: Iterable<[string, VFSEntry]>): void {
+    this.entries = new Map(
+      [...entries].map(([path, entry]) => [path, { ...entry }] as [string, VFSEntry])
+    );
+  }
+
+  paths(prefix?: string): string[] {
+    const paths = [...this.entries.keys()];
+    return prefix ? paths.filter((path) => path.startsWith(prefix)) : paths;
+  }
+
+  treePaths(path: string): string[] {
+    return this.paths().filter(
+      (candidate) => candidate === path || candidate.startsWith(`${path}/`)
+    );
+  }
+}

--- a/ui/src/lib/vfs/VfsEntryIndex.ts
+++ b/ui/src/lib/vfs/VfsEntryIndex.ts
@@ -1,4 +1,19 @@
-import type { VFSEntry } from './types';
+import { type VFSEntry, parseVFSPath } from './types';
+
+export type VfsRenameMove = {
+  oldPath: string;
+  newPath: string;
+  entry: VFSEntry;
+};
+
+export type VfsRenamePlan = {
+  moves: VfsRenameMove[];
+};
+
+export type VfsDeletePlan = {
+  roots: string[];
+  paths: string[];
+};
 
 /** In-memory index for VFS entries and complete path trees. */
 export class VfsEntryIndex implements Iterable<[string, VFSEntry]> {
@@ -45,6 +60,10 @@ export class VfsEntryIndex implements Iterable<[string, VFSEntry]> {
     return this.entries.values();
   }
 
+  toMap(): Map<string, VFSEntry> {
+    return new Map(this.entries);
+  }
+
   snapshot(): Map<string, VFSEntry> {
     return new Map(
       [...this.entries].map(([path, entry]) => [path, { ...entry }] as [string, VFSEntry])
@@ -60,9 +79,13 @@ export class VfsEntryIndex implements Iterable<[string, VFSEntry]> {
   paths(prefix?: string): string[] {
     const paths = [...this.entries.keys()];
     if (!prefix) return paths;
-    if (prefix.endsWith('://')) return paths.filter((path) => path.startsWith(prefix));
+
+    if (prefix.endsWith('://')) {
+      return paths.filter((path) => path.startsWith(prefix));
+    }
 
     const normalizedPrefix = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+
     return paths.filter(
       (path) => path === normalizedPrefix || path.startsWith(`${normalizedPrefix}/`)
     );
@@ -72,5 +95,93 @@ export class VfsEntryIndex implements Iterable<[string, VFSEntry]> {
     return this.paths().filter(
       (candidate) => candidate === path || candidate.startsWith(`${path}/`)
     );
+  }
+
+  immediateChildPaths(directory: string): string[] {
+    const prefix = directory.endsWith('://') ? directory : `${directory}/`;
+    const children = new Set<string>();
+
+    for (const path of this.entries.keys()) {
+      if (!path.startsWith(prefix)) continue;
+
+      const child = path.slice(prefix.length).split('/')[0];
+
+      if (child) {
+        children.add(`${prefix}${child}`);
+      }
+    }
+
+    return [...children];
+  }
+
+  hasDescendant(path: string): boolean {
+    const prefix = path.endsWith('://') ? path : `${path}/`;
+    return [...this.entries.keys()].some((candidate) => candidate.startsWith(prefix));
+  }
+
+  planRename(oldPath: string, newPath: string): VfsRenamePlan {
+    const oldParsed = parseVFSPath(oldPath);
+    const newParsed = parseVFSPath(newPath);
+
+    if (!oldParsed || !newParsed || oldParsed.namespace !== newParsed.namespace) {
+      throw new Error('VFS: Files can only be renamed within their namespace');
+    }
+
+    if (!this.entries.has(oldPath)) throw new Error(`VFS: Path not found: ${oldPath}`);
+    if (this.entries.has(newPath)) throw new Error(`VFS: Path already exists: ${newPath}`);
+
+    const paths = this.treePaths(oldPath);
+    const movedPaths = new Set(paths);
+
+    const moves = paths.map((path) => {
+      const current = this.entries.get(path)!;
+      const destination = path === oldPath ? newPath : `${newPath}${path.slice(oldPath.length)}`;
+      const entry = {
+        ...current,
+        filename: destination.split('/').pop() ?? current.filename
+      };
+
+      if (this.entries.has(destination) && !movedPaths.has(destination)) {
+        throw new Error(`VFS: Path already exists: ${destination}`);
+      }
+
+      return { oldPath: path, newPath: destination, entry };
+    });
+
+    return { moves };
+  }
+
+  applyRename(plan: VfsRenamePlan): void {
+    for (const move of plan.moves) {
+      this.entries.delete(move.oldPath);
+    }
+
+    for (const move of plan.moves) {
+      this.entries.set(move.newPath, move.entry);
+    }
+  }
+
+  planDelete(requestedPaths: Iterable<string>): VfsDeletePlan {
+    const requested = [...new Set(requestedPaths)];
+
+    const roots = requested.filter(
+      (path) => !requested.some((other) => other !== path && path.startsWith(`${other}/`))
+    );
+
+    for (const path of roots) {
+      if (!this.entries.has(path)) {
+        throw new Error(`VFS: Path not found: ${path}`);
+      }
+    }
+
+    const paths = this.paths().filter((path) =>
+      roots.some((root) => path === root || path.startsWith(`${root}/`))
+    );
+
+    return { roots, paths };
+  }
+
+  removePaths(paths: Iterable<string>): void {
+    for (const path of paths) this.entries.delete(path);
   }
 }

--- a/ui/src/lib/vfs/VfsMutationCoordinator.ts
+++ b/ui/src/lib/vfs/VfsMutationCoordinator.ts
@@ -1,14 +1,19 @@
 import { HistoryManager, type Command } from '$lib/history';
 import type { VFSEntry } from './types';
 
+export type VfsMutationSnapshot = {
+  entries: Map<string, VFSEntry>;
+  pendingPermissions: Set<string>;
+};
+
 type VfsMutationCallbacks = {
   redo?: () => void;
   undo?: () => void;
 };
 
 type VfsMutationAccess = {
-  snapshot: () => Map<string, VFSEntry>;
-  restore: (entries: Map<string, VFSEntry>) => void;
+  snapshot: () => VfsMutationSnapshot;
+  restore: (snapshot: VfsMutationSnapshot) => void;
   afterMutation: () => void;
 };
 

--- a/ui/src/lib/vfs/VfsMutationCoordinator.ts
+++ b/ui/src/lib/vfs/VfsMutationCoordinator.ts
@@ -1,0 +1,40 @@
+import { HistoryManager, type Command } from '$lib/history';
+import type { VFSEntry } from './types';
+
+type VfsMutationCallbacks = {
+  redo?: () => void;
+  undo?: () => void;
+};
+
+type VfsMutationAccess = {
+  snapshot: () => Map<string, VFSEntry>;
+  restore: (entries: Map<string, VFSEntry>) => void;
+  afterMutation: () => void;
+};
+
+/** Records entry-map transitions as one reversible VFS history operation. */
+export class VfsMutationCoordinator {
+  constructor(private access: VfsMutationAccess) {}
+
+  record(description: string, mutate: () => void, callbacks?: VfsMutationCallbacks): void {
+    const before = this.access.snapshot();
+
+    mutate();
+    this.access.afterMutation();
+
+    const after = this.access.snapshot();
+    const command: Command = {
+      description,
+      execute: () => {
+        this.access.restore(after);
+        callbacks?.redo?.();
+      },
+      undo: () => {
+        this.access.restore(before);
+        callbacks?.undo?.();
+      }
+    };
+
+    HistoryManager.getInstance().record(command);
+  }
+}

--- a/ui/src/lib/vfs/VfsMutationCoordinator.ts
+++ b/ui/src/lib/vfs/VfsMutationCoordinator.ts
@@ -17,8 +17,10 @@ type VfsMutationAccess = {
   afterMutation: () => void;
 };
 
-/** Records entry-map transitions as one reversible VFS history operation. */
+/** Records VFS entry change as one reversible VFS history operation. */
 export class VfsMutationCoordinator {
+  private effectQueue: Promise<void> = Promise.resolve();
+
   constructor(private access: VfsMutationAccess) {}
 
   record(description: string, mutate: () => void, callbacks?: VfsMutationCallbacks): void {
@@ -28,6 +30,7 @@ export class VfsMutationCoordinator {
     this.access.afterMutation();
 
     const after = this.access.snapshot();
+
     const command: Command = {
       description,
       execute: () => {
@@ -41,5 +44,13 @@ export class VfsMutationCoordinator {
     };
 
     HistoryManager.getInstance().record(command);
+  }
+
+  /** Serialize asynchronous provider effects initiated by synchronous history commands. */
+  queueEffect(description: string, operation: () => Promise<void>): void {
+    const queued = this.effectQueue.catch(() => {}).then(operation);
+    this.effectQueue = queued;
+
+    queued.catch((error) => console.error(`VFS: Failed to ${description}`, error));
   }
 }

--- a/ui/src/lib/vfs/VfsPermissionTracker.ts
+++ b/ui/src/lib/vfs/VfsPermissionTracker.ts
@@ -1,0 +1,120 @@
+import type { LocalFilesystemProvider } from './providers/LocalFilesystemProvider';
+import type { VFSEntry, VFSProvider } from './types';
+import type { VfsEntryIndex } from './VfsEntryIndex';
+
+type LocalPermissionProvider = VFSProvider & {
+  needsPermission?: (path: string) => Promise<boolean>;
+  requestPermission?: (path: string) => Promise<boolean>;
+};
+
+/** Tracks local resources that require permission or relinking. */
+export class VfsPermissionTracker {
+  private pending = new Set<string>();
+
+  snapshot(): Set<string> {
+    return new Set(this.pending);
+  }
+
+  restore(paths: Iterable<string>, entries: VfsEntryIndex): void {
+    this.pending = new Set([...paths].filter((path) => entries.has(path)));
+  }
+
+  getAll(): string[] {
+    return [...this.pending];
+  }
+
+  has(path: string): boolean {
+    return this.pending.has(path);
+  }
+
+  add(path: string): void {
+    this.pending.add(path);
+  }
+
+  delete(path: string): void {
+    this.pending.delete(path);
+  }
+
+  deleteAll(paths: Iterable<string>): void {
+    for (const path of paths) this.pending.delete(path);
+  }
+
+  clear(): void {
+    this.pending.clear();
+  }
+
+  async scan(
+    entries: Iterable<[string, VFSEntry]>,
+    localProvider: LocalPermissionProvider | undefined,
+    linkedFolderProvider: LocalFilesystemProvider | undefined
+  ): Promise<void> {
+    this.pending.clear();
+
+    for (const [path, entry] of entries) {
+      if (entry.provider === 'local') {
+        const needsPermission = await localProvider?.needsPermission?.(path);
+
+        if (needsPermission) {
+          this.pending.add(path);
+        }
+
+        continue;
+      }
+
+      if (entry.provider !== 'local-folder' || !linkedFolderProvider) continue;
+
+      const handle = await linkedFolderProvider.getDirHandle(path);
+
+      if (!handle || !(await linkedFolderProvider.hasDirPermission(path))) {
+        this.pending.add(path);
+      }
+    }
+  }
+
+  async request(
+    path: string,
+    entry: VFSEntry | undefined,
+    provider: LocalPermissionProvider | undefined
+  ): Promise<boolean> {
+    if (entry?.provider !== 'local' || !provider?.requestPermission) return false;
+
+    const granted = await provider.requestPermission(path);
+
+    if (granted) {
+      this.pending.delete(path);
+    }
+
+    return granted;
+  }
+
+  async requestAll(
+    getEntry: (path: string) => VFSEntry | undefined,
+    provider: LocalPermissionProvider | undefined
+  ): Promise<Map<string, boolean>> {
+    const results = new Map<string, boolean>();
+
+    for (const path of this.pending) {
+      const ok = await this.request(path, getEntry(path), provider);
+      results.set(path, ok);
+    }
+
+    return results;
+  }
+
+  async loadStoredDirectories(
+    entries: VfsEntryIndex,
+    provider: LocalFilesystemProvider
+  ): Promise<void> {
+    const handles = await provider.loadDirHandlesFromStorage();
+
+    for (const [path, handle] of handles) {
+      if (!entries.has(path)) {
+        entries.set(path, { provider: 'local-folder', filename: handle.name });
+      }
+
+      if (!(await provider.hasDirPermission(path))) {
+        this.pending.add(path);
+      }
+    }
+  }
+}

--- a/ui/src/lib/vfs/VfsTreeCodec.ts
+++ b/ui/src/lib/vfs/VfsTreeCodec.ts
@@ -1,0 +1,82 @@
+import {
+  type VFSEntry,
+  type VFSTree,
+  type VFSTreeNode,
+  isVFSEntry,
+  parseVFSPath,
+  VFS_PREFIXES
+} from './types';
+
+type EntryValidator = (path: string, entry: VFSEntry) => void;
+
+/** Converts between the flat runtime entry index and the serialized VFS tree. */
+export class VfsTreeCodec {
+  serialize(entries: Iterable<[string, VFSEntry]>): VFSTree {
+    const tree: VFSTree = {};
+
+    for (const [path, entry] of entries) {
+      const parsed = parseVFSPath(path);
+      if (!parsed) continue;
+
+      if (parsed.namespace === 'obj') continue;
+
+      const namespace = parsed.namespace === 'patch' ? 'patch' : 'user';
+      tree[namespace] ??= {};
+
+      this.setNestedEntry(tree[namespace], parsed.segments, { ...entry });
+    }
+
+    return tree;
+  }
+
+  deserialize(tree: VFSTree, validate: EntryValidator): Map<string, VFSEntry> {
+    const entries = new Map<string, VFSEntry>();
+    this.collectNamespace(entries, tree.patch, VFS_PREFIXES.PATCH, validate);
+    this.collectNamespace(entries, tree.user, VFS_PREFIXES.USER, validate);
+
+    return entries;
+  }
+
+  private collectNamespace(
+    entries: Map<string, VFSEntry>,
+    node: { [key: string]: VFSTreeNode } | undefined,
+    prefix: string,
+    validate: EntryValidator
+  ): void {
+    if (!node) return;
+
+    for (const [key, value] of Object.entries(node)) {
+      const path = `${prefix}${key}`;
+
+      if (isVFSEntry(value)) {
+        const entry = { ...value };
+        validate(path, entry);
+
+        entries.set(path, entry);
+      } else {
+        this.collectNamespace(entries, value, `${path}/`, validate);
+      }
+    }
+  }
+
+  private setNestedEntry(
+    target: { [key: string]: VFSTreeNode },
+    segments: string[],
+    entry: VFSEntry
+  ): void {
+    if (segments.length === 0) return;
+
+    if (segments.length === 1) {
+      target[segments[0]] = entry;
+      return;
+    }
+
+    const [first, ...rest] = segments;
+
+    if (!target[first] || isVFSEntry(target[first])) {
+      target[first] = {};
+    }
+
+    this.setNestedEntry(target[first] as { [key: string]: VFSTreeNode }, rest, entry);
+  }
+}

--- a/ui/src/lib/vfs/VirtualFilesystem.test.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.test.ts
@@ -73,6 +73,18 @@ describe('VirtualFilesystem patch files', () => {
     expect(vfs.getEntry('patch://archive.zip')).toBeUndefined();
   });
 
+  it('rejects an oversized User file before trying to resolve it for a Patch copy', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.registerEntry('user://large.txt', {
+      provider: 'url',
+      filename: 'large.txt',
+      size: 256 * 1024 + 1,
+      url: 'https://example.test/large.txt'
+    });
+
+    await expect(vfs.copyToPatch('user://large.txt')).rejects.toThrow('exceeds 256 KiB');
+  });
+
   it('uses numbered names for collision-safe imports and leaves rejected batches untouched', async () => {
     const vfs = VirtualFilesystem.getInstance();
     vfs.createEmbeddedFile('patch://utility.js', 'export const one = 1');

--- a/ui/src/lib/vfs/VirtualFilesystem.test.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.test.ts
@@ -26,11 +26,13 @@ describe('VirtualFilesystem patch files', () => {
     expect(hydrated.readEmbeddedFile('patch://shaders/noise.glsl')).toBe(
       'float noise() { return 2.; }'
     );
+
     expect(hydrated.getEntry('patch://shaders/noise.glsl')).toMatchObject({ revision: 2 });
   });
 
   it('keeps user files in their namespace when a patch has no embedded files', async () => {
     const vfs = VirtualFilesystem.getInstance();
+
     vfs.registerEntry('user://shared.js', {
       provider: 'url',
       filename: 'shared.js',
@@ -44,6 +46,29 @@ describe('VirtualFilesystem patch files', () => {
 
     expect(vfs.getEntry('user://shared.js')).toMatchObject({ provider: 'url' });
     expect(vfs.getEntry('patch://shared.js')).toBeUndefined();
+  });
+
+  it('keeps object files runtime-only during serialization and hydration', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+
+    vfs.registerEntry('obj://script-1/source.js', {
+      provider: 'url',
+      filename: 'source.js',
+      url: '/source.js'
+    });
+
+    expect(vfs.getEntry('obj://script-1/source.js')).toBeDefined();
+    expect(vfs.serialize()).toEqual({});
+
+    await vfs.hydrate({
+      objects: {
+        'legacy-object': {
+          'source.js': { provider: 'url', filename: 'source.js', url: '/legacy.js' }
+        }
+      }
+    } as never);
+
+    expect(vfs.getEntry('obj://legacy-object/source.js')).toBeUndefined();
   });
 
   it('rejects embedded entries outside Patch and enforces embedded byte limits', () => {
@@ -78,6 +103,7 @@ describe('VirtualFilesystem patch files', () => {
 
   it('rejects an oversized User file before trying to resolve it for a Patch copy', async () => {
     const vfs = VirtualFilesystem.getInstance();
+
     vfs.registerEntry('user://large.txt', {
       provider: 'url',
       filename: 'large.txt',
@@ -113,6 +139,7 @@ describe('VirtualFilesystem patch files', () => {
 
   it('keeps folder imports relative to the selected Patch folder', async () => {
     const vfs = VirtualFilesystem.getInstance();
+
     const file = new File(['export const color = 1'], 'color.js');
     Object.defineProperty(file, 'webkitRelativePath', { value: 'shaders/palette/color.js' });
 
@@ -125,6 +152,7 @@ describe('VirtualFilesystem patch files', () => {
     const vfs = VirtualFilesystem.getInstance();
     vfs.createFolder('patch://', 'bundle');
     vfs.createEmbeddedFile('patch://bundle/old.js', 'export const old = true');
+
     const items = [
       { kind: 'directory' as const, relativePath: 'bundle' },
       { kind: 'directory' as const, relativePath: 'bundle/empty' },
@@ -136,6 +164,7 @@ describe('VirtualFilesystem patch files', () => {
     ];
 
     expect(vfs.getPatchImportCollisions(items)).toEqual(['patch://bundle']);
+
     await expect(vfs.importToPatch(items, 'patch://', 'keep-both')).resolves.toEqual([
       'patch://bundle-1/src/index.js'
     ]);
@@ -172,6 +201,7 @@ describe('VirtualFilesystem patch files', () => {
   it('replaces and restores complete imported folder trees as one history operation', async () => {
     const vfs = VirtualFilesystem.getInstance();
     const history = HistoryManager.getInstance();
+
     vfs.createFolder('patch://', 'bundle');
     vfs.createEmbeddedFile('patch://bundle/old.js', 'export const old = true');
     history.clear();
@@ -282,7 +312,9 @@ describe('VirtualFilesystem patch files', () => {
   it('restores local file bytes and metadata when replacement is undone and redone', async () => {
     const vfs = VirtualFilesystem.getInstance();
     const history = HistoryManager.getInstance();
+
     let storedFile: File | undefined = new File(['before'], 'before.txt', { type: 'text/plain' });
+
     vfs.registerProvider({
       type: 'local',
       resolve: async () => {
@@ -296,6 +328,7 @@ describe('VirtualFilesystem patch files', () => {
         storedFile = state.file;
       }
     } as never);
+
     vfs.registerEntry('user://before.txt', {
       provider: 'local',
       filename: 'before.txt',
@@ -314,6 +347,7 @@ describe('VirtualFilesystem patch files', () => {
       mimeType: 'text/markdown',
       size: 5
     });
+
     await expect((await vfs.resolve('user://before.txt')).text()).resolves.toBe('after');
 
     history.undo();
@@ -322,6 +356,7 @@ describe('VirtualFilesystem patch files', () => {
       mimeType: 'text/plain',
       size: 6
     });
+
     await expect((await vfs.resolve('user://before.txt')).text()).resolves.toBe('before');
 
     history.redo();
@@ -330,6 +365,7 @@ describe('VirtualFilesystem patch files', () => {
       mimeType: 'text/markdown',
       size: 5
     });
+
     await expect((await vfs.resolve('user://before.txt')).text()).resolves.toBe('after');
   });
 
@@ -338,9 +374,11 @@ describe('VirtualFilesystem patch files', () => {
     const history = HistoryManager.getInstance();
     const eventBus = PatchiesEventBus.getInstance();
     const renames: VfsPathRenamedEvent[] = [];
+
     const handleRename = (event: VfsPathRenamedEvent) => {
       renames.push(event);
     };
+
     eventBus.addEventListener('vfsPathRenamed', handleRename);
 
     vfs.createEmbeddedFile('patch://before.js', 'export {}');
@@ -362,15 +400,19 @@ describe('VirtualFilesystem patch files', () => {
     const vfs = VirtualFilesystem.getInstance();
     const history = HistoryManager.getInstance();
     const calls: string[] = [];
+
     let releaseFirstMove: () => void;
     let markFirstMoveStarted: () => void;
     let markSecondMoveFinished: () => void;
+
     const firstMoveStarted = new Promise<void>((resolve) => {
       markFirstMoveStarted = resolve;
     });
+
     const firstMoveReleased = new Promise<void>((resolve) => {
       releaseFirstMove = resolve;
     });
+
     const secondMoveFinished = new Promise<void>((resolve) => {
       markSecondMoveFinished = resolve;
     });

--- a/ui/src/lib/vfs/VirtualFilesystem.test.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { HistoryManager } from '$lib/history';
+import { getPatchImportError, VirtualFilesystem } from './VirtualFilesystem';
+
+describe('VirtualFilesystem patch files', () => {
+  beforeEach(() => {
+    VirtualFilesystem.resetInstance();
+    HistoryManager.getInstance().clear();
+  });
+
+  it('round-trips embedded content and its revision through serialization', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.createEmbeddedFile('patch://shaders/noise.glsl', 'float noise() { return 1.; }');
+    vfs.writeEmbeddedFile('patch://shaders/noise.glsl', 'float noise() { return 2.; }');
+
+    const serialized = vfs.serialize();
+
+    VirtualFilesystem.resetInstance();
+    const hydrated = VirtualFilesystem.getInstance();
+    await hydrated.hydrate(serialized);
+
+    expect(hydrated.readEmbeddedFile('patch://shaders/noise.glsl')).toBe(
+      'float noise() { return 2.; }'
+    );
+    expect(hydrated.getEntry('patch://shaders/noise.glsl')).toMatchObject({ revision: 2 });
+  });
+
+  it('keeps user files in their namespace when a patch has no embedded files', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.registerEntry('user://shared.js', {
+      provider: 'url',
+      filename: 'shared.js',
+      url: '/shared.js'
+    });
+
+    await vfs.hydrate({
+      patch: {},
+      user: { 'shared.js': { provider: 'url', filename: 'shared.js', url: '/shared.js' } }
+    });
+
+    expect(vfs.getEntry('user://shared.js')).toMatchObject({ provider: 'url' });
+    expect(vfs.getEntry('patch://shared.js')).toBeUndefined();
+  });
+
+  it('rejects embedded entries outside Patch and enforces embedded byte limits', () => {
+    const vfs = VirtualFilesystem.getInstance();
+
+    expect(() =>
+      vfs.registerEntry('user://not-portable.js', {
+        provider: 'embedded',
+        filename: 'not-portable.js',
+        content: 'export {}'
+      } as never)
+    ).toThrow('only valid under patch://');
+
+    expect(() => vfs.createEmbeddedFile('patch://large.txt', 'x'.repeat(256 * 1024 + 1))).toThrow(
+      'exceeds 256 KiB'
+    );
+  });
+
+  it('rejects known binary formats and oversized files before decoding them', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const zip = new File(['PK'], 'archive.zip', { type: 'application/zip' });
+    const pdf = new File(['%PDF'], 'notes.pdf', { type: 'application/pdf' });
+    const large = new File(['x'.repeat(256 * 1024 + 1)], 'large.txt', { type: 'text/plain' });
+
+    expect(getPatchImportError(zip)).toContain('not a supported text file');
+    expect(getPatchImportError(pdf)).toContain('not a supported text file');
+    expect(getPatchImportError(large)).toContain('256 KiB');
+
+    await expect(vfs.importToPatch([zip])).rejects.toThrow('not a supported text file');
+    expect(vfs.getEntry('patch://archive.zip')).toBeUndefined();
+  });
+
+  it('uses numbered names for collision-safe imports and leaves rejected batches untouched', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.createEmbeddedFile('patch://utility.js', 'export const one = 1');
+
+    const imported = await vfs.importToPatch(
+      [new File(['export const two = 2'], 'utility.js', { type: 'text/javascript' })],
+      'patch://',
+      'keep-both'
+    );
+
+    expect(imported).toEqual(['patch://utility-1.js']);
+    expect(vfs.readEmbeddedFile('patch://utility-1.js')).toContain('two');
+
+    await expect(
+      vfs.importToPatch([
+        new File(['valid'], 'valid.txt'),
+        new File(['x'.repeat(256 * 1024 + 1)], 'too-large.txt')
+      ])
+    ).rejects.toThrow('exceeds 256 KiB');
+
+    expect(vfs.getEntry('patch://valid.txt')).toBeUndefined();
+  });
+
+  it('keeps folder imports relative to the selected Patch folder', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const file = new File(['export const color = 1'], 'color.js');
+    Object.defineProperty(file, 'webkitRelativePath', { value: 'shaders/palette/color.js' });
+
+    await vfs.importToPatch([file], 'patch://assets');
+
+    expect(vfs.readEmbeddedFile('patch://assets/shaders/palette/color.js')).toContain('color');
+  });
+
+  it('restores content and revisions with global undo and redo', () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const history = HistoryManager.getInstance();
+    vfs.createEmbeddedFile('patch://utility.js', 'export const value = 1');
+    vfs.writeEmbeddedFile('patch://utility.js', 'export const value = 2');
+
+    history.undo();
+    expect(vfs.readEmbeddedFile('patch://utility.js')).toContain('1');
+    expect(vfs.getEntry('patch://utility.js')).toMatchObject({ revision: 1 });
+
+    history.redo();
+    expect(vfs.readEmbeddedFile('patch://utility.js')).toContain('2');
+    expect(vfs.getEntry('patch://utility.js')).toMatchObject({ revision: 2 });
+  });
+});

--- a/ui/src/lib/vfs/VirtualFilesystem.test.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.test.ts
@@ -118,6 +118,32 @@ describe('VirtualFilesystem patch files', () => {
     expect(vfs.readEmbeddedFile('patch://assets/shaders/palette/color.js')).toContain('color');
   });
 
+  it('rejects a folder rename that would overwrite a descendant', () => {
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.createFolder('patch://', 'source');
+    vfs.createEmbeddedFile('patch://source/utility.js', 'export const source = true');
+    vfs.createEmbeddedFile('patch://target/utility.js', 'export const target = true');
+
+    expect(() => vfs.renamePath('patch://source', 'patch://target')).toThrow(
+      'Path already exists: patch://target/utility.js'
+    );
+    expect(vfs.readEmbeddedFile('patch://source/utility.js')).toContain('source');
+    expect(vfs.readEmbeddedFile('patch://target/utility.js')).toContain('target');
+  });
+
+  it('uses the final size when replacing an embedded import', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const fullSize = 256 * 1024;
+    vfs.createEmbeddedFile('patch://replace.js', 'a'.repeat(fullSize));
+    vfs.createEmbeddedFile('patch://one.js', 'b'.repeat(fullSize));
+    vfs.createEmbeddedFile('patch://two.js', 'c'.repeat(fullSize));
+    vfs.createEmbeddedFile('patch://three.js', 'd'.repeat(fullSize));
+
+    await expect(
+      vfs.importToPatch([new File(['e'.repeat(fullSize)], 'replace.js')], 'patch://', 'replace')
+    ).resolves.toEqual(['patch://replace.js']);
+  });
+
   it('restores content and revisions with global undo and redo', () => {
     const vfs = VirtualFilesystem.getInstance();
     const history = HistoryManager.getInstance();

--- a/ui/src/lib/vfs/VirtualFilesystem.test.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.test.ts
@@ -358,6 +358,79 @@ describe('VirtualFilesystem patch files', () => {
     eventBus.removeEventListener('vfsPathRenamed', handleRename);
   });
 
+  it('serializes persisted renames when undo follows an in-flight move', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const history = HistoryManager.getInstance();
+    const calls: string[] = [];
+    let releaseFirstMove: () => void;
+    let markFirstMoveStarted: () => void;
+    let markSecondMoveFinished: () => void;
+    const firstMoveStarted = new Promise<void>((resolve) => {
+      markFirstMoveStarted = resolve;
+    });
+    const firstMoveReleased = new Promise<void>((resolve) => {
+      releaseFirstMove = resolve;
+    });
+    const secondMoveFinished = new Promise<void>((resolve) => {
+      markSecondMoveFinished = resolve;
+    });
+
+    vfs.registerProvider({
+      type: 'local',
+      resolve: async () => new Blob(),
+      storeDirHandle: async () => {},
+      rename: async (from: string, to: string) => {
+        calls.push(`${from}->${to}`);
+        if (calls.length === 1) {
+          markFirstMoveStarted();
+          await firstMoveReleased;
+        } else {
+          markSecondMoveFinished();
+        }
+      }
+    } as never);
+    vfs.registerEntry('user://before.txt', { provider: 'local', filename: 'before.txt' });
+    history.clear();
+
+    vfs.renamePath('user://before.txt', 'user://after.txt');
+    await firstMoveStarted;
+    history.undo();
+
+    expect(calls).toEqual(['user://before.txt->user://after.txt']);
+
+    releaseFirstMove!();
+    await secondMoveFinished;
+
+    expect(calls).toEqual([
+      'user://before.txt->user://after.txt',
+      'user://after.txt->user://before.txt'
+    ]);
+  });
+
+  it('restores pending permissions when undoing a deletion', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const history = HistoryManager.getInstance();
+    vfs.registerProvider({
+      type: 'local',
+      resolve: async () => new Blob(),
+      needsPermission: async () => true,
+      storeDirHandle: async () => {}
+    } as never);
+    await vfs.hydrate({
+      user: {
+        'locked.txt': { provider: 'local', filename: 'locked.txt' }
+      }
+    });
+    history.clear();
+
+    expect(vfs.getPendingPermissions()).toEqual(['user://locked.txt']);
+
+    vfs.deletePath('user://locked.txt');
+    history.undo();
+
+    expect(vfs.getPendingPermissions()).toEqual(['user://locked.txt']);
+  });
+
   it('clears path-only provider caches when switching patches', async () => {
     const vfs = VirtualFilesystem.getInstance();
     let activeContent = 'patch-a';

--- a/ui/src/lib/vfs/VirtualFilesystem.test.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.test.ts
@@ -121,6 +121,123 @@ describe('VirtualFilesystem patch files', () => {
     expect(vfs.readEmbeddedFile('patch://assets/shaders/palette/color.js')).toContain('color');
   });
 
+  it('imports complete folder trees atomically and applies one collision strategy to the root', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.createFolder('patch://', 'bundle');
+    vfs.createEmbeddedFile('patch://bundle/old.js', 'export const old = true');
+    const items = [
+      { kind: 'directory' as const, relativePath: 'bundle' },
+      { kind: 'directory' as const, relativePath: 'bundle/empty' },
+      {
+        kind: 'file' as const,
+        relativePath: 'bundle/src/index.js',
+        file: new File(['export const next = true'], 'index.js', { type: 'text/javascript' })
+      }
+    ];
+
+    expect(vfs.getPatchImportCollisions(items)).toEqual(['patch://bundle']);
+    await expect(vfs.importToPatch(items, 'patch://', 'keep-both')).resolves.toEqual([
+      'patch://bundle-1/src/index.js'
+    ]);
+
+    expect(vfs.getEntry('patch://bundle-1')).toMatchObject({ provider: 'folder' });
+    expect(vfs.getEntry('patch://bundle-1/empty')).toMatchObject({ provider: 'folder' });
+    expect(vfs.readEmbeddedFile('patch://bundle-1/src/index.js')).toContain('next');
+    expect(vfs.readEmbeddedFile('patch://bundle/old.js')).toContain('old');
+
+    await expect(
+      vfs.importToPatch(
+        [
+          { kind: 'directory', relativePath: 'rejected' },
+          {
+            kind: 'file',
+            relativePath: 'rejected/valid.txt',
+            file: new File(['valid'], 'valid.txt', { type: 'text/plain' })
+          },
+          {
+            kind: 'file',
+            relativePath: 'rejected/archive.zip',
+            file: new File(['PK'], 'archive.zip', { type: 'application/zip' })
+          }
+        ],
+        'patch://',
+        'replace'
+      )
+    ).rejects.toThrow('archive.zip is not a supported text file');
+
+    expect(vfs.getEntry('patch://rejected')).toBeUndefined();
+    expect(vfs.getEntry('patch://rejected/valid.txt')).toBeUndefined();
+  });
+
+  it('replaces and restores complete imported folder trees as one history operation', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const history = HistoryManager.getInstance();
+    vfs.createFolder('patch://', 'bundle');
+    vfs.createEmbeddedFile('patch://bundle/old.js', 'export const old = true');
+    history.clear();
+
+    await vfs.importToPatch(
+      [
+        { kind: 'directory', relativePath: 'bundle' },
+        {
+          kind: 'file',
+          relativePath: 'bundle/new.js',
+          file: new File(['export const next = true'], 'new.js', { type: 'text/javascript' })
+        }
+      ],
+      'patch://',
+      'replace'
+    );
+
+    expect(vfs.getEntry('patch://bundle/old.js')).toBeUndefined();
+    expect(vfs.readEmbeddedFile('patch://bundle/new.js')).toContain('next');
+
+    history.undo();
+    expect(vfs.readEmbeddedFile('patch://bundle/old.js')).toContain('old');
+    expect(vfs.getEntry('patch://bundle/new.js')).toBeUndefined();
+  });
+
+  it('keeps a file separate from an existing implicit directory collision', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.createEmbeddedFile('patch://utility/dependency.js', 'export {}');
+
+    await expect(
+      vfs.importToPatch(
+        [new File(['root'], 'utility', { type: 'text/plain' })],
+        'patch://',
+        'keep-both'
+      )
+    ).resolves.toEqual(['patch://utility-1']);
+
+    expect(vfs.getEntry('patch://utility')).toBeUndefined();
+    expect(vfs.readEmbeddedFile('patch://utility-1')).toBe('root');
+  });
+
+  it('increments replacement import revisions and restores them through undo and redo', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const history = HistoryManager.getInstance();
+    vfs.createEmbeddedFile('patch://utility.js', 'export const value = 1');
+    vfs.writeEmbeddedFile('patch://utility.js', 'export const value = 2');
+    history.clear();
+
+    await vfs.importToPatch(
+      [new File(['export const value = 3'], 'utility.js', { type: 'text/javascript' })],
+      'patch://',
+      'replace'
+    );
+
+    expect(vfs.getEntry('patch://utility.js')).toMatchObject({ revision: 3 });
+    expect(vfs.readEmbeddedFile('patch://utility.js')).toContain('3');
+
+    history.undo();
+    expect(vfs.getEntry('patch://utility.js')).toMatchObject({ revision: 2 });
+    expect(vfs.readEmbeddedFile('patch://utility.js')).toContain('2');
+
+    history.redo();
+    expect(vfs.getEntry('patch://utility.js')).toMatchObject({ revision: 3 });
+    expect(vfs.readEmbeddedFile('patch://utility.js')).toContain('3');
+  });
+
   it('rejects a folder rename that would overwrite a descendant', () => {
     const vfs = VirtualFilesystem.getInstance();
     vfs.createFolder('patch://', 'source');
@@ -160,6 +277,60 @@ describe('VirtualFilesystem patch files', () => {
     history.redo();
     expect(vfs.readEmbeddedFile('patch://utility.js')).toContain('2');
     expect(vfs.getEntry('patch://utility.js')).toMatchObject({ revision: 2 });
+  });
+
+  it('restores local file bytes and metadata when replacement is undone and redone', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const history = HistoryManager.getInstance();
+    let storedFile: File | undefined = new File(['before'], 'before.txt', { type: 'text/plain' });
+    vfs.registerProvider({
+      type: 'local',
+      resolve: async () => {
+        if (!storedFile) throw new Error('missing file');
+
+        return storedFile;
+      },
+      storeDirHandle: async () => {},
+      captureFileState: async () => ({ file: storedFile }),
+      restoreFileState: async (_path: string, state: { file?: File }) => {
+        storedFile = state.file;
+      }
+    } as never);
+    vfs.registerEntry('user://before.txt', {
+      provider: 'local',
+      filename: 'before.txt',
+      mimeType: 'text/plain',
+      size: 6
+    });
+    history.clear();
+
+    await vfs.replaceFile(
+      'user://before.txt',
+      new File(['after'], 'after.txt', { type: 'text/markdown' })
+    );
+
+    expect(vfs.getEntry('user://before.txt')).toMatchObject({
+      filename: 'after.txt',
+      mimeType: 'text/markdown',
+      size: 5
+    });
+    await expect((await vfs.resolve('user://before.txt')).text()).resolves.toBe('after');
+
+    history.undo();
+    expect(vfs.getEntry('user://before.txt')).toMatchObject({
+      filename: 'before.txt',
+      mimeType: 'text/plain',
+      size: 6
+    });
+    await expect((await vfs.resolve('user://before.txt')).text()).resolves.toBe('before');
+
+    history.redo();
+    expect(vfs.getEntry('user://before.txt')).toMatchObject({
+      filename: 'after.txt',
+      mimeType: 'text/markdown',
+      size: 5
+    });
+    await expect((await vfs.resolve('user://before.txt')).text()).resolves.toBe('after');
   });
 
   it('emits reverse and forward path changes when undoing and redoing a rename', () => {

--- a/ui/src/lib/vfs/VirtualFilesystem.test.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { HistoryManager } from '$lib/history';
+import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+import type { VfsPathRenamedEvent } from '$lib/eventbus/events';
 import { getPatchImportError, VirtualFilesystem } from './VirtualFilesystem';
+import type { EmbeddedVFSEntry } from './types';
 
 describe('VirtualFilesystem patch files', () => {
   beforeEach(() => {
@@ -157,5 +160,97 @@ describe('VirtualFilesystem patch files', () => {
     history.redo();
     expect(vfs.readEmbeddedFile('patch://utility.js')).toContain('2');
     expect(vfs.getEntry('patch://utility.js')).toMatchObject({ revision: 2 });
+  });
+
+  it('emits reverse and forward path changes when undoing and redoing a rename', () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const history = HistoryManager.getInstance();
+    const eventBus = PatchiesEventBus.getInstance();
+    const renames: VfsPathRenamedEvent[] = [];
+    const handleRename = (event: VfsPathRenamedEvent) => {
+      renames.push(event);
+    };
+    eventBus.addEventListener('vfsPathRenamed', handleRename);
+
+    vfs.createEmbeddedFile('patch://before.js', 'export {}');
+    history.clear();
+    vfs.renamePath('patch://before.js', 'patch://after.js');
+    history.undo();
+    history.redo();
+
+    expect(renames).toEqual([
+      { type: 'vfsPathRenamed', oldPath: 'patch://before.js', newPath: 'patch://after.js' },
+      { type: 'vfsPathRenamed', oldPath: 'patch://after.js', newPath: 'patch://before.js' },
+      { type: 'vfsPathRenamed', oldPath: 'patch://before.js', newPath: 'patch://after.js' }
+    ]);
+
+    eventBus.removeEventListener('vfsPathRenamed', handleRename);
+  });
+
+  it('clears path-only provider caches when switching patches', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    let activeContent = 'patch-a';
+    let cachedFile: File | undefined;
+
+    vfs.registerProvider({
+      type: 'local',
+      resolve: async () => {
+        cachedFile ??= new File([activeContent], 'shared.txt');
+
+        return cachedFile;
+      },
+      clear: () => {
+        cachedFile = undefined;
+      },
+      clearDirHandles: () => {},
+      storeDirHandle: async () => {}
+    } as never);
+    vfs.registerEntry('user://shared.txt', { provider: 'local', filename: 'shared.txt' });
+
+    await expect((await vfs.resolve('user://shared.txt')).text()).resolves.toBe('patch-a');
+
+    activeContent = 'patch-b';
+    vfs.clear();
+    vfs.registerEntry('user://shared.txt', { provider: 'local', filename: 'shared.txt' });
+
+    await expect((await vfs.resolve('user://shared.txt')).text()).resolves.toBe('patch-b');
+  });
+
+  it('loads oversized embedded files for recovery but refuses to resolve them', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const content = 'x'.repeat(256 * 1024 + 1);
+
+    await vfs.hydrate({
+      patch: {
+        'oversized.txt': {
+          provider: 'embedded',
+          filename: 'oversized.txt',
+          content,
+          size: content.length
+        } as EmbeddedVFSEntry
+      }
+    });
+
+    expect(vfs.getEntry('patch://oversized.txt')).toBeDefined();
+    expect(() => vfs.readEmbeddedFile('patch://oversized.txt')).toThrow('exceeds 256 KiB');
+    await expect(vfs.resolve('patch://oversized.txt')).rejects.toThrow('exceeds 256 KiB');
+    await expect(vfs.exportEmbeddedFile('patch://oversized.txt').text()).resolves.toBe(content);
+  });
+
+  it('deletes selected ancestors and descendants as one undoable operation', () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const history = HistoryManager.getInstance();
+    vfs.createFolder('patch://', 'folder');
+    vfs.createEmbeddedFile('patch://folder/child.js', 'export {}');
+    history.clear();
+
+    vfs.deletePaths(['patch://folder', 'patch://folder/child.js']);
+
+    expect(vfs.getEntry('patch://folder')).toBeUndefined();
+    expect(vfs.getEntry('patch://folder/child.js')).toBeUndefined();
+
+    history.undo();
+    expect(vfs.getEntry('patch://folder')).toBeDefined();
+    expect(vfs.getEntry('patch://folder/child.js')).toBeDefined();
   });
 });

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -4,6 +4,7 @@ import { writable, derived, type Readable } from 'svelte/store';
 import { match } from 'ts-pattern';
 import {
   type VFSEntry,
+  type EmbeddedVFSEntry,
   type VFSTree,
   type VFSTreeNode,
   type VFSProvider,
@@ -11,14 +12,73 @@ import {
   type VFSListPage,
   type VFSSearchPage,
   isVFSFolder,
+  isEmbeddedVFSEntry,
   isVFSEntry,
   isVFSPath,
   parseVFSPath,
   VFS_PREFIXES
 } from './types';
-import { generateUserPath, getFilenameFromUrl, guessMimeType } from './path-utils';
+import {
+  generateUserPath,
+  getBasename,
+  getExtension,
+  getFilenameFromUrl,
+  guessMimeType
+} from './path-utils';
 import { clearFileData, clearHandles } from './persistence';
 import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+import { HistoryManager, type Command } from '$lib/history';
+
+export const MAX_EMBEDDED_FILE_BYTES = 256 * 1024;
+export const MAX_EMBEDDED_PATCH_BYTES = 1024 * 1024;
+
+export const PATCH_TEXT_FILE_ACCEPT =
+  'text/*,.js,.mjs,.gl,.glsl,.frag,.vert,.glslf,.glslv,.json,.jsonc,.css,.html,.htm,.svg,.xml,.yaml,.yml,.md,.txt,.csv';
+
+const PATCH_TEXT_EXTENSIONS = new Set([
+  '.js',
+  '.mjs',
+  '.gl',
+  '.glsl',
+  '.frag',
+  '.vert',
+  '.glslf',
+  '.glslv',
+  '.json',
+  '.jsonc',
+  '.css',
+  '.html',
+  '.htm',
+  '.svg',
+  '.xml',
+  '.yaml',
+  '.yml',
+  '.md',
+  '.txt',
+  '.csv'
+]);
+
+export type VfsCollisionStrategy = 'replace' | 'keep-both' | 'cancel';
+
+export function getPatchImportError(file: File): string | null {
+  if (file.size > MAX_EMBEDDED_FILE_BYTES) {
+    return `${file.name} exceeds 256 KiB Patch-file limit`;
+  }
+
+  const extension = getExtension(file.name).toLowerCase();
+  const isTextMimeType =
+    file.type.startsWith('text/') ||
+    file.type === 'application/javascript' ||
+    file.type === 'application/json' ||
+    file.type === 'application/xml' ||
+    file.type === 'image/svg+xml';
+
+  if (!isTextMimeType && !PATCH_TEXT_EXTENSIONS.has(extension)) {
+    return `${file.name} is not a supported text file`;
+  }
+
+  return null;
+}
 
 declare global {
   interface Window {
@@ -70,6 +130,90 @@ export class VirtualFilesystem {
     this.versionStore.update((v) => v + 1);
   }
 
+  private cloneEntries(entries = this.entries): Map<string, VFSEntry> {
+    return new Map([...entries].map(([path, entry]) => [path, { ...entry }] as [string, VFSEntry]));
+  }
+
+  private restoreEntries(entries: Map<string, VFSEntry>): void {
+    const previous = this.entries;
+    this.entries = this.cloneEntries(entries);
+    this.pendingPermissions = new Set(
+      [...this.pendingPermissions].filter((path) => this.entries.has(path))
+    );
+    this.notifyChange();
+
+    for (const [path, entry] of this.entries) {
+      const prior = previous.get(path);
+      if (
+        isEmbeddedVFSEntry(entry) &&
+        (!prior ||
+          !isEmbeddedVFSEntry(prior) ||
+          prior.content !== entry.content ||
+          prior.revision !== entry.revision)
+      ) {
+        this.emitContentModified(path, entry.revision ?? 1);
+      }
+    }
+  }
+
+  private recordMutation(description: string, mutate: () => void): void {
+    const before = this.cloneEntries();
+
+    mutate();
+
+    const after = this.cloneEntries();
+    const command: Command = {
+      description,
+      execute: () => this.restoreEntries(after),
+      undo: () => this.restoreEntries(before)
+    };
+
+    HistoryManager.getInstance().record(command);
+  }
+
+  private assertValidEntry(path: string, entry: VFSEntry): void {
+    const parsed = parseVFSPath(path);
+    if (!parsed || parsed.segments.length === 0) {
+      throw new Error(`VFS: Invalid path: ${path}`);
+    }
+
+    if (parsed.namespace === 'patch') {
+      if (entry.provider !== 'embedded' && entry.provider !== 'folder') {
+        throw new Error(`VFS: patch:// entries must use the embedded provider: ${path}`);
+      }
+    } else if (entry.provider === 'embedded') {
+      throw new Error(`VFS: embedded entries are only valid under patch://: ${path}`);
+    }
+
+    if (isEmbeddedVFSEntry(entry)) {
+      this.assertEmbeddedContent(entry.content, path);
+    }
+  }
+
+  private assertEmbeddedContent(content: string, path: string): void {
+    const size = new TextEncoder().encode(content).byteLength;
+    if (size > MAX_EMBEDDED_FILE_BYTES) {
+      throw new Error(`VFS: Embedded file exceeds 256 KiB: ${path}`);
+    }
+
+    const total = this.getEmbeddedByteLength(path) + size;
+    if (total > MAX_EMBEDDED_PATCH_BYTES) {
+      throw new Error('VFS: Embedded patch files exceed 1 MiB');
+    }
+  }
+
+  private getEmbeddedByteLength(excludingPath?: string): number {
+    const encoder = new TextEncoder();
+    let total = 0;
+
+    for (const [path, entry] of this.entries) {
+      if (path === excludingPath || !isEmbeddedVFSEntry(entry)) continue;
+      total += encoder.encode(entry.content).byteLength;
+    }
+
+    return total;
+  }
+
   static getInstance(): VirtualFilesystem {
     if (!VirtualFilesystem.instance) {
       VirtualFilesystem.instance = new VirtualFilesystem();
@@ -109,8 +253,96 @@ export class VirtualFilesystem {
    * Register a file entry at a specific path.
    */
   registerEntry(path: string, entry: VFSEntry): void {
+    this.assertValidEntry(path, entry);
     this.entries.set(path, entry);
     this.notifyChange();
+  }
+
+  /** Create or replace a UTF-8 text file embedded in the current patch. */
+  createEmbeddedFile(
+    path: string,
+    content = '',
+    collision: VfsCollisionStrategy = 'cancel'
+  ): string | null {
+    const parsed = parseVFSPath(path);
+    if (parsed?.namespace !== 'patch') {
+      throw new Error(`VFS: Embedded files must use patch:// paths: ${path}`);
+    }
+
+    const destination = this.resolveCollision(path, collision);
+    if (!destination) return null;
+
+    const filename = destination.split('/').pop() ?? destination;
+    const entry: EmbeddedVFSEntry = {
+      provider: 'embedded',
+      filename,
+      mimeType: guessMimeType(filename) ?? 'text/plain;charset=utf-8',
+      content,
+      size: new TextEncoder().encode(content).byteLength,
+      revision: 1
+    };
+
+    this.assertValidEntry(destination, entry);
+    this.recordMutation(`Create ${filename}`, () => {
+      this.entries.set(destination, entry);
+      this.notifyChange();
+      this.emitContentModified(destination, entry.revision ?? 1);
+    });
+
+    return destination;
+  }
+
+  /** Save embedded content as one undoable VFS operation. */
+  writeEmbeddedFile(path: string, content: string): void {
+    const entry = this.entries.get(path);
+    if (!entry || !isEmbeddedVFSEntry(entry)) {
+      throw new Error(`VFS: Embedded file not found: ${path}`);
+    }
+
+    this.assertEmbeddedContent(content, path);
+    const updated: EmbeddedVFSEntry = {
+      ...entry,
+      content,
+      size: new TextEncoder().encode(content).byteLength,
+      revision: (entry.revision ?? 0) + 1
+    };
+
+    this.recordMutation(`Write ${entry.filename}`, () => {
+      this.entries.set(path, updated);
+      this.notifyChange();
+      this.emitContentModified(path, updated.revision ?? 1);
+    });
+  }
+
+  readEmbeddedFile(path: string): string {
+    const entry = this.entries.get(path);
+    if (!entry || !isEmbeddedVFSEntry(entry)) {
+      throw new Error(`VFS: Embedded file not found: ${path}`);
+    }
+
+    return entry.content;
+  }
+
+  private resolveCollision(path: string, collision: VfsCollisionStrategy): string | null {
+    if (!this.entries.has(path)) return path;
+    if (collision === 'replace') return path;
+    if (collision === 'cancel') return null;
+
+    const extension = getExtension(path);
+    const basename = getBasename(path);
+    let counter = 1;
+    let candidate = `${basename}-${counter}${extension}`;
+
+    while (this.entries.has(candidate)) {
+      counter += 1;
+      candidate = `${basename}-${counter}${extension}`;
+    }
+
+    return candidate;
+  }
+
+  private emitContentModified(path: string, revision: number): void {
+    PatchiesEventBus.getInstance().dispatch({ type: 'vfsContentModified', path, revision });
   }
 
   /**
@@ -147,8 +379,6 @@ export class VirtualFilesystem {
       size: file.size
     };
 
-    this.entries.set(path, entry);
-
     // Store via provider
     const provider = this.providers.get('local');
     if (provider && 'storeFile' in provider) {
@@ -168,7 +398,10 @@ export class VirtualFilesystem {
       }
     }
 
-    this.notifyChange();
+    this.recordMutation(`Add ${file.name}`, () => {
+      this.entries.set(path, entry);
+      this.notifyChange();
+    });
     return path;
   }
 
@@ -239,8 +472,10 @@ export class VirtualFilesystem {
       mimeType
     };
 
-    this.entries.set(path, entry);
-    this.notifyChange();
+    this.recordMutation(`Add ${filename}`, () => {
+      this.entries.set(path, entry);
+      this.notifyChange();
+    });
 
     return path;
   }
@@ -268,8 +503,10 @@ export class VirtualFilesystem {
       filename: folderName
     };
 
-    this.entries.set(folderPath, entry);
-    this.notifyChange();
+    this.recordMutation(`Create ${folderName}`, () => {
+      this.entries.set(folderPath, entry);
+      this.notifyChange();
+    });
 
     return folderPath;
   }
@@ -280,6 +517,174 @@ export class VirtualFilesystem {
   isFolder(path: string): boolean {
     const entry = this.entries.get(path);
     return entry?.provider === 'folder' || entry?.provider === 'local-folder';
+  }
+
+  /** Rename a file or folder tree without changing its ownership namespace. */
+  renamePath(oldPath: string, newPath: string): void {
+    const oldParsed = parseVFSPath(oldPath);
+    const newParsed = parseVFSPath(newPath);
+    if (!oldParsed || !newParsed || oldParsed.namespace !== newParsed.namespace) {
+      throw new Error('VFS: Files can only be renamed within their namespace');
+    }
+    if (!this.entries.has(oldPath)) throw new Error(`VFS: Path not found: ${oldPath}`);
+    if (this.entries.has(newPath)) throw new Error(`VFS: Path already exists: ${newPath}`);
+
+    const paths = this.list().filter((path) => path === oldPath || path.startsWith(`${oldPath}/`));
+    const renamed = paths.map((path) => {
+      const entry = this.entries.get(path)!;
+      const destination = path === oldPath ? newPath : `${newPath}${path.slice(oldPath.length)}`;
+      const filename = destination.split('/').pop() ?? entry.filename;
+
+      return [destination, { ...entry, filename }] as const;
+    });
+
+    this.recordMutation(`Rename ${oldPath.split('/').pop()}`, () => {
+      for (const path of paths) this.entries.delete(path);
+      for (const [path, entry] of renamed) this.entries.set(path, entry);
+      this.notifyChange();
+      for (const path of paths) {
+        const destination = path === oldPath ? newPath : `${newPath}${path.slice(oldPath.length)}`;
+        PatchiesEventBus.getInstance().dispatch({
+          type: 'vfsPathRenamed',
+          oldPath: path,
+          newPath: destination
+        });
+      }
+    });
+  }
+
+  /** Delete a file or a complete folder tree as one undoable operation. */
+  deletePath(path: string): void {
+    const paths = this.list().filter((item) => item === path || item.startsWith(`${path}/`));
+    if (paths.length === 0) throw new Error(`VFS: Path not found: ${path}`);
+
+    this.recordMutation(`Delete ${path.split('/').pop()}`, () => {
+      for (const item of paths) {
+        this.entries.delete(item);
+        this.pendingPermissions.delete(item);
+      }
+      this.notifyChange();
+    });
+  }
+
+  /** Copy a user-owned text file into patch ownership without moving the original. */
+  async copyToPatch(
+    sourcePath: string,
+    targetFolder: string = VFS_PREFIXES.PATCH,
+    collision: VfsCollisionStrategy = 'cancel'
+  ): Promise<string | null> {
+    const source = this.getEntryOrLinkedFile(sourcePath);
+    if (!source || isVFSFolder(source)) throw new Error(`VFS: File not found: ${sourcePath}`);
+    if (!targetFolder.startsWith(VFS_PREFIXES.PATCH)) {
+      throw new Error(`VFS: Patch destination required: ${targetFolder}`);
+    }
+
+    const blob = await this.resolve(sourcePath);
+    const content = await this.decodeUtf8(blob, sourcePath);
+    const destination = `${targetFolder.endsWith('/') ? targetFolder : `${targetFolder}/`}${source.filename}`;
+
+    return this.createEmbeddedFile(destination, content, collision);
+  }
+
+  /** Import text files atomically: an invalid file or budget violation imports nothing. */
+  async importToPatch(
+    files: Iterable<File>,
+    targetFolder: string = VFS_PREFIXES.PATCH,
+    collision: VfsCollisionStrategy = 'keep-both'
+  ): Promise<string[]> {
+    if (!targetFolder.startsWith(VFS_PREFIXES.PATCH)) {
+      throw new Error(`VFS: Patch destination required: ${targetFolder}`);
+    }
+
+    const staged: Array<{ path: string; entry: EmbeddedVFSEntry }> = [];
+    const occupied = new Set(this.entries.keys());
+    let totalBytes = this.getEmbeddedByteLength();
+
+    for (const file of files) {
+      const importError = getPatchImportError(file);
+      if (importError) throw new Error(`VFS: ${importError}`);
+
+      const relativePath = this.getImportRelativePath(file);
+      const rawPath = `${targetFolder.endsWith('/') ? targetFolder : `${targetFolder}/`}${relativePath}`;
+      const path = this.resolveStagedCollision(rawPath, collision, occupied);
+      if (!path) throw new Error(`VFS: Import cancelled because ${file.name} already exists`);
+
+      const content = await this.decodeUtf8(file, file.name);
+      const size = new TextEncoder().encode(content).byteLength;
+      if (size > MAX_EMBEDDED_FILE_BYTES) {
+        throw new Error(`VFS: Embedded file exceeds 256 KiB: ${file.name}`);
+      }
+      totalBytes += size;
+      if (totalBytes > MAX_EMBEDDED_PATCH_BYTES) {
+        throw new Error('VFS: Embedded patch files exceed 1 MiB');
+      }
+
+      occupied.add(path);
+      staged.push({
+        path,
+        entry: {
+          provider: 'embedded',
+          filename: file.name,
+          mimeType: file.type || guessMimeType(file.name) || 'text/plain;charset=utf-8',
+          content,
+          size,
+          revision: 1
+        }
+      });
+    }
+
+    this.recordMutation(
+      `Import ${staged.length} patch file${staged.length === 1 ? '' : 's'}`,
+      () => {
+        for (const { path, entry } of staged) {
+          this.entries.set(path, entry);
+          this.emitContentModified(path, entry.revision ?? 1);
+        }
+        this.notifyChange();
+      }
+    );
+
+    return staged.map(({ path }) => path);
+  }
+
+  private resolveStagedCollision(
+    path: string,
+    collision: VfsCollisionStrategy,
+    occupied: Set<string>
+  ): string | null {
+    if (!occupied.has(path)) return path;
+    if (collision === 'replace') return path;
+    if (collision === 'cancel') return null;
+
+    const extension = getExtension(path);
+    const basename = getBasename(path);
+    let counter = 1;
+    let candidate = `${basename}-${counter}${extension}`;
+    while (occupied.has(candidate)) {
+      counter += 1;
+      candidate = `${basename}-${counter}${extension}`;
+    }
+    return candidate;
+  }
+
+  private async decodeUtf8(blob: Blob, path: string): Promise<string> {
+    try {
+      return new TextDecoder('utf-8', { fatal: true }).decode(await blob.arrayBuffer());
+    } catch {
+      throw new Error(`VFS: Only UTF-8 text can be embedded: ${path}`);
+    }
+  }
+
+  private getImportRelativePath(file: File): string {
+    const relativePath = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+    const normalized = (relativePath || file.name).replaceAll('\\', '/');
+    const segments = normalized.split('/').filter(Boolean);
+
+    if (segments.length === 0 || segments.some((segment) => segment === '.' || segment === '..')) {
+      throw new Error(`VFS: Invalid import path: ${normalized}`);
+    }
+
+    return segments.join('/');
   }
 
   // ─────────────────────────────────────────────────────────────────
@@ -367,6 +772,11 @@ export class VirtualFilesystem {
   async resolve(path: string): Promise<File | Blob> {
     const entry = this.entries.get(path);
     if (entry) {
+      if (isEmbeddedVFSEntry(entry)) {
+        return new File([entry.content], entry.filename, {
+          type: entry.mimeType || 'text/plain;charset=utf-8'
+        });
+      }
       // Direct entry found
       const provider = this.providers.get(entry.provider);
       if (!provider) {
@@ -486,7 +896,10 @@ export class VirtualFilesystem {
     const prefix = directory.endsWith('://') ? directory : `${directory}/`;
     const linkedFolderPath = this.getLinkedFolderForPath(directory);
     const hasChildren = [...this.entries.keys()].some((path) => path.startsWith(prefix));
-    const isNamespaceRoot = directory === VFS_PREFIXES.USER || directory === VFS_PREFIXES.OBJECT;
+    const isNamespaceRoot =
+      directory === VFS_PREFIXES.PATCH ||
+      directory === VFS_PREFIXES.USER ||
+      directory === VFS_PREFIXES.OBJECT;
 
     if (entry && entry.provider !== 'folder' && entry.provider !== 'local-folder') {
       throw new TypeError(`VFS: Path is not a directory: ${directory}`);
@@ -743,9 +1156,13 @@ export class VirtualFilesystem {
       if (!parsed) continue;
 
       match(parsed.namespace)
+        .with('patch', () => {
+          if (!tree.patch) tree.patch = {};
+          this.setNestedEntry(tree.patch, parsed.segments, { ...entry });
+        })
         .with('user', () => {
           if (!tree.user) tree.user = {};
-          this.setNestedEntry(tree.user, parsed.segments, entry);
+          this.setNestedEntry(tree.user, parsed.segments, { ...entry });
         })
         .with('obj', () => {
           if (!tree.objects) tree.objects = {};
@@ -754,7 +1171,7 @@ export class VirtualFilesystem {
           if (!nodeId) return;
           if (!tree.objects[nodeId]) tree.objects[nodeId] = {};
           if (rest.length > 0) {
-            this.setNestedEntry(tree.objects[nodeId], rest, entry);
+            this.setNestedEntry(tree.objects[nodeId], rest, { ...entry });
           }
         })
         .exhaustive();
@@ -767,20 +1184,28 @@ export class VirtualFilesystem {
    * Hydrate the VFS from a saved tree structure.
    */
   async hydrate(tree: VFSTree): Promise<void> {
-    this.entries.clear();
-    this.pendingPermissions.clear();
-
-    // user namespace -- for user-uploaded files
-    if (tree.user) {
-      this.hydrateNamespace(tree.user, VFS_PREFIXES.USER);
-    }
-
-    // objects namespace -- for each objects
+    const hydrated = new Map<string, VFSEntry>();
+    this.collectHydratedNamespace(hydrated, tree.patch, VFS_PREFIXES.PATCH);
+    this.collectHydratedNamespace(hydrated, tree.user, VFS_PREFIXES.USER);
     if (tree.objects) {
       for (const [nodeId, nodeTree] of Object.entries(tree.objects)) {
-        this.hydrateNamespace(nodeTree, `${VFS_PREFIXES.OBJECT}${nodeId}/`);
+        this.collectHydratedNamespace(hydrated, nodeTree, `${VFS_PREFIXES.OBJECT}${nodeId}/`);
       }
     }
+
+    let totalEmbeddedBytes = 0;
+    for (const entry of hydrated.values()) {
+      if (isEmbeddedVFSEntry(entry)) {
+        totalEmbeddedBytes += new TextEncoder().encode(entry.content).byteLength;
+      }
+    }
+    if (totalEmbeddedBytes > MAX_EMBEDDED_PATCH_BYTES) {
+      throw new Error('VFS: Embedded patch files exceed 1 MiB');
+    }
+
+    this.entries.clear();
+    this.pendingPermissions.clear();
+    this.entries = hydrated;
 
     // Check which local files need permission
     for (const [path, entry] of this.entries) {
@@ -834,6 +1259,25 @@ export class VirtualFilesystem {
       } else {
         // It's a directory, recurse
         this.hydrateNamespace(value as { [key: string]: VFSTreeNode }, `${prefix}${key}/`);
+      }
+    }
+  }
+
+  private collectHydratedNamespace(
+    entries: Map<string, VFSEntry>,
+    node: { [key: string]: VFSTreeNode } | undefined,
+    prefix: string
+  ): void {
+    if (!node) return;
+
+    for (const [key, value] of Object.entries(node)) {
+      const path = `${prefix}${key}`;
+      if (isVFSEntry(value)) {
+        const entry = { ...value };
+        this.assertValidEntry(path, entry);
+        entries.set(path, entry);
+      } else {
+        this.collectHydratedNamespace(entries, value as { [key: string]: VFSTreeNode }, `${path}/`);
       }
     }
   }

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -156,7 +156,11 @@ export class VirtualFilesystem {
     }
   }
 
-  private recordMutation(description: string, mutate: () => void): void {
+  private recordMutation(
+    description: string,
+    mutate: () => void,
+    callbacks?: { redo?: () => void; undo?: () => void }
+  ): void {
     const before = this.cloneEntries();
 
     mutate();
@@ -164,8 +168,14 @@ export class VirtualFilesystem {
     const after = this.cloneEntries();
     const command: Command = {
       description,
-      execute: () => this.restoreEntries(after),
-      undo: () => this.restoreEntries(before)
+      execute: () => {
+        this.restoreEntries(after);
+        callbacks?.redo?.();
+      },
+      undo: () => {
+        this.restoreEntries(before);
+        callbacks?.undo?.();
+      }
     };
 
     HistoryManager.getInstance().record(command);
@@ -538,19 +548,49 @@ export class VirtualFilesystem {
       return [destination, { ...entry, filename }] as const;
     });
 
-    this.recordMutation(`Rename ${oldPath.split('/').pop()}`, () => {
-      for (const path of paths) this.entries.delete(path);
-      for (const [path, entry] of renamed) this.entries.set(path, entry);
-      this.notifyChange();
-      for (const path of paths) {
-        const destination = path === oldPath ? newPath : `${newPath}${path.slice(oldPath.length)}`;
-        PatchiesEventBus.getInstance().dispatch({
-          type: 'vfsPathRenamed',
-          oldPath: path,
-          newPath: destination
-        });
+    const moves = renamed.map(([newPath, entry], index) => ({
+      oldPath: paths[index],
+      newPath,
+      entry
+    }));
+    const movePersistedEntries = (direction: 'forward' | 'backward') => {
+      const provider = this.getLocalProvider();
+      if (!provider) return;
+
+      for (const move of moves) {
+        const from = direction === 'forward' ? move.oldPath : move.newPath;
+        const to = direction === 'forward' ? move.newPath : move.oldPath;
+
+        if (move.entry.provider === 'local') {
+          void provider.rename(from, to);
+        } else if (move.entry.provider === 'local-folder') {
+          void provider.renameDirHandle(from, to);
+        }
       }
-    });
+    };
+
+    this.recordMutation(
+      `Rename ${oldPath.split('/').pop()}`,
+      () => {
+        for (const path of paths) this.entries.delete(path);
+        for (const [path, entry] of renamed) this.entries.set(path, entry);
+        movePersistedEntries('forward');
+        this.notifyChange();
+        for (const path of paths) {
+          const destination =
+            path === oldPath ? newPath : `${newPath}${path.slice(oldPath.length)}`;
+          PatchiesEventBus.getInstance().dispatch({
+            type: 'vfsPathRenamed',
+            oldPath: path,
+            newPath: destination
+          });
+        }
+      },
+      {
+        redo: () => movePersistedEntries('forward'),
+        undo: () => movePersistedEntries('backward')
+      }
+    );
   }
 
   /** Delete a file or a complete folder tree as one undoable operation. */
@@ -577,6 +617,9 @@ export class VirtualFilesystem {
     if (!source || isVFSFolder(source)) throw new Error(`VFS: File not found: ${sourcePath}`);
     if (!targetFolder.startsWith(VFS_PREFIXES.PATCH)) {
       throw new Error(`VFS: Patch destination required: ${targetFolder}`);
+    }
+    if (source.size && source.size > MAX_EMBEDDED_FILE_BYTES) {
+      throw new Error(`VFS: ${source.filename} exceeds 256 KiB Patch-file limit`);
     }
 
     const blob = await this.resolve(sourcePath);

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -5,6 +5,7 @@ import { match } from 'ts-pattern';
 import {
   type VFSEntry,
   type EmbeddedVFSEntry,
+  type PatchImportItem,
   type VFSTree,
   type VFSTreeNode,
   type VFSProvider,
@@ -22,6 +23,7 @@ import {
   generateUserPath,
   getBasename,
   getExtension,
+  getFilename,
   getFilenameFromUrl,
   guessMimeType
 } from './path-utils';
@@ -384,19 +386,29 @@ export class VirtualFilesystem {
     });
   }
 
-  private resolveCollision(path: string, collision: VfsCollisionStrategy): string | null {
-    if (!this.entries.has(path)) return path;
+  private resolveCollision(
+    path: string,
+    collision: VfsCollisionStrategy,
+    occupied = new Set(this.entries.keys()),
+    directory = false
+  ): string | null {
+    const hasCollision = (candidate: string) =>
+      occupied.has(candidate) || [...occupied].some((item) => item.startsWith(`${candidate}/`));
+
+    if (!hasCollision(path)) return path;
     if (collision === 'replace') return path;
     if (collision === 'cancel') return null;
 
-    const extension = getExtension(path);
-    const basename = getBasename(path);
+    const filename = getFilename(path);
+    const extension = directory ? '' : getExtension(filename);
+    const basename = directory ? filename : getBasename(filename);
+    const parent = path.slice(0, -filename.length);
     let counter = 1;
-    let candidate = `${basename}-${counter}${extension}`;
+    let candidate = `${parent}${basename}-${counter}${extension}`;
 
-    while (this.entries.has(candidate)) {
+    while (hasCollision(candidate)) {
       counter += 1;
-      candidate = `${basename}-${counter}${extension}`;
+      candidate = `${parent}${basename}-${counter}${extension}`;
     }
 
     return candidate;
@@ -476,38 +488,65 @@ export class VirtualFilesystem {
       throw new Error(`VFS: Cannot replace file at non-existent path: ${path}`);
     }
 
-    // Update entry metadata
-    entry.filename = file.name;
-    entry.mimeType = file.type || guessMimeType(file.name);
-
-    // Store via provider
-    const provider = this.providers.get('local');
-    if (provider && 'storeFile' in provider) {
-      const localProvider = provider as VFSProvider & {
-        storeFile: (path: string, file: File, handle?: FileSystemFileHandle) => Promise<void>;
-        storeFileWithHandle: (
-          path: string,
-          file: File,
-          handle: FileSystemFileHandle
-        ) => Promise<void>;
-      };
-
-      if (handle && 'storeFileWithHandle' in localProvider) {
-        await localProvider.storeFileWithHandle(path, file, handle);
+    const localProvider = this.getLocalProvider();
+    const previousProviderState = await localProvider?.captureFileState(path);
+    const replacementProviderState = { file, handle };
+    const wasPendingPermission = this.pendingPermissions.has(path);
+    const updatedEntry: VFSEntry = {
+      ...entry,
+      filename: file.name,
+      mimeType: file.type || guessMimeType(file.name),
+      size: file.size
+    };
+    const dispatchRelinked = () =>
+      PatchiesEventBus.getInstance().dispatch({ type: 'fileRelinked', path });
+    const restoreProviderState = (
+      state: import('./providers/LocalFilesystemProvider').LocalFileState | undefined,
+      pendingPermission: boolean
+    ) => {
+      if (pendingPermission) {
+        this.pendingPermissions.add(path);
       } else {
-        await localProvider.storeFile(path, file);
+        this.pendingPermissions.delete(path);
+      }
+      this.notifyChange();
+
+      if (!localProvider || !state) {
+        dispatchRelinked();
+        return;
+      }
+
+      void localProvider
+        .restoreFileState(path, state)
+        .then(dispatchRelinked)
+        .catch((error) => console.error('VFS: Failed to restore replaced file state', error));
+    };
+
+    if (localProvider) {
+      try {
+        await localProvider.restoreFileState(path, replacementProviderState);
+      } catch (error) {
+        if (previousProviderState) {
+          await localProvider.restoreFileState(path, previousProviderState);
+        }
+
+        throw error;
       }
     }
 
-    // Clear pending permission status
-    this.pendingPermissions.delete(path);
-    this.notifyChange();
-
-    // Dispatch event so nodes know the file was relinked
-    PatchiesEventBus.getInstance().dispatch({
-      type: 'fileRelinked',
-      path
-    });
+    this.recordMutation(
+      `Replace ${entry.filename}`,
+      () => {
+        this.entries.set(path, updatedEntry);
+        this.pendingPermissions.delete(path);
+        this.notifyChange();
+        dispatchRelinked();
+      },
+      {
+        redo: () => restoreProviderState(replacementProviderState, false),
+        undo: () => restoreProviderState(previousProviderState, wasPendingPermission)
+      }
+    );
   }
 
   /**
@@ -719,25 +758,88 @@ export class VirtualFilesystem {
     targetFolder: string = VFS_PREFIXES.PATCH,
     collision: VfsCollisionStrategy = 'cancel'
   ): Promise<string | null> {
+    const items = await this.preparePatchCopy(sourcePath);
+    const imported = await this.importToPatch(items, targetFolder, collision);
+
+    return imported[0] ?? null;
+  }
+
+  /** Resolve a User file or folder into a portable, atomic Patch import batch. */
+  async preparePatchCopy(sourcePath: string): Promise<PatchImportItem[]> {
     const source = this.getEntryOrLinkedFile(sourcePath);
-    if (!source || isVFSFolder(source)) throw new Error(`VFS: File not found: ${sourcePath}`);
-    if (!targetFolder.startsWith(VFS_PREFIXES.PATCH)) {
-      throw new Error(`VFS: Patch destination required: ${targetFolder}`);
-    }
-    if (source.size && source.size > MAX_EMBEDDED_FILE_BYTES) {
-      throw new Error(`VFS: ${source.filename} exceeds 256 KiB Patch-file limit`);
+    if (!source) throw new Error(`VFS: Path not found: ${sourcePath}`);
+
+    if (!isVFSFolder(source)) {
+      this.assertPatchCopySize(source);
+
+      const blob = await this.resolve(sourcePath);
+      const file =
+        blob instanceof File
+          ? blob
+          : new File([blob], source.filename, { type: source.mimeType ?? blob.type });
+
+      return [{ kind: 'file', file, relativePath: source.filename }];
     }
 
-    const blob = await this.resolve(sourcePath);
-    const content = await this.decodeUtf8(blob, sourcePath);
-    const destination = `${targetFolder.endsWith('/') ? targetFolder : `${targetFolder}/`}${source.filename}`;
+    const rootName = source.filename;
+    const items: PatchImportItem[] = [{ kind: 'directory', relativePath: rootName }];
+    const collectChildren = async (directory: string, relativeDirectory: string): Promise<void> => {
+      for (const child of await this.listChildren(directory)) {
+        const relativePath = `${relativeDirectory}/${child.name}`;
 
-    return this.createEmbeddedFile(destination, content, collision);
+        if (child.kind === 'directory') {
+          items.push({ kind: 'directory', relativePath });
+          await collectChildren(child.path, relativePath);
+
+          continue;
+        }
+
+        const entry = this.getEntryOrLinkedFile(child.path);
+        if (!entry) throw new Error(`VFS: File not found: ${child.path}`);
+        this.assertPatchCopySize(entry);
+
+        const blob = await this.resolve(child.path);
+        const file =
+          blob instanceof File
+            ? blob
+            : new File([blob], entry.filename, { type: entry.mimeType ?? blob.type });
+        items.push({ kind: 'file', file, relativePath });
+      }
+    };
+
+    await collectChildren(sourcePath, rootName);
+
+    return items;
+  }
+
+  private assertPatchCopySize(entry: VFSEntry): void {
+    if (entry.size && entry.size > MAX_EMBEDDED_FILE_BYTES) {
+      throw new Error(`VFS: ${entry.filename} exceeds 256 KiB Patch-file limit`);
+    }
+  }
+
+  /** Return top-level destination paths that require a collision decision. */
+  getPatchImportCollisions(
+    files: Iterable<File | PatchImportItem>,
+    targetFolder: string = VFS_PREFIXES.PATCH
+  ): string[] {
+    const items = this.normalizePatchImportItems(files);
+    const collisions = items
+      .map((item) => this.joinVfsPath(targetFolder, item.relativePath))
+      .filter((path) =>
+        [...this.entries.keys()].some(
+          (existing) => existing === path || existing.startsWith(`${path}/`)
+        )
+      );
+
+    return [...new Set(collisions)].filter(
+      (path, _, all) => !all.some((other) => other !== path && path.startsWith(`${other}/`))
+    );
   }
 
   /** Import text files atomically: an invalid file or budget violation imports nothing. */
   async importToPatch(
-    files: Iterable<File>,
+    files: Iterable<File | PatchImportItem>,
     targetFolder: string = VFS_PREFIXES.PATCH,
     collision: VfsCollisionStrategy = 'keep-both'
   ): Promise<string[]> {
@@ -745,29 +847,95 @@ export class VirtualFilesystem {
       throw new Error(`VFS: Patch destination required: ${targetFolder}`);
     }
 
-    const staged: Array<{ path: string; entry: EmbeddedVFSEntry }> = [];
+    const items = this.normalizePatchImportItems(files);
+    const decodedContent = new Map<PatchImportItem, string>();
+    const errors: string[] = [];
+
+    for (const item of items) {
+      if (item.kind === 'directory') continue;
+
+      const importError = getPatchImportError(item.file);
+      if (importError) {
+        errors.push(importError);
+        continue;
+      }
+
+      try {
+        decodedContent.set(item, await this.decodeUtf8(item.file, item.relativePath));
+      } catch (error) {
+        errors.push(
+          error instanceof Error ? error.message.replace('VFS: ', '') : item.relativePath
+        );
+      }
+    }
+
+    if (errors.length > 0) throw new Error(`VFS: ${errors.join('; ')}`);
+
+    const staged = new Map<string, VFSEntry>();
     const occupied = new Set(this.entries.keys());
+    const removedExistingPaths = new Set<string>();
+    const resolvedDirectories = new Map<string, string>();
     let totalBytes = this.getEmbeddedByteLength();
 
-    for (const file of files) {
-      const importError = getPatchImportError(file);
-      if (importError) throw new Error(`VFS: ${importError}`);
+    const removeExistingTree = (path: string) => {
+      for (const [existingPath, entry] of this.entries) {
+        if (existingPath !== path && !existingPath.startsWith(`${path}/`)) continue;
+        if (removedExistingPaths.has(existingPath)) continue;
 
-      const relativePath = this.getImportRelativePath(file);
-      const rawPath = `${targetFolder.endsWith('/') ? targetFolder : `${targetFolder}/`}${relativePath}`;
-      const path = this.resolveStagedCollision(rawPath, collision, occupied);
-      if (!path) throw new Error(`VFS: Import cancelled because ${file.name} already exists`);
+        removedExistingPaths.add(existingPath);
+        occupied.delete(existingPath);
+        if (isEmbeddedVFSEntry(entry)) {
+          totalBytes -= new TextEncoder().encode(entry.content).byteLength;
+        }
+      }
+    };
+    const removeStagedTree = (path: string) => {
+      for (const [stagedPath, entry] of staged) {
+        if (stagedPath !== path && !stagedPath.startsWith(`${path}/`)) continue;
 
-      const content = await this.decodeUtf8(file, file.name);
+        staged.delete(stagedPath);
+        occupied.delete(stagedPath);
+        if (isEmbeddedVFSEntry(entry)) {
+          totalBytes -= new TextEncoder().encode(entry.content).byteLength;
+        }
+      }
+    };
+    const resolveParent = (relativePath: string) => {
+      const separator = relativePath.lastIndexOf('/');
+      if (separator === -1) {
+        return targetFolder;
+      }
+
+      const relativeParent = relativePath.slice(0, separator);
+
+      return resolvedDirectories.get(relativeParent);
+    };
+
+    for (const item of items) {
+      const parent = resolveParent(item.relativePath);
+      if (!parent) throw new Error(`VFS: Invalid import path: ${item.relativePath}`);
+
+      const name = getFilename(item.relativePath);
+      const rawPath = this.joinVfsPath(parent, name);
+      const priorEntry = staged.get(rawPath) ?? this.entries.get(rawPath);
+      const path = this.resolveCollision(rawPath, collision, occupied, item.kind === 'directory');
+      if (!path) throw new Error(`VFS: Import cancelled because ${name} already exists`);
+
+      if (collision === 'replace' && path === rawPath) {
+        removeStagedTree(path);
+        removeExistingTree(path);
+      }
+
+      if (item.kind === 'directory') {
+        resolvedDirectories.set(item.relativePath, path);
+        staged.set(path, { provider: 'folder', filename: getFilename(path) });
+        occupied.add(path);
+
+        continue;
+      }
+
+      const content = decodedContent.get(item)!;
       const size = new TextEncoder().encode(content).byteLength;
-      if (size > MAX_EMBEDDED_FILE_BYTES) {
-        throw new Error(`VFS: Embedded file exceeds 256 KiB: ${file.name}`);
-      }
-      const stagedEntry = staged.find((item) => item.path === path)?.entry;
-      const existingEntry = stagedEntry ?? this.entries.get(path);
-      if (collision === 'replace' && existingEntry && isEmbeddedVFSEntry(existingEntry)) {
-        totalBytes -= new TextEncoder().encode(existingEntry.content).byteLength;
-      }
 
       totalBytes += size;
       if (totalBytes > MAX_EMBEDDED_PATCH_BYTES) {
@@ -775,51 +943,62 @@ export class VirtualFilesystem {
       }
 
       occupied.add(path);
-      staged.push({
-        path,
-        entry: {
-          provider: 'embedded',
-          filename: file.name,
-          mimeType: file.type || guessMimeType(file.name) || 'text/plain;charset=utf-8',
-          content,
-          size,
-          revision: 1
-        }
-      });
+      const entry: EmbeddedVFSEntry = {
+        provider: 'embedded',
+        filename: getFilename(path),
+        mimeType: item.file.type || guessMimeType(item.file.name) || 'text/plain;charset=utf-8',
+        content,
+        size,
+        revision: priorEntry && isEmbeddedVFSEntry(priorEntry) ? (priorEntry.revision ?? 0) + 1 : 1
+      };
+      staged.set(path, entry);
     }
 
+    const importedFiles = [...staged].filter(([, entry]) => isEmbeddedVFSEntry(entry));
     this.recordMutation(
-      `Import ${staged.length} patch file${staged.length === 1 ? '' : 's'}`,
+      `Import ${importedFiles.length} patch file${importedFiles.length === 1 ? '' : 's'}`,
       () => {
-        for (const { path, entry } of staged) {
+        for (const path of removedExistingPaths) this.entries.delete(path);
+        for (const [path, entry] of staged) {
           this.entries.set(path, entry);
-          this.emitContentModified(path, entry.revision ?? 1);
+          if (isEmbeddedVFSEntry(entry)) {
+            this.emitContentModified(path, entry.revision ?? 1);
+          }
         }
         this.notifyChange();
       }
     );
 
-    return staged.map(({ path }) => path);
+    return importedFiles.map(([path]) => path);
   }
 
-  private resolveStagedCollision(
-    path: string,
-    collision: VfsCollisionStrategy,
-    occupied: Set<string>
-  ): string | null {
-    if (!occupied.has(path)) return path;
-    if (collision === 'replace') return path;
-    if (collision === 'cancel') return null;
+  private normalizePatchImportItems(files: Iterable<File | PatchImportItem>): PatchImportItem[] {
+    const directories = new Set<string>();
+    const fileItems: PatchImportItem[] = [];
 
-    const extension = getExtension(path);
-    const basename = getBasename(path);
-    let counter = 1;
-    let candidate = `${basename}-${counter}${extension}`;
-    while (occupied.has(candidate)) {
-      counter += 1;
-      candidate = `${basename}-${counter}${extension}`;
+    for (const input of files) {
+      const item: PatchImportItem =
+        input instanceof File
+          ? { kind: 'file', file: input, relativePath: this.getImportRelativePath(input) }
+          : { ...input, relativePath: this.normalizeImportRelativePath(input.relativePath) };
+      const segments = item.relativePath.split('/');
+
+      for (let index = 1; index < segments.length; index += 1) {
+        directories.add(segments.slice(0, index).join('/'));
+      }
+
+      if (item.kind === 'directory') {
+        directories.add(item.relativePath);
+      } else {
+        fileItems.push(item);
+      }
     }
-    return candidate;
+
+    const directoryItems: PatchImportItem[] = [...directories]
+      .sort((a, b) => a.split('/').length - b.split('/').length || a.localeCompare(b))
+      .map((relativePath) => ({ kind: 'directory', relativePath }));
+
+    return [...directoryItems, ...fileItems];
   }
 
   private async decodeUtf8(blob: Blob, path: string): Promise<string> {
@@ -832,7 +1011,11 @@ export class VirtualFilesystem {
 
   private getImportRelativePath(file: File): string {
     const relativePath = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
-    const normalized = (relativePath || file.name).replaceAll('\\', '/');
+    return this.normalizeImportRelativePath(relativePath || file.name);
+  }
+
+  private normalizeImportRelativePath(relativePath: string): string {
+    const normalized = relativePath.replaceAll('\\', '/');
     const segments = normalized.split('/').filter(Boolean);
 
     if (segments.length === 0 || segments.some((segment) => segment === '.' || segment === '..')) {
@@ -840,6 +1023,12 @@ export class VirtualFilesystem {
     }
 
     return segments.join('/');
+  }
+
+  private joinVfsPath(parent: string, child: string): string {
+    if (parent.endsWith('://') || parent.endsWith('/')) return `${parent}${child}`;
+
+    return `${parent}/${child}`;
   }
 
   // ─────────────────────────────────────────────────────────────────

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -107,6 +107,9 @@ export class VirtualFilesystem {
   /** Paths that need permission re-grant (local files after reload) */
   private pendingPermissions: Set<string> = new Set();
 
+  /** Hydrated embedded files that exceed the patch limits and cannot be executed. */
+  private invalidEmbeddedPaths: Map<string, string> = new Map();
+
   /** Version counter for reactivity - increments on any mutation */
   private versionStore = writable(0);
 
@@ -137,6 +140,7 @@ export class VirtualFilesystem {
   private restoreEntries(entries: Map<string, VFSEntry>): void {
     const previous = this.entries;
     this.entries = this.cloneEntries(entries);
+    this.invalidEmbeddedPaths = this.findInvalidEmbeddedPaths(this.entries);
     this.pendingPermissions = new Set(
       [...this.pendingPermissions].filter((path) => this.entries.has(path))
     );
@@ -164,6 +168,7 @@ export class VirtualFilesystem {
     const before = this.cloneEntries();
 
     mutate();
+    this.invalidEmbeddedPaths = this.findInvalidEmbeddedPaths(this.entries);
 
     const after = this.cloneEntries();
     const command: Command = {
@@ -181,7 +186,7 @@ export class VirtualFilesystem {
     HistoryManager.getInstance().record(command);
   }
 
-  private assertValidEntry(path: string, entry: VFSEntry): void {
+  private assertValidEntry(path: string, entry: VFSEntry, enforceEmbeddedLimits = true): void {
     const parsed = parseVFSPath(path);
     if (!parsed || parsed.segments.length === 0) {
       throw new Error(`VFS: Invalid path: ${path}`);
@@ -195,9 +200,40 @@ export class VirtualFilesystem {
       throw new Error(`VFS: embedded entries are only valid under patch://: ${path}`);
     }
 
-    if (isEmbeddedVFSEntry(entry)) {
+    if (entry.provider === 'embedded' && !isEmbeddedVFSEntry(entry)) {
+      throw new Error(`VFS: Embedded file content must be UTF-8 text: ${path}`);
+    }
+
+    if (enforceEmbeddedLimits && isEmbeddedVFSEntry(entry)) {
       this.assertEmbeddedContent(entry.content, path);
     }
+  }
+
+  private findInvalidEmbeddedPaths(entries: Map<string, VFSEntry>): Map<string, string> {
+    const invalidPaths = new Map<string, string>();
+    const encoder = new TextEncoder();
+    let totalBytes = 0;
+
+    for (const [path, entry] of entries) {
+      if (!isEmbeddedVFSEntry(entry)) continue;
+
+      const size = encoder.encode(entry.content).byteLength;
+      totalBytes += size;
+
+      if (size > MAX_EMBEDDED_FILE_BYTES) {
+        invalidPaths.set(path, `VFS: Embedded file exceeds 256 KiB: ${path}`);
+      }
+    }
+
+    if (totalBytes > MAX_EMBEDDED_PATCH_BYTES) {
+      for (const [path, entry] of entries) {
+        if (isEmbeddedVFSEntry(entry) && !invalidPaths.has(path)) {
+          invalidPaths.set(path, 'VFS: Embedded patch files exceed 1 MiB');
+        }
+      }
+    }
+
+    return invalidPaths;
   }
 
   private assertEmbeddedContent(content: string, path: string): void {
@@ -330,7 +366,22 @@ export class VirtualFilesystem {
       throw new Error(`VFS: Embedded file not found: ${path}`);
     }
 
+    const validationError = this.invalidEmbeddedPaths.get(path);
+    if (validationError) throw new Error(validationError);
+
     return entry.content;
+  }
+
+  /** Return embedded bytes for explicit export, including quarantined recovery files. */
+  exportEmbeddedFile(path: string): File {
+    const entry = this.entries.get(path);
+    if (!entry || !isEmbeddedVFSEntry(entry)) {
+      throw new Error(`VFS: Embedded file not found: ${path}`);
+    }
+
+    return new File([entry.content], entry.filename, {
+      type: entry.mimeType || 'text/plain;charset=utf-8'
+    });
   }
 
   private resolveCollision(path: string, collision: VfsCollisionStrategy): string | null {
@@ -575,6 +626,15 @@ export class VirtualFilesystem {
         }
       }
     };
+    const emitPathRenames = (direction: 'forward' | 'backward') => {
+      for (const move of moves) {
+        PatchiesEventBus.getInstance().dispatch({
+          type: 'vfsPathRenamed',
+          oldPath: direction === 'forward' ? move.oldPath : move.newPath,
+          newPath: direction === 'forward' ? move.newPath : move.oldPath
+        });
+      }
+    };
 
     this.recordMutation(
       `Rename ${oldPath.split('/').pop()}`,
@@ -583,27 +643,41 @@ export class VirtualFilesystem {
         for (const [path, entry] of renamed) this.entries.set(path, entry);
         movePersistedEntries('forward');
         this.notifyChange();
-        for (const path of paths) {
-          const destination =
-            path === oldPath ? newPath : `${newPath}${path.slice(oldPath.length)}`;
-          PatchiesEventBus.getInstance().dispatch({
-            type: 'vfsPathRenamed',
-            oldPath: path,
-            newPath: destination
-          });
-        }
+        emitPathRenames('forward');
       },
       {
-        redo: () => movePersistedEntries('forward'),
-        undo: () => movePersistedEntries('backward')
+        redo: () => {
+          movePersistedEntries('forward');
+          emitPathRenames('forward');
+        },
+        undo: () => {
+          movePersistedEntries('backward');
+          emitPathRenames('backward');
+        }
       }
     );
   }
 
   /** Delete a file or a complete folder tree as one undoable operation. */
   deletePath(path: string): void {
-    const paths = this.list().filter((item) => item === path || item.startsWith(`${path}/`));
-    if (paths.length === 0) throw new Error(`VFS: Path not found: ${path}`);
+    this.deletePaths([path]);
+  }
+
+  /** Delete multiple paths, collapsing descendants into one undoable operation. */
+  deletePaths(requestedPaths: Iterable<string>): void {
+    const requested = [...new Set(requestedPaths)];
+    const roots = requested.filter(
+      (path) => !requested.some((other) => other !== path && path.startsWith(`${other}/`))
+    );
+
+    for (const path of roots) {
+      if (!this.entries.has(path)) throw new Error(`VFS: Path not found: ${path}`);
+    }
+
+    const paths = this.list().filter((item) =>
+      roots.some((root) => item === root || item.startsWith(`${root}/`))
+    );
+    if (paths.length === 0) return;
 
     const linkedFolderPaths = paths.filter(
       (item) => this.entries.get(item)?.provider === 'local-folder'
@@ -623,7 +697,7 @@ export class VirtualFilesystem {
     };
 
     this.recordMutation(
-      `Delete ${path.split('/').pop()}`,
+      roots.length === 1 ? `Delete ${roots[0].split('/').pop()}` : `Delete ${roots.length} paths`,
       () => {
         for (const item of paths) {
           this.entries.delete(item);
@@ -854,10 +928,10 @@ export class VirtualFilesystem {
     const entry = this.entries.get(path);
     if (entry) {
       if (isEmbeddedVFSEntry(entry)) {
-        return new File([entry.content], entry.filename, {
-          type: entry.mimeType || 'text/plain;charset=utf-8'
-        });
+        const validationError = this.invalidEmbeddedPaths.get(path);
+        if (validationError) throw new Error(validationError);
       }
+
       // Direct entry found
       const provider = this.providers.get(entry.provider);
       if (!provider) {
@@ -1274,19 +1348,10 @@ export class VirtualFilesystem {
       }
     }
 
-    let totalEmbeddedBytes = 0;
-    for (const entry of hydrated.values()) {
-      if (isEmbeddedVFSEntry(entry)) {
-        totalEmbeddedBytes += new TextEncoder().encode(entry.content).byteLength;
-      }
-    }
-    if (totalEmbeddedBytes > MAX_EMBEDDED_PATCH_BYTES) {
-      throw new Error('VFS: Embedded patch files exceed 1 MiB');
-    }
-
     this.entries.clear();
     this.pendingPermissions.clear();
     this.entries = hydrated;
+    this.invalidEmbeddedPaths = this.findInvalidEmbeddedPaths(hydrated);
 
     // Check which local files need permission
     for (const [path, entry] of this.entries) {
@@ -1355,7 +1420,7 @@ export class VirtualFilesystem {
       const path = `${prefix}${key}`;
       if (isVFSEntry(value)) {
         const entry = { ...value };
-        this.assertValidEntry(path, entry);
+        this.assertValidEntry(path, entry, false);
         entries.set(path, entry);
       } else {
         this.collectHydratedNamespace(entries, value as { [key: string]: VFSTreeNode }, `${path}/`);
@@ -1461,7 +1526,12 @@ export class VirtualFilesystem {
   clear(): void {
     this.entries.clear();
     this.pendingPermissions.clear();
-    this.getLocalProvider()?.clearDirHandles();
+    this.invalidEmbeddedPaths.clear();
+
+    const localProvider = this.getLocalProvider();
+    localProvider?.clear();
+    localProvider?.clearDirHandles();
+
     this.notifyChange();
   }
 

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -1,42 +1,30 @@
 // Virtual Filesystem Singleton
 
-import { writable, derived, type Readable } from 'svelte/store';
 import { match } from 'ts-pattern';
+import { derived, writable, type Readable } from 'svelte/store';
+import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+import { PatchFileOperations } from './PatchFileOperations';
+import type { VfsCollisionStrategy } from './PatchImportPlanner';
+import { clearFileData, clearHandles } from './persistence';
+import { generateUserPath, getFilenameFromUrl, guessMimeType } from './path-utils';
+import type { LocalFileState, LocalFilesystemProvider } from './providers/LocalFilesystemProvider';
 import {
-  type VFSEntry,
-  type EmbeddedVFSEntry,
   type PatchImportItem,
-  type VFSTree,
-  type VFSTreeNode,
-  type VFSProvider,
+  type VFSEntry,
   type VFSListEntry,
   type VFSListPage,
+  type VFSProvider,
   type VFSSearchPage,
-  isVFSFolder,
+  type VFSTree,
   isEmbeddedVFSEntry,
-  isVFSEntry,
   isVFSPath,
-  parseVFSPath,
   VFS_PREFIXES
 } from './types';
-import {
-  generateUserPath,
-  getBasename,
-  getExtension,
-  getFilename,
-  getFilenameFromUrl,
-  guessMimeType
-} from './path-utils';
-import { clearFileData, clearHandles } from './persistence';
-import {
-  MAX_EMBEDDED_FILE_BYTES,
-  MAX_EMBEDDED_PATCH_BYTES,
-  PatchImportPlanner
-} from './PatchImportPlanner';
-import type { VfsCollisionStrategy } from './PatchImportPlanner';
-import { VfsEntryIndex } from './VfsEntryIndex';
+import { VfsDirectoryReader } from './VfsDirectoryReader';
+import { VfsEntryIndex, type VfsRenameMove } from './VfsEntryIndex';
 import { VfsMutationCoordinator, type VfsMutationSnapshot } from './VfsMutationCoordinator';
-import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+import { VfsPermissionTracker } from './VfsPermissionTracker';
+import { VfsTreeCodec } from './VfsTreeCodec';
 
 export {
   MAX_EMBEDDED_FILE_BYTES,
@@ -44,6 +32,7 @@ export {
   PATCH_TEXT_FILE_ACCEPT,
   getPatchImportError
 } from './PatchImportPlanner';
+
 export type { VfsCollisionStrategy } from './PatchImportPlanner';
 
 declare global {
@@ -52,205 +41,61 @@ declare global {
   }
 }
 
-/**
- * Virtual Filesystem - singleton for managing file references.
- *
- * Files are referenced by VFS paths like:
- * - user://images/photo.jpg (user uploads)
- * - obj://csound~-24/sound.csd (node-specific files)
- *
- * The VFS stores metadata (VFSEntry) and delegates resolution to providers.
- */
+/** Stable public façade for virtual file operations and provider coordination. */
 export class VirtualFilesystem {
   private static instance: VirtualFilesystem | null = null;
 
-  /** Flat map of path -> entry for quick lookups */
   private entries = new VfsEntryIndex();
-
-  /** Registered providers */
-  private providers: Map<string, VFSProvider> = new Map();
-
-  /** Paths that need permission re-grant (local files after reload) */
-  private pendingPermissions: Set<string> = new Set();
-
-  /** Hydrated embedded files that exceed the patch limits and cannot be executed. */
-  private invalidEmbeddedPaths: Map<string, string> = new Map();
-
-  private mutationCoordinator = new VfsMutationCoordinator({
-    snapshot: () => this.createMutationSnapshot(),
-    restore: (snapshot) => this.restoreEntries(snapshot),
-    afterMutation: () => {
-      this.invalidEmbeddedPaths = this.findInvalidEmbeddedPaths(this.entries);
-    }
-  });
-
-  /** Serialize persisted rename effects across synchronous history callbacks. */
-  private persistedRenameQueue: Promise<void> = Promise.resolve();
-
-  /** Version counter for reactivity - increments on any mutation */
+  private providers = new Map<string, VFSProvider>();
+  private permissions = new VfsPermissionTracker();
   private versionStore = writable(0);
+  private mutationCoordinator: VfsMutationCoordinator;
+  private patchFiles: PatchFileOperations;
+  private directoryReader: VfsDirectoryReader;
+  private treeCodec = new VfsTreeCodec();
 
-  /** Readable store of all entries - subscribe to this for reactive updates */
   readonly entries$: Readable<Map<string, VFSEntry>> = derived(this.versionStore, () =>
     this.getAllEntries()
   );
 
-  /** Readable store of paths needing permission re-grant */
   readonly pendingPermissions$: Readable<Set<string>> = derived(
     this.versionStore,
-    () => new Set(this.pendingPermissions)
+    () => new Set(this.permissions.getAll())
   );
 
   private constructor() {
-    // Private constructor for singleton
-  }
+    this.mutationCoordinator = new VfsMutationCoordinator({
+      snapshot: () => this.createMutationSnapshot(),
+      restore: (snapshot) => this.restoreEntries(snapshot),
+      afterMutation: () => this.patchFiles.refreshValidation()
+    });
 
-  /** Notify subscribers that the VFS has changed */
-  private notifyChange(): void {
-    this.versionStore.update((v) => v + 1);
-  }
+    this.patchFiles = new PatchFileOperations({
+      entries: this.entries,
+      recordMutation: (description, mutate, callbacks) =>
+        this.mutationCoordinator.record(description, mutate, callbacks),
+      notifyChange: () => this.notifyChange(),
+      emitContentModified: (path, revision) => this.emitContentModified(path, revision)
+    });
 
-  private createMutationSnapshot(): VfsMutationSnapshot {
-    return {
-      entries: this.entries.snapshot(),
-      pendingPermissions: new Set(this.pendingPermissions)
-    };
-  }
-
-  private restoreEntries({ entries, pendingPermissions }: VfsMutationSnapshot): void {
-    const previous = this.entries.snapshot();
-    this.entries.replace(entries);
-    this.invalidEmbeddedPaths = this.findInvalidEmbeddedPaths(this.entries);
-    this.pendingPermissions = new Set(
-      [...pendingPermissions].filter((path) => this.entries.has(path))
-    );
-    this.notifyChange();
-
-    for (const [path, entry] of this.entries) {
-      const prior = previous.get(path);
-      if (
-        isEmbeddedVFSEntry(entry) &&
-        (!prior ||
-          !isEmbeddedVFSEntry(prior) ||
-          prior.content !== entry.content ||
-          prior.revision !== entry.revision)
-      ) {
-        this.emitContentModified(path, entry.revision ?? 1);
-      }
-    }
-  }
-
-  private recordMutation(
-    description: string,
-    mutate: () => void,
-    callbacks?: { redo?: () => void; undo?: () => void }
-  ): void {
-    this.mutationCoordinator.record(description, mutate, callbacks);
-  }
-
-  private queuePersistedRename(operation: () => Promise<void>): void {
-    const queued = this.persistedRenameQueue.catch(() => {}).then(operation);
-    this.persistedRenameQueue = queued;
-
-    void queued.catch((error) => console.error('VFS: Failed to persist renamed paths', error));
-  }
-
-  private assertValidEntry(path: string, entry: VFSEntry, enforceEmbeddedLimits = true): void {
-    const parsed = parseVFSPath(path);
-    if (!parsed || parsed.segments.length === 0) {
-      throw new Error(`VFS: Invalid path: ${path}`);
-    }
-
-    if (parsed.namespace === 'patch') {
-      if (entry.provider !== 'embedded' && entry.provider !== 'folder') {
-        throw new Error(`VFS: patch:// entries must use the embedded provider: ${path}`);
-      }
-    } else if (entry.provider === 'embedded') {
-      throw new Error(`VFS: embedded entries are only valid under patch://: ${path}`);
-    }
-
-    if (entry.provider === 'embedded' && !isEmbeddedVFSEntry(entry)) {
-      throw new Error(`VFS: Embedded file content must be UTF-8 text: ${path}`);
-    }
-
-    if (enforceEmbeddedLimits && isEmbeddedVFSEntry(entry)) {
-      this.assertEmbeddedContent(entry.content, path);
-    }
-  }
-
-  private findInvalidEmbeddedPaths(entries: Iterable<[string, VFSEntry]>): Map<string, string> {
-    const invalidPaths = new Map<string, string>();
-    const encoder = new TextEncoder();
-    let totalBytes = 0;
-
-    for (const [path, entry] of entries) {
-      if (!isEmbeddedVFSEntry(entry)) continue;
-
-      const size = encoder.encode(entry.content).byteLength;
-      totalBytes += size;
-
-      if (size > MAX_EMBEDDED_FILE_BYTES) {
-        invalidPaths.set(path, `VFS: Embedded file exceeds 256 KiB: ${path}`);
-      }
-    }
-
-    if (totalBytes > MAX_EMBEDDED_PATCH_BYTES) {
-      for (const [path, entry] of entries) {
-        if (isEmbeddedVFSEntry(entry) && !invalidPaths.has(path)) {
-          invalidPaths.set(path, 'VFS: Embedded patch files exceed 1 MiB');
-        }
-      }
-    }
-
-    return invalidPaths;
-  }
-
-  private assertEmbeddedContent(content: string, path: string): void {
-    const size = new TextEncoder().encode(content).byteLength;
-    if (size > MAX_EMBEDDED_FILE_BYTES) {
-      throw new Error(`VFS: Embedded file exceeds 256 KiB: ${path}`);
-    }
-
-    const total = this.getEmbeddedByteLength(path) + size;
-    if (total > MAX_EMBEDDED_PATCH_BYTES) {
-      throw new Error('VFS: Embedded patch files exceed 1 MiB');
-    }
-  }
-
-  private getEmbeddedByteLength(excludingPath?: string): number {
-    const encoder = new TextEncoder();
-    let total = 0;
-
-    for (const [path, entry] of this.entries) {
-      if (path === excludingPath || !isEmbeddedVFSEntry(entry)) continue;
-      total += encoder.encode(entry.content).byteLength;
-    }
-
-    return total;
+    this.directoryReader = new VfsDirectoryReader(this.entries, () => this.getLocalProvider());
   }
 
   static getInstance(): VirtualFilesystem {
     if (!VirtualFilesystem.instance) {
       VirtualFilesystem.instance = new VirtualFilesystem();
 
-      // Expose for debugging
       if (typeof window !== 'undefined') {
         window.vfs = VirtualFilesystem.instance;
       }
     }
+
     return VirtualFilesystem.instance;
   }
 
-  /**
-   * Reset the singleton (useful for testing).
-   */
   static resetInstance(): void {
     VirtualFilesystem.instance = null;
   }
-
-  // ─────────────────────────────────────────────────────────────────
-  // Provider Management
-  // ─────────────────────────────────────────────────────────────────
 
   registerProvider(provider: VFSProvider): void {
     this.providers.set(provider.type, provider);
@@ -260,152 +105,43 @@ export class VirtualFilesystem {
     return this.providers.get(type);
   }
 
-  // ─────────────────────────────────────────────────────────────────
-  // Registration
-  // ─────────────────────────────────────────────────────────────────
-
-  /**
-   * Register a file entry at a specific path.
-   */
   registerEntry(path: string, entry: VFSEntry): void {
-    this.assertValidEntry(path, entry);
+    this.patchFiles.validateEntry(path, entry);
     this.entries.set(path, entry);
     this.notifyChange();
   }
 
-  /** Create or replace a UTF-8 text file embedded in the current patch. */
   createEmbeddedFile(
     path: string,
     content = '',
     collision: VfsCollisionStrategy = 'cancel'
   ): string | null {
-    const parsed = parseVFSPath(path);
-    if (parsed?.namespace !== 'patch') {
-      throw new Error(`VFS: Embedded files must use patch:// paths: ${path}`);
-    }
-
-    const destination = this.resolveCollision(path, collision);
-    if (!destination) return null;
-
-    const filename = destination.split('/').pop() ?? destination;
-    const entry: EmbeddedVFSEntry = {
-      provider: 'embedded',
-      filename,
-      mimeType: guessMimeType(filename) ?? 'text/plain;charset=utf-8',
-      content,
-      size: new TextEncoder().encode(content).byteLength,
-      revision: 1
-    };
-
-    this.assertValidEntry(destination, entry);
-    this.recordMutation(`Create ${filename}`, () => {
-      this.entries.set(destination, entry);
-      this.notifyChange();
-      this.emitContentModified(destination, entry.revision ?? 1);
-    });
-
-    return destination;
+    return this.patchFiles.create(path, content, collision);
   }
 
-  /** Save embedded content as one undoable VFS operation. */
   writeEmbeddedFile(path: string, content: string): void {
-    const entry = this.entries.get(path);
-    if (!entry || !isEmbeddedVFSEntry(entry)) {
-      throw new Error(`VFS: Embedded file not found: ${path}`);
-    }
-
-    this.assertEmbeddedContent(content, path);
-    const updated: EmbeddedVFSEntry = {
-      ...entry,
-      content,
-      size: new TextEncoder().encode(content).byteLength,
-      revision: (entry.revision ?? 0) + 1
-    };
-
-    this.recordMutation(`Write ${entry.filename}`, () => {
-      this.entries.set(path, updated);
-      this.notifyChange();
-      this.emitContentModified(path, updated.revision ?? 1);
-    });
+    this.patchFiles.write(path, content);
   }
 
   readEmbeddedFile(path: string): string {
-    const entry = this.entries.get(path);
-    if (!entry || !isEmbeddedVFSEntry(entry)) {
-      throw new Error(`VFS: Embedded file not found: ${path}`);
-    }
-
-    const validationError = this.invalidEmbeddedPaths.get(path);
-    if (validationError) throw new Error(validationError);
-
-    return entry.content;
+    return this.patchFiles.read(path);
   }
 
-  /** Return embedded bytes for explicit export, including quarantined recovery files. */
   exportEmbeddedFile(path: string): File {
-    const entry = this.entries.get(path);
-    if (!entry || !isEmbeddedVFSEntry(entry)) {
-      throw new Error(`VFS: Embedded file not found: ${path}`);
-    }
-
-    return new File([entry.content], entry.filename, {
-      type: entry.mimeType || 'text/plain;charset=utf-8'
-    });
+    return this.patchFiles.export(path);
   }
 
-  private resolveCollision(
-    path: string,
-    collision: VfsCollisionStrategy,
-    occupied = new Set(this.entries.keys()),
-    directory = false
-  ): string | null {
-    const hasCollision = (candidate: string) =>
-      occupied.has(candidate) || [...occupied].some((item) => item.startsWith(`${candidate}/`));
-
-    if (!hasCollision(path)) return path;
-    if (collision === 'replace') return path;
-    if (collision === 'cancel') return null;
-
-    const filename = getFilename(path);
-    const extension = directory ? '' : getExtension(filename);
-    const basename = directory ? filename : getBasename(filename);
-    const parent = path.slice(0, -filename.length);
-    let counter = 1;
-    let candidate = `${parent}${basename}-${counter}${extension}`;
-
-    while (hasCollision(candidate)) {
-      counter += 1;
-      candidate = `${parent}${basename}-${counter}${extension}`;
-    }
-
-    return candidate;
-  }
-
-  private emitContentModified(path: string, revision: number): void {
-    PatchiesEventBus.getInstance().dispatch({ type: 'vfsContentModified', path, revision });
-  }
-
-  /**
-   * Register a local file and return its generated VFS path.
-   * The file will be stored via the LocalFilesystemProvider.
-   * @deprecated Use storeFile() instead for clarity
-   */
+  /** @deprecated Use storeFile() instead for clarity. */
   async registerLocalFile(file: File): Promise<string> {
     return this.storeFile(file);
   }
 
-  /**
-   * Store a local file in the VFS and return its generated path.
-   * Optionally provide a FileSystemFileHandle for better persistence in Chrome/Edge.
-   * Optionally provide a targetFolder to place the file in a specific folder.
-   */
   async storeFile(
     file: File,
     handle?: FileSystemFileHandle,
     targetFolder?: string
   ): Promise<string> {
-    const existingPaths = new Set(this.entries.keys());
-    const path = generateUserPath(file.name, file.type, existingPaths, targetFolder);
+    const path = generateUserPath(file.name, file.type, new Set(this.entries.keys()), targetFolder);
 
     const entry: VFSEntry = {
       provider: 'local',
@@ -419,19 +155,19 @@ export class VirtualFilesystem {
       size: file.size
     };
 
-    // Store via provider
     const provider = this.providers.get('local');
+
     if (provider && 'storeFile' in provider) {
       const localProvider = provider as VFSProvider & {
         storeFile: (path: string, file: File, handle?: FileSystemFileHandle) => Promise<void>;
-        storeFileWithHandle: (
+        storeFileWithHandle?: (
           path: string,
           file: File,
           handle: FileSystemFileHandle
         ) => Promise<void>;
       };
 
-      if (handle && 'storeFileWithHandle' in localProvider) {
+      if (handle && localProvider.storeFileWithHandle) {
         await localProvider.storeFileWithHandle(path, file, handle);
       } else {
         await localProvider.storeFile(path, file);
@@ -442,61 +178,55 @@ export class VirtualFilesystem {
       this.entries.set(path, entry);
       this.notifyChange();
     });
+
     return path;
   }
 
-  /**
-   * Replace a file at an existing path (for re-linking files that lost permission).
-   * This updates the file data and clears the pending permission status.
-   */
   async replaceFile(path: string, file: File, handle?: FileSystemFileHandle): Promise<void> {
     const entry = this.entries.get(path);
     if (!entry) {
       throw new Error(`VFS: Cannot replace file at non-existent path: ${path}`);
     }
 
-    const localProvider = this.getLocalProvider();
-    const previousProviderState = await localProvider?.captureFileState(path);
+    const provider = this.getLocalProvider();
+    const previousProviderState = await provider?.captureFileState(path);
     const replacementProviderState = { file, handle };
-    const wasPendingPermission = this.pendingPermissions.has(path);
+    const wasPendingPermission = this.permissions.has(path);
+
     const updatedEntry: VFSEntry = {
       ...entry,
       filename: file.name,
       mimeType: file.type || guessMimeType(file.name),
       size: file.size
     };
+
     const dispatchRelinked = () =>
       PatchiesEventBus.getInstance().dispatch({ type: 'fileRelinked', path });
+
     const restoreProviderState = (
-      state: import('./providers/LocalFilesystemProvider').LocalFileState | undefined,
+      state: LocalFileState | undefined,
       pendingPermission: boolean
     ) => {
-      if (pendingPermission) {
-        this.pendingPermissions.add(path);
-      } else {
-        this.pendingPermissions.delete(path);
-      }
+      if (pendingPermission) this.permissions.add(path);
+      else this.permissions.delete(path);
       this.notifyChange();
 
-      if (!localProvider || !state) {
+      if (!provider || !state) {
         dispatchRelinked();
         return;
       }
 
-      void localProvider
+      void provider
         .restoreFileState(path, state)
         .then(dispatchRelinked)
         .catch((error) => console.error('VFS: Failed to restore replaced file state', error));
     };
 
-    if (localProvider) {
+    if (provider) {
       try {
-        await localProvider.restoreFileState(path, replacementProviderState);
+        await provider.restoreFileState(path, replacementProviderState);
       } catch (error) {
-        if (previousProviderState) {
-          await localProvider.restoreFileState(path, previousProviderState);
-        }
-
+        if (previousProviderState) await provider.restoreFileState(path, previousProviderState);
         throw error;
       }
     }
@@ -505,7 +235,7 @@ export class VirtualFilesystem {
       `Replace ${entry.filename}`,
       () => {
         this.entries.set(path, updatedEntry);
-        this.pendingPermissions.delete(path);
+        this.permissions.delete(path);
         this.notifyChange();
         dispatchRelinked();
       },
@@ -516,201 +246,113 @@ export class VirtualFilesystem {
     );
   }
 
-  /**
-   * Register a URL and return its generated VFS path.
-   * Optionally provide a targetFolder to place the file in a specific folder.
-   */
   async registerUrl(url: string, targetFolder?: string): Promise<string> {
     const filename = getFilenameFromUrl(url);
     const mimeType = guessMimeType(filename);
-    const existingPaths = new Set(this.entries.keys());
-    const path = generateUserPath(filename, mimeType, existingPaths, targetFolder);
+    const path = generateUserPath(filename, mimeType, new Set(this.entries.keys()), targetFolder);
 
-    // Ensure the target folder entry exists in VFS so it appears in the tree
     if (targetFolder && !this.entries.has(targetFolder)) {
-      const folderName = targetFolder.split('/').pop() ?? targetFolder;
-      this.entries.set(targetFolder, { provider: 'folder', filename: folderName });
+      this.entries.set(targetFolder, {
+        provider: 'folder',
+        filename: targetFolder.split('/').pop() ?? targetFolder
+      });
     }
 
-    const entry: VFSEntry = {
-      provider: 'url',
-      url,
-      filename,
-      mimeType
-    };
-
     this.recordMutation(`Add ${filename}`, () => {
-      this.entries.set(path, entry);
+      this.entries.set(path, { provider: 'url', url, filename, mimeType });
       this.notifyChange();
     });
 
     return path;
   }
 
-  /**
-   * Create a folder at the specified path.
-   * @param parentPath - Parent folder path (e.g., 'user://' or 'user://images')
-   * @param folderName - Name of the new folder
-   * @returns The full path of the created folder
-   */
   createFolder(parentPath: string, folderName: string): string {
-    // Normalize parent path (remove trailing slash if present, except for namespace roots)
     const normalizedParent =
       parentPath.endsWith('/') && !parentPath.endsWith('://')
         ? parentPath.slice(0, -1)
         : parentPath;
 
-    // Build the full folder path
     const folderPath = normalizedParent.endsWith('://')
       ? `${normalizedParent}${folderName}`
       : `${normalizedParent}/${folderName}`;
 
-    const entry: VFSEntry = {
-      provider: 'folder',
-      filename: folderName
-    };
-
     this.recordMutation(`Create ${folderName}`, () => {
-      this.entries.set(folderPath, entry);
+      this.entries.set(folderPath, { provider: 'folder', filename: folderName });
       this.notifyChange();
     });
 
     return folderPath;
   }
 
-  /**
-   * Check if a path is a folder.
-   */
   isFolder(path: string): boolean {
-    const entry = this.entries.get(path);
-    return entry?.provider === 'folder' || entry?.provider === 'local-folder';
+    const provider = this.entries.get(path)?.provider;
+
+    return provider === 'folder' || provider === 'local-folder';
   }
 
-  /** Rename a file or folder tree without changing its ownership namespace. */
   renamePath(oldPath: string, newPath: string): void {
-    const oldParsed = parseVFSPath(oldPath);
-    const newParsed = parseVFSPath(newPath);
-    if (!oldParsed || !newParsed || oldParsed.namespace !== newParsed.namespace) {
-      throw new Error('VFS: Files can only be renamed within their namespace');
-    }
-    if (!this.entries.has(oldPath)) throw new Error(`VFS: Path not found: ${oldPath}`);
-    if (this.entries.has(newPath)) throw new Error(`VFS: Path already exists: ${newPath}`);
+    const plan = this.entries.planRename(oldPath, newPath);
 
-    const paths = this.entries.treePaths(oldPath);
-    const renamed = paths.map((path) => {
-      const entry = this.entries.get(path)!;
-      const destination = path === oldPath ? newPath : `${newPath}${path.slice(oldPath.length)}`;
-      const filename = destination.split('/').pop() ?? entry.filename;
+    const persist = (direction: 'forward' | 'backward') =>
+      this.queuePersistedRename(plan.moves, direction);
 
-      return [destination, { ...entry, filename }] as const;
-    });
-
-    const movedPaths = new Set(paths);
-    for (const [destination] of renamed) {
-      if (this.entries.has(destination) && !movedPaths.has(destination)) {
-        throw new Error(`VFS: Path already exists: ${destination}`);
-      }
-    }
-
-    const moves = renamed.map(([newPath, entry], index) => ({
-      oldPath: paths[index],
-      newPath,
-      entry
-    }));
-    const movePersistedEntries = (direction: 'forward' | 'backward') => {
-      const provider = this.getLocalProvider();
-      if (!provider) return;
-
-      this.queuePersistedRename(async () => {
-        for (const move of moves) {
-          const from = direction === 'forward' ? move.oldPath : move.newPath;
-          const to = direction === 'forward' ? move.newPath : move.oldPath;
-
-          if (move.entry.provider === 'local') {
-            await provider.rename(from, to);
-          } else if (move.entry.provider === 'local-folder') {
-            await provider.renameDirHandle(from, to);
-          }
-        }
-      });
-    };
-    const emitPathRenames = (direction: 'forward' | 'backward') => {
-      for (const move of moves) {
-        PatchiesEventBus.getInstance().dispatch({
-          type: 'vfsPathRenamed',
-          oldPath: direction === 'forward' ? move.oldPath : move.newPath,
-          newPath: direction === 'forward' ? move.newPath : move.oldPath
-        });
-      }
-    };
+    const emit = (direction: 'forward' | 'backward') => this.emitPathRenames(plan.moves, direction);
 
     this.recordMutation(
       `Rename ${oldPath.split('/').pop()}`,
       () => {
-        for (const path of paths) this.entries.delete(path);
-        for (const [path, entry] of renamed) this.entries.set(path, entry);
-        movePersistedEntries('forward');
+        this.entries.applyRename(plan);
+        persist('forward');
         this.notifyChange();
-        emitPathRenames('forward');
+        emit('forward');
       },
       {
         redo: () => {
-          movePersistedEntries('forward');
-          emitPathRenames('forward');
+          persist('forward');
+          emit('forward');
         },
         undo: () => {
-          movePersistedEntries('backward');
-          emitPathRenames('backward');
+          persist('backward');
+          emit('backward');
         }
       }
     );
   }
 
-  /** Delete a file or a complete folder tree as one undoable operation. */
   deletePath(path: string): void {
     this.deletePaths([path]);
   }
 
-  /** Delete multiple paths, collapsing descendants into one undoable operation. */
   deletePaths(requestedPaths: Iterable<string>): void {
-    const requested = [...new Set(requestedPaths)];
-    const roots = requested.filter(
-      (path) => !requested.some((other) => other !== path && path.startsWith(`${other}/`))
+    const plan = this.entries.planDelete(requestedPaths);
+    if (plan.paths.length === 0) return;
+
+    const linkedFolderPaths = plan.paths.filter(
+      (path) => this.entries.get(path)?.provider === 'local-folder'
     );
 
-    for (const path of roots) {
-      if (!this.entries.has(path)) throw new Error(`VFS: Path not found: ${path}`);
-    }
-
-    const paths = this.entries
-      .paths()
-      .filter((item) => roots.some((root) => item === root || item.startsWith(`${root}/`)));
-    if (paths.length === 0) return;
-
-    const linkedFolderPaths = paths.filter(
-      (item) => this.entries.get(item)?.provider === 'local-folder'
-    );
     const setLinkedFoldersDeleted = (deleted: boolean) => {
       const provider = this.getLocalProvider();
       if (!provider) return;
 
-      for (const linkedFolderPath of linkedFolderPaths) {
-        const operation = deleted
-          ? provider.hideDirHandle(linkedFolderPath)
-          : provider.restoreDirHandle(linkedFolderPath);
-        void operation.catch((error) =>
-          console.error('VFS: Failed to update deleted folder state', error)
-        );
-      }
+      this.mutationCoordinator.queueEffect('update deleted folder state', async () => {
+        for (const path of linkedFolderPaths) {
+          if (deleted) {
+            await provider.hideDirHandle(path);
+          } else {
+            await provider.restoreDirHandle(path);
+          }
+        }
+      });
     };
 
     this.recordMutation(
-      roots.length === 1 ? `Delete ${roots[0].split('/').pop()}` : `Delete ${roots.length} paths`,
+      plan.roots.length === 1
+        ? `Delete ${plan.roots[0].split('/').pop()}`
+        : `Delete ${plan.roots.length} paths`,
       () => {
-        for (const item of paths) {
-          this.entries.delete(item);
-          this.pendingPermissions.delete(item);
-        }
+        this.entries.removePaths(plan.paths);
+        this.permissions.deleteAll(plan.paths);
         setLinkedFoldersDeleted(true);
         this.notifyChange();
       },
@@ -721,7 +363,6 @@ export class VirtualFilesystem {
     );
   }
 
-  /** Copy a user-owned text file into patch ownership without moving the original. */
   async copyToPatch(
     sourcePath: string,
     targetFolder: string = VFS_PREFIXES.PATCH,
@@ -733,738 +374,187 @@ export class VirtualFilesystem {
     return imported[0] ?? null;
   }
 
-  /** Resolve a User file or folder into a portable, atomic Patch import batch. */
   async preparePatchCopy(sourcePath: string): Promise<PatchImportItem[]> {
-    return this.createPatchImportPlanner().prepareCopy(sourcePath, {
+    return this.patchFiles.prepareCopy(sourcePath, {
       getEntry: (path) => this.getEntryOrLinkedFile(path),
       listChildren: (path) => this.listChildren(path),
       resolve: (path) => this.resolve(path)
     });
   }
 
-  /** Return top-level destination paths that require a collision decision. */
   getPatchImportCollisions(
     files: Iterable<File | PatchImportItem>,
     targetFolder: string = VFS_PREFIXES.PATCH
   ): string[] {
-    return this.createPatchImportPlanner().getCollisions(files, targetFolder);
+    return this.patchFiles.getImportCollisions(files, targetFolder);
   }
 
-  /** Import text files atomically: an invalid file or budget violation imports nothing. */
   async importToPatch(
     files: Iterable<File | PatchImportItem>,
     targetFolder: string = VFS_PREFIXES.PATCH,
     collision: VfsCollisionStrategy = 'keep-both'
   ): Promise<string[]> {
-    const plan = await this.createPatchImportPlanner().plan(files, targetFolder, collision);
-    this.recordMutation(
-      `Import ${plan.importedPaths.length} patch file${plan.importedPaths.length === 1 ? '' : 's'}`,
-      () => {
-        for (const path of plan.removedExistingPaths) this.entries.delete(path);
-        for (const [path, entry] of plan.stagedEntries) {
-          this.entries.set(path, entry);
-          if (isEmbeddedVFSEntry(entry)) {
-            this.emitContentModified(path, entry.revision ?? 1);
-          }
-        }
-        this.notifyChange();
-      }
-    );
-
-    return plan.importedPaths;
+    return this.patchFiles.import(files, targetFolder, collision);
   }
 
-  private createPatchImportPlanner(): PatchImportPlanner {
-    return new PatchImportPlanner(this.entries.snapshot());
-  }
-
-  // ─────────────────────────────────────────────────────────────────
-  // Local Folder Linking (delegates to LocalFilesystemProvider)
-  // ─────────────────────────────────────────────────────────────────
-
-  /**
-   * Link a local folder using a FileSystemDirectoryHandle.
-   * The VFS only stores the folder entry; contents are resolved on-demand by the provider.
-   */
   async linkLocalFolder(handle: FileSystemDirectoryHandle): Promise<string> {
     const folderName = handle.name;
-    const existingPaths = new Set(this.entries.keys());
-
-    // Generate a unique path under user://
     let path = `user://${folderName}`;
     let counter = 1;
-    while (existingPaths.has(path)) {
+
+    while (this.entries.has(path)) {
       path = `user://${folderName}-${counter}`;
-      counter++;
+      counter += 1;
     }
 
-    const entry: VFSEntry = {
-      provider: 'local-folder',
-      filename: folderName
-    };
-
-    this.entries.set(path, entry);
-
-    // Delegate storage to provider
-    const provider = this.getLocalProvider();
-    if (provider) {
-      await provider.storeDirHandle(path, handle);
-    }
-
+    this.entries.set(path, { provider: 'local-folder', filename: folderName });
+    await this.getLocalProvider()?.storeDirHandle(path, handle);
     this.notifyChange();
+
     return path;
   }
 
-  /**
-   * Re-link a local folder that lost its handle (e.g., after sharing a patch).
-   * Updates the existing entry with a new directory handle.
-   */
   async relinkLocalFolder(path: string, handle: FileSystemDirectoryHandle): Promise<void> {
     const entry = this.entries.get(path);
-    if (!entry || entry.provider !== 'local-folder') {
+    if (entry?.provider !== 'local-folder') {
       throw new Error(`VFS: Cannot relink - path is not a linked folder: ${path}`);
     }
 
-    // Update the entry filename in case the new folder has a different name
     entry.filename = handle.name;
-
-    // Store the new handle
-    const provider = this.getLocalProvider();
-    if (provider) {
-      await provider.storeDirHandle(path, handle);
-    }
-
-    // Clear pending permission status
-    this.pendingPermissions.delete(path);
+    await this.getLocalProvider()?.storeDirHandle(path, handle);
+    this.permissions.delete(path);
     this.notifyChange();
   }
 
-  /**
-   * Get the local provider instance (for directory operations).
-   */
-  private getLocalProvider():
-    | import('./providers/LocalFilesystemProvider').LocalFilesystemProvider
-    | undefined {
-    const provider = this.providers.get('local');
-    if (provider && 'storeDirHandle' in provider) {
-      return provider as import('./providers/LocalFilesystemProvider').LocalFilesystemProvider;
-    }
-    return undefined;
-  }
-
-  // ─────────────────────────────────────────────────────────────────
-  // Resolution
-  // ─────────────────────────────────────────────────────────────────
-
-  /**
-   * Resolve a VFS path to actual file content.
-   * Supports paths within linked folders (e.g., user://my-folder/subdir/file.jpg)
-   */
   async resolve(path: string): Promise<File | Blob> {
     const entry = this.entries.get(path);
     if (entry) {
-      if (isEmbeddedVFSEntry(entry)) {
-        const validationError = this.invalidEmbeddedPaths.get(path);
-        if (validationError) throw new Error(validationError);
-      }
+      if (isEmbeddedVFSEntry(entry)) this.patchFiles.assertReadable(path);
 
-      // Direct entry found
       const provider = this.providers.get(entry.provider);
+
       if (!provider) {
         throw new Error(`VFS: No provider registered for type: ${entry.provider}`);
       }
+
       return provider.resolve(entry, path);
     }
 
-    // Entry not found - check if it's a path within a linked folder
-    const linkedFolderPath = this.findLinkedFolderForPath(path);
-    if (linkedFolderPath) {
-      const localProvider = this.getLocalProvider();
-      if (!localProvider) {
-        throw new Error(`VFS: Local provider not available for linked folder resolution`);
-      }
-
-      // Extract relative path within the linked folder
-      const relativePath = path.slice(linkedFolderPath.length + 1).split('/');
-      return localProvider.resolveFileInDir(linkedFolderPath, relativePath);
-    }
+    const linkedFile = await this.directoryReader.resolveLinkedFile(path);
+    if (linkedFile) return linkedFile;
 
     throw new Error(`VFS: Path not found: ${path}`);
   }
 
-  /**
-   * Find the linked folder path that contains a given path.
-   * E.g., for "user://my-folder/sub/file.jpg" returns "user://my-folder" if it's a linked folder.
-   */
-  private findLinkedFolderForPath(path: string): string | null {
-    // Check each potential parent path to find a linked folder
-    const segments = path.split('/');
-
-    // Start from the namespace (e.g., "user://my-folder")
-    for (let i = 3; i < segments.length; i++) {
-      const potentialFolderPath = segments.slice(0, i).join('/');
-      const entry = this.entries.get(potentialFolderPath);
-      if (entry?.provider === 'local-folder') {
-        return potentialFolderPath;
-      }
-    }
-    return null;
-  }
-
-  /**
-   * Check if a path is within a linked folder.
-   */
   isPathInLinkedFolder(path: string): boolean {
-    return this.findLinkedFolderForPath(path) !== null;
+    const linkedFolder = this.directoryReader.findLinkedFolder(path);
+
+    return linkedFolder !== null && linkedFolder !== path;
   }
 
-  /**
-   * Get metadata for a path, including paths within linked folders.
-   * For linked folder files, returns a synthetic entry.
-   */
   getEntryOrLinkedFile(path: string): VFSEntry | undefined {
-    const entry = this.entries.get(path);
-
-    if (entry) {
-      // Fall back to guessing MIME type if not stored (for files added before MIME support)
-      if (!entry.mimeType) {
-        return { ...entry, mimeType: guessMimeType(entry.filename) };
-      }
-
-      return entry;
-    }
-
-    // Check if it's within a linked folder
-    const linkedFolderPath = this.findLinkedFolderForPath(path);
-    if (linkedFolderPath) {
-      const filename = path.split('/').pop() || '';
-      return {
-        provider: 'local',
-        filename,
-        mimeType: guessMimeType(filename)
-      };
-    }
-    return undefined;
+    return this.directoryReader.getEntry(path);
   }
 
-  /**
-   * Get the entry metadata for a path.
-   */
   getEntry(path: string): VFSEntry | undefined {
     return this.entries.get(path);
   }
 
-  /**
-   * Check if a path exists in the VFS.
-   */
   has(path: string): boolean {
     return this.entries.has(path);
   }
 
-  /**
-   * Check if a string is a VFS path.
-   */
   isVFSPath(path: string): boolean {
     return isVFSPath(path);
   }
 
-  // ─────────────────────────────────────────────────────────────────
-  // Listing
-  // ─────────────────────────────────────────────────────────────────
-
-  /**
-   * List all paths, optionally filtered by prefix.
-   */
   list(prefix?: string): string[] {
     return this.entries.paths(prefix);
   }
 
-  /** List the immediate children of a VFS directory, including linked local folders. */
   async listChildren(directory: string): Promise<VFSListEntry[]> {
-    const entry = this.entries.get(directory);
-    const prefix = directory.endsWith('://') ? directory : `${directory}/`;
-    const linkedFolderPath = this.getLinkedFolderForPath(directory);
-    const hasChildren = [...this.entries.keys()].some((path) => path.startsWith(prefix));
-    const isNamespaceRoot =
-      directory === VFS_PREFIXES.PATCH ||
-      directory === VFS_PREFIXES.USER ||
-      directory === VFS_PREFIXES.OBJECT;
-
-    if (entry && entry.provider !== 'folder' && entry.provider !== 'local-folder') {
-      throw new TypeError(`VFS: Path is not a directory: ${directory}`);
-    }
-
-    if (!entry && !linkedFolderPath && !hasChildren && !isNamespaceRoot) {
-      throw new Error(`VFS: Directory not found: ${directory}`);
-    }
-
-    const children = new Map<string, VFSListEntry>();
-
-    for (const path of this.entries.keys()) {
-      if (!path.startsWith(prefix)) continue;
-
-      const child = path.slice(prefix.length).split('/')[0];
-      if (!child) continue;
-
-      const childPath = `${prefix}${child}`;
-      children.set(childPath, this.createListEntry(childPath));
-    }
-
-    if (linkedFolderPath) {
-      const linkedChildren = await this.listLinkedFolderChildren(directory, linkedFolderPath);
-
-      for (const child of linkedChildren) {
-        children.set(child.path, this.createListEntry(child.path, child.kind));
-      }
-    }
-
-    return [...children.values()].sort((a, b) => a.path.localeCompare(b.path));
+    return this.directoryReader.listChildren(directory);
   }
 
-  /** List one bounded page of immediate VFS directory entries. */
   async listChildrenPage(
     directory: string,
     options: { offset?: number; limit?: number } = {}
   ): Promise<VFSListPage> {
-    const offset = Math.max(0, Math.floor(options.offset ?? 0));
-    const limit = Math.max(1, Math.floor(options.limit ?? 50));
-
-    const linkedFolderPath = this.getLinkedFolderForPath(directory);
-
-    if (linkedFolderPath) {
-      const children = await this.listLinkedFolderChildren(directory, linkedFolderPath, {
-        offset,
-        limit: limit + 1
-      });
-
-      const truncated = children.length > limit;
-
-      const entries = children
-        .slice(0, limit)
-        .map((child) => this.createListEntry(child.path, child.kind));
-
-      return {
-        entries,
-        offset,
-        limit,
-        truncated,
-        ...(truncated ? { nextOffset: offset + entries.length } : {})
-      };
-    }
-
-    const children = await this.listChildren(directory);
-
-    const entries = children.slice(offset, offset + limit);
-    const truncated = offset + entries.length < children.length;
-
-    return {
-      entries,
-      offset,
-      limit,
-      truncated,
-      ...(truncated ? { nextOffset: offset + entries.length } : {})
-    };
+    return this.directoryReader.listChildrenPage(directory, options);
   }
 
-  /** Recursively find VFS paths whose path includes the query, case-insensitively. */
   async search(query: string, directory: string): Promise<VFSListEntry[]> {
-    const prefix = directory.endsWith('://') ? directory : `${directory}/`;
-    const normalizedQuery = query.toLowerCase();
-    const matches = new Map<string, VFSListEntry>();
-
-    for (const path of this.list(prefix)) {
-      if (path.toLowerCase().includes(normalizedQuery)) {
-        matches.set(path, this.createListEntry(path));
-      }
-    }
-
-    const containingLinkedFolder = this.getLinkedFolderForPath(directory);
-
-    const linkedFolderPaths = containingLinkedFolder
-      ? [containingLinkedFolder]
-      : [...this.entries]
-          .filter(([path, entry]) => entry.provider === 'local-folder' && path.startsWith(prefix))
-          .map(([path]) => path);
-
-    for (const linkedFolderPath of linkedFolderPaths) {
-      const searchRoot = containingLinkedFolder ? directory : linkedFolderPath;
-
-      for (const entry of await this.searchLinkedFolder(searchRoot, linkedFolderPath)) {
-        if (entry.path.toLowerCase().includes(normalizedQuery)) {
-          matches.set(entry.path, entry);
-        }
-      }
-    }
-
-    return [...matches.values()].sort((a, b) => a.path.localeCompare(b.path));
+    return this.directoryReader.search(query, directory);
   }
 
-  /**
-   * Recursively search VFS paths without materializing more than one result page.
-   * Entries are visited in deterministic directory traversal order.
-   */
   async searchPage(
     query: string,
     directory: string,
     options: { offset?: number; limit?: number } = {}
   ): Promise<VFSSearchPage> {
-    const offset = Math.max(0, Math.floor(options.offset ?? 0));
-    const limit = Math.max(1, Math.floor(options.limit ?? 50));
-
-    const normalizedQuery = query.toLowerCase();
-    const entries: VFSListEntry[] = [];
-
-    let skipped = 0;
-
-    const visit = async (currentDirectory: string): Promise<boolean> => {
-      const children = await this.listChildren(currentDirectory);
-
-      for (const child of children) {
-        if (child.path.toLowerCase().includes(normalizedQuery)) {
-          if (skipped < offset) {
-            skipped++;
-          } else if (entries.length < limit) {
-            entries.push(child);
-          } else {
-            return true;
-          }
-        }
-
-        if (child.kind === 'directory' && (await visit(child.path))) {
-          return true;
-        }
-      }
-
-      return false;
-    };
-
-    const truncated = await visit(directory);
-
-    return {
-      entries,
-      offset,
-      limit,
-      truncated,
-      ...(truncated ? { nextOffset: offset + entries.length } : {})
-    };
+    return this.directoryReader.searchPage(query, directory, options);
   }
 
-  private createListEntry(path: string, kind?: VFSListEntry['kind']): VFSListEntry {
-    const name = path.split('/').filter(Boolean).pop() ?? path;
-
-    return { path, name, kind: kind ?? this.getPathKind(path) };
-  }
-
-  private getPathKind(path: string): VFSListEntry['kind'] {
-    const entry = this.entries.get(path);
-    if (entry && isVFSFolder(entry)) return 'directory';
-
-    return [...this.entries.keys()].some((entryPath) => entryPath.startsWith(`${path}/`))
-      ? 'directory'
-      : 'file';
-  }
-
-  private getLinkedFolderForPath(path: string): string | null {
-    return this.entries.get(path)?.provider === 'local-folder'
-      ? path
-      : this.findLinkedFolderForPath(path);
-  }
-
-  private async listLinkedFolderChildren(
-    directory: string,
-    linkedFolderPath: string,
-    options?: { offset?: number; limit?: number }
-  ): Promise<Array<{ path: string; kind: 'file' | 'directory' }>> {
-    const localProvider = this.getLocalProvider();
-
-    if (!localProvider) {
-      throw new Error('VFS: Local provider not available for linked folder listing');
-    }
-
-    let handle = await localProvider.getDirHandle(linkedFolderPath);
-
-    if (!handle) {
-      throw new Error(`VFS: No directory handle for linked folder: ${linkedFolderPath}`);
-    }
-
-    const hasDirectoryPermission = await localProvider.hasDirPermission(linkedFolderPath);
-
-    if (!hasDirectoryPermission) {
-      throw new Error(`VFS: Permission denied for linked folder: ${linkedFolderPath}`);
-    }
-
-    const relativeSegments =
-      directory === linkedFolderPath ? [] : directory.slice(linkedFolderPath.length + 1).split('/');
-
-    for (const segment of relativeSegments) {
-      handle = await handle.getDirectoryHandle(segment);
-    }
-
-    const entries = await localProvider.listHandleContents(handle, options);
-    const pathPrefix = directory.endsWith('/') ? directory : `${directory}/`;
-
-    return entries.map((entry) => ({ path: `${pathPrefix}${entry.name}`, kind: entry.kind }));
-  }
-
-  private async searchLinkedFolder(
-    directory: string,
-    linkedFolderPath: string
-  ): Promise<VFSListEntry[]> {
-    const matches: VFSListEntry[] = [];
-
-    for (const child of await this.listLinkedFolderChildren(directory, linkedFolderPath)) {
-      matches.push(this.createListEntry(child.path, child.kind));
-
-      if (child.kind === 'directory') {
-        matches.push(...(await this.searchLinkedFolder(child.path, linkedFolderPath)));
-      }
-    }
-
-    return matches;
-  }
-
-  /**
-   * Get all entries as a map.
-   */
   getAllEntries(): Map<string, VFSEntry> {
-    return new Map(this.entries);
+    return this.entries.toMap();
   }
 
-  // ─────────────────────────────────────────────────────────────────
-  // Persistence (Serialize/Hydrate)
-  // ─────────────────────────────────────────────────────────────────
-
-  /**
-   * Serialize the VFS to a tree structure for patch saving.
-   */
   serialize(): VFSTree {
-    const tree: VFSTree = {};
-
-    for (const [path, entry] of this.entries) {
-      const parsed = parseVFSPath(path);
-      if (!parsed) continue;
-
-      match(parsed.namespace)
-        .with('patch', () => {
-          if (!tree.patch) tree.patch = {};
-          this.setNestedEntry(tree.patch, parsed.segments, { ...entry });
-        })
-        .with('user', () => {
-          if (!tree.user) tree.user = {};
-          this.setNestedEntry(tree.user, parsed.segments, { ...entry });
-        })
-        .with('obj', () => {
-          if (!tree.objects) tree.objects = {};
-          // First segment is the node ID
-          const [nodeId, ...rest] = parsed.segments;
-          if (!nodeId) return;
-          if (!tree.objects[nodeId]) tree.objects[nodeId] = {};
-          if (rest.length > 0) {
-            this.setNestedEntry(tree.objects[nodeId], rest, { ...entry });
-          }
-        })
-        .exhaustive();
-    }
-
-    return tree;
+    return this.treeCodec.serialize(this.entries);
   }
 
-  /**
-   * Hydrate the VFS from a saved tree structure.
-   */
   async hydrate(tree: VFSTree): Promise<void> {
-    const hydrated = new Map<string, VFSEntry>();
-    this.collectHydratedNamespace(hydrated, tree.patch, VFS_PREFIXES.PATCH);
-    this.collectHydratedNamespace(hydrated, tree.user, VFS_PREFIXES.USER);
-    if (tree.objects) {
-      for (const [nodeId, nodeTree] of Object.entries(tree.objects)) {
-        this.collectHydratedNamespace(hydrated, nodeTree, `${VFS_PREFIXES.OBJECT}${nodeId}/`);
-      }
-    }
+    const hydrated = this.treeCodec.deserialize(tree, (path, entry) =>
+      this.patchFiles.validateEntry(path, entry, false)
+    );
 
-    this.entries.clear();
-    this.pendingPermissions.clear();
     this.entries.replace(hydrated);
-    this.invalidEmbeddedPaths = this.findInvalidEmbeddedPaths(hydrated);
+    this.patchFiles.refreshValidation();
 
-    // Check which local files need permission
-    for (const [path, entry] of this.entries) {
-      if (entry.provider === 'local') {
-        const provider = this.providers.get('local');
-
-        if (provider && 'needsPermission' in provider) {
-          const needs = await (
-            provider as VFSProvider & { needsPermission: (path: string) => Promise<boolean> }
-          ).needsPermission(path);
-
-          if (needs) {
-            this.pendingPermissions.add(path);
-          }
-        }
-
-        continue;
-      }
-
-      if (entry.provider === 'local-folder') {
-        // Check if linked folder has its handle available
-        const localProvider = this.getLocalProvider();
-
-        if (localProvider) {
-          const handle = await localProvider.getDirHandle(path);
-
-          if (!handle) {
-            // Handle is missing - needs re-link
-            this.pendingPermissions.add(path);
-          } else {
-            // Handle exists, check permission
-            const hasPermission = await localProvider.hasDirPermission(path);
-
-            if (!hasPermission) {
-              this.pendingPermissions.add(path);
-            }
-          }
-        }
-
-        continue;
-      }
-    }
+    await this.permissions.scan(this.entries, this.providers.get('local'), this.getLocalProvider());
 
     this.notifyChange();
   }
 
-  private hydrateNamespace(node: { [key: string]: VFSTreeNode }, prefix: string): void {
-    for (const [key, value] of Object.entries(node)) {
-      if (isVFSEntry(value)) {
-        this.entries.set(`${prefix}${key}`, value);
-      } else {
-        // It's a directory, recurse
-        this.hydrateNamespace(value as { [key: string]: VFSTreeNode }, `${prefix}${key}/`);
-      }
-    }
-  }
-
-  private collectHydratedNamespace(
-    entries: Map<string, VFSEntry>,
-    node: { [key: string]: VFSTreeNode } | undefined,
-    prefix: string
-  ): void {
-    if (!node) return;
-
-    for (const [key, value] of Object.entries(node)) {
-      const path = `${prefix}${key}`;
-      if (isVFSEntry(value)) {
-        const entry = { ...value };
-        this.assertValidEntry(path, entry, false);
-        entries.set(path, entry);
-      } else {
-        this.collectHydratedNamespace(entries, value as { [key: string]: VFSTreeNode }, `${path}/`);
-      }
-    }
-  }
-
-  private setNestedEntry(
-    obj: { [key: string]: VFSTreeNode },
-    segments: string[],
-    entry: VFSEntry
-  ): void {
-    if (segments.length === 0) return;
-
-    if (segments.length === 1) {
-      obj[segments[0]] = entry;
-      return;
-    }
-
-    const [first, ...rest] = segments;
-    if (!obj[first] || isVFSEntry(obj[first])) {
-      obj[first] = {};
-    }
-    this.setNestedEntry(obj[first] as { [key: string]: VFSTreeNode }, rest, entry);
-  }
-
-  // ─────────────────────────────────────────────────────────────────
-  // Permission Management
-  // ─────────────────────────────────────────────────────────────────
-
-  /**
-   * Get paths that need permission re-grant.
-   */
   getPendingPermissions(): string[] {
-    return Array.from(this.pendingPermissions);
+    return this.permissions.getAll();
   }
 
-  /**
-   * Request permission for a single path.
-   */
   async requestPermission(path: string): Promise<boolean> {
-    const entry = this.entries.get(path);
-    if (!entry || entry.provider !== 'local') return false;
-
-    const provider = this.providers.get('local');
-    if (!provider || !('requestPermission' in provider)) return false;
-
-    const granted = await (
-      provider as VFSProvider & { requestPermission: (path: string) => Promise<boolean> }
-    ).requestPermission(path);
-    if (granted) {
-      this.pendingPermissions.delete(path);
-    }
-    return granted;
+    return this.permissions.request(path, this.entries.get(path), this.providers.get('local'));
   }
 
-  /**
-   * Request permission for all pending paths.
-   */
   async requestAllPermissions(): Promise<Map<string, boolean>> {
-    const results = new Map<string, boolean>();
-
-    for (const path of this.pendingPermissions) {
-      const granted = await this.requestPermission(path);
-      results.set(path, granted);
-    }
-
-    return results;
+    return this.permissions.requestAll(
+      (path) => this.entries.get(path),
+      this.providers.get('local')
+    );
   }
 
-  /**
-   * Mark a path as having permission granted.
-   */
   markPermissionGranted(path: string): void {
-    this.pendingPermissions.delete(path);
+    this.permissions.delete(path);
   }
 
-  // ─────────────────────────────────────────────────────────────────
-  // Cleanup
-  // ─────────────────────────────────────────────────────────────────
-
-  /**
-   * Remove a single entry.
-   */
   remove(path: string): void {
     const entry = this.entries.get(path);
-
     this.entries.delete(path);
-    this.pendingPermissions.delete(path);
+    this.permissions.delete(path);
 
-    // Clean up directory handle if it's a local folder
     if (entry?.provider === 'local-folder') {
-      const provider = this.getLocalProvider();
-      provider?.removeDirHandle(path);
+      this.getLocalProvider()?.removeDirHandle(path);
     }
 
     this.notifyChange();
   }
 
-  /**
-   * Clear all entries.
-   */
   clear(): void {
     this.entries.clear();
-    this.pendingPermissions.clear();
-    this.invalidEmbeddedPaths.clear();
+    this.permissions.clear();
+    this.patchFiles.refreshValidation();
 
-    const localProvider = this.getLocalProvider();
-    localProvider?.clear();
-    localProvider?.clearDirHandles();
+    const provider = this.getLocalProvider();
+    provider?.clear();
+    provider?.clearDirHandles();
 
     this.notifyChange();
   }
@@ -1474,31 +564,102 @@ export class VirtualFilesystem {
     clearFileData();
   }
 
-  /**
-   * Load directory handles from storage and create entries for them.
-   * Call this during app initialization.
-   */
   async loadDirHandlesFromStorage(): Promise<void> {
     const provider = this.getLocalProvider();
     if (!provider) return;
 
-    const handles = await provider.loadDirHandlesFromStorage();
-    for (const [path, handle] of handles) {
-      // Create entry if it doesn't exist
-      if (!this.entries.has(path)) {
-        this.entries.set(path, {
-          provider: 'local-folder',
-          filename: handle.name
+    await this.permissions.loadStoredDirectories(this.entries, provider);
+    this.notifyChange();
+  }
+
+  private notifyChange(): void {
+    this.versionStore.update((version) => version + 1);
+  }
+
+  private createMutationSnapshot(): VfsMutationSnapshot {
+    return {
+      entries: this.entries.snapshot(),
+      pendingPermissions: this.permissions.snapshot()
+    };
+  }
+
+  private restoreEntries({ entries, pendingPermissions }: VfsMutationSnapshot): void {
+    const previous = this.entries.snapshot();
+    this.entries.replace(entries);
+    this.permissions.restore(pendingPermissions, this.entries);
+    this.patchFiles.refreshValidation();
+    this.notifyChange();
+
+    for (const [path, entry] of this.entries) {
+      const prior = previous.get(path);
+
+      const hasVfsModified =
+        isEmbeddedVFSEntry(entry) &&
+        (!prior ||
+          !isEmbeddedVFSEntry(prior) ||
+          prior.content !== entry.content ||
+          prior.revision !== entry.revision);
+
+      if (hasVfsModified) {
+        PatchiesEventBus.getInstance().dispatch({
+          type: 'vfsContentModified',
+          path,
+          revision: entry.revision ?? 1
         });
       }
+    }
+  }
 
-      // Check permission status
-      const hasPermission = await provider.hasDirPermission(path);
-      if (!hasPermission) {
-        this.pendingPermissions.add(path);
-      }
+  private recordMutation(
+    description: string,
+    mutate: () => void,
+    callbacks?: { redo?: () => void; undo?: () => void }
+  ): void {
+    this.mutationCoordinator.record(description, mutate, callbacks);
+  }
+
+  private getLocalProvider(): LocalFilesystemProvider | undefined {
+    const provider = this.providers.get('local');
+
+    if (provider && 'storeDirHandle' in provider) {
+      return provider as LocalFilesystemProvider;
     }
 
-    this.notifyChange();
+    return undefined;
+  }
+
+  private queuePersistedRename(moves: VfsRenameMove[], direction: 'forward' | 'backward'): void {
+    const provider = this.getLocalProvider();
+    if (!provider) return;
+
+    this.mutationCoordinator.queueEffect('persist renamed paths', async () => {
+      for (const move of moves) {
+        const from = direction === 'forward' ? move.oldPath : move.newPath;
+        const to = direction === 'forward' ? move.newPath : move.oldPath;
+
+        await match(move.entry.provider)
+          .with('local', async () => {
+            await provider.rename(from, to);
+          })
+          .with('local-folder', async () => {
+            await provider.renameDirHandle(from, to);
+          })
+          .otherwise(() => {});
+      }
+    });
+  }
+
+  private emitPathRenames(moves: VfsRenameMove[], direction: 'forward' | 'backward'): void {
+    for (const move of moves) {
+      PatchiesEventBus.getInstance().dispatch({
+        type: 'vfsPathRenamed',
+        oldPath: direction === 'forward' ? move.oldPath : move.newPath,
+        newPath: direction === 'forward' ? move.newPath : move.oldPath
+      });
+    }
+  }
+
+  private emitContentModified(path: string, revision: number): void {
+    PatchiesEventBus.getInstance().dispatch({ type: 'vfsContentModified', path, revision });
   }
 }

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -35,7 +35,7 @@ import {
 } from './PatchImportPlanner';
 import type { VfsCollisionStrategy } from './PatchImportPlanner';
 import { VfsEntryIndex } from './VfsEntryIndex';
-import { VfsMutationCoordinator } from './VfsMutationCoordinator';
+import { VfsMutationCoordinator, type VfsMutationSnapshot } from './VfsMutationCoordinator';
 import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
 
 export {
@@ -77,12 +77,15 @@ export class VirtualFilesystem {
   private invalidEmbeddedPaths: Map<string, string> = new Map();
 
   private mutationCoordinator = new VfsMutationCoordinator({
-    snapshot: () => this.cloneEntries(),
-    restore: (entries) => this.restoreEntries(entries),
+    snapshot: () => this.createMutationSnapshot(),
+    restore: (snapshot) => this.restoreEntries(snapshot),
     afterMutation: () => {
       this.invalidEmbeddedPaths = this.findInvalidEmbeddedPaths(this.entries);
     }
   });
+
+  /** Serialize persisted rename effects across synchronous history callbacks. */
+  private persistedRenameQueue: Promise<void> = Promise.resolve();
 
   /** Version counter for reactivity - increments on any mutation */
   private versionStore = writable(0);
@@ -107,16 +110,19 @@ export class VirtualFilesystem {
     this.versionStore.update((v) => v + 1);
   }
 
-  private cloneEntries(): Map<string, VFSEntry> {
-    return this.entries.snapshot();
+  private createMutationSnapshot(): VfsMutationSnapshot {
+    return {
+      entries: this.entries.snapshot(),
+      pendingPermissions: new Set(this.pendingPermissions)
+    };
   }
 
-  private restoreEntries(entries: Map<string, VFSEntry>): void {
+  private restoreEntries({ entries, pendingPermissions }: VfsMutationSnapshot): void {
     const previous = this.entries.snapshot();
     this.entries.replace(entries);
     this.invalidEmbeddedPaths = this.findInvalidEmbeddedPaths(this.entries);
     this.pendingPermissions = new Set(
-      [...this.pendingPermissions].filter((path) => this.entries.has(path))
+      [...pendingPermissions].filter((path) => this.entries.has(path))
     );
     this.notifyChange();
 
@@ -140,6 +146,13 @@ export class VirtualFilesystem {
     callbacks?: { redo?: () => void; undo?: () => void }
   ): void {
     this.mutationCoordinator.record(description, mutate, callbacks);
+  }
+
+  private queuePersistedRename(operation: () => Promise<void>): void {
+    const queued = this.persistedRenameQueue.catch(() => {}).then(operation);
+    this.persistedRenameQueue = queued;
+
+    void queued.catch((error) => console.error('VFS: Failed to persist renamed paths', error));
   }
 
   private assertValidEntry(path: string, entry: VFSEntry, enforceEmbeddedLimits = true): void {
@@ -608,16 +621,18 @@ export class VirtualFilesystem {
       const provider = this.getLocalProvider();
       if (!provider) return;
 
-      for (const move of moves) {
-        const from = direction === 'forward' ? move.oldPath : move.newPath;
-        const to = direction === 'forward' ? move.newPath : move.oldPath;
+      this.queuePersistedRename(async () => {
+        for (const move of moves) {
+          const from = direction === 'forward' ? move.oldPath : move.newPath;
+          const to = direction === 'forward' ? move.newPath : move.oldPath;
 
-        if (move.entry.provider === 'local') {
-          void provider.rename(from, to);
-        } else if (move.entry.provider === 'local-folder') {
-          void provider.renameDirHandle(from, to);
+          if (move.entry.provider === 'local') {
+            await provider.rename(from, to);
+          } else if (move.entry.provider === 'local-folder') {
+            await provider.renameDirHandle(from, to);
+          }
         }
-      }
+      });
     };
     const emitPathRenames = (direction: 'forward' | 'backward') => {
       for (const move of moves) {

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -28,59 +28,23 @@ import {
   guessMimeType
 } from './path-utils';
 import { clearFileData, clearHandles } from './persistence';
+import {
+  MAX_EMBEDDED_FILE_BYTES,
+  MAX_EMBEDDED_PATCH_BYTES,
+  PatchImportPlanner
+} from './PatchImportPlanner';
+import type { VfsCollisionStrategy } from './PatchImportPlanner';
+import { VfsEntryIndex } from './VfsEntryIndex';
+import { VfsMutationCoordinator } from './VfsMutationCoordinator';
 import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
-import { HistoryManager, type Command } from '$lib/history';
 
-export const MAX_EMBEDDED_FILE_BYTES = 256 * 1024;
-export const MAX_EMBEDDED_PATCH_BYTES = 1024 * 1024;
-
-export const PATCH_TEXT_FILE_ACCEPT =
-  'text/*,.js,.mjs,.gl,.glsl,.frag,.vert,.glslf,.glslv,.json,.jsonc,.css,.html,.htm,.svg,.xml,.yaml,.yml,.md,.txt,.csv';
-
-const PATCH_TEXT_EXTENSIONS = new Set([
-  '.js',
-  '.mjs',
-  '.gl',
-  '.glsl',
-  '.frag',
-  '.vert',
-  '.glslf',
-  '.glslv',
-  '.json',
-  '.jsonc',
-  '.css',
-  '.html',
-  '.htm',
-  '.svg',
-  '.xml',
-  '.yaml',
-  '.yml',
-  '.md',
-  '.txt',
-  '.csv'
-]);
-
-export type VfsCollisionStrategy = 'replace' | 'keep-both' | 'cancel';
-
-export function getPatchImportError(file: File): string | null {
-  if (file.size > MAX_EMBEDDED_FILE_BYTES) {
-    return `${file.name} exceeds 256 KiB Patch-file limit`;
-  }
-
-  const extension = getExtension(file.name).toLowerCase();
-  const isTextMimeType =
-    file.type.startsWith('text/') ||
-    file.type === 'application/javascript' ||
-    file.type === 'application/json' ||
-    file.type === 'application/xml' ||
-    file.type === 'image/svg+xml';
-
-  if (!isTextMimeType && !PATCH_TEXT_EXTENSIONS.has(extension)) {
-    return `${file.name} is not a supported text file`;
-  }
-
-  return null;
-}
+export {
+  MAX_EMBEDDED_FILE_BYTES,
+  MAX_EMBEDDED_PATCH_BYTES,
+  PATCH_TEXT_FILE_ACCEPT,
+  getPatchImportError
+} from './PatchImportPlanner';
+export type { VfsCollisionStrategy } from './PatchImportPlanner';
 
 declare global {
   interface Window {
@@ -101,7 +65,7 @@ export class VirtualFilesystem {
   private static instance: VirtualFilesystem | null = null;
 
   /** Flat map of path -> entry for quick lookups */
-  private entries: Map<string, VFSEntry> = new Map();
+  private entries = new VfsEntryIndex();
 
   /** Registered providers */
   private providers: Map<string, VFSProvider> = new Map();
@@ -111,6 +75,14 @@ export class VirtualFilesystem {
 
   /** Hydrated embedded files that exceed the patch limits and cannot be executed. */
   private invalidEmbeddedPaths: Map<string, string> = new Map();
+
+  private mutationCoordinator = new VfsMutationCoordinator({
+    snapshot: () => this.cloneEntries(),
+    restore: (entries) => this.restoreEntries(entries),
+    afterMutation: () => {
+      this.invalidEmbeddedPaths = this.findInvalidEmbeddedPaths(this.entries);
+    }
+  });
 
   /** Version counter for reactivity - increments on any mutation */
   private versionStore = writable(0);
@@ -135,13 +107,13 @@ export class VirtualFilesystem {
     this.versionStore.update((v) => v + 1);
   }
 
-  private cloneEntries(entries = this.entries): Map<string, VFSEntry> {
-    return new Map([...entries].map(([path, entry]) => [path, { ...entry }] as [string, VFSEntry]));
+  private cloneEntries(): Map<string, VFSEntry> {
+    return this.entries.snapshot();
   }
 
   private restoreEntries(entries: Map<string, VFSEntry>): void {
-    const previous = this.entries;
-    this.entries = this.cloneEntries(entries);
+    const previous = this.entries.snapshot();
+    this.entries.replace(entries);
     this.invalidEmbeddedPaths = this.findInvalidEmbeddedPaths(this.entries);
     this.pendingPermissions = new Set(
       [...this.pendingPermissions].filter((path) => this.entries.has(path))
@@ -167,25 +139,7 @@ export class VirtualFilesystem {
     mutate: () => void,
     callbacks?: { redo?: () => void; undo?: () => void }
   ): void {
-    const before = this.cloneEntries();
-
-    mutate();
-    this.invalidEmbeddedPaths = this.findInvalidEmbeddedPaths(this.entries);
-
-    const after = this.cloneEntries();
-    const command: Command = {
-      description,
-      execute: () => {
-        this.restoreEntries(after);
-        callbacks?.redo?.();
-      },
-      undo: () => {
-        this.restoreEntries(before);
-        callbacks?.undo?.();
-      }
-    };
-
-    HistoryManager.getInstance().record(command);
+    this.mutationCoordinator.record(description, mutate, callbacks);
   }
 
   private assertValidEntry(path: string, entry: VFSEntry, enforceEmbeddedLimits = true): void {
@@ -211,7 +165,7 @@ export class VirtualFilesystem {
     }
   }
 
-  private findInvalidEmbeddedPaths(entries: Map<string, VFSEntry>): Map<string, string> {
+  private findInvalidEmbeddedPaths(entries: Iterable<[string, VFSEntry]>): Map<string, string> {
     const invalidPaths = new Map<string, string>();
     const encoder = new TextEncoder();
     let totalBytes = 0;
@@ -629,7 +583,7 @@ export class VirtualFilesystem {
     if (!this.entries.has(oldPath)) throw new Error(`VFS: Path not found: ${oldPath}`);
     if (this.entries.has(newPath)) throw new Error(`VFS: Path already exists: ${newPath}`);
 
-    const paths = this.list().filter((path) => path === oldPath || path.startsWith(`${oldPath}/`));
+    const paths = this.entries.treePaths(oldPath);
     const renamed = paths.map((path) => {
       const entry = this.entries.get(path)!;
       const destination = path === oldPath ? newPath : `${newPath}${path.slice(oldPath.length)}`;
@@ -713,9 +667,9 @@ export class VirtualFilesystem {
       if (!this.entries.has(path)) throw new Error(`VFS: Path not found: ${path}`);
     }
 
-    const paths = this.list().filter((item) =>
-      roots.some((root) => item === root || item.startsWith(`${root}/`))
-    );
+    const paths = this.entries
+      .paths()
+      .filter((item) => roots.some((root) => item === root || item.startsWith(`${root}/`)));
     if (paths.length === 0) return;
 
     const linkedFolderPaths = paths.filter(
@@ -766,56 +720,11 @@ export class VirtualFilesystem {
 
   /** Resolve a User file or folder into a portable, atomic Patch import batch. */
   async preparePatchCopy(sourcePath: string): Promise<PatchImportItem[]> {
-    const source = this.getEntryOrLinkedFile(sourcePath);
-    if (!source) throw new Error(`VFS: Path not found: ${sourcePath}`);
-
-    if (!isVFSFolder(source)) {
-      this.assertPatchCopySize(source);
-
-      const blob = await this.resolve(sourcePath);
-      const file =
-        blob instanceof File
-          ? blob
-          : new File([blob], source.filename, { type: source.mimeType ?? blob.type });
-
-      return [{ kind: 'file', file, relativePath: source.filename }];
-    }
-
-    const rootName = source.filename;
-    const items: PatchImportItem[] = [{ kind: 'directory', relativePath: rootName }];
-    const collectChildren = async (directory: string, relativeDirectory: string): Promise<void> => {
-      for (const child of await this.listChildren(directory)) {
-        const relativePath = `${relativeDirectory}/${child.name}`;
-
-        if (child.kind === 'directory') {
-          items.push({ kind: 'directory', relativePath });
-          await collectChildren(child.path, relativePath);
-
-          continue;
-        }
-
-        const entry = this.getEntryOrLinkedFile(child.path);
-        if (!entry) throw new Error(`VFS: File not found: ${child.path}`);
-        this.assertPatchCopySize(entry);
-
-        const blob = await this.resolve(child.path);
-        const file =
-          blob instanceof File
-            ? blob
-            : new File([blob], entry.filename, { type: entry.mimeType ?? blob.type });
-        items.push({ kind: 'file', file, relativePath });
-      }
-    };
-
-    await collectChildren(sourcePath, rootName);
-
-    return items;
-  }
-
-  private assertPatchCopySize(entry: VFSEntry): void {
-    if (entry.size && entry.size > MAX_EMBEDDED_FILE_BYTES) {
-      throw new Error(`VFS: ${entry.filename} exceeds 256 KiB Patch-file limit`);
-    }
+    return this.createPatchImportPlanner().prepareCopy(sourcePath, {
+      getEntry: (path) => this.getEntryOrLinkedFile(path),
+      listChildren: (path) => this.listChildren(path),
+      resolve: (path) => this.resolve(path)
+    });
   }
 
   /** Return top-level destination paths that require a collision decision. */
@@ -823,18 +732,7 @@ export class VirtualFilesystem {
     files: Iterable<File | PatchImportItem>,
     targetFolder: string = VFS_PREFIXES.PATCH
   ): string[] {
-    const items = this.normalizePatchImportItems(files);
-    const collisions = items
-      .map((item) => this.joinVfsPath(targetFolder, item.relativePath))
-      .filter((path) =>
-        [...this.entries.keys()].some(
-          (existing) => existing === path || existing.startsWith(`${path}/`)
-        )
-      );
-
-    return [...new Set(collisions)].filter(
-      (path, _, all) => !all.some((other) => other !== path && path.startsWith(`${other}/`))
-    );
+    return this.createPatchImportPlanner().getCollisions(files, targetFolder);
   }
 
   /** Import text files atomically: an invalid file or budget violation imports nothing. */
@@ -843,123 +741,12 @@ export class VirtualFilesystem {
     targetFolder: string = VFS_PREFIXES.PATCH,
     collision: VfsCollisionStrategy = 'keep-both'
   ): Promise<string[]> {
-    if (!targetFolder.startsWith(VFS_PREFIXES.PATCH)) {
-      throw new Error(`VFS: Patch destination required: ${targetFolder}`);
-    }
-
-    const items = this.normalizePatchImportItems(files);
-    const decodedContent = new Map<PatchImportItem, string>();
-    const errors: string[] = [];
-
-    for (const item of items) {
-      if (item.kind === 'directory') continue;
-
-      const importError = getPatchImportError(item.file);
-      if (importError) {
-        errors.push(importError);
-        continue;
-      }
-
-      try {
-        decodedContent.set(item, await this.decodeUtf8(item.file, item.relativePath));
-      } catch (error) {
-        errors.push(
-          error instanceof Error ? error.message.replace('VFS: ', '') : item.relativePath
-        );
-      }
-    }
-
-    if (errors.length > 0) throw new Error(`VFS: ${errors.join('; ')}`);
-
-    const staged = new Map<string, VFSEntry>();
-    const occupied = new Set(this.entries.keys());
-    const removedExistingPaths = new Set<string>();
-    const resolvedDirectories = new Map<string, string>();
-    let totalBytes = this.getEmbeddedByteLength();
-
-    const removeExistingTree = (path: string) => {
-      for (const [existingPath, entry] of this.entries) {
-        if (existingPath !== path && !existingPath.startsWith(`${path}/`)) continue;
-        if (removedExistingPaths.has(existingPath)) continue;
-
-        removedExistingPaths.add(existingPath);
-        occupied.delete(existingPath);
-        if (isEmbeddedVFSEntry(entry)) {
-          totalBytes -= new TextEncoder().encode(entry.content).byteLength;
-        }
-      }
-    };
-    const removeStagedTree = (path: string) => {
-      for (const [stagedPath, entry] of staged) {
-        if (stagedPath !== path && !stagedPath.startsWith(`${path}/`)) continue;
-
-        staged.delete(stagedPath);
-        occupied.delete(stagedPath);
-        if (isEmbeddedVFSEntry(entry)) {
-          totalBytes -= new TextEncoder().encode(entry.content).byteLength;
-        }
-      }
-    };
-    const resolveParent = (relativePath: string) => {
-      const separator = relativePath.lastIndexOf('/');
-      if (separator === -1) {
-        return targetFolder;
-      }
-
-      const relativeParent = relativePath.slice(0, separator);
-
-      return resolvedDirectories.get(relativeParent);
-    };
-
-    for (const item of items) {
-      const parent = resolveParent(item.relativePath);
-      if (!parent) throw new Error(`VFS: Invalid import path: ${item.relativePath}`);
-
-      const name = getFilename(item.relativePath);
-      const rawPath = this.joinVfsPath(parent, name);
-      const priorEntry = staged.get(rawPath) ?? this.entries.get(rawPath);
-      const path = this.resolveCollision(rawPath, collision, occupied, item.kind === 'directory');
-      if (!path) throw new Error(`VFS: Import cancelled because ${name} already exists`);
-
-      if (collision === 'replace' && path === rawPath) {
-        removeStagedTree(path);
-        removeExistingTree(path);
-      }
-
-      if (item.kind === 'directory') {
-        resolvedDirectories.set(item.relativePath, path);
-        staged.set(path, { provider: 'folder', filename: getFilename(path) });
-        occupied.add(path);
-
-        continue;
-      }
-
-      const content = decodedContent.get(item)!;
-      const size = new TextEncoder().encode(content).byteLength;
-
-      totalBytes += size;
-      if (totalBytes > MAX_EMBEDDED_PATCH_BYTES) {
-        throw new Error('VFS: Embedded patch files exceed 1 MiB');
-      }
-
-      occupied.add(path);
-      const entry: EmbeddedVFSEntry = {
-        provider: 'embedded',
-        filename: getFilename(path),
-        mimeType: item.file.type || guessMimeType(item.file.name) || 'text/plain;charset=utf-8',
-        content,
-        size,
-        revision: priorEntry && isEmbeddedVFSEntry(priorEntry) ? (priorEntry.revision ?? 0) + 1 : 1
-      };
-      staged.set(path, entry);
-    }
-
-    const importedFiles = [...staged].filter(([, entry]) => isEmbeddedVFSEntry(entry));
+    const plan = await this.createPatchImportPlanner().plan(files, targetFolder, collision);
     this.recordMutation(
-      `Import ${importedFiles.length} patch file${importedFiles.length === 1 ? '' : 's'}`,
+      `Import ${plan.importedPaths.length} patch file${plan.importedPaths.length === 1 ? '' : 's'}`,
       () => {
-        for (const path of removedExistingPaths) this.entries.delete(path);
-        for (const [path, entry] of staged) {
+        for (const path of plan.removedExistingPaths) this.entries.delete(path);
+        for (const [path, entry] of plan.stagedEntries) {
           this.entries.set(path, entry);
           if (isEmbeddedVFSEntry(entry)) {
             this.emitContentModified(path, entry.revision ?? 1);
@@ -969,66 +756,11 @@ export class VirtualFilesystem {
       }
     );
 
-    return importedFiles.map(([path]) => path);
+    return plan.importedPaths;
   }
 
-  private normalizePatchImportItems(files: Iterable<File | PatchImportItem>): PatchImportItem[] {
-    const directories = new Set<string>();
-    const fileItems: PatchImportItem[] = [];
-
-    for (const input of files) {
-      const item: PatchImportItem =
-        input instanceof File
-          ? { kind: 'file', file: input, relativePath: this.getImportRelativePath(input) }
-          : { ...input, relativePath: this.normalizeImportRelativePath(input.relativePath) };
-      const segments = item.relativePath.split('/');
-
-      for (let index = 1; index < segments.length; index += 1) {
-        directories.add(segments.slice(0, index).join('/'));
-      }
-
-      if (item.kind === 'directory') {
-        directories.add(item.relativePath);
-      } else {
-        fileItems.push(item);
-      }
-    }
-
-    const directoryItems: PatchImportItem[] = [...directories]
-      .sort((a, b) => a.split('/').length - b.split('/').length || a.localeCompare(b))
-      .map((relativePath) => ({ kind: 'directory', relativePath }));
-
-    return [...directoryItems, ...fileItems];
-  }
-
-  private async decodeUtf8(blob: Blob, path: string): Promise<string> {
-    try {
-      return new TextDecoder('utf-8', { fatal: true }).decode(await blob.arrayBuffer());
-    } catch {
-      throw new Error(`VFS: Only UTF-8 text can be embedded: ${path}`);
-    }
-  }
-
-  private getImportRelativePath(file: File): string {
-    const relativePath = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
-    return this.normalizeImportRelativePath(relativePath || file.name);
-  }
-
-  private normalizeImportRelativePath(relativePath: string): string {
-    const normalized = relativePath.replaceAll('\\', '/');
-    const segments = normalized.split('/').filter(Boolean);
-
-    if (segments.length === 0 || segments.some((segment) => segment === '.' || segment === '..')) {
-      throw new Error(`VFS: Invalid import path: ${normalized}`);
-    }
-
-    return segments.join('/');
-  }
-
-  private joinVfsPath(parent: string, child: string): string {
-    if (parent.endsWith('://') || parent.endsWith('/')) return `${parent}${child}`;
-
-    return `${parent}/${child}`;
+  private createPatchImportPlanner(): PatchImportPlanner {
+    return new PatchImportPlanner(this.entries.snapshot());
   }
 
   // ─────────────────────────────────────────────────────────────────
@@ -1229,9 +961,7 @@ export class VirtualFilesystem {
    * List all paths, optionally filtered by prefix.
    */
   list(prefix?: string): string[] {
-    const paths = Array.from(this.entries.keys());
-    if (!prefix) return paths;
-    return paths.filter((p) => p.startsWith(prefix));
+    return this.entries.paths(prefix);
   }
 
   /** List the immediate children of a VFS directory, including linked local folders. */
@@ -1539,7 +1269,7 @@ export class VirtualFilesystem {
 
     this.entries.clear();
     this.pendingPermissions.clear();
-    this.entries = hydrated;
+    this.entries.replace(hydrated);
     this.invalidEmbeddedPaths = this.findInvalidEmbeddedPaths(hydrated);
 
     // Check which local files need permission

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -548,6 +548,13 @@ export class VirtualFilesystem {
       return [destination, { ...entry, filename }] as const;
     });
 
+    const movedPaths = new Set(paths);
+    for (const [destination] of renamed) {
+      if (this.entries.has(destination) && !movedPaths.has(destination)) {
+        throw new Error(`VFS: Path already exists: ${destination}`);
+      }
+    }
+
     const moves = renamed.map(([newPath, entry], index) => ({
       oldPath: paths[index],
       newPath,
@@ -598,13 +605,38 @@ export class VirtualFilesystem {
     const paths = this.list().filter((item) => item === path || item.startsWith(`${path}/`));
     if (paths.length === 0) throw new Error(`VFS: Path not found: ${path}`);
 
-    this.recordMutation(`Delete ${path.split('/').pop()}`, () => {
-      for (const item of paths) {
-        this.entries.delete(item);
-        this.pendingPermissions.delete(item);
+    const linkedFolderPaths = paths.filter(
+      (item) => this.entries.get(item)?.provider === 'local-folder'
+    );
+    const setLinkedFoldersDeleted = (deleted: boolean) => {
+      const provider = this.getLocalProvider();
+      if (!provider) return;
+
+      for (const linkedFolderPath of linkedFolderPaths) {
+        const operation = deleted
+          ? provider.hideDirHandle(linkedFolderPath)
+          : provider.restoreDirHandle(linkedFolderPath);
+        void operation.catch((error) =>
+          console.error('VFS: Failed to update deleted folder state', error)
+        );
       }
-      this.notifyChange();
-    });
+    };
+
+    this.recordMutation(
+      `Delete ${path.split('/').pop()}`,
+      () => {
+        for (const item of paths) {
+          this.entries.delete(item);
+          this.pendingPermissions.delete(item);
+        }
+        setLinkedFoldersDeleted(true);
+        this.notifyChange();
+      },
+      {
+        redo: () => setLinkedFoldersDeleted(true),
+        undo: () => setLinkedFoldersDeleted(false)
+      }
+    );
   }
 
   /** Copy a user-owned text file into patch ownership without moving the original. */
@@ -657,6 +689,12 @@ export class VirtualFilesystem {
       if (size > MAX_EMBEDDED_FILE_BYTES) {
         throw new Error(`VFS: Embedded file exceeds 256 KiB: ${file.name}`);
       }
+      const stagedEntry = staged.find((item) => item.path === path)?.entry;
+      const existingEntry = stagedEntry ?? this.entries.get(path);
+      if (collision === 'replace' && existingEntry && isEmbeddedVFSEntry(existingEntry)) {
+        totalBytes -= new TextEncoder().encode(existingEntry.content).byteLength;
+      }
+
       totalBytes += size;
       if (totalBytes > MAX_EMBEDDED_PATCH_BYTES) {
         throw new Error('VFS: Embedded patch files exceed 1 MiB');

--- a/ui/src/lib/vfs/drop-import.test.ts
+++ b/ui/src/lib/vfs/drop-import.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { collectDroppedPatchItems } from './drop-import';
+
+const fileEntry = (name: string, content: string): FileSystemFileEntry =>
+  ({
+    name,
+    isFile: true,
+    isDirectory: false,
+    file: (resolve: (file: File) => void) => resolve(new File([content], name))
+  }) as FileSystemFileEntry;
+
+function directoryEntry(name: string, batches: FileSystemEntry[][]): FileSystemDirectoryEntry {
+  return {
+    name,
+    isFile: false,
+    isDirectory: true,
+    createReader: () => ({
+      readEntries: (resolve: (entries: FileSystemEntry[]) => void) => resolve(batches.shift() ?? [])
+    })
+  } as FileSystemDirectoryEntry;
+}
+
+describe('collectDroppedPatchItems', () => {
+  it('collects recursive folders, empty folders, and every directory reader batch', async () => {
+    const empty = directoryEntry('empty', [[]]);
+    const nested = directoryEntry('nested', [[fileEntry('two.js', 'two')], []]);
+    const root = directoryEntry('bundle', [[fileEntry('one.js', 'one')], [empty, nested], []]);
+    const dataTransfer = {
+      items: [{ kind: 'file', webkitGetAsEntry: () => root }],
+      files: []
+    } as unknown as DataTransfer;
+
+    const items = await collectDroppedPatchItems(dataTransfer);
+
+    expect(items.map((item) => `${item.kind}:${item.relativePath}`)).toEqual([
+      'directory:bundle',
+      'file:bundle/one.js',
+      'directory:bundle/empty',
+      'directory:bundle/nested',
+      'file:bundle/nested/two.js'
+    ]);
+  });
+});

--- a/ui/src/lib/vfs/drop-import.ts
+++ b/ui/src/lib/vfs/drop-import.ts
@@ -1,0 +1,68 @@
+import type { PatchImportItem } from './types';
+
+const readFileEntry = (entry: FileSystemFileEntry): Promise<File> =>
+  new Promise((resolve, reject) => entry.file(resolve, reject));
+
+async function readDirectoryEntries(entry: FileSystemDirectoryEntry): Promise<FileSystemEntry[]> {
+  const reader = entry.createReader();
+  const entries: FileSystemEntry[] = [];
+
+  while (true) {
+    const batch = await new Promise<FileSystemEntry[]>((resolve, reject) =>
+      reader.readEntries(resolve, reject)
+    );
+    if (batch.length === 0) return entries;
+
+    entries.push(...batch);
+  }
+}
+
+async function collectEntry(
+  entry: FileSystemEntry,
+  parentPath: string,
+  items: PatchImportItem[]
+): Promise<void> {
+  const relativePath = parentPath ? `${parentPath}/${entry.name}` : entry.name;
+
+  if (entry.isFile) {
+    items.push({
+      kind: 'file',
+      file: await readFileEntry(entry as FileSystemFileEntry),
+      relativePath
+    });
+
+    return;
+  }
+
+  items.push({ kind: 'directory', relativePath });
+
+  const children = await readDirectoryEntries(entry as FileSystemDirectoryEntry);
+  for (const child of children) {
+    await collectEntry(child, relativePath, items);
+  }
+}
+
+/** Collect dropped files and folders before the DataTransfer becomes invalid. */
+export async function collectDroppedPatchItems(
+  dataTransfer: DataTransfer
+): Promise<PatchImportItem[]> {
+  const entries = Array.from(dataTransfer.items)
+    .filter((item) => item.kind === 'file')
+    .map((item) => item.webkitGetAsEntry())
+    .filter((entry): entry is FileSystemEntry => entry !== null);
+
+  if (entries.length === 0) {
+    return Array.from(dataTransfer.files).map((file) => ({
+      kind: 'file' as const,
+      file,
+      relativePath: file.webkitRelativePath || file.name
+    }));
+  }
+
+  const items: PatchImportItem[] = [];
+  for (const entry of entries) {
+    await collectEntry(entry, '', items);
+  }
+
+  return items;
+}

--- a/ui/src/lib/vfs/file-reader.test.ts
+++ b/ui/src/lib/vfs/file-reader.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createVfsFileReader } from './file-reader';
+import { createVfsApi } from './user-api';
+
+describe('VFS file reader', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reads each supported response body representation', async () => {
+    const getUrl = vi.fn(async () => 'blob:file');
+    const fetchFile = vi.fn(async () => new Response('{"answer":42}'));
+
+    vi.stubGlobal('fetch', fetchFile);
+
+    const file = createVfsFileReader('./file.json', getUrl);
+
+    await expect(file.json<{ answer: number }>()).resolves.toEqual({ answer: 42 });
+    await expect(file.text()).resolves.toBe('{"answer":42}');
+    await expect(file.blob()).resolves.toBeInstanceOf(Blob);
+
+    const buffer = await file.arrayBuffer();
+    expect(new TextDecoder().decode(buffer)).toBe('{"answer":42}');
+
+    expect(getUrl).toHaveBeenCalledTimes(4);
+    expect(getUrl).toHaveBeenCalledWith('./file.json');
+    expect(fetchFile).toHaveBeenCalledTimes(4);
+    expect(fetchFile).toHaveBeenCalledWith('blob:file');
+  });
+
+  it('exposes a lazy reader through the main-thread VFS API', async () => {
+    const fetchFile = vi.fn(async () => new Response('main-thread file'));
+
+    vi.stubGlobal('fetch', fetchFile);
+
+    const file = createVfsApi(() => {}).get('https://example.com/file.txt');
+    expect(fetchFile).not.toHaveBeenCalled();
+
+    await expect(file.text()).resolves.toBe('main-thread file');
+    expect(fetchFile).toHaveBeenCalledWith('https://example.com/file.txt');
+  });
+});

--- a/ui/src/lib/vfs/file-reader.ts
+++ b/ui/src/lib/vfs/file-reader.ts
@@ -1,0 +1,20 @@
+export interface VfsFileReader {
+  arrayBuffer(): Promise<ArrayBuffer>;
+  blob(): Promise<Blob>;
+  json<T = unknown>(): Promise<T>;
+  text(): Promise<string>;
+}
+
+export function createVfsFileReader(
+  path: string,
+  getUrl: (path: string) => Promise<string>
+): VfsFileReader {
+  const fetchFile = async () => fetch(await getUrl(path));
+
+  return {
+    arrayBuffer: async () => (await fetchFile()).arrayBuffer(),
+    blob: async () => (await fetchFile()).blob(),
+    json: async <T = unknown>() => (await fetchFile()).json() as Promise<T>,
+    text: async () => (await fetchFile()).text()
+  };
+}

--- a/ui/src/lib/vfs/index.ts
+++ b/ui/src/lib/vfs/index.ts
@@ -1,6 +1,6 @@
 // Virtual Filesystem - main exports
 
-export { VirtualFilesystem } from './VirtualFilesystem';
+export { VirtualFilesystem, type VfsCollisionStrategy } from './VirtualFilesystem';
 export {
   MAX_EMBEDDED_FILE_BYTES,
   MAX_EMBEDDED_PATCH_BYTES,
@@ -14,6 +14,7 @@ export { useVfsMedia, type UseVfsMediaOptions, type UseVfsMediaReturn } from './
 export {
   type VFSEntry,
   type EmbeddedVFSEntry,
+  type PatchImportItem,
   type VFSListEntry,
   type VFSListPage,
   type VFSSearchPage,
@@ -31,6 +32,7 @@ export {
   VFS_FOLDERS,
   VFS_DEFAULT_EXPANDED
 } from './types';
+export { collectDroppedPatchItems } from './drop-import';
 export {
   generateUserPath,
   generateObjectPath,

--- a/ui/src/lib/vfs/index.ts
+++ b/ui/src/lib/vfs/index.ts
@@ -1,12 +1,19 @@
 // Virtual Filesystem - main exports
 
 export { VirtualFilesystem } from './VirtualFilesystem';
+export {
+  MAX_EMBEDDED_FILE_BYTES,
+  MAX_EMBEDDED_PATCH_BYTES,
+  PATCH_TEXT_FILE_ACCEPT,
+  getPatchImportError
+} from './VirtualFilesystem';
 
 // Composables
 export { useVfsMedia, type UseVfsMediaOptions, type UseVfsMediaReturn } from './useVfsMedia.svelte';
 
 export {
   type VFSEntry,
+  type EmbeddedVFSEntry,
   type VFSListEntry,
   type VFSListPage,
   type VFSSearchPage,
@@ -15,6 +22,7 @@ export {
   type VFSProvider,
   type VFSProviderType,
   isVFSEntry,
+  isEmbeddedVFSEntry,
   isVFSPath,
   isVFSFolder,
   isLocalFolder,
@@ -36,6 +44,7 @@ export {
 } from './path-utils';
 export { UrlProvider } from './providers/UrlProvider';
 export { LocalFilesystemProvider } from './providers/LocalFilesystemProvider';
+export { EmbeddedProvider } from './providers/EmbeddedProvider';
 export { createVfs, revokeObjectUrls } from './vfs-url-helper';
 export type { VfsApi } from './user-api';
 
@@ -59,6 +68,7 @@ export {
 import { VirtualFilesystem } from './VirtualFilesystem';
 import { UrlProvider } from './providers/UrlProvider';
 import { LocalFilesystemProvider } from './providers/LocalFilesystemProvider';
+import { EmbeddedProvider } from './providers/EmbeddedProvider';
 
 /**
  * Initialize the VFS with default providers.
@@ -70,6 +80,7 @@ export function initializeVFS(): VirtualFilesystem {
   // Register default providers
   vfs.registerProvider(new UrlProvider());
   vfs.registerProvider(new LocalFilesystemProvider());
+  vfs.registerProvider(new EmbeddedProvider());
 
   return vfs;
 }

--- a/ui/src/lib/vfs/index.ts
+++ b/ui/src/lib/vfs/index.ts
@@ -48,6 +48,7 @@ export { UrlProvider } from './providers/UrlProvider';
 export { LocalFilesystemProvider } from './providers/LocalFilesystemProvider';
 export { EmbeddedProvider } from './providers/EmbeddedProvider';
 export { createVfs, revokeObjectUrls } from './vfs-url-helper';
+export type { VfsFileReader } from './file-reader';
 export type { VfsApi } from './user-api';
 
 // Persistence utilities (for advanced use)

--- a/ui/src/lib/vfs/persistence.ts
+++ b/ui/src/lib/vfs/persistence.ts
@@ -1,6 +1,8 @@
 // IndexedDB persistence for FileSystemHandles
 
 import { openDB, type IDBPDatabase } from 'idb';
+import { get } from 'svelte/store';
+import { currentPatchId } from '../../stores/ui.store';
 
 // Extend FileSystemFileHandle with permission methods (File System Access API)
 // These are available in Chrome/Edge but not in TypeScript's lib.dom.d.ts
@@ -47,6 +49,34 @@ interface VfsDB {
 /** Cached database connection */
 let dbInstance: IDBPDatabase<VfsDB> | null = null;
 
+const scopedKey = (path: string): string => `${get(currentPatchId)}:${path}`;
+
+async function getWithLegacyFallback<T>(store: keyof VfsDB, path: string): Promise<T | undefined> {
+  const db = await getDb();
+  const key = scopedKey(path);
+  const scoped = await db.get(store, key);
+  if (scoped !== undefined) return scoped as T;
+
+  const legacy = await db.get(store, path);
+  if (legacy !== undefined) {
+    await db.put(store, legacy, key);
+  }
+
+  return legacy as T | undefined;
+}
+
+async function clearScoped(store: keyof VfsDB): Promise<void> {
+  const db = await getDb();
+  const prefix = `${get(currentPatchId)}:`;
+  const keys = await db.getAllKeys(store);
+
+  await Promise.all(
+    keys
+      .filter((key) => typeof key === 'string' && key.startsWith(prefix))
+      .map((key) => db.delete(store, key))
+  );
+}
+
 /**
  * Get or create the database connection.
  */
@@ -87,7 +117,7 @@ async function getDb(): Promise<IDBPDatabase<VfsDB>> {
 export async function storeHandle(path: string, handle: FileSystemFileHandle): Promise<void> {
   const db = await getDb();
 
-  await db.put(HANDLES_STORE, handle, path);
+  await db.put(HANDLES_STORE, handle, scopedKey(path));
 }
 
 /**
@@ -96,7 +126,7 @@ export async function storeHandle(path: string, handle: FileSystemFileHandle): P
 export async function getHandle(path: string): Promise<FileSystemFileHandle | undefined> {
   const db = await getDb();
 
-  return db.get(HANDLES_STORE, path);
+  return getWithLegacyFallback<FileSystemFileHandle>(HANDLES_STORE, path);
 }
 
 /**
@@ -105,7 +135,7 @@ export async function getHandle(path: string): Promise<FileSystemFileHandle | un
 export async function removeHandle(path: string): Promise<void> {
   const db = await getDb();
 
-  await db.delete(HANDLES_STORE, path);
+  await db.delete(HANDLES_STORE, scopedKey(path));
 }
 
 /**
@@ -113,13 +143,16 @@ export async function removeHandle(path: string): Promise<void> {
  */
 export async function getAllHandles(): Promise<Map<string, FileSystemFileHandle>> {
   const db = await getDb();
-  const keys = await db.getAllKeys(HANDLES_STORE);
-  const values = await db.getAll(HANDLES_STORE);
+  const prefix = `${get(currentPatchId)}:`;
+  const keys = (await db.getAllKeys(HANDLES_STORE)).filter(
+    (key): key is string => typeof key === 'string' && key.startsWith(prefix)
+  );
 
   const handles = new Map<string, FileSystemFileHandle>();
 
-  for (let i = 0; i < keys.length; i++) {
-    handles.set(keys[i] as string, values[i]);
+  for (const key of keys) {
+    const value = await db.get(HANDLES_STORE, key);
+    if (value) handles.set(key.slice(prefix.length), value);
   }
 
   return handles;
@@ -131,7 +164,7 @@ export async function getAllHandles(): Promise<Map<string, FileSystemFileHandle>
 export async function clearHandles(): Promise<void> {
   const db = await getDb();
 
-  await db.clear(HANDLES_STORE);
+  await clearScoped(HANDLES_STORE);
 }
 
 /**
@@ -181,15 +214,14 @@ export async function storeFileData(path: string, file: File): Promise<void> {
     lastModified: file.lastModified
   };
 
-  await db.put(FILES_STORE, cachedData, path);
+  await db.put(FILES_STORE, cachedData, scopedKey(path));
 }
 
 /**
  * Get file data from IndexedDB.
  */
 export async function getFileData(path: string): Promise<File | undefined> {
-  const db = await getDb();
-  const cached = await db.get(FILES_STORE, path);
+  const cached = await getWithLegacyFallback<CachedFileData>(FILES_STORE, path);
 
   if (cached) {
     return new File([cached.data], cached.name, {
@@ -206,26 +238,21 @@ export async function getFileData(path: string): Promise<File | undefined> {
 export async function removeFileData(path: string): Promise<void> {
   const db = await getDb();
 
-  await db.delete(FILES_STORE, path);
+  await db.delete(FILES_STORE, scopedKey(path));
 }
 
 /**
  * Clear all stored file data.
  */
 export async function clearFileData(): Promise<void> {
-  const db = await getDb();
-
-  await db.clear(FILES_STORE);
+  await clearScoped(FILES_STORE);
 }
 
 /**
  * Check if file data exists for a path.
  */
 export async function hasFileData(path: string): Promise<boolean> {
-  const db = await getDb();
-  const count = await db.count(FILES_STORE, path);
-
-  return count > 0;
+  return (await getFileData(path)) !== undefined;
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -241,7 +268,7 @@ export async function storeDirHandle(
 ): Promise<void> {
   const db = await getDb();
 
-  await db.put(DIR_HANDLES_STORE, handle, path);
+  await db.put(DIR_HANDLES_STORE, handle, scopedKey(path));
 }
 
 /**
@@ -250,7 +277,7 @@ export async function storeDirHandle(
 export async function getDirHandle(path: string): Promise<FileSystemDirectoryHandle | undefined> {
   const db = await getDb();
 
-  return db.get(DIR_HANDLES_STORE, path);
+  return getWithLegacyFallback<FileSystemDirectoryHandle>(DIR_HANDLES_STORE, path);
 }
 
 /**
@@ -259,7 +286,7 @@ export async function getDirHandle(path: string): Promise<FileSystemDirectoryHan
 export async function removeDirHandle(path: string): Promise<void> {
   const db = await getDb();
 
-  await db.delete(DIR_HANDLES_STORE, path);
+  await db.delete(DIR_HANDLES_STORE, scopedKey(path));
 }
 
 /**
@@ -267,13 +294,16 @@ export async function removeDirHandle(path: string): Promise<void> {
  */
 export async function getAllDirHandles(): Promise<Map<string, FileSystemDirectoryHandle>> {
   const db = await getDb();
-  const keys = await db.getAllKeys(DIR_HANDLES_STORE);
-  const values = await db.getAll(DIR_HANDLES_STORE);
+  const prefix = `${get(currentPatchId)}:`;
+  const keys = (await db.getAllKeys(DIR_HANDLES_STORE)).filter(
+    (key): key is string => typeof key === 'string' && key.startsWith(prefix)
+  );
 
   const handles = new Map<string, FileSystemDirectoryHandle>();
 
-  for (let i = 0; i < keys.length; i++) {
-    handles.set(keys[i] as string, values[i]);
+  for (const key of keys) {
+    const value = await db.get(DIR_HANDLES_STORE, key);
+    if (value) handles.set(key.slice(prefix.length), value);
   }
 
   return handles;

--- a/ui/src/lib/vfs/persistence.ts
+++ b/ui/src/lib/vfs/persistence.ts
@@ -16,10 +16,11 @@ interface FileSystemFileHandleWithPermissions extends FileSystemFileHandle {
 }
 
 const DB_NAME = 'patchies-vfs';
-const DB_VERSION = 3;
+const DB_VERSION = 4;
 const HANDLES_STORE = 'handles';
 const FILES_STORE = 'files'; // Fallback store for file data (Firefox, Safari)
 const DIR_HANDLES_STORE = 'dir-handles'; // Store for FileSystemDirectoryHandle
+const DELETED_DIR_HANDLES_STORE = 'deleted-dir-handles';
 
 /**
  * Cached file data for browsers without FileSystemFileHandle support.
@@ -43,6 +44,10 @@ interface VfsDB {
   [DIR_HANDLES_STORE]: {
     key: string;
     value: FileSystemDirectoryHandle;
+  };
+  [DELETED_DIR_HANDLES_STORE]: {
+    key: string;
+    value: true;
   };
 }
 
@@ -97,6 +102,10 @@ async function getDb(): Promise<IDBPDatabase<VfsDB>> {
 
       if (!db.objectStoreNames.contains(DIR_HANDLES_STORE)) {
         db.createObjectStore(DIR_HANDLES_STORE);
+      }
+
+      if (!db.objectStoreNames.contains(DELETED_DIR_HANDLES_STORE)) {
+        db.createObjectStore(DELETED_DIR_HANDLES_STORE);
       }
     },
     blocked() {
@@ -302,11 +311,27 @@ export async function getAllDirHandles(): Promise<Map<string, FileSystemDirector
   const handles = new Map<string, FileSystemDirectoryHandle>();
 
   for (const key of keys) {
+    if (await db.get(DELETED_DIR_HANDLES_STORE, key)) continue;
+
     const value = await db.get(DIR_HANDLES_STORE, key);
     if (value) handles.set(key.slice(prefix.length), value);
   }
 
   return handles;
+}
+
+/** Hide a persisted directory handle while its delete action remains undoable. */
+export async function markDirHandleDeleted(path: string): Promise<void> {
+  const db = await getDb();
+
+  await db.put(DELETED_DIR_HANDLES_STORE, true, scopedKey(path));
+}
+
+/** Restore a directory handle hidden by an undoable delete. */
+export async function restoreDeletedDirHandle(path: string): Promise<void> {
+  const db = await getDb();
+
+  await db.delete(DELETED_DIR_HANDLES_STORE, scopedKey(path));
 }
 
 /**

--- a/ui/src/lib/vfs/providers/EmbeddedProvider.ts
+++ b/ui/src/lib/vfs/providers/EmbeddedProvider.ts
@@ -1,0 +1,16 @@
+import { isEmbeddedVFSEntry, type VFSEntry, type VFSProvider } from '../types';
+
+/** Resolves text embedded in a patch without any external storage dependency. */
+export class EmbeddedProvider implements VFSProvider {
+  readonly type = 'embedded' as const;
+
+  async resolve(entry: VFSEntry, _path: string): Promise<File | Blob> {
+    if (!isEmbeddedVFSEntry(entry)) {
+      throw new Error('EmbeddedProvider: Entry is not embedded');
+    }
+
+    return new File([entry.content], entry.filename, {
+      type: entry.mimeType || 'text/plain;charset=utf-8'
+    });
+  }
+}

--- a/ui/src/lib/vfs/providers/LocalFilesystemProvider.ts
+++ b/ui/src/lib/vfs/providers/LocalFilesystemProvider.ts
@@ -275,6 +275,17 @@ export class LocalFilesystemProvider implements VFSProvider {
     await removeDirHandle(path);
   }
 
+  /** Move a linked directory handle when its VFS path changes. */
+  async renameDirHandle(oldPath: string, newPath: string): Promise<void> {
+    const handle = await this.getDirHandle(oldPath);
+    if (!handle) return;
+
+    this.dirHandleCache.set(newPath, handle);
+    this.dirHandleCache.delete(oldPath);
+    await this.storeDirHandle(newPath, handle);
+    await this.removeDirHandle(oldPath);
+  }
+
   /**
    * Check if a directory handle has permission.
    */

--- a/ui/src/lib/vfs/providers/LocalFilesystemProvider.ts
+++ b/ui/src/lib/vfs/providers/LocalFilesystemProvider.ts
@@ -21,6 +21,11 @@ import {
   requestDirHandlePermission
 } from '../persistence';
 
+export interface LocalFileState {
+  file?: File;
+  handle?: FileSystemFileHandle;
+}
+
 /**
  * Provider that uses the File System Access API for persistent file access.
  *
@@ -38,6 +43,9 @@ export class LocalFilesystemProvider implements VFSProvider {
 
   /** In-memory cache of file data for the current session */
   private fileCache: Map<string, File> = new Map();
+
+  /** Serialize persistence updates so rapid undo/redo cannot reorder stored state. */
+  private fileStateWriteQueues: Map<string, Promise<void>> = new Map();
 
   /** In-memory cache of directory handles for the current session */
   private dirHandleCache: Map<string, FileSystemDirectoryHandle> = new Map();
@@ -118,6 +126,45 @@ export class LocalFilesystemProvider implements VFSProvider {
 
     // Store both handle and file data for maximum compatibility
     await Promise.all([storeHandle(path, handle), storeFileData(path, file)]);
+  }
+
+  /** Capture the browser-local resources needed to restore a file operation. */
+  async captureFileState(path: string): Promise<LocalFileState> {
+    const file = this.fileCache.get(path) ?? (await getFileData(path));
+    const handle = this.handleCache.get(path) ?? (await getHandle(path));
+
+    return { file, handle };
+  }
+
+  /** Replace all browser-local resources for a path with a captured state. */
+  async restoreFileState(path: string, state: LocalFileState): Promise<void> {
+    this.fileCache.delete(path);
+    this.handleCache.delete(path);
+
+    if (state.file) this.fileCache.set(path, state.file);
+    if (state.handle) this.handleCache.set(path, state.handle);
+
+    const previousWrite = this.fileStateWriteQueues.get(path) ?? Promise.resolve();
+    const write = previousWrite
+      .catch(() => {})
+      .then(async () => {
+        await Promise.all([removeHandle(path), removeFileData(path)]);
+
+        const writes: Promise<void>[] = [];
+        if (state.file) writes.push(storeFileData(path, state.file));
+        if (state.handle) writes.push(storeHandle(path, state.handle));
+
+        await Promise.all(writes);
+      });
+    this.fileStateWriteQueues.set(path, write);
+
+    try {
+      await write;
+    } finally {
+      if (this.fileStateWriteQueues.get(path) === write) {
+        this.fileStateWriteQueues.delete(path);
+      }
+    }
   }
 
   /**

--- a/ui/src/lib/vfs/providers/LocalFilesystemProvider.ts
+++ b/ui/src/lib/vfs/providers/LocalFilesystemProvider.ts
@@ -14,6 +14,8 @@ import {
   storeDirHandle,
   getDirHandle,
   removeDirHandle,
+  markDirHandleDeleted,
+  restoreDeletedDirHandle,
   getAllDirHandles,
   hasDirPermission,
   requestDirHandlePermission
@@ -273,6 +275,15 @@ export class LocalFilesystemProvider implements VFSProvider {
   async removeDirHandle(path: string): Promise<void> {
     this.dirHandleCache.delete(path);
     await removeDirHandle(path);
+  }
+
+  async hideDirHandle(path: string): Promise<void> {
+    this.dirHandleCache.delete(path);
+    await markDirHandleDeleted(path);
+  }
+
+  async restoreDirHandle(path: string): Promise<void> {
+    await restoreDeletedDirHandle(path);
   }
 
   /** Move a linked directory handle when its VFS path changes. */

--- a/ui/src/lib/vfs/types.ts
+++ b/ui/src/lib/vfs/types.ts
@@ -1,6 +1,6 @@
 // Virtual Filesystem Types
 
-export type VFSProviderType = 'url' | 'local' | 'folder' | 'local-folder';
+export type VFSProviderType = 'url' | 'local' | 'folder' | 'local-folder' | 'embedded';
 
 /**
  * Entry metadata stored in the VFS tree.
@@ -20,6 +20,19 @@ export interface VFSEntry {
 
   /** File size in bytes. Used for duplicate detection. */
   size?: number;
+
+  /** Monotonic revision for content changes. */
+  revision?: number;
+}
+
+/** Text embedded directly in a patch file. Valid only below patch://. */
+export interface EmbeddedVFSEntry extends Omit<VFSEntry, 'provider'> {
+  provider: 'embedded';
+  content: string;
+}
+
+export function isEmbeddedVFSEntry(entry: VFSEntry): entry is EmbeddedVFSEntry {
+  return entry.provider === 'embedded' && 'content' in entry;
 }
 
 /** A file or directory returned from the user-facing VFS browsing API. */
@@ -85,6 +98,7 @@ export interface VFSProvider {
 export type VFSTreeNode = VFSEntry | { [key: string]: VFSTreeNode };
 
 export interface VFSTree {
+  patch?: { [key: string]: VFSTreeNode };
   user?: { [key: string]: VFSTreeNode };
   objects?: { [nodeId: string]: { [key: string]: VFSTreeNode } };
 }
@@ -100,6 +114,7 @@ export function isVFSEntry(node: VFSTreeNode): node is VFSEntry {
  * VFS path prefixes
  */
 export const VFS_PREFIXES = {
+  PATCH: 'patch://',
   USER: 'user://',
   OBJECT: 'obj://'
 } as const;
@@ -114,13 +129,19 @@ export const VFS_FOLDERS = {
 /**
  * Default set of VFS namespace roots expanded in the file tree on first load
  */
-export const VFS_DEFAULT_EXPANDED = [VFS_PREFIXES.USER, VFS_PREFIXES.OBJECT] as const;
+export const VFS_DEFAULT_EXPANDED = [
+  VFS_PREFIXES.PATCH,
+  VFS_PREFIXES.USER,
+  VFS_PREFIXES.OBJECT
+] as const;
 
 /**
  * Check if a path is a VFS path (has user:// or obj:// prefix)
  */
 export const isVFSPath = (path: string): boolean =>
-  path.startsWith(VFS_PREFIXES.USER) || path.startsWith(VFS_PREFIXES.OBJECT);
+  path.startsWith(VFS_PREFIXES.PATCH) ||
+  path.startsWith(VFS_PREFIXES.USER) ||
+  path.startsWith(VFS_PREFIXES.OBJECT);
 
 /**
  * Parse a VFS path into its components.
@@ -128,7 +149,13 @@ export const isVFSPath = (path: string): boolean =>
  */
 export function parseVFSPath(
   path: string
-): { namespace: 'user' | 'obj'; segments: string[] } | null {
+): { namespace: 'patch' | 'user' | 'obj'; segments: string[] } | null {
+  if (path.startsWith(VFS_PREFIXES.PATCH)) {
+    const rest = path.slice(VFS_PREFIXES.PATCH.length);
+
+    return { namespace: 'patch', segments: rest.split('/').filter(Boolean) };
+  }
+
   if (path.startsWith(VFS_PREFIXES.USER)) {
     const rest = path.slice(VFS_PREFIXES.USER.length);
 

--- a/ui/src/lib/vfs/types.ts
+++ b/ui/src/lib/vfs/types.ts
@@ -31,6 +31,11 @@ export interface EmbeddedVFSEntry extends Omit<VFSEntry, 'provider'> {
   content: string;
 }
 
+/** A file or directory staged for an atomic Patch import. */
+export type PatchImportItem =
+  | { kind: 'file'; file: File; relativePath: string }
+  | { kind: 'directory'; relativePath: string };
+
 export function isEmbeddedVFSEntry(entry: VFSEntry): entry is EmbeddedVFSEntry {
   return (
     entry.provider === 'embedded' &&

--- a/ui/src/lib/vfs/types.ts
+++ b/ui/src/lib/vfs/types.ts
@@ -32,7 +32,11 @@ export interface EmbeddedVFSEntry extends Omit<VFSEntry, 'provider'> {
 }
 
 export function isEmbeddedVFSEntry(entry: VFSEntry): entry is EmbeddedVFSEntry {
-  return entry.provider === 'embedded' && 'content' in entry;
+  return (
+    entry.provider === 'embedded' &&
+    'content' in entry &&
+    typeof (entry as EmbeddedVFSEntry).content === 'string'
+  );
 }
 
 /** A file or directory returned from the user-facing VFS browsing API. */

--- a/ui/src/lib/vfs/types.ts
+++ b/ui/src/lib/vfs/types.ts
@@ -72,16 +72,13 @@ export interface VFSSearchPage {
 /**
  * Check if a VFSEntry is a folder (regular or linked)
  */
-export function isVFSFolder(entry: VFSEntry): boolean {
-  return entry.provider === 'folder' || entry.provider === 'local-folder';
-}
+export const isVFSFolder = (entry: VFSEntry): boolean =>
+  entry.provider === 'folder' || entry.provider === 'local-folder';
 
 /**
  * Check if a VFSEntry is a linked local folder
  */
-export function isLocalFolder(entry: VFSEntry): boolean {
-  return entry.provider === 'local-folder';
-}
+export const isLocalFolder = (entry: VFSEntry): boolean => entry.provider === 'local-folder';
 
 /**
  * Provider interface for resolving VFS entries to actual file content.
@@ -107,17 +104,20 @@ export interface VFSProvider {
 export type VFSTreeNode = VFSEntry | { [key: string]: VFSTreeNode };
 
 export interface VFSTree {
-  patch?: { [key: string]: VFSTreeNode };
-  user?: { [key: string]: VFSTreeNode };
-  objects?: { [nodeId: string]: { [key: string]: VFSTreeNode } };
+  patch?: {
+    [key: string]: VFSTreeNode;
+  };
+
+  user?: {
+    [key: string]: VFSTreeNode;
+  };
 }
 
 /**
  * Check if a tree node is a VFSEntry (leaf) or a directory (branch).
  */
-export function isVFSEntry(node: VFSTreeNode): node is VFSEntry {
-  return typeof node === 'object' && node !== null && 'provider' in node && 'filename' in node;
-}
+export const isVFSEntry = (node: VFSTreeNode): node is VFSEntry =>
+  typeof node === 'object' && node !== null && 'provider' in node && 'filename' in node;
 
 /**
  * VFS path prefixes
@@ -152,8 +152,11 @@ export const isVFSPath = (path: string): boolean =>
   path.startsWith(VFS_PREFIXES.USER) ||
   path.startsWith(VFS_PREFIXES.OBJECT);
 
+const getSegments = (path: string) => path.split('/').filter(Boolean);
+
 /**
  * Parse a VFS path into its components.
+ *
  * Example: 'user://images/photo.jpg' -> { namespace: 'user', segments: ['images', 'photo.jpg'] }
  */
 export function parseVFSPath(
@@ -162,19 +165,19 @@ export function parseVFSPath(
   if (path.startsWith(VFS_PREFIXES.PATCH)) {
     const rest = path.slice(VFS_PREFIXES.PATCH.length);
 
-    return { namespace: 'patch', segments: rest.split('/').filter(Boolean) };
+    return { namespace: 'patch', segments: getSegments(rest) };
   }
 
   if (path.startsWith(VFS_PREFIXES.USER)) {
     const rest = path.slice(VFS_PREFIXES.USER.length);
 
-    return { namespace: 'user', segments: rest.split('/').filter(Boolean) };
+    return { namespace: 'user', segments: getSegments(rest) };
   }
 
   if (path.startsWith(VFS_PREFIXES.OBJECT)) {
     const rest = path.slice(VFS_PREFIXES.OBJECT.length);
 
-    return { namespace: 'obj', segments: rest.split('/').filter(Boolean) };
+    return { namespace: 'obj', segments: getSegments(rest) };
   }
 
   return null;

--- a/ui/src/lib/vfs/user-api-paths.test.ts
+++ b/ui/src/lib/vfs/user-api-paths.test.ts
@@ -99,6 +99,15 @@ describe('VFS user API paths', () => {
     });
   });
 
+  it('does not include paths that only share a directory prefix', () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const entry = { provider: 'url' as const, filename: 'placeholder' };
+    vfs.registerEntry('user://samples/kick.wav', entry);
+    vfs.registerEntry('user://samples-old/snare.wav', entry);
+
+    expect(vfs.list('user://samples')).toEqual(['user://samples/kick.wav']);
+  });
+
   it('lists and searches the contents of linked local folders', async () => {
     const linkedFolder = {
       name: 'samples',

--- a/ui/src/lib/vfs/user-api.ts
+++ b/ui/src/lib/vfs/user-api.ts
@@ -1,8 +1,10 @@
 import { VirtualFilesystem } from './VirtualFilesystem';
+import { createVfsFileReader, type VfsFileReader } from './file-reader';
 import type { VFSListEntry } from './types';
 import { isExternalUrl, normalizeUserVfsPath } from './user-api-paths';
 
 export interface VfsApi {
+  get(path: string): VfsFileReader;
   getUrl(path: string): Promise<string>;
   list(path?: string): Promise<VFSListEntry[]>;
   search(query: string, path?: string): Promise<VFSListEntry[]>;
@@ -10,7 +12,8 @@ export interface VfsApi {
 
 /** Create the VFS API exposed to code that runs on the main thread. */
 export function createVfsApi(trackObjectUrl: (url: string) => void): VfsApi {
-  return {
+  const api: VfsApi = {
+    get: (path) => createVfsFileReader(path, api.getUrl),
     async getUrl(path) {
       if (typeof window === 'undefined' || isExternalUrl(path)) return path;
 
@@ -33,4 +36,6 @@ export function createVfsApi(trackObjectUrl: (url: string) => void): VfsApi {
       return vfs.search(query, normalizeUserVfsPath(path));
     }
   };
+
+  return api;
 }

--- a/ui/src/lib/vfs/vfs-url-helper.ts
+++ b/ui/src/lib/vfs/vfs-url-helper.ts
@@ -34,12 +34,12 @@ export function revokeObjectUrls(nodeId: string): void {
 /**
  * Create the `vfs` object for a specific node.
  *
- * The object provides `getUrl()`, `list()`, and `search()`. URLs created by
- * `getUrl()` are tied to the node lifecycle and revoked on destroy.
+ * The object provides `get()`, `getUrl()`, `list()`, and `search()`. URLs created
+ * while reading or resolving files are tied to the node lifecycle and revoked on destroy.
  *
  * @example
  * const files = await vfs.list('.');
- * const url = await vfs.getUrl(files[0].path);
+ * const contents = await vfs.get(files[0].path).text();
  */
 export const createVfs = (nodeId: string): VfsApi =>
   createVfsApi((url) => trackObjectUrl(nodeId, url));

--- a/ui/src/objects/pixi/PixiDom.svelte
+++ b/ui/src/objects/pixi/PixiDom.svelte
@@ -205,7 +205,7 @@
 
   const setPortCount = createPixiDomSetPortCount({
     getNodeId: () => nodeId,
-    updateNodeData: (id, updates) => updateNodeData(id, updates),
+    updateNodeData: (id, updates) => updateNodeData(id, updates as Record<string, unknown>),
     updateNodeInternals
   });
 

--- a/ui/src/workers/rendering/vfsWorkerUtils.test.ts
+++ b/ui/src/workers/rendering/vfsWorkerUtils.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createWorkerVfs, handleVfsUrlResolved } from './vfsWorkerUtils';
+
+describe('worker VFS API', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reads VFS file contents through the worker URL request', async () => {
+    const postMessage = vi.fn();
+    const fetchFile = vi.fn(async () => new Response('worker file'));
+
+    vi.stubGlobal('self', { postMessage });
+    vi.stubGlobal('fetch', fetchFile);
+
+    const textPromise = createWorkerVfs('node-1').get('./file.txt').text();
+    const request = postMessage.mock.calls[0][0];
+
+    handleVfsUrlResolved({
+      requestId: request.requestId,
+      nodeId: 'node-1',
+      url: 'blob:worker-file'
+    });
+
+    await expect(textPromise).resolves.toBe('worker file');
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'resolveVfsUrl',
+      requestId: request.requestId,
+      nodeId: 'node-1',
+      path: './file.txt'
+    });
+    expect(fetchFile).toHaveBeenCalledWith('blob:worker-file');
+  });
+});

--- a/ui/src/workers/rendering/vfsWorkerUtils.ts
+++ b/ui/src/workers/rendering/vfsWorkerUtils.ts
@@ -5,9 +5,11 @@
  * The main thread resolves the path using VirtualFilesystem, creates an object URL,
  * and sends back the URL string. Workers can use it directly (same origin).
  */
+import { createVfsFileReader, type VfsFileReader } from '$lib/vfs/file-reader';
 import type { VFSListEntry } from '$lib/vfs/types';
 
 export interface WorkerVfs {
+  get(path: string): VfsFileReader;
   getUrl(path: string): Promise<string>;
   list(path?: string): Promise<VFSListEntry[]>;
   search(query: string, path?: string): Promise<VFSListEntry[]>;
@@ -97,9 +99,12 @@ export function createWorkerVfs(nodeId: string): WorkerVfs {
     });
   };
 
-  return {
+  const api: WorkerVfs = {
+    get: (path) => createVfsFileReader(path, api.getUrl),
     getUrl: (path) => request<string>('resolveVfsUrl', { path }),
     list: (path = '.') => request<VFSListEntry[]>('listVfs', { path }),
     search: (query, path = '.') => request<VFSListEntry[]>('searchVfs', { query, path })
   };
+
+  return api;
 }

--- a/ui/static/content/topics/js-integrations.md
+++ b/ui/static/content/topics/js-integrations.md
@@ -7,6 +7,8 @@ Load images, videos, fonts, and other files from the patch virtual filesystem:
 ```javascript
 const url = await vfs.getUrl("./my-image.png");
 const img = loadImage(url); // works in p5, for example
+
+const config = await vfs.get("./config.json").json();
 ```
 
 List one folder level or search recursively:

--- a/ui/static/content/topics/virtual-filesystem.md
+++ b/ui/static/content/topics/virtual-filesystem.md
@@ -26,8 +26,7 @@ async function setup() {
 }
 
 // In js or canvas.dom:
-const url = await vfs.getUrl("user://data.json");
-const data = await fetch(url).then(r => r.json());
+const data = await vfs.get("user://data.json").json();
 ```
 
 VFS paths use the `user://` prefix for uploaded files. Patchies clears object URLs when it destroys the object.
@@ -48,17 +47,20 @@ Both methods also browse linked local folders after you grant Patchies permissio
 
 ## Getting File Content
 
-Get the underlying Blob or raw data:
+Read a file in the format you need:
 
 ```javascript
+// Parse JSON
+const data = await vfs.get("user://data.json").json();
+
 // Get as Blob
-const blob = await fetch(await vfs.getUrl("user://image.png")).then(r => r.blob());
+const blob = await vfs.get("user://image.png").blob();
 
 // Get as ArrayBuffer (for binary data)
-const buffer = await fetch(await vfs.getUrl("user://audio.wav")).then(r => r.arrayBuffer());
+const buffer = await vfs.get("user://audio.wav").arrayBuffer();
 
 // Get as text
-const text = await fetch(await vfs.getUrl("user://data.csv")).then(r => r.text());
+const text = await vfs.get("user://data.csv").text();
 ```
 
 ## Supported Objects


### PR DESCRIPTION
Adds the `patch://` namespace to the VFS tree. `patch://` is a storage namespace that persists directly to the saved patch's JSON file.

It's only appropriate for smaller files. We prevent using it for files that are larger than 256K in size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `patch://` workspace for embedded patch files.
  * Import, upload, copy, rename, delete, and export patch files with collision handling.
  * Added “Save to Disk…” for patch files.
  * Added undo/redo support for file changes.
  * Added validation and size limits for embedded files.

* **Improvements**
  * Patch files now persist correctly when saving and loading.
  * File storage is isolated between patches.
  * File tree controls adapt to the selected namespace.
  * Added revision tracking for file content changes.
  * Added folder drop support and collision choices for replacing or keeping both items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->