### PR TITLE
feat(vfs, glsl): edit and include patch GLSL files

### DIFF
--- a/docs/design-docs/specs/52-virtual-filesystem.md
+++ b/docs/design-docs/specs/52-virtual-filesystem.md
@@ -1,6 +1,6 @@
 # 52. Virtual Filesystem
 
-> Status: Implemented (original VFS); `patch://` extension planned
+> Status: Implemented through Stage 2; Patch JavaScript modules planned for Stage 3
 
 I wanted the ability to persist, browse and resolve files in a virtual file system.
 
@@ -517,6 +517,8 @@ Verification:
 Release criterion: Patch files are portable and manageable through the Files tree without requiring the editor or a runtime import consumer.
 
 ### Stage 2: Patch GLSL Editing and Imports
+
+Status: Implemented.
 
 Users can create, edit, and import GLSL utilities from `patch://`. JavaScript Patch files remain visible and portable but read-only until Stage 3.
 

--- a/docs/design-docs/specs/52-virtual-filesystem.md
+++ b/docs/design-docs/specs/52-virtual-filesystem.md
@@ -532,6 +532,7 @@ Scope:
 - resolve relative, explicit Patch, and explicit User GLSL includes;
 - infer only the `.glsl` extension;
 - invalidate affected caches and direct and transitive shader consumers after saved revisions;
+- report missing includes in the consumer's virtual console and highlight the originating `#include` line;
 - retain the last working visual output when saved source fails.
 
 Verification:
@@ -541,6 +542,7 @@ Verification:
 3. Saved changes refresh direct and transitive consumers exactly once.
 4. Unsaved drafts do not invalidate consumers.
 5. Invalid saved source reports an error and preserves the previous visual output.
+6. A missing VFS include appears in the consumer's virtual console and highlights the originating `#include` line.
 
 Release criterion: GLSL Patch-file authoring works end to end without depending on JavaScript module support.
 

--- a/docs/design-docs/specs/52-virtual-filesystem.md
+++ b/docs/design-docs/specs/52-virtual-filesystem.md
@@ -526,7 +526,7 @@ Scope:
 
 - transform the Files panel into a CodeMirror editor for supported GLSL files;
 - support New File for GLSL files in Patch folders;
-- implement drafts, dirty state, explicit Save, and the shared navigation guard;
+- implement drafts, dirty state, equivalent button / shortcut / Vim `:w` saves, and the shared navigation guard;
 - provide the same GLSL assistance as the `glsl` object;
 - save inline value-widget edits and refresh shader consumers immediately;
 - add Edit actions to normal rows, search results, and the mobile toolbar;
@@ -538,7 +538,7 @@ Scope:
 
 Verification:
 
-1. Editor tests cover entry points, draft isolation, `Cmd/Ctrl+S`, Save / Discard / Cancel, and global history while open.
+1. Editor tests cover entry points, draft isolation, `Cmd/Ctrl+S`, `Shift+Enter`, Vim `:w`, Save / Discard / Cancel, and global history while open.
 2. Resolver tests cover relative, explicit, inferred-extension, circular, and namespace-escape cases.
 3. Saved changes refresh direct and transitive consumers exactly once.
 4. Unsaved drafts do not invalidate consumers.

--- a/docs/design-docs/specs/52-virtual-filesystem.md
+++ b/docs/design-docs/specs/52-virtual-filesystem.md
@@ -528,6 +528,7 @@ Scope:
 - support New File for GLSL files in Patch folders;
 - implement drafts, dirty state, explicit Save, and the shared navigation guard;
 - provide the same GLSL assistance as the `glsl` object;
+- save inline value-widget edits and refresh shader consumers immediately;
 - add Edit actions to normal rows, search results, and the mobile toolbar;
 - resolve relative, explicit Patch, and explicit User GLSL includes;
 - infer only the `.glsl` extension;
@@ -543,6 +544,7 @@ Verification:
 4. Unsaved drafts do not invalidate consumers.
 5. Invalid saved source reports an error and preserves the previous visual output.
 6. A missing VFS include appears in the consumer's virtual console and highlights the originating `#include` line.
+7. Inline value-widget edits save the Patch file and refresh its shader consumers.
 
 Release criterion: GLSL Patch-file authoring works end to end without depending on JavaScript module support.
 

--- a/ui/src/lib/canvas/GLSystem.test.ts
+++ b/ui/src/lib/canvas/GLSystem.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';
 
 vi.mock('$workers/rendering/renderWorkerEntry?worker', () => ({
@@ -23,8 +23,15 @@ vi.mock('./IpcSystem', () => ({
 import { GLSystem } from './GLSystem';
 import { VideoChannelRegistry } from './VideoChannelRegistry';
 import { previewVisibleMap } from '../../stores/renderer.store';
+import { VirtualFilesystem } from '$lib/vfs';
+import { HistoryManager } from '$lib/history';
 
 describe('GLSystem', () => {
+  beforeEach(() => {
+    VirtualFilesystem.resetInstance();
+    HistoryManager.getInstance().clear();
+  });
+
   it('sends connected video output node ids with render graph updates', () => {
     const glSystem = new GLSystem();
     const worker = glSystem.renderWorker as unknown as { postMessage: ReturnType<typeof vi.fn> };
@@ -111,5 +118,55 @@ describe('GLSystem', () => {
     glSystem.removeNode(nodeId);
 
     expect(get(previewVisibleMap)).not.toHaveProperty(nodeId);
+  });
+
+  it('refreshes direct and transitive GLSL consumers exactly once for same-length saves', () => {
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.createEmbeddedFile(
+      'patch://shaders/material.glsl',
+      '#include "./math.glsl"\nfloat material() { return tone; }'
+    );
+    vfs.createEmbeddedFile('patch://shaders/math.glsl', 'float tone = 1.0;');
+
+    const glSystem = new GLSystem();
+    const worker = glSystem.renderWorker as unknown as { postMessage: ReturnType<typeof vi.fn> };
+
+    glSystem.upsertNode('glsl-transitive', 'glsl', {
+      code: '#include "./shaders/material.glsl"',
+      glUniformDefs: []
+    });
+    glSystem.upsertNode('glsl-direct', 'glsl', {
+      code: '#include "patch://shaders/math.glsl"',
+      glUniformDefs: []
+    });
+    glSystem.upsertNode('glsl-unrelated', 'glsl', {
+      code: 'void mainImage() {}',
+      glUniformDefs: []
+    });
+    worker.postMessage.mockClear();
+
+    vfs.writeEmbeddedFile('patch://shaders/math.glsl', 'float tone = 2.0;');
+
+    const rebuilds = worker.postMessage.mock.calls
+      .map(([message]) => message)
+      .filter((message) => message.type === 'buildRenderGraph');
+
+    expect(rebuilds).toHaveLength(1);
+    expect(rebuilds[0].graph.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'glsl-transitive',
+          data: expect.objectContaining({ _includeRevision: 1 })
+        }),
+        expect.objectContaining({
+          id: 'glsl-direct',
+          data: expect.objectContaining({ _includeRevision: 1 })
+        }),
+        expect.objectContaining({
+          id: 'glsl-unrelated',
+          data: expect.not.objectContaining({ _includeRevision: 1 })
+        })
+      ])
+    );
   });
 });

--- a/ui/src/lib/canvas/GLSystem.test.ts
+++ b/ui/src/lib/canvas/GLSystem.test.ts
@@ -125,6 +125,8 @@ describe('GLSystem', () => {
   it('routes shader line errors to the node virtual console', async () => {
     const nodeId = `glsl-${crypto.randomUUID()}`;
     const eventBus = PatchiesEventBus.getInstance();
+    const glSystem = new GLSystem();
+
     const consoleOutput = new Promise<ConsoleOutputEvent>((resolve) => {
       const handleConsoleOutput = (event: ConsoleOutputEvent) => {
         if (event.nodeId !== nodeId) return;
@@ -135,7 +137,7 @@ describe('GLSystem', () => {
 
       eventBus.addEventListener('consoleOutput', handleConsoleOutput);
     });
-    const glSystem = new GLSystem();
+
     const reason = 'VFS: Path not found: patch://missing.glsl';
     const message = `Include error on line 2: ${reason}`;
 
@@ -158,11 +160,12 @@ describe('GLSystem', () => {
 
   it('refreshes direct and transitive GLSL consumers exactly once for same-length saves', () => {
     const vfs = VirtualFilesystem.getInstance();
+    vfs.createEmbeddedFile('patch://shaders/math.glsl', 'float tone = 1.0;');
+
     vfs.createEmbeddedFile(
       'patch://shaders/material.glsl',
       '#include "./math.glsl"\nfloat material() { return tone; }'
     );
-    vfs.createEmbeddedFile('patch://shaders/math.glsl', 'float tone = 1.0;');
 
     const glSystem = new GLSystem();
     const worker = glSystem.renderWorker as unknown as { postMessage: ReturnType<typeof vi.fn> };
@@ -171,14 +174,17 @@ describe('GLSystem', () => {
       code: '#include "./shaders/material.glsl"',
       glUniformDefs: []
     });
+
     glSystem.upsertNode('glsl-direct', 'glsl', {
       code: '#include "patch://shaders/math.glsl"',
       glUniformDefs: []
     });
+
     glSystem.upsertNode('glsl-unrelated', 'glsl', {
       code: 'void mainImage() {}',
       glUniformDefs: []
     });
+
     worker.postMessage.mockClear();
 
     vfs.writeEmbeddedFile('patch://shaders/math.glsl', 'float tone = 2.0;');
@@ -188,6 +194,7 @@ describe('GLSystem', () => {
       .filter((message) => message.type === 'buildRenderGraph');
 
     expect(rebuilds).toHaveLength(1);
+
     expect(rebuilds[0].graph.nodes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/ui/src/lib/canvas/GLSystem.test.ts
+++ b/ui/src/lib/canvas/GLSystem.test.ts
@@ -25,6 +25,8 @@ import { VideoChannelRegistry } from './VideoChannelRegistry';
 import { previewVisibleMap } from '../../stores/renderer.store';
 import { VirtualFilesystem } from '$lib/vfs';
 import { HistoryManager } from '$lib/history';
+import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+import type { ConsoleOutputEvent } from '$lib/eventbus/events';
 
 describe('GLSystem', () => {
   beforeEach(() => {
@@ -118,6 +120,40 @@ describe('GLSystem', () => {
     glSystem.removeNode(nodeId);
 
     expect(get(previewVisibleMap)).not.toHaveProperty(nodeId);
+  });
+
+  it('routes shader line errors to the node virtual console', async () => {
+    const nodeId = `glsl-${crypto.randomUUID()}`;
+    const eventBus = PatchiesEventBus.getInstance();
+    const consoleOutput = new Promise<ConsoleOutputEvent>((resolve) => {
+      const handleConsoleOutput = (event: ConsoleOutputEvent) => {
+        if (event.nodeId !== nodeId) return;
+
+        eventBus.removeEventListener('consoleOutput', handleConsoleOutput);
+        resolve(event);
+      };
+
+      eventBus.addEventListener('consoleOutput', handleConsoleOutput);
+    });
+    const glSystem = new GLSystem();
+    const reason = 'VFS: Path not found: patch://missing.glsl';
+    const message = `Include error on line 2: ${reason}`;
+
+    glSystem.handleRenderWorkerMessage({
+      data: {
+        type: 'shaderError',
+        nodeId,
+        error: message,
+        lineErrors: { 2: [reason] }
+      }
+    } as MessageEvent);
+
+    await expect(consoleOutput).resolves.toMatchObject({
+      nodeId,
+      messageType: 'error',
+      args: ['Shader compilation failed:', message],
+      lineErrors: { 2: [reason] }
+    });
   });
 
   it('refreshes direct and transitive GLSL consumers exactly once for same-length saves', () => {

--- a/ui/src/lib/canvas/GLSystem.ts
+++ b/ui/src/lib/canvas/GLSystem.ts
@@ -32,6 +32,9 @@ import {
   outputTarget
 } from '../../stores/canvas.store';
 import { currentPatchId } from '../../stores/ui.store';
+import { GlslDependencyIndex } from '$lib/glsl-include/dependency-index';
+import { clearBrowserVfsIncludeCache } from '$lib/glsl-include/browser-resolver';
+import { isEmbeddedVFSEntry } from '$lib/vfs/types';
 import { renderFpsCap, showCookStats } from '../../stores/renderer.store';
 import { IpcSystem } from './IpcSystem';
 import { isExternalTextureNode } from './node-types';
@@ -171,19 +174,9 @@ export class GLSystem {
   >();
 
   /** Node types whose shaders may contain #include directives */
-  private static SHADER_NODE_TYPES = new Set(['glsl', 'swgl', 'regl', 'three']);
+  private static SHADER_NODE_TYPES = new Set(['glsl', 'swgl', 'regl', 'three', 'hydra']);
 
-  /** File extensions that could be #included in shaders */
-  private static SHADER_EXTENSIONS = new Set([
-    '.gl',
-    '.glsl',
-    '.frag',
-    '.vert',
-    '.glslf',
-    '.glslv',
-    '.hlsl',
-    '.wgsl'
-  ]);
+  private glslDependencies = new GlslDependencyIndex();
 
   public outputSize = DEFAULT_OUTPUT_SIZE;
   public hasExplicitOutputSize = false;
@@ -238,34 +231,12 @@ export class GLSystem {
       this.syncOutputEnabled();
     });
 
-    // Invalidate shader nodes when VFS shader files are added, removed, or modified
-    let lastShaderEntryHash = '';
+    this.eventBus.addEventListener('vfsContentModified', ({ path }) => {
+      this.invalidateShaderIncludes([path]);
+    });
 
-    VirtualFilesystem.getInstance().entries$.subscribe((entries) => {
-      // Build a fingerprint of only shader-relevant VFS entries, including content metadata
-      const shaderPaths: string[] = [];
-
-      for (const [path, entry] of entries.entries()) {
-        const ext = path.slice(path.lastIndexOf('.'));
-
-        if (GLSystem.SHADER_EXTENSIONS.has(ext)) {
-          // Include content-sensitive metadata (size) so changes to file contents trigger invalidation
-          const size = entry.size ?? '';
-
-          shaderPaths.push(`${path}\0${size}`);
-        }
-      }
-
-      const hash = shaderPaths.sort().join('\0');
-      if (hash === lastShaderEntryHash) return;
-
-      const isInitial = lastShaderEntryHash === '';
-      lastShaderEntryHash = hash;
-
-      // Skip the initial subscription — no change to react to yet
-      if (isInitial) return;
-
-      this.invalidateShaderIncludes();
+    this.eventBus.addEventListener('vfsPathRenamed', ({ oldPath, newPath }) => {
+      this.invalidateShaderIncludes([oldPath, newPath]);
     });
 
     // Listen for video frame requests from WorkerNodeSystem
@@ -928,12 +899,33 @@ export class GLSystem {
    * Bump _includeRevision on all shader nodes so their fingerprint changes,
    * forcing the render worker to recompile shaders with fresh #include content.
    */
-  private invalidateShaderIncludes() {
+  private invalidateShaderIncludes(paths: string[]) {
+    const vfs = VirtualFilesystem.getInstance();
+    const consumers = this.nodes
+      .filter((node) => GLSystem.SHADER_NODE_TYPES.has(node.type))
+      .map((node) => ({ id: node.id, code: String(node.data.code ?? '') }));
+
+    this.glslDependencies.rebuild(consumers, (path) => {
+      const entry = vfs.getEntry(path);
+
+      return entry && isEmbeddedVFSEntry(entry) ? entry.content : undefined;
+    });
+
+    const affectedNodeIds = new Set<string>();
+
+    for (const path of paths) {
+      clearBrowserVfsIncludeCache(path);
+
+      for (const nodeId of this.glslDependencies.getConsumers(path)) {
+        affectedNodeIds.add(nodeId);
+      }
+    }
+
     let dirty = false;
 
     for (let i = 0; i < this.nodes.length; i++) {
       const node = this.nodes[i];
-      if (!GLSystem.SHADER_NODE_TYPES.has(node.type)) continue;
+      if (!affectedNodeIds.has(node.id)) continue;
 
       const rev = ((node.data._includeRevision as number) ?? 0) + 1;
       this.nodes[i] = { ...node, data: { ...node.data, _includeRevision: rev } };

--- a/ui/src/lib/codemirror/glsl-completions.test.ts
+++ b/ui/src/lib/codemirror/glsl-completions.test.ts
@@ -119,7 +119,19 @@ describe('glsl completions', () => {
 
   it('suggests include snippets from preprocessor context', () => {
     expect(getGlslCompletionLabels('#inc')).toContain('#include <lygia/...>');
-    expect(getGlslCompletionLabels('#inc')).toContain('#include "..."');
+    expect(getGlslCompletionLabels('#inc')).toContain('#include "patch://..."');
+    expect(getGlslCompletionLabels('#inc')).toContain('#include "user://..."');
+    expect(getGlslCompletionLabels('#inc')).not.toContain('#include "..."');
+
+    expect(getGlslCompletion('#inc', '#include "patch://..."')).toMatchObject({
+      detail: 'include embedded Patch GLSL',
+      info: 'Import a GLSL file that is embedded in the current patch.'
+    });
+
+    expect(getGlslCompletion('#inc', '#include "user://..."')).toMatchObject({
+      detail: 'include external User GLSL',
+      info: 'Import GLSL from an uploaded, browser-local, or linked User file.'
+    });
   });
 
   it('suggests documented GLSL directive variants', () => {

--- a/ui/src/lib/codemirror/glsl-completions.ts
+++ b/ui/src/lib/codemirror/glsl-completions.ts
@@ -186,11 +186,17 @@ const includeCompletions: Completion[] = [
     detail: 'include Lygia shader library code',
     info: 'Import a GLSL helper from Lygia.'
   }),
-  snippetCompletion('#include "${path}"', {
-    label: '#include "..."',
+  snippetCompletion('#include "patch://${path}"', {
+    label: '#include "patch://..."',
     type: 'keyword',
-    detail: 'include VFS or URL shader code',
-    info: 'Import GLSL from the patch VFS, npm-style path, or URL.'
+    detail: 'include embedded Patch GLSL',
+    info: 'Import a GLSL file that is embedded in the current patch.'
+  }),
+  snippetCompletion('#include "user://${path}"', {
+    label: '#include "user://..."',
+    type: 'keyword',
+    detail: 'include external User GLSL',
+    info: 'Import GLSL from an uploaded, browser-local, or linked User file.'
   })
 ];
 

--- a/ui/src/lib/codemirror/vim-write-command.test.ts
+++ b/ui/src/lib/codemirror/vim-write-command.test.ts
@@ -5,15 +5,19 @@ import { VimWriteCommandDispatcher } from './vim-write-command';
 describe('VimWriteCommandDispatcher', () => {
   it('routes :w to the editor that invoked it when multiple editors exist', () => {
     const dispatcher = new VimWriteCommandDispatcher<object>();
+
     const firstSave = vi.fn();
     const secondSave = vi.fn();
+
     const firstEditor = {};
     const secondEditor = {};
+
     let writeCommand: ((view: object) => void) | undefined;
 
     dispatcher.register((command) => {
       writeCommand = command;
     });
+
     dispatcher.setHandler(firstEditor, firstSave);
     dispatcher.setHandler(secondEditor, secondSave);
 
@@ -26,17 +30,22 @@ describe('VimWriteCommandDispatcher', () => {
 
   it('registers the global :w command once and removes destroyed editors', () => {
     const dispatcher = new VimWriteCommandDispatcher<object>();
+
     const registerFirst = vi.fn();
     const registerSecond = vi.fn();
+
     const save = vi.fn();
     const editor = {};
+
     let writeCommand: ((view: object) => void) | undefined;
 
     dispatcher.register((command) => {
       writeCommand = command;
       registerFirst();
     });
+
     dispatcher.register(registerSecond);
+
     const removeHandler = dispatcher.setHandler(editor, save);
 
     removeHandler();

--- a/ui/src/lib/codemirror/vim-write-command.test.ts
+++ b/ui/src/lib/codemirror/vim-write-command.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { VimWriteCommandDispatcher } from './vim-write-command';
+
+describe('VimWriteCommandDispatcher', () => {
+  it('routes :w to the editor that invoked it when multiple editors exist', () => {
+    const dispatcher = new VimWriteCommandDispatcher<object>();
+    const firstSave = vi.fn();
+    const secondSave = vi.fn();
+    const firstEditor = {};
+    const secondEditor = {};
+    let writeCommand: ((view: object) => void) | undefined;
+
+    dispatcher.register((command) => {
+      writeCommand = command;
+    });
+    dispatcher.setHandler(firstEditor, firstSave);
+    dispatcher.setHandler(secondEditor, secondSave);
+
+    writeCommand?.(firstEditor);
+    writeCommand?.(secondEditor);
+
+    expect(firstSave).toHaveBeenCalledOnce();
+    expect(secondSave).toHaveBeenCalledOnce();
+  });
+
+  it('registers the global :w command once and removes destroyed editors', () => {
+    const dispatcher = new VimWriteCommandDispatcher<object>();
+    const registerFirst = vi.fn();
+    const registerSecond = vi.fn();
+    const save = vi.fn();
+    const editor = {};
+    let writeCommand: ((view: object) => void) | undefined;
+
+    dispatcher.register((command) => {
+      writeCommand = command;
+      registerFirst();
+    });
+    dispatcher.register(registerSecond);
+    const removeHandler = dispatcher.setHandler(editor, save);
+
+    removeHandler();
+    writeCommand?.(editor);
+
+    expect(registerFirst).toHaveBeenCalledOnce();
+    expect(registerSecond).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/codemirror/vim-write-command.ts
+++ b/ui/src/lib/codemirror/vim-write-command.ts
@@ -11,6 +11,7 @@ export class VimWriteCommandDispatcher<TView extends object> {
     if (this.registered) return;
 
     registerCommand((view) => this.handlers.get(view)?.());
+
     this.registered = true;
   }
 
@@ -18,7 +19,9 @@ export class VimWriteCommandDispatcher<TView extends object> {
     this.handlers.set(view, handler);
 
     return () => {
-      if (this.handlers.get(view) === handler) this.handlers.delete(view);
+      if (this.handlers.get(view) === handler) {
+        this.handlers.delete(view);
+      }
     };
   }
 }

--- a/ui/src/lib/codemirror/vim-write-command.ts
+++ b/ui/src/lib/codemirror/vim-write-command.ts
@@ -1,0 +1,26 @@
+import type { EditorView } from '@codemirror/view';
+
+type RegisterWriteCommand<TView> = (dispatchWrite: (view: TView) => void) => void;
+
+/** Routes Vim's global :w command to the CodeEditor instance that invoked it. */
+export class VimWriteCommandDispatcher<TView extends object> {
+  private handlers = new WeakMap<TView, () => void>();
+  private registered = false;
+
+  register(registerCommand: RegisterWriteCommand<TView>): void {
+    if (this.registered) return;
+
+    registerCommand((view) => this.handlers.get(view)?.());
+    this.registered = true;
+  }
+
+  setHandler(view: TView, handler: () => void): () => void {
+    this.handlers.set(view, handler);
+
+    return () => {
+      if (this.handlers.get(view) === handler) this.handlers.delete(view);
+    };
+  }
+}
+
+export const vimWriteCommandDispatcher = new VimWriteCommandDispatcher<EditorView>();

--- a/ui/src/lib/components/CodeEditor.svelte
+++ b/ui/src/lib/components/CodeEditor.svelte
@@ -41,6 +41,7 @@
     setInlineDecorationsEffect,
     type InlineDecoration
   } from '$lib/codemirror/inline-decorations';
+  import { vimWriteCommandDispatcher } from '$lib/codemirror/vim-write-command';
 
   // Effect to set error lines (supports multiple lines)
   const setErrorLinesEffect = StateEffect.define<number[] | null>();
@@ -190,6 +191,7 @@
   let lastValueWidgetRunAt = 0;
   let pendingValueWidgetRunCode: string | undefined;
   let languageRequestVersion = 0;
+  let removeVimWriteHandler: (() => void) | null = null;
 
   function runValueWidgetCode(code: string | undefined) {
     onrun(code);
@@ -552,15 +554,15 @@
         ...extraExtensions
       ];
 
-      if ($useVimInEditor) {
+      const vimEnabled = $useVimInEditor;
+
+      if (vimEnabled) {
         const { vim, Vim } = await import('@replit/codemirror-vim');
 
-        Vim.defineEx('write', 'w', () => {
-          if (onsave) {
-            onsave();
-          } else {
-            onrun(editorView?.state.doc.toString());
-          }
+        vimWriteCommandDispatcher.register((dispatchWrite) => {
+          Vim.defineEx('write', 'w', (cm) => {
+            dispatchWrite(cm.cm6);
+          });
         });
 
         extensions.push(drawSelection());
@@ -581,6 +583,20 @@
         state,
         parent: editorElement
       });
+
+      if (vimEnabled) {
+        const view = editorView;
+
+        removeVimWriteHandler = vimWriteCommandDispatcher.setHandler(view, () => {
+          if (onsave) {
+            onsave();
+
+            return;
+          }
+
+          onrun(view.state.doc.toString());
+        });
+      }
 
       onready?.();
     }
@@ -609,6 +625,8 @@
     if (valueWidgetRunTimeout) {
       clearTimeout(valueWidgetRunTimeout);
     }
+
+    removeVimWriteHandler?.();
 
     if (editorView) {
       editorView.destroy();

--- a/ui/src/lib/components/CodeEditor.svelte
+++ b/ui/src/lib/components/CodeEditor.svelte
@@ -132,6 +132,7 @@
     placeholder = '',
     class: className = '',
     onrun = () => {},
+    onsave,
     onchange = () => {},
     oncommit,
     nodeId,
@@ -152,6 +153,7 @@
     placeholder?: string;
     class?: string;
     onrun?: (code?: string) => void;
+    onsave?: () => void;
     onchange?: (code: string) => void;
 
     /** Called on blur if value changed since focus. For undo/redo tracking. */
@@ -290,9 +292,24 @@
         Prec.highest(
           keymap.of([
             {
+              key: 'Mod-s',
+              run: () => {
+                if (!onsave) return false;
+
+                onsave();
+
+                return true;
+              }
+            },
+            {
               key: 'Shift-Enter',
               run: () => {
-                onrun(editorView?.state.doc.toString());
+                if (onsave) {
+                  onsave();
+                } else {
+                  onrun(editorView?.state.doc.toString());
+                }
+
                 return true;
               }
             },
@@ -537,7 +554,15 @@
 
       if ($useVimInEditor) {
         const { vim, Vim } = await import('@replit/codemirror-vim');
-        Vim.defineEx('write', 'w', () => onrun(editorView?.state.doc.toString()));
+
+        Vim.defineEx('write', 'w', () => {
+          if (onsave) {
+            onsave();
+          } else {
+            onrun(editorView?.state.doc.toString());
+          }
+        });
+
         extensions.push(drawSelection());
         extensions.push(vim({ status: false }));
       }

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -1274,10 +1274,13 @@
         pendingSharedPatchUrl = null;
         pendingReadOnlyMode = false;
         urlLoadError = result.error ?? 'Unknown error occurred';
+
         return;
       }
     } else if (pendingSharedPatch) {
-      if (!(await patchManager.loadSharedPatch(pendingSharedPatch))) return;
+      const patchLoaded = await patchManager.loadSharedPatch(pendingSharedPatch);
+
+      if (!patchLoaded) return;
     }
 
     pendingSharedPatch = null;

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -601,15 +601,18 @@
   // Keyboard shortcuts delegated to KeyboardShortcutManager (created in onMount)
 
   async function toggleSidebar() {
-    if (!(await canNavigateAwayFromPatchFile())) return;
+    const canNavigate = await canNavigateAwayFromPatchFile();
+    if (!canNavigate) return;
 
     $isSidebarOpen = !$isSidebarOpen;
   }
 
   function triggerCommandPalette() {
     const dialogWidth = 320; // w-80
+
     const currentSidebarWidth = $isSidebarOpen && !$isMobile ? $sidebarWidth : 0;
     const availableWidth = window.innerWidth - currentSidebarWidth;
+
     const centerX = (availableWidth - dialogWidth) / 2;
     const centerY = window.innerHeight / 2 - 200;
 
@@ -876,7 +879,9 @@
       undo: () => historyManager.undo(),
       redo: () => historyManager.redo(),
       toggleSidebar: () => {
-        if (!$isFullscreenActive) void toggleSidebar();
+        if (!$isFullscreenActive) {
+          toggleSidebar();
+        }
       },
       openObjectBrowser: openObjectBrowser,
       openSettings: () => ($isSettingsOpen = true),
@@ -1251,7 +1256,8 @@
   }
 
   async function confirmNewPatch() {
-    if (!(await patchManager.createNewPatch())) return;
+    const ok = await patchManager.createNewPatch();
+    if (!ok) return;
 
     showNewPatchDialog = false;
   }

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -1256,6 +1256,8 @@
       const result = await patchManager.loadSharedPatchFromUrl(pendingSharedPatchUrl);
 
       if (!result.success) {
+        if (result.cancelled) return;
+
         pendingSharedPatchUrl = null;
         pendingReadOnlyMode = false;
         urlLoadError = result.error ?? 'Unknown error occurred';

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -121,6 +121,7 @@
   import { isFullscreenActive } from '$lib/canvas/SurfaceOverlay';
   import { PREVIEW_ZOOM_LOD_TIERS } from '$workers/rendering/constants';
   import { initializeVFS } from '$lib/vfs';
+  import { canNavigateAwayFromPatchFile } from '$lib/vfs/file-editor-navigation';
 
   import {
     HistoryManager,
@@ -599,6 +600,12 @@
 
   // Keyboard shortcuts delegated to KeyboardShortcutManager (created in onMount)
 
+  async function toggleSidebar() {
+    if (!(await canNavigateAwayFromPatchFile())) return;
+
+    $isSidebarOpen = !$isSidebarOpen;
+  }
+
   function triggerCommandPalette() {
     const dialogWidth = 320; // w-80
     const currentSidebarWidth = $isSidebarOpen && !$isMobile ? $sidebarWidth : 0;
@@ -869,7 +876,7 @@
       undo: () => historyManager.undo(),
       redo: () => historyManager.redo(),
       toggleSidebar: () => {
-        if (!$isFullscreenActive) $isSidebarOpen = !$isSidebarOpen;
+        if (!$isFullscreenActive) void toggleSidebar();
       },
       openObjectBrowser: openObjectBrowser,
       openSettings: () => ($isSettingsOpen = true),
@@ -1672,7 +1679,7 @@
             showMissingApiKeyDialog = true;
           }}
           onNewPatch={newPatch}
-          onToggleSidebar={() => ($isSidebarOpen = !$isSidebarOpen)}
+          onToggleSidebar={toggleSidebar}
           onSaveAsPreset={(node) => {
             nodeToSaveAsPreset = node;
             showSavePresetDialog = true;
@@ -1726,9 +1733,7 @@
         onCommandPalette={triggerCommandPalette}
         onNewPatch={newPatch}
         onLoadPatch={loadDemoPatch}
-        onToggleLeftSidebar={() => {
-          $isSidebarOpen = !$isSidebarOpen;
-        }}
+        onToggleLeftSidebar={toggleSidebar}
         onSaveSelectedAsPreset={() => {
           if (selectedNodeIds.length === 1) {
             const node = nodes.find((n) => n.id === selectedNodeIds[0]);

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -1243,8 +1243,9 @@
     showNewPatchDialog = true;
   }
 
-  function confirmNewPatch() {
-    patchManager.createNewPatch();
+  async function confirmNewPatch() {
+    if (!(await patchManager.createNewPatch())) return;
+
     showNewPatchDialog = false;
   }
 
@@ -1261,7 +1262,7 @@
         return;
       }
     } else if (pendingSharedPatch) {
-      await patchManager.loadSharedPatch(pendingSharedPatch);
+      if (!(await patchManager.loadSharedPatch(pendingSharedPatch))) return;
     }
 
     pendingSharedPatch = null;

--- a/ui/src/lib/components/sidebar/FileTreeView.svelte
+++ b/ui/src/lib/components/sidebar/FileTreeView.svelte
@@ -189,8 +189,16 @@
       refreshEditor();
     }
 
-    await action?.();
-    resolve?.(true);
+    let completed = false;
+
+    try {
+      await action?.();
+      completed = true;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message.replace('VFS: ', '') : 'Action failed');
+    } finally {
+      resolve?.(completed);
+    }
   }
 
   async function openEditor(path: string) {
@@ -1124,11 +1132,17 @@
   }
 
   async function handleDeleteFromContextMenu(path: string) {
-    await requestEditorNavigation(() => {
+    const deletePath = () => {
       vfs.deletePath(path);
       if (editorSession.path === path) editorSession.close();
       refreshEditor();
-    });
+    };
+
+    if (editorSession.path === path) {
+      await requestEditorNavigation(deletePath);
+    } else {
+      deletePath();
+    }
 
     selectedPaths.clear();
     lastSelectedPath = null;

--- a/ui/src/lib/components/sidebar/FileTreeView.svelte
+++ b/ui/src/lib/components/sidebar/FileTreeView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
   import { isDismissKey } from '$lib/keyboard/dismiss';
   import {
     ChevronRight,
@@ -52,6 +53,14 @@
   import { isMobile, isSidebarOpen } from '../../../stores/ui.store';
   import FolderPickerDialog, { type FolderNode } from './FolderPickerDialog.svelte';
   import VfsCollisionDialog from './VfsCollisionDialog.svelte';
+  import PatchFileEditorView from './PatchFileEditorView.svelte';
+  import UnsavedPatchFileDialog from './UnsavedPatchFileDialog.svelte';
+  import {
+    PatchFileEditorSession,
+    type UnsavedChangesDecision
+  } from '$lib/vfs/PatchFileEditorSession';
+  import { registerUnsavedChangesGuard } from '$lib/vfs/file-editor-navigation';
+  import { isEditablePatchGlslPath } from '$lib/glsl-include/vfs-paths';
   import {
     getExpandedChildDirectories,
     getExpandedLinkedFolderPathsToLoad,
@@ -69,6 +78,7 @@
 
   const vfs = VirtualFilesystem.getInstance();
   const eventBus = PatchiesEventBus.getInstance();
+  const editorSession = new PatchFileEditorSession(vfs);
 
   // Reactive store of VFS entries
   const vfsEntries = vfs.entries$;
@@ -100,6 +110,167 @@
   let collisionDialogOpen = $state(false);
   let collisionPaths = $state<string[]>([]);
   let collisionResolver: ((strategy: VfsCollisionStrategy) => void) | null = null;
+  let editorVersion = $state(0);
+  let unsavedDialogOpen = $state(false);
+  let unsavedResolver: ((allowed: boolean) => void) | null = null;
+  let pendingNavigation: (() => void | Promise<void>) | null = null;
+
+  const editorPath = $derived.by(() => {
+    void editorVersion;
+
+    return editorSession.path;
+  });
+
+  const editorDraft = $derived.by(() => {
+    void editorVersion;
+
+    return editorSession.draft;
+  });
+
+  const editorDirty = $derived.by(() => {
+    void editorVersion;
+
+    return editorSession.isDirty;
+  });
+
+  const refreshEditor = () => {
+    editorVersion += 1;
+  };
+
+  function saveEditor(): boolean {
+    try {
+      const saved = editorSession.save();
+      refreshEditor();
+
+      return saved;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message.replace('VFS: ', '') : 'Save failed');
+
+      return false;
+    }
+  }
+
+  function requestEditorNavigation(action: () => void | Promise<void>): Promise<boolean> {
+    if (!editorSession.isDirty) {
+      void action();
+
+      return Promise.resolve(true);
+    }
+
+    if (unsavedResolver) return Promise.resolve(false);
+
+    pendingNavigation = action;
+    unsavedDialogOpen = true;
+
+    return new Promise((resolve) => {
+      unsavedResolver = resolve;
+    });
+  }
+
+  async function handleUnsavedChoice(decision: UnsavedChangesDecision) {
+    const resolve = unsavedResolver;
+    const action = pendingNavigation;
+    unsavedResolver = null;
+    pendingNavigation = null;
+    unsavedDialogOpen = false;
+
+    if (decision === 'cancel') {
+      resolve?.(false);
+      return;
+    }
+
+    if (decision === 'save' && !saveEditor()) {
+      resolve?.(false);
+      return;
+    }
+
+    if (decision === 'discard') {
+      editorSession.discard();
+      refreshEditor();
+    }
+
+    await action?.();
+    resolve?.(true);
+  }
+
+  async function openEditor(path: string) {
+    if (!isEditablePatchGlslPath(path)) return;
+
+    await requestEditorNavigation(() => {
+      editorSession.open(path);
+      refreshEditor();
+    });
+  }
+
+  function closeEditor() {
+    void requestEditorNavigation(() => {
+      editorSession.close();
+      refreshEditor();
+    });
+  }
+
+  function handleEditorContentModified(path: string, revision: number) {
+    if (editorSession.path !== path || editorSession.revision === revision) return;
+
+    queueMicrotask(() => {
+      const result = editorSession.syncSavedContent();
+
+      if (result === 'conflict') {
+        void requestEditorNavigation(() => {
+          editorSession.discard();
+          const synced = editorSession.syncSavedContent();
+          if (synced === 'deleted') editorSession.close();
+
+          refreshEditor();
+        });
+      } else if (result === 'deleted') {
+        editorSession.close();
+      }
+
+      refreshEditor();
+    });
+  }
+
+  function handleEditorPathRenamed(oldPath: string, newPath: string) {
+    editorSession.rename(oldPath, newPath);
+    refreshEditor();
+
+    if (editorSession.isDirty) {
+      void requestEditorNavigation(() => refreshEditor());
+    }
+  }
+
+  let unregisterNavigationGuard: (() => void) | null = null;
+
+  onMount(() => {
+    unregisterNavigationGuard = registerUnsavedChangesGuard(() =>
+      requestEditorNavigation(() => editorSession.close())
+    );
+
+    const contentListener = (event: { path: string; revision: number }) =>
+      handleEditorContentModified(event.path, event.revision);
+    const renameListener = (event: { oldPath: string; newPath: string }) =>
+      handleEditorPathRenamed(event.oldPath, event.newPath);
+
+    eventBus.addEventListener('vfsContentModified', contentListener);
+    eventBus.addEventListener('vfsPathRenamed', renameListener);
+
+    return () => {
+      eventBus.removeEventListener('vfsContentModified', contentListener);
+      eventBus.removeEventListener('vfsPathRenamed', renameListener);
+    };
+  });
+
+  onDestroy(() => {
+    unregisterNavigationGuard?.();
+  });
+
+  function handleBeforeUnload(event: BeforeUnloadEvent) {
+    if (!editorSession.isDirty) return;
+
+    event.preventDefault();
+    event.returnValue = '';
+  }
 
   function handleCollisionChoice(strategy: VfsCollisionStrategy) {
     const resolve = collisionResolver;
@@ -797,12 +968,53 @@
   // Create folder state
   let showFolderInput = $state<string | null>(null);
   let folderInputValue = $state('');
+  let showFileInput = $state<string | null>(null);
+  let fileInputValue = $state('');
 
   function handleCreateFolderClick(folderPath: string, event: MouseEvent) {
     event.stopPropagation();
 
     showFolderInput = folderPath;
     folderInputValue = '';
+  }
+
+  function handleCreateFileClick(folderPath: string, event: MouseEvent) {
+    event.stopPropagation();
+
+    showFileInput = folderPath;
+    fileInputValue = '';
+  }
+
+  function handleFileNameSubmit(event: KeyboardEvent) {
+    if (event.key === 'Enter' && fileInputValue.trim() && showFileInput) {
+      event.preventDefault();
+
+      const parent = showFileInput.endsWith('/') ? showFileInput : `${showFileInput}/`;
+      const path = `${parent}${fileInputValue.trim()}`;
+
+      if (!isEditablePatchGlslPath(path)) {
+        toast.error('New Patch files must use a supported GLSL extension');
+        return;
+      }
+
+      try {
+        const createdPath = vfs.createEmbeddedFile(path);
+        if (!createdPath) {
+          toast.error('A file already exists at that path');
+          return;
+        }
+
+        expandedPaths.add(showFileInput);
+        showFileInput = null;
+        fileInputValue = '';
+        void openEditor(createdPath);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message.replace('VFS: ', '') : 'Create failed');
+      }
+    } else if (isDismissKey(event)) {
+      showFileInput = null;
+      fileInputValue = '';
+    }
   }
 
   function handleFolderInputSubmit(event: KeyboardEvent) {
@@ -833,8 +1045,13 @@
   let renameInputValue = $state('');
 
   function handleRenameClick(path: string, currentName: string) {
-    renamingPath = path;
-    renameInputValue = currentName;
+    void requestEditorNavigation(() => {
+      if (editorSession.path === path) editorSession.close();
+
+      renamingPath = path;
+      renameInputValue = currentName;
+      refreshEditor();
+    });
   }
 
   async function handleRenameSubmit(event: KeyboardEvent) {
@@ -907,7 +1124,11 @@
   }
 
   async function handleDeleteFromContextMenu(path: string) {
-    vfs.deletePath(path);
+    await requestEditorNavigation(() => {
+      vfs.deletePath(path);
+      if (editorSession.path === path) editorSession.close();
+      refreshEditor();
+    });
 
     selectedPaths.clear();
     lastSelectedPath = null;
@@ -1268,6 +1489,8 @@
             style="padding-left: {paddingLeft}px"
             draggable={isDraggable ? 'true' : 'false'}
             ondragstart={(e) => isDraggable && handleDragStart(e, node)}
+            ondblclick={() =>
+              node.path && isEditablePatchGlslPath(node.path) && openEditor(node.path)}
             onclick={async (e) => {
               if (isRenaming) return;
 
@@ -1358,6 +1581,21 @@
                 </Tooltip.Trigger>
                 <Tooltip.Content side="bottom">Create folder</Tooltip.Content>
               </Tooltip.Root>
+
+              {#if node.path.startsWith('patch://')}
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <button
+                      class="cursor-pointer rounded p-0.5 text-zinc-500 hover:bg-zinc-700 hover:text-zinc-300"
+                      onclick={(e) => handleCreateFileClick(node.path!, e)}
+                      aria-label="Create GLSL file"
+                    >
+                      <Plus class="h-3.5 w-3.5" />
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content side="bottom">New File</Tooltip.Content>
+                </Tooltip.Root>
+              {/if}
 
               {#if isUserNamespace && supportsDirectoryPicker}
                 <Tooltip.Root>
@@ -1463,6 +1701,12 @@
 
       {#if showContextMenu}
         <ContextMenu.Content>
+          {#if node.path && isEditablePatchGlslPath(node.path)}
+            <ContextMenu.Item onclick={() => openEditor(node.path!)}>
+              <FileCode class="mr-2 h-4 w-4" />
+              Edit
+            </ContextMenu.Item>
+          {/if}
           <ContextMenu.Item
             onclick={() => handleRenameClick(node.path!, node.entry?.filename || node.name)}
           >
@@ -1527,6 +1771,22 @@
         />
       </div>
     {/if}
+
+    {#if showFileInput === node.path}
+      <div class="flex items-center gap-1.5 py-1" style="padding-left: {(depth + 1) * 12 + 8}px">
+        <span class="w-3"></span>
+        <FileCode class="h-3.5 w-3.5 shrink-0 text-emerald-400" />
+        <!-- svelte-ignore a11y_autofocus -->
+        <input
+          type="text"
+          class="min-w-0 flex-1 bg-transparent font-mono text-xs text-zinc-300 placeholder-zinc-500 outline-none"
+          placeholder="utility.glsl"
+          bind:value={fileInputValue}
+          onkeydown={handleFileNameSubmit}
+          autofocus
+        />
+      </div>
+    {/if}
   {/if}
 
   {#if isFolder && (node.name === 'root' || isExpanded)}
@@ -1560,165 +1820,210 @@
   {/if}
 {/snippet}
 
-<div class="flex h-full flex-col">
-  <!-- Search bar -->
-  <SearchBar bind:value={searchQuery} placeholder="Search files..." />
+<svelte:window onbeforeunload={handleBeforeUnload} />
 
-  <div
-    class="flex-1 overflow-y-auto py-2 outline-none {dropTargetPath === 'user://' &&
-    (!tree.children || tree.children.size === 0)
-      ? 'bg-blue-600/30'
-      : ''} {$isMobile && selectedFilePath ? 'pb-14' : ''}"
-    tabindex="0"
-    role="tree"
-    onkeydown={handleKeydown}
-    ondragover={handleTreeDragOver}
-    ondragleave={handleFolderDragLeave}
-    ondrop={handleFolderDrop}
-  >
-    {#if searchQuery.trim()}
-      <!-- Flat search results -->
-      {#if searchResults.length === 0}
-        <div class="px-4 py-8 text-center text-xs text-zinc-500">
-          No files matching "{searchQuery}"
-        </div>
+{#if editorPath}
+  <PatchFileEditorView
+    path={editorPath}
+    draft={editorDraft}
+    dirty={editorDirty}
+    onchange={(content) => {
+      editorSession.updateDraft(content);
+      refreshEditor();
+    }}
+    onback={closeEditor}
+    onsave={saveEditor}
+    onrename={() => handleRenameClick(editorPath, editorPath.split('/').pop() ?? '')}
+    oncopy={() => handleCopyPath(editorPath)}
+    onexport={() => handleSaveToDisk(editorPath)}
+    ondelete={() => handleDeleteFromContextMenu(editorPath)}
+  />
+{:else}
+  <div class="flex h-full flex-col">
+    <!-- Search bar -->
+    <SearchBar bind:value={searchQuery} placeholder="Search files..." />
+
+    <div
+      class="flex-1 overflow-y-auto py-2 outline-none {dropTargetPath === 'user://' &&
+      (!tree.children || tree.children.size === 0)
+        ? 'bg-blue-600/30'
+        : ''} {$isMobile && selectedFilePath ? 'pb-14' : ''}"
+      tabindex="0"
+      role="tree"
+      onkeydown={handleKeydown}
+      ondragover={handleTreeDragOver}
+      ondragleave={handleFolderDragLeave}
+      ondrop={handleFolderDrop}
+    >
+      {#if searchQuery.trim()}
+        <!-- Flat search results -->
+        {#if searchResults.length === 0}
+          <div class="px-4 py-8 text-center text-xs text-zinc-500">
+            No files matching "{searchQuery}"
+          </div>
+        {:else}
+          {#each searchResults as result (result.path)}
+            {@const isSelected = selectedPaths.has(result.path)}
+            {@const mimeType = result.entry ? result.entry.mimeType : guessMimeType(result.name)}
+            {@const fileIcon = getFileIcon(mimeType)}
+            <div
+              class="group flex w-full items-center {isSelected
+                ? 'bg-blue-900/40 hover:bg-blue-900/50'
+                : 'hover:bg-zinc-800'}"
+            >
+              <button
+                class="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 py-1 pl-2 text-left text-xs"
+                draggable="true"
+                ondblclick={() => isEditablePatchGlslPath(result.path) && openEditor(result.path)}
+                ondragstart={(e) => {
+                  e.dataTransfer?.setData('application/x-vfs-path', result.path);
+                  e.dataTransfer?.setData('text/plain', result.path);
+                  if (e.dataTransfer) {
+                    e.dataTransfer.effectAllowed = result.isLinked ? 'copy' : 'copyMove';
+                  }
+                }}
+                onclick={(e) => {
+                  if (e.shiftKey && lastSelectedPath) {
+                    const paths = searchResults.map((r) => r.path);
+                    const startIdx = paths.indexOf(lastSelectedPath);
+                    const endIdx = paths.indexOf(result.path);
+
+                    if (startIdx !== -1 && endIdx !== -1) {
+                      const [from, to] =
+                        startIdx < endIdx ? [startIdx, endIdx] : [endIdx, startIdx];
+                      selectedPaths.clear();
+                      for (const p of paths.slice(from, to + 1)) selectedPaths.add(p);
+
+                      return;
+                    }
+                  }
+
+                  toggleSelected(result.path);
+                }}
+              >
+                <fileIcon.icon class="h-3.5 w-3.5 shrink-0 {fileIcon.color}" />
+
+                <span class="truncate font-mono text-zinc-300">{result.name}</span>
+              </button>
+              {#if isEditablePatchGlslPath(result.path)}
+                <button
+                  class="mr-1 cursor-pointer rounded p-1 text-zinc-500 opacity-100 hover:bg-zinc-700 hover:text-zinc-200 sm:opacity-0 sm:group-hover:opacity-100"
+                  onclick={() => openEditor(result.path)}
+                  aria-label={`Edit ${result.name}`}
+                >
+                  <Pencil class="h-3.5 w-3.5" />
+                </button>
+              {/if}
+            </div>
+          {/each}
+        {/if}
       {:else}
-        {#each searchResults as result (result.path)}
-          {@const isSelected = selectedPaths.has(result.path)}
-          {@const mimeType = result.entry ? result.entry.mimeType : guessMimeType(result.name)}
-          {@const fileIcon = getFileIcon(mimeType)}
-          <button
-            class="flex w-full cursor-pointer items-center gap-1.5 py-1 pl-2 text-left text-xs {isSelected
-              ? 'bg-blue-900/40 hover:bg-blue-900/50'
-              : 'hover:bg-zinc-800'}"
-            draggable="true"
-            ondragstart={(e) => {
-              e.dataTransfer?.setData('application/x-vfs-path', result.path);
-              e.dataTransfer?.setData('text/plain', result.path);
-              if (e.dataTransfer) {
-                e.dataTransfer.effectAllowed = result.isLinked ? 'copy' : 'copyMove';
-              }
-            }}
-            onclick={(e) => {
-              if (e.shiftKey && lastSelectedPath) {
-                const paths = searchResults.map((r) => r.path);
-                const startIdx = paths.indexOf(lastSelectedPath);
-                const endIdx = paths.indexOf(result.path);
-
-                if (startIdx !== -1 && endIdx !== -1) {
-                  const [from, to] = startIdx < endIdx ? [startIdx, endIdx] : [endIdx, startIdx];
-                  selectedPaths.clear();
-                  for (const p of paths.slice(from, to + 1)) selectedPaths.add(p);
-
-                  return;
-                }
-              }
-
-              toggleSelected(result.path);
-            }}
-          >
-            <fileIcon.icon class="h-3.5 w-3.5 shrink-0 {fileIcon.color}" />
-
-            <span class="truncate font-mono text-zinc-300">{result.name}</span>
-          </button>
-        {/each}
+        {@render treeNode(tree)}
       {/if}
-    {:else}
-      {@render treeNode(tree)}
-    {/if}
-  </div>
-</div>
-
-<!-- Mobile floating toolbar -->
-{#if $isMobile && selectedFilePath}
-  <div
-    class="fixed right-0 bottom-0 left-0 border-t border-zinc-800 bg-zinc-900/95 px-4 pt-2 backdrop-blur-sm"
-    style="padding-bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px))"
-  >
-    <div class="flex items-center justify-center gap-2">
-      <span class="mr-2 max-w-32 truncate font-mono text-xs text-zinc-400">
-        {selectedFileEntry?.filename || selectedFilePath.split('/').pop()}
-      </span>
-
-      <button
-        class="flex cursor-pointer items-center gap-1.5 rounded bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
-        onclick={handleInsertToCanvas}
-        title="Insert to Canvas"
-      >
-        <Plus class="h-3.5 w-3.5" />
-        <span>Insert</span>
-      </button>
-
-      <button
-        class="flex cursor-pointer items-center gap-1.5 rounded bg-zinc-700 px-3 py-1.5 text-xs text-zinc-200 hover:bg-zinc-600"
-        onclick={() => (showMoveDialog = true)}
-        title="Move to folder"
-      >
-        <FolderInput class="h-3.5 w-3.5" />
-        <span>Move</span>
-      </button>
-
-      <Popover.Root bind:open={mobileMoreOpen}>
-        <Popover.Trigger
-          class="flex cursor-pointer items-center rounded bg-zinc-700 p-1.5 text-zinc-200 hover:bg-zinc-600"
-        >
-          <Ellipsis class="h-4 w-4" />
-        </Popover.Trigger>
-        <Popover.Content class="w-40 border-zinc-700 bg-zinc-900 p-1" side="top" align="end">
-          <button
-            class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800"
-            onclick={() => {
-              if (selectedFilePath) {
-                const entry = vfs.getEntry(selectedFilePath);
-                handleRenameClick(
-                  selectedFilePath,
-                  entry?.filename || selectedFilePath.split('/').pop() || ''
-                );
-              }
-              mobileMoreOpen = false;
-            }}
-          >
-            <Pencil class="h-4 w-4 text-zinc-400" />
-            Rename
-          </button>
-          <button
-            class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800"
-            onclick={async () => {
-              if (selectedFilePath) {
-                await handleCopyPath(selectedFilePath);
-              }
-              mobileMoreOpen = false;
-            }}
-          >
-            <Copy class="h-4 w-4 text-zinc-400" />
-            Copy Path
-          </button>
-          <button
-            class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-red-400 hover:bg-zinc-800"
-            onclick={async () => {
-              if (selectedFilePath) {
-                await handleDeleteFromContextMenu(selectedFilePath);
-              }
-              mobileMoreOpen = false;
-            }}
-          >
-            <Trash2 class="h-4 w-4" />
-            Delete
-          </button>
-        </Popover.Content>
-      </Popover.Root>
-
-      <button
-        class="ml-auto text-xs text-zinc-500 hover:text-zinc-300"
-        onclick={() => {
-          selectedPaths.clear();
-          lastSelectedPath = null;
-        }}
-      >
-        Cancel
-      </button>
     </div>
   </div>
+
+  <!-- Mobile floating toolbar -->
+  {#if $isMobile && selectedFilePath}
+    <div
+      class="fixed right-0 bottom-0 left-0 border-t border-zinc-800 bg-zinc-900/95 px-4 pt-2 backdrop-blur-sm"
+      style="padding-bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px))"
+    >
+      <div class="flex items-center justify-center gap-2">
+        <span class="mr-2 max-w-32 truncate font-mono text-xs text-zinc-400">
+          {selectedFileEntry?.filename || selectedFilePath.split('/').pop()}
+        </span>
+
+        {#if isEditablePatchGlslPath(selectedFilePath)}
+          <button
+            class="flex cursor-pointer items-center gap-1.5 rounded bg-emerald-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-600"
+            onclick={() => openEditor(selectedFilePath)}
+          >
+            <Pencil class="h-3.5 w-3.5" />
+            <span>Edit</span>
+          </button>
+        {/if}
+
+        <button
+          class="flex cursor-pointer items-center gap-1.5 rounded bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+          onclick={handleInsertToCanvas}
+          title="Insert to Canvas"
+        >
+          <Plus class="h-3.5 w-3.5" />
+          <span>Insert</span>
+        </button>
+
+        <button
+          class="flex cursor-pointer items-center gap-1.5 rounded bg-zinc-700 px-3 py-1.5 text-xs text-zinc-200 hover:bg-zinc-600"
+          onclick={() => (showMoveDialog = true)}
+          title="Move to folder"
+        >
+          <FolderInput class="h-3.5 w-3.5" />
+          <span>Move</span>
+        </button>
+
+        <Popover.Root bind:open={mobileMoreOpen}>
+          <Popover.Trigger
+            class="flex cursor-pointer items-center rounded bg-zinc-700 p-1.5 text-zinc-200 hover:bg-zinc-600"
+          >
+            <Ellipsis class="h-4 w-4" />
+          </Popover.Trigger>
+          <Popover.Content class="w-40 border-zinc-700 bg-zinc-900 p-1" side="top" align="end">
+            <button
+              class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800"
+              onclick={() => {
+                if (selectedFilePath) {
+                  const entry = vfs.getEntry(selectedFilePath);
+                  handleRenameClick(
+                    selectedFilePath,
+                    entry?.filename || selectedFilePath.split('/').pop() || ''
+                  );
+                }
+                mobileMoreOpen = false;
+              }}
+            >
+              <Pencil class="h-4 w-4 text-zinc-400" />
+              Rename
+            </button>
+            <button
+              class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800"
+              onclick={async () => {
+                if (selectedFilePath) {
+                  await handleCopyPath(selectedFilePath);
+                }
+                mobileMoreOpen = false;
+              }}
+            >
+              <Copy class="h-4 w-4 text-zinc-400" />
+              Copy Path
+            </button>
+            <button
+              class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-red-400 hover:bg-zinc-800"
+              onclick={async () => {
+                if (selectedFilePath) {
+                  await handleDeleteFromContextMenu(selectedFilePath);
+                }
+                mobileMoreOpen = false;
+              }}
+            >
+              <Trash2 class="h-4 w-4" />
+              Delete
+            </button>
+          </Popover.Content>
+        </Popover.Root>
+
+        <button
+          class="ml-auto text-xs text-zinc-500 hover:text-zinc-300"
+          onclick={() => {
+            selectedPaths.clear();
+            lastSelectedPath = null;
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  {/if}
 {/if}
 
 <!-- Move to folder dialog -->
@@ -1735,4 +2040,10 @@
   bind:open={collisionDialogOpen}
   paths={collisionPaths}
   onChoose={handleCollisionChoice}
+/>
+
+<UnsavedPatchFileDialog
+  bind:open={unsavedDialogOpen}
+  path={editorPath ?? ''}
+  onChoose={handleUnsavedChoice}
 />

--- a/ui/src/lib/components/sidebar/PatchFileEditorView.svelte
+++ b/ui/src/lib/components/sidebar/PatchFileEditorView.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import { ArrowLeft, Copy, Ellipsis, File, Pencil, Save, Trash2 } from '@lucide/svelte/icons';
+
+  import CodeEditor from '$lib/components/CodeEditor.svelte';
+  import * as Popover from '$lib/components/ui/popover';
+  import * as Tooltip from '$lib/components/ui/tooltip';
+
+  let {
+    path,
+    draft,
+    dirty,
+    onchange,
+    onback,
+    onsave,
+    onrename,
+    oncopy,
+    onexport,
+    ondelete
+  }: {
+    path: string;
+    draft: string;
+    dirty: boolean;
+    onchange: (content: string) => void;
+    onback: () => void;
+    onsave: () => void;
+    onrename: () => void;
+    oncopy: () => void;
+    onexport: () => void;
+    ondelete: () => void;
+  } = $props();
+
+  const GLSL_PLACEHOLDER = `float circle(vec2 point, float radius) {
+  return length(point) - radius;
+}`;
+
+  let menuOpen = $state(false);
+  const displayPath = $derived(path.replace(/^patch:\/\//, ''));
+
+  function runMenuAction(action: () => void) {
+    menuOpen = false;
+    action();
+  }
+</script>
+
+<div class="flex h-full min-h-0 flex-col">
+  <div class="flex shrink-0 items-center gap-2 border-b border-zinc-800 bg-zinc-950 px-2 py-2">
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-orange-400/30 focus-visible:outline-none"
+          onclick={onback}
+          aria-label="Back to files"
+        >
+          <ArrowLeft class="h-4 w-4" />
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content>Back to Files</Tooltip.Content>
+    </Tooltip.Root>
+
+    <div class="min-w-0 flex-1">
+      <div class="flex items-center gap-1.5">
+        <span class="truncate font-mono text-xs text-zinc-200" title={displayPath}
+          >{displayPath}</span
+        >
+        {#if dirty}
+          <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-orange-400" aria-label="Unsaved changes"
+          ></span>
+        {/if}
+      </div>
+    </div>
+
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 text-zinc-300 hover:border-zinc-600 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+          disabled={!dirty}
+          onclick={onsave}
+          aria-label="Save file"
+        >
+          <Save class="h-3.5 w-3.5" />
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content>Save Changes (⌘/Ctrl+S)</Tooltip.Content>
+    </Tooltip.Root>
+
+    <Popover.Root bind:open={menuOpen}>
+      <Popover.Trigger
+        class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
+        aria-label="File actions"
+      >
+        <Ellipsis class="h-4 w-4" />
+      </Popover.Trigger>
+      <Popover.Content class="w-44 border-zinc-700 bg-zinc-900 p-1" align="end">
+        <button class="menu-item" onclick={() => runMenuAction(onrename)}>
+          <Pencil class="h-4 w-4" /> Rename
+        </button>
+        <button class="menu-item" onclick={() => runMenuAction(oncopy)}>
+          <Copy class="h-4 w-4" /> Copy Path
+        </button>
+        <button class="menu-item" onclick={() => runMenuAction(onexport)}>
+          <File class="h-4 w-4" /> Save to Disk…
+        </button>
+        <div class="my-1 h-px bg-zinc-800"></div>
+        <button
+          class="menu-item text-red-400 hover:text-red-300"
+          onclick={() => runMenuAction(ondelete)}
+        >
+          <Trash2 class="h-4 w-4" /> Delete
+        </button>
+      </Popover.Content>
+    </Popover.Root>
+  </div>
+
+  <div class="patch-file-editor min-h-0 flex-1 overflow-hidden">
+    <CodeEditor
+      value={draft}
+      {onchange}
+      {onsave}
+      language="glsl"
+      nodeType="glsl"
+      placeholder={GLSL_PLACEHOLDER}
+      class="h-full w-full resize-none"
+    />
+  </div>
+</div>
+
+<style>
+  .menu-item {
+    display: flex;
+    width: 100%;
+    cursor: pointer;
+    align-items: center;
+    gap: 0.5rem;
+    border-radius: 0.25rem;
+    padding: 0.375rem 0.5rem;
+    text-align: left;
+    font-size: 0.875rem;
+    color: rgb(228 228 231);
+  }
+
+  .menu-item:hover {
+    background: rgb(39 39 42);
+  }
+
+  :global(.patch-file-editor .code-editor-container),
+  :global(.patch-file-editor .cm-editor),
+  :global(.patch-file-editor .cm-scroller) {
+    height: 100% !important;
+  }
+
+  :global(.patch-file-editor .cm-editor) {
+    border: none !important;
+    border-radius: 0 !important;
+  }
+</style>

--- a/ui/src/lib/components/sidebar/PatchFileEditorView.svelte
+++ b/ui/src/lib/components/sidebar/PatchFileEditorView.svelte
@@ -115,6 +115,7 @@
     <CodeEditor
       value={draft}
       {onchange}
+      onrun={onsave}
       {onsave}
       language="glsl"
       nodeType="glsl"

--- a/ui/src/lib/components/sidebar/SidebarPanel.svelte
+++ b/ui/src/lib/components/sidebar/SidebarPanel.svelte
@@ -286,7 +286,7 @@
           {#if contextMenuTargetTab}
             {@const target = availableViews.find((v) => v.id === contextMenuTargetTab)}
             {#if target}
-              <ContextMenu.Item onclick={() => toggleSidebarTab(target.id)}>
+              <ContextMenu.Item onclick={() => handleContextMenuToggle(target.id)}>
                 Hide {target.title}
               </ContextMenu.Item>
               <ContextMenu.Separator />

--- a/ui/src/lib/components/sidebar/SidebarPanel.svelte
+++ b/ui/src/lib/components/sidebar/SidebarPanel.svelte
@@ -44,6 +44,7 @@
     showSidebarTab
   } from '../../../stores/sidebar-visibility.store';
   import type { CodeEditorTarget } from '../../../stores/code-editor-layout.store';
+  import { canNavigateAwayFromPatchFile } from '$lib/vfs/file-editor-navigation';
 
   import type { AiPromptCallbacks } from '$lib/ai/ai-prompt-controller.svelte';
   import type { ChatNode, ChatGraphSummary, ChatViewportSummary } from '$lib/ai/chat/resolver';
@@ -134,11 +135,15 @@
     }
   });
 
-  function handleTabClick(id: SidebarView) {
+  async function handleTabClick(id: SidebarView) {
+    if (!(await canNavigateAwayFromPatchFile())) return;
+
     view = id;
   }
 
-  function handleContextMenuToggle(id: SidebarView) {
+  async function handleContextMenuToggle(id: SidebarView) {
+    if (!(await canNavigateAwayFromPatchFile())) return;
+
     if (!$sidebarVisibleTabs.has(id)) {
       // Show the tab and switch to it
       showSidebarTab(id);
@@ -146,6 +151,12 @@
     } else {
       toggleSidebarTab(id);
     }
+  }
+
+  async function handleClose() {
+    if (!(await canNavigateAwayFromPatchFile())) return;
+
+    open = false;
   }
 
   // Track which tab was right-clicked for the "Hide" action
@@ -243,8 +254,8 @@
                   {#each availableViews as v (v.id)}
                     <button
                       class="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm text-zinc-200 transition-colors hover:bg-zinc-800"
-                      onclick={() => {
-                        handleContextMenuToggle(v.id);
+                      onclick={async () => {
+                        await handleContextMenuToggle(v.id);
                         popoverOpen = false;
                       }}
                     >
@@ -264,7 +275,7 @@
 
           <button
             class="cursor-pointer rounded p-1 text-zinc-500 hover:bg-zinc-700 hover:text-zinc-300"
-            onclick={() => (open = false)}
+            onclick={handleClose}
             title="Close sidebar"
           >
             <X class="h-4 w-4" />

--- a/ui/src/lib/components/sidebar/SidebarPanel.svelte
+++ b/ui/src/lib/components/sidebar/SidebarPanel.svelte
@@ -130,19 +130,22 @@
   // If the active view gets hidden, switch to the first visible tab
   $effect(() => {
     const visible = visibleViews;
+
     if (visible.length > 0 && !visible.some((v) => v.id === view)) {
       view = visible[0].id;
     }
   });
 
   async function handleTabClick(id: SidebarView) {
-    if (!(await canNavigateAwayFromPatchFile())) return;
+    const ok = await canNavigateAwayFromPatchFile();
+    if (!ok) return;
 
     view = id;
   }
 
   async function handleContextMenuToggle(id: SidebarView) {
-    if (!(await canNavigateAwayFromPatchFile())) return;
+    const ok = await canNavigateAwayFromPatchFile();
+    if (!ok) return;
 
     if (!$sidebarVisibleTabs.has(id)) {
       // Show the tab and switch to it
@@ -154,13 +157,15 @@
   }
 
   async function handleClose() {
-    if (!(await canNavigateAwayFromPatchFile())) return;
+    const ok = await canNavigateAwayFromPatchFile();
+    if (!ok) return;
 
     open = false;
   }
 
   // Track which tab was right-clicked for the "Hide" action
   let contextMenuTargetTab = $state<SidebarView | null>(null);
+
   // Block tooltips while context menu is open; reset key on close to clear stale focus
   let tooltipsBlocked = $state(false);
   let tooltipResetKey = $state(0);

--- a/ui/src/lib/components/sidebar/UnsavedPatchFileDialog.svelte
+++ b/ui/src/lib/components/sidebar/UnsavedPatchFileDialog.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import * as Dialog from '$lib/components/ui/dialog';
+  import type { UnsavedChangesDecision } from '$lib/vfs/PatchFileEditorSession';
+
+  let {
+    open = $bindable(false),
+    path,
+    onChoose
+  }: {
+    open: boolean;
+    path: string;
+    onChoose: (decision: UnsavedChangesDecision) => void;
+  } = $props();
+
+  function choose(decision: UnsavedChangesDecision) {
+    open = false;
+    onChoose(decision);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && open) onChoose('cancel');
+
+    open = nextOpen;
+  }
+</script>
+
+<Dialog.Root bind:open onOpenChange={handleOpenChange}>
+  <Dialog.Content class="max-w-md border-zinc-700 bg-zinc-900">
+    <Dialog.Header>
+      <Dialog.Title>Save changes?</Dialog.Title>
+      <Dialog.Description class="text-left text-zinc-400">
+        <span class="font-mono text-zinc-300">{path}</span> has unsaved changes.
+      </Dialog.Description>
+    </Dialog.Header>
+
+    <Dialog.Footer class="flex gap-2">
+      <button
+        class="modal-action modal-action--secondary cursor-pointer"
+        onclick={() => choose('cancel')}
+      >
+        Cancel
+      </button>
+      <button
+        class="modal-action modal-action--secondary cursor-pointer"
+        onclick={() => choose('discard')}
+      >
+        Discard
+      </button>
+      <button
+        class="modal-action modal-action--primary cursor-pointer"
+        onclick={() => choose('save')}
+      >
+        Save
+      </button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/ui/src/lib/glsl-include/browser-resolver.ts
+++ b/ui/src/lib/glsl-include/browser-resolver.ts
@@ -3,7 +3,7 @@
  */
 
 import { VirtualFilesystem } from '$lib/vfs';
-import { createCachedResolver, type CachedIncludeResolver } from './cache';
+import { clearVfsCache, createCachedResolver, type CachedIncludeResolver } from './cache';
 import type { IncludeResolver } from './preprocessor';
 import { resolveNpmPackage } from './npm-resolver';
 
@@ -33,4 +33,8 @@ export function createBrowserResolver(): IncludeResolver {
   });
 
   return sharedResolver;
+}
+
+export function clearBrowserVfsIncludeCache(path: string): void {
+  if (sharedResolver) clearVfsCache(sharedResolver, path);
 }

--- a/ui/src/lib/glsl-include/cache.test.ts
+++ b/ui/src/lib/glsl-include/cache.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { clearVfsCache, createCachedResolver } from './cache';
+
+describe('GLSL include cache', () => {
+  it('does not let an invalidated inflight VFS read repopulate the cache', async () => {
+    let resolveFirstRead: ((content: string) => void) | undefined;
+    const resolveVfs = vi
+      .fn<(path: string) => Promise<string>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstRead = resolve;
+          })
+      )
+      .mockResolvedValue('new source');
+    const resolver = createCachedResolver({
+      resolveNpm: vi.fn(async () => ''),
+      resolveVfs,
+      resolveUrl: vi.fn(async () => '')
+    });
+
+    const staleRead = resolver.resolveVfs('patch://utility.glsl');
+    clearVfsCache(resolver, 'patch://utility.glsl');
+    const freshRead = resolver.resolveVfs('patch://utility.glsl');
+
+    resolveFirstRead?.('old source');
+
+    await expect(staleRead).resolves.toBe('old source');
+    await expect(freshRead).resolves.toBe('new source');
+    await expect(resolver.resolveVfs('patch://utility.glsl')).resolves.toBe('new source');
+    expect(resolveVfs).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/src/lib/glsl-include/cache.ts
+++ b/ui/src/lib/glsl-include/cache.ts
@@ -64,9 +64,9 @@ export function createCachedResolver(base: IncludeResolver): CachedIncludeResolv
  * is added: on every file-modified event, call this with the shared resolver
  * and trigger updateCode() on any GLSL nodes that reference the changed path.
  */
-export function clearVfsCache(resolver: CachedIncludeResolver): void {
+export function clearVfsCache(resolver: CachedIncludeResolver, path?: string): void {
   for (const key of resolver._cache.keys()) {
-    if (key.startsWith('vfs:')) {
+    if (key.startsWith('vfs:') && (!path || key === `vfs:${path}`)) {
       resolver._cache.delete(key);
     }
   }

--- a/ui/src/lib/glsl-include/cache.ts
+++ b/ui/src/lib/glsl-include/cache.ts
@@ -19,12 +19,16 @@ export function createCachedResolver(base: IncludeResolver): CachedIncludeResolv
 
   function dedup(key: string, fetch: () => Promise<string>): Promise<string> {
     const cached = cache.get(key);
-    if (cached !== undefined) return Promise.resolve(cached);
+
+    if (cached !== undefined) {
+      return Promise.resolve(cached);
+    }
 
     const pending = inflight.get(key);
     if (pending) return pending;
 
     const generation = generations.get(key) ?? 0;
+
     const promise = fetch().then(
       (content) => {
         if ((generations.get(key) ?? 0) === generation) cache.set(key, content);
@@ -48,6 +52,7 @@ export function createCachedResolver(base: IncludeResolver): CachedIncludeResolv
     _cache: cache,
     _invalidateVfs(path?: string): void {
       const prefix = 'vfs:';
+
       const keys = path
         ? [`${prefix}${path}`]
         : new Set(

--- a/ui/src/lib/glsl-include/cache.ts
+++ b/ui/src/lib/glsl-include/cache.ts
@@ -7,11 +7,15 @@
 
 import type { IncludeResolver } from './preprocessor';
 
-export type CachedIncludeResolver = IncludeResolver & { _cache: Map<string, string> };
+export type CachedIncludeResolver = IncludeResolver & {
+  _cache: Map<string, string>;
+  _invalidateVfs: (path?: string) => void;
+};
 
 export function createCachedResolver(base: IncludeResolver): CachedIncludeResolver {
   const cache = new Map<string, string>();
   const inflight = new Map<string, Promise<string>>();
+  const generations = new Map<string, number>();
 
   function dedup(key: string, fetch: () => Promise<string>): Promise<string> {
     const cached = cache.get(key);
@@ -20,15 +24,16 @@ export function createCachedResolver(base: IncludeResolver): CachedIncludeResolv
     const pending = inflight.get(key);
     if (pending) return pending;
 
+    const generation = generations.get(key) ?? 0;
     const promise = fetch().then(
       (content) => {
-        cache.set(key, content);
-        inflight.delete(key);
+        if ((generations.get(key) ?? 0) === generation) cache.set(key, content);
+        if (inflight.get(key) === promise) inflight.delete(key);
 
         return content;
       },
       (error) => {
-        inflight.delete(key);
+        if (inflight.get(key) === promise) inflight.delete(key);
 
         throw error;
       }
@@ -41,6 +46,22 @@ export function createCachedResolver(base: IncludeResolver): CachedIncludeResolv
 
   return {
     _cache: cache,
+    _invalidateVfs(path?: string): void {
+      const prefix = 'vfs:';
+      const keys = path
+        ? [`${prefix}${path}`]
+        : new Set(
+            [...cache.keys(), ...inflight.keys(), ...generations.keys()].filter((key) =>
+              key.startsWith(prefix)
+            )
+          );
+
+      for (const key of keys) {
+        cache.delete(key);
+        inflight.delete(key);
+        generations.set(key, (generations.get(key) ?? 0) + 1);
+      }
+    },
 
     resolveNpm(packagePath: string): Promise<string> {
       return dedup(`npm:${packagePath}`, () => base.resolveNpm(packagePath));
@@ -59,15 +80,7 @@ export function createCachedResolver(base: IncludeResolver): CachedIncludeResolv
 /**
  * Clear VFS entries from cache (call when VFS files change).
  *
- * NOTE: Currently unused — VFS file editing is not yet supported, so cached
- * VFS includes can never go stale. Wire this up once in-place VFS file editing
- * is added: on every file-modified event, call this with the shared resolver
- * and trigger updateCode() on any GLSL nodes that reference the changed path.
  */
 export function clearVfsCache(resolver: CachedIncludeResolver, path?: string): void {
-  for (const key of resolver._cache.keys()) {
-    if (key.startsWith('vfs:') && (!path || key === `vfs:${path}`)) {
-      resolver._cache.delete(key);
-    }
-  }
+  resolver._invalidateVfs(path);
 }

--- a/ui/src/lib/glsl-include/dependency-index.test.ts
+++ b/ui/src/lib/glsl-include/dependency-index.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { GlslDependencyIndex } from './dependency-index';
+
+describe('GlslDependencyIndex', () => {
+  it('finds direct and transitive consumers once', () => {
+    const files = new Map([
+      ['patch://shaders/material.glsl', '#include "./math"\nvec3 material() { return tone(); }'],
+      ['patch://shaders/math.glsl', 'vec3 tone() { return vec3(1.0); }']
+    ]);
+
+    const index = new GlslDependencyIndex();
+    index.rebuild(
+      [
+        { id: 'glsl-1', code: '#include "./shaders/material"\nvoid mainImage() {}' },
+        { id: 'glsl-2', code: '#include "patch://shaders/math.glsl"\nvoid mainImage() {}' },
+        { id: 'glsl-3', code: 'void mainImage() {}' }
+      ],
+      (path) => files.get(path)
+    );
+
+    expect(index.getConsumers('patch://shaders/material.glsl')).toEqual(new Set(['glsl-1']));
+    expect(index.getConsumers('patch://shaders/math.glsl')).toEqual(new Set(['glsl-1', 'glsl-2']));
+  });
+
+  it('tracks a missing exact import so creating it refreshes its consumer', () => {
+    const index = new GlslDependencyIndex();
+    index.rebuild([{ id: 'glsl-1', code: '#include "./missing.glsl"' }], () => undefined);
+
+    expect(index.getConsumers('patch://missing.glsl')).toEqual(new Set(['glsl-1']));
+  });
+});

--- a/ui/src/lib/glsl-include/dependency-index.test.ts
+++ b/ui/src/lib/glsl-include/dependency-index.test.ts
@@ -29,4 +29,14 @@ describe('GlslDependencyIndex', () => {
 
     expect(index.getConsumers('patch://missing.glsl')).toEqual(new Set(['glsl-1']));
   });
+
+  it('tracks an unresolved exact candidate that can outrank an inferred extension', () => {
+    const files = new Map([['patch://utility.glsl', 'vec3 utility() { return vec3(1.0); }']]);
+    const index = new GlslDependencyIndex();
+
+    index.rebuild([{ id: 'glsl-1', code: '#include "./utility"' }], (path) => files.get(path));
+
+    expect(index.getConsumers('patch://utility')).toEqual(new Set(['glsl-1']));
+    expect(index.getConsumers('patch://utility.glsl')).toEqual(new Set(['glsl-1']));
+  });
 });

--- a/ui/src/lib/glsl-include/dependency-index.ts
+++ b/ui/src/lib/glsl-include/dependency-index.ts
@@ -1,0 +1,78 @@
+import { resolveVfsIncludeCandidates } from './vfs-paths';
+
+const QUOTED_INCLUDE_RE = /^[ \t]*#include\s+"([^"]+)"/gm;
+
+export type GlslConsumer = {
+  id: string;
+  code: string;
+};
+
+type ReadSource = (path: string) => string | undefined;
+
+export function findQuotedGlslIncludes(source: string): string[] {
+  const includes: string[] = [];
+  QUOTED_INCLUDE_RE.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+
+  while ((match = QUOTED_INCLUDE_RE.exec(source)) !== null) {
+    includes.push(match[1]);
+  }
+
+  return includes;
+}
+
+export class GlslDependencyIndex {
+  private consumersByPath = new Map<string, Set<string>>();
+
+  rebuild(consumers: GlslConsumer[], readSource: ReadSource): void {
+    this.consumersByPath.clear();
+
+    for (const consumer of consumers) {
+      this.collectConsumerDependencies(consumer, readSource);
+    }
+  }
+
+  getConsumers(path: string): Set<string> {
+    return new Set(this.consumersByPath.get(path) ?? []);
+  }
+
+  private collectConsumerDependencies(consumer: GlslConsumer, readSource: ReadSource): void {
+    const visited = new Set<string>();
+
+    const visit = (source: string, importerPath: string) => {
+      for (const specifier of findQuotedGlslIncludes(source)) {
+        if (
+          specifier.startsWith('http://') ||
+          specifier.startsWith('https://') ||
+          (!specifier.startsWith('./') &&
+            !specifier.startsWith('../') &&
+            !specifier.startsWith('patch://') &&
+            !specifier.startsWith('user://'))
+        ) {
+          continue;
+        }
+
+        const candidates = resolveVfsIncludeCandidates(specifier, importerPath);
+        const resolved = candidates.find((candidate) => readSource(candidate) !== undefined);
+        const dependency = resolved ?? candidates[0];
+
+        let consumers = this.consumersByPath.get(dependency);
+        if (!consumers) {
+          consumers = new Set();
+          this.consumersByPath.set(dependency, consumers);
+        }
+
+        consumers.add(consumer.id);
+
+        if (visited.has(dependency)) continue;
+        visited.add(dependency);
+
+        const dependencySource = readSource(dependency);
+        if (dependencySource !== undefined) visit(dependencySource, dependency);
+      }
+    };
+
+    visit(consumer.code, 'patch://');
+  }
+}

--- a/ui/src/lib/glsl-include/dependency-index.ts
+++ b/ui/src/lib/glsl-include/dependency-index.ts
@@ -54,21 +54,31 @@ export class GlslDependencyIndex {
         }
 
         const candidates = resolveVfsIncludeCandidates(specifier, importerPath);
-        const resolved = candidates.find((candidate) => readSource(candidate) !== undefined);
-        const dependency = resolved ?? candidates[0];
+        let dependency: string | undefined;
+        let dependencySource: string | undefined;
 
-        let consumers = this.consumersByPath.get(dependency);
-        if (!consumers) {
-          consumers = new Set();
-          this.consumersByPath.set(dependency, consumers);
+        for (const candidate of candidates) {
+          let consumers = this.consumersByPath.get(candidate);
+          if (!consumers) {
+            consumers = new Set();
+            this.consumersByPath.set(candidate, consumers);
+          }
+
+          consumers.add(consumer.id);
+
+          const source = readSource(candidate);
+          if (source !== undefined) {
+            dependency = candidate;
+            dependencySource = source;
+            break;
+          }
         }
 
-        consumers.add(consumer.id);
+        dependency ??= candidates[0];
 
         if (visited.has(dependency)) continue;
         visited.add(dependency);
 
-        const dependencySource = readSource(dependency);
         if (dependencySource !== undefined) visit(dependencySource, dependency);
       }
     };

--- a/ui/src/lib/glsl-include/preprocessor.test.ts
+++ b/ui/src/lib/glsl-include/preprocessor.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { processIncludes, type IncludeResolver } from './preprocessor';
+
+function vfsResolver(files: Map<string, string>): IncludeResolver {
+  return {
+    resolveNpm: vi.fn(async () => ''),
+    resolveUrl: vi.fn(async () => ''),
+    resolveVfs: vi.fn(async (path) => {
+      const source = files.get(path);
+      if (source === undefined) throw new Error(`Missing ${path}`);
+
+      return source;
+    })
+  };
+}
+
+describe('processIncludes VFS resolution', () => {
+  it('resolves Patch-relative imports recursively and infers only .glsl', async () => {
+    const resolver = vfsResolver(
+      new Map([
+        ['patch://shaders/material.glsl', '#include "../shared/math"\nfloat material = tone;'],
+        ['patch://shared/math.glsl', 'float tone = 1.0;']
+      ])
+    );
+
+    await expect(processIncludes('#include "./shaders/material"', resolver)).resolves.toContain(
+      'float tone = 1.0;'
+    );
+
+    expect(resolver.resolveVfs).toHaveBeenCalledWith('patch://shaders/material');
+    expect(resolver.resolveVfs).toHaveBeenCalledWith('patch://shaders/material.glsl');
+    expect(resolver.resolveVfs).toHaveBeenCalledWith('patch://shared/math.glsl');
+  });
+
+  it('prefers an exact extensionless Patch file before .glsl', async () => {
+    const resolver = vfsResolver(
+      new Map([
+        ['patch://utility', 'float exact = 1.0;'],
+        ['patch://utility.glsl', 'float inferred = 1.0;']
+      ])
+    );
+
+    await expect(processIncludes('#include "./utility"', resolver)).resolves.toContain('exact');
+    expect(resolver.resolveVfs).not.toHaveBeenCalledWith('patch://utility.glsl');
+  });
+
+  it('resolves explicit User files without changing their namespace', async () => {
+    const resolver = vfsResolver(
+      new Map([['user://shared/color.glsl', 'vec3 color = vec3(1.0);']])
+    );
+
+    await expect(
+      processIncludes('#include "user://shared/color.glsl"', resolver)
+    ).resolves.toContain('vec3 color');
+    expect(resolver.resolveVfs).toHaveBeenCalledWith('user://shared/color.glsl');
+  });
+
+  it('resolves an explicit Patch file from node code', async () => {
+    const resolver = vfsResolver(
+      new Map([
+        [
+          'patch://world.glsl',
+          'float circle(vec2 point, float radius) { return length(point) - radius; }'
+        ]
+      ])
+    );
+
+    await expect(processIncludes('#include "patch://world.glsl"', resolver)).resolves.toContain(
+      'float circle'
+    );
+    expect(resolver.resolveVfs).toHaveBeenCalledWith('patch://world.glsl');
+  });
+
+  it('detects circular Patch imports by canonical path', async () => {
+    const resolver = vfsResolver(
+      new Map([
+        ['patch://a.glsl', '#include "./b.glsl"'],
+        ['patch://b.glsl', '#include "./a.glsl"']
+      ])
+    );
+
+    await expect(processIncludes('#include "./a.glsl"', resolver)).rejects.toThrow(
+      'Circular #include detected: vfs:patch://a.glsl'
+    );
+  });
+});

--- a/ui/src/lib/glsl-include/preprocessor.test.ts
+++ b/ui/src/lib/glsl-include/preprocessor.test.ts
@@ -72,6 +72,24 @@ describe('processIncludes VFS resolution', () => {
     expect(resolver.resolveVfs).toHaveBeenCalledWith('patch://world.glsl');
   });
 
+  it('reports the source line for a missing Patch include', async () => {
+    const resolver = vfsResolver(new Map());
+
+    await expect(
+      processIncludes(
+        'float before = 1.0;\n#include "patch://non-existent-file"\nfloat after = 2.0;',
+        resolver
+      )
+    ).rejects.toMatchObject({
+      line: 2,
+      includePath: 'patch://non-existent-file',
+      message: 'Include error on line 2: Missing patch://non-existent-file.glsl',
+      lineErrors: {
+        2: ['Missing patch://non-existent-file.glsl']
+      }
+    });
+  });
+
   it('detects circular Patch imports by canonical path', async () => {
     const resolver = vfsResolver(
       new Map([

--- a/ui/src/lib/glsl-include/preprocessor.ts
+++ b/ui/src/lib/glsl-include/preprocessor.ts
@@ -22,6 +22,25 @@ const INCLUDE_RE = /^[ \t]*#include\s+(?:<([^>]+)>|"([^"]+)")/gm;
 
 const MAX_DEPTH = 32;
 
+export class GlslIncludeError extends Error {
+  readonly lineErrors: Record<number, string[]>;
+
+  constructor(
+    readonly includePath: string,
+    readonly line: number,
+    reason: string
+  ) {
+    const message = `Include error on line ${line}: ${reason}`;
+
+    super(message);
+    this.name = 'GlslIncludeError';
+    this.lineErrors = { [line]: [reason] };
+  }
+}
+
+const getSourceLine = (source: string, index: number): number =>
+  source.slice(0, index).split('\n').length;
+
 function ensureGlslExtension(path: string): string {
   const lastSegment = path.split('/').pop() ?? '';
   if (lastSegment.includes('.')) return path;
@@ -105,31 +124,34 @@ export async function processIncludes(
 
   // Resolve all includes in parallel
   const resolutions = await Promise.all(
-    matches.map(async ({ npmPath, quotedPath }) => {
-      const { resolvedPath, content, nextNpmBasePath, nextVfsImporterPath } = await resolveInclude(
-        resolver,
-        npmPath,
-        quotedPath,
-        npmBasePath,
-        vfsImporterPath
-      );
+    matches.map(async ({ npmPath, quotedPath, index }) => {
+      const includePath = npmPath ?? quotedPath ?? '';
 
-      if (seen.has(resolvedPath)) {
-        throw new Error(`Circular #include detected: ${resolvedPath}`);
+      try {
+        const { resolvedPath, content, nextNpmBasePath, nextVfsImporterPath } =
+          await resolveInclude(resolver, npmPath, quotedPath, npmBasePath, vfsImporterPath);
+
+        if (seen.has(resolvedPath)) {
+          throw new Error(`Circular #include detected: ${resolvedPath}`);
+        }
+
+        const innerSeen = new Set(seen);
+        innerSeen.add(resolvedPath);
+
+        // Recursively resolve nested includes, passing the base path for relative resolution
+        return processIncludes(
+          content,
+          resolver,
+          innerSeen,
+          depth + 1,
+          nextNpmBasePath,
+          nextVfsImporterPath
+        );
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+
+        throw new GlslIncludeError(includePath, getSourceLine(source, index), reason);
       }
-
-      const innerSeen = new Set(seen);
-      innerSeen.add(resolvedPath);
-
-      // Recursively resolve nested includes, passing the base path for relative resolution
-      return processIncludes(
-        content,
-        resolver,
-        innerSeen,
-        depth + 1,
-        nextNpmBasePath,
-        nextVfsImporterPath
-      );
     })
   );
 

--- a/ui/src/lib/glsl-include/preprocessor.ts
+++ b/ui/src/lib/glsl-include/preprocessor.ts
@@ -1,3 +1,5 @@
+import { resolveVfsIncludeCandidates } from './vfs-paths';
+
 /**
  * GLSL #include preprocessor.
  *
@@ -70,7 +72,8 @@ export async function processIncludes(
   resolver: IncludeResolver,
   seen: Set<string> = new Set(),
   depth: number = 0,
-  npmBasePath: string = ''
+  npmBasePath: string = '',
+  vfsImporterPath: string = 'patch://'
 ): Promise<string> {
   if (depth > MAX_DEPTH) {
     throw new Error(`#include recursion depth exceeded (max ${MAX_DEPTH})`);
@@ -103,11 +106,12 @@ export async function processIncludes(
   // Resolve all includes in parallel
   const resolutions = await Promise.all(
     matches.map(async ({ npmPath, quotedPath }) => {
-      const { resolvedPath, content, nextBasePath } = await resolveInclude(
+      const { resolvedPath, content, nextNpmBasePath, nextVfsImporterPath } = await resolveInclude(
         resolver,
         npmPath,
         quotedPath,
-        npmBasePath
+        npmBasePath,
+        vfsImporterPath
       );
 
       if (seen.has(resolvedPath)) {
@@ -118,7 +122,14 @@ export async function processIncludes(
       innerSeen.add(resolvedPath);
 
       // Recursively resolve nested includes, passing the base path for relative resolution
-      return processIncludes(content, resolver, innerSeen, depth + 1, nextBasePath);
+      return processIncludes(
+        content,
+        resolver,
+        innerSeen,
+        depth + 1,
+        nextNpmBasePath,
+        nextVfsImporterPath
+      );
     })
   );
 
@@ -142,42 +153,74 @@ async function resolveInclude(
   resolver: IncludeResolver,
   npmPath: string | undefined,
   quotedPath: string | undefined,
-  npmBasePath: string
-): Promise<{ resolvedPath: string; content: string; nextBasePath: string }> {
+  npmBasePath: string,
+  vfsImporterPath: string
+): Promise<{
+  resolvedPath: string;
+  content: string;
+  nextNpmBasePath: string;
+  nextVfsImporterPath: string;
+}> {
   // npm package imports: #include <lygia/generative/snoise>
   if (npmPath) {
     const resolved = ensureGlslExtension(npmPath);
     const content = await resolver.resolveNpm(resolved);
 
-    return { resolvedPath: `npm:${resolved}`, content, nextBasePath: dirname(resolved) };
+    return {
+      resolvedPath: `npm:${resolved}`,
+      content,
+      nextNpmBasePath: dirname(resolved),
+      nextVfsImporterPath: 'patch://'
+    };
   }
 
   if (quotedPath) {
-    // virtual filesystem imports
-    if (quotedPath.startsWith('user://')) {
-      const content = await resolver.resolveVfs(quotedPath);
-
-      return { resolvedPath: `vfs:${quotedPath}`, content, nextBasePath: '' };
-    }
-
     // HTTP imports
     if (quotedPath.startsWith('https://') || quotedPath.startsWith('http://')) {
       const content = await resolver.resolveUrl(quotedPath);
 
-      return { resolvedPath: `url:${quotedPath}`, content, nextBasePath: '' };
+      return {
+        resolvedPath: `url:${quotedPath}`,
+        content,
+        nextNpmBasePath: '',
+        nextVfsImporterPath: 'patch://'
+      };
     }
 
     // Relative imports within npm packages: #include "../math/mod289.glsl" or #include "mod289.glsl"
-    if (npmBasePath) {
+    if (npmBasePath && !quotedPath.startsWith('patch://') && !quotedPath.startsWith('user://')) {
       const resolved = ensureGlslExtension(resolveRelativePath(npmBasePath, quotedPath));
       const content = await resolver.resolveNpm(resolved);
 
-      return { resolvedPath: `npm:${resolved}`, content, nextBasePath: dirname(resolved) };
+      return {
+        resolvedPath: `npm:${resolved}`,
+        content,
+        nextNpmBasePath: dirname(resolved),
+        nextVfsImporterPath: 'patch://'
+      };
     }
 
-    throw new Error(
-      `Unsupported #include path: "${quotedPath}". Use <pkg/path> for npm, user:// for VFS, or https:// for URLs.`
-    );
+    const candidates = resolveVfsIncludeCandidates(quotedPath, vfsImporterPath);
+    let lastError: unknown;
+
+    for (const candidate of candidates) {
+      try {
+        const content = await resolver.resolveVfs(candidate);
+
+        return {
+          resolvedPath: `vfs:${candidate}`,
+          content,
+          nextNpmBasePath: '',
+          nextVfsImporterPath: candidate
+        };
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(`Failed to resolve GLSL #include "${quotedPath}"`);
   }
 
   throw new Error('Invalid #include directive');

--- a/ui/src/lib/glsl-include/vfs-paths.test.ts
+++ b/ui/src/lib/glsl-include/vfs-paths.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { isEditablePatchGlslPath, resolveVfsIncludeCandidates } from './vfs-paths';
+
+describe('GLSL VFS include paths', () => {
+  it('resolves relative paths from node code and nested Patch files', () => {
+    expect(resolveVfsIncludeCandidates('./shaders/noise')).toEqual([
+      'patch://shaders/noise',
+      'patch://shaders/noise.glsl'
+    ]);
+
+    expect(
+      resolveVfsIncludeCandidates('../shared/color.glsl', 'patch://shaders/material/main.glsl')
+    ).toEqual(['patch://shaders/shared/color.glsl']);
+  });
+
+  it('preserves explicit Patch and User namespaces', () => {
+    expect(resolveVfsIncludeCandidates('patch://shared/math')).toEqual([
+      'patch://shared/math',
+      'patch://shared/math.glsl'
+    ]);
+    expect(resolveVfsIncludeCandidates('user://shaders/color.frag')).toEqual([
+      'user://shaders/color.frag'
+    ]);
+  });
+
+  it('rejects namespace escapes', () => {
+    expect(() => resolveVfsIncludeCandidates('../secret.glsl')).toThrow('cannot escape patch://');
+    expect(() =>
+      resolveVfsIncludeCandidates('../../../secret.glsl', 'user://shaders/main.glsl')
+    ).toThrow('cannot escape user://');
+  });
+
+  it('only exposes Patch GLSL files as editable during Stage 2', () => {
+    expect(isEditablePatchGlslPath('patch://shaders/noise.glsl')).toBe(true);
+    expect(isEditablePatchGlslPath('patch://shader.js')).toBe(false);
+    expect(isEditablePatchGlslPath('user://shaders/noise.glsl')).toBe(false);
+  });
+});

--- a/ui/src/lib/glsl-include/vfs-paths.ts
+++ b/ui/src/lib/glsl-include/vfs-paths.ts
@@ -1,0 +1,69 @@
+import { parseVFSPath } from '$lib/vfs/types';
+
+const GLSL_EXTENSION = '.glsl';
+
+const hasExtension = (path: string): boolean => {
+  const filename = path.split('/').pop() ?? '';
+
+  return filename.includes('.');
+};
+
+function normalizeSegments(segments: string[], namespace: 'patch' | 'user'): string[] {
+  const normalized: string[] = [];
+
+  for (const segment of segments) {
+    if (!segment || segment === '.') continue;
+
+    if (segment === '..') {
+      if (normalized.length === 0) {
+        throw new Error(`GLSL #include cannot escape ${namespace}://`);
+      }
+
+      normalized.pop();
+      continue;
+    }
+
+    normalized.push(segment);
+  }
+
+  return normalized;
+}
+
+export function resolveVfsIncludeCandidates(
+  specifier: string,
+  importerPath: string = 'patch://'
+): string[] {
+  const explicit = parseVFSPath(specifier);
+  const importer = parseVFSPath(importerPath);
+
+  let namespace: 'patch' | 'user';
+  let segments: string[];
+
+  if (explicit) {
+    if (explicit.namespace === 'obj') {
+      throw new Error('GLSL #include does not support obj:// paths');
+    }
+
+    namespace = explicit.namespace;
+    segments = explicit.segments;
+  } else {
+    if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
+      throw new Error(`Unsupported #include path: "${specifier}"`);
+    }
+
+    if (!importer || importer.namespace === 'obj') {
+      throw new Error(`Relative GLSL #include requires a Patch or User importer: ${importerPath}`);
+    }
+
+    namespace = importer.namespace;
+    segments = [...importer.segments.slice(0, -1), ...specifier.split('/')];
+  }
+
+  const normalized = normalizeSegments(segments, namespace);
+  const exact = `${namespace}://${normalized.join('/')}`;
+
+  return hasExtension(exact) ? [exact] : [exact, `${exact}${GLSL_EXTENSION}`];
+}
+
+export const isEditablePatchGlslPath = (path: string): boolean =>
+  /^patch:\/\/.+\.(?:gl|glsl|frag|vert|glslf|glslv)$/.test(path);

--- a/ui/src/lib/glsl-include/vfs-resolver.ts
+++ b/ui/src/lib/glsl-include/vfs-resolver.ts
@@ -1,7 +1,7 @@
 /**
  * VFS resolver for GLSL #include in web workers.
  *
- * Resolves "user://..." paths by posting a message to the main thread,
+ * Resolves Patch and User VFS paths by posting a message to the main thread,
  * which reads the VFS file and sends back the text content.
  *
  * Uses the same request/response pattern as vfsWorkerUtils.ts but returns

--- a/ui/src/lib/rendering/types.ts
+++ b/ui/src/lib/rendering/types.ts
@@ -246,7 +246,7 @@ export type RenderWorkerMessage =
       nodeId: string;
       error: string;
       stack?: string;
-      lineErrors?: Record<number, string>;
+      lineErrors?: Record<number, string[]>;
     }
   | {
       type: 'consoleOutput';
@@ -254,7 +254,7 @@ export type RenderWorkerMessage =
       level: 'log' | 'warn' | 'error';
       message?: string;
       args?: unknown[];
-      lineErrors?: Record<number, string>;
+      lineErrors?: Record<number, string[]>;
     }
   | {
       type: 'sendMessageFromNode';

--- a/ui/src/lib/services/PatchManager.ts
+++ b/ui/src/lib/services/PatchManager.ts
@@ -3,6 +3,7 @@ import { migratePatch } from '$lib/migration';
 import { cleanupPatch } from '$lib/save-load/cleanup-patch';
 import { savePatchToLocalStorage } from '$lib/save-load/save-local-storage';
 import { loadPatchFromUrl } from '$lib/save-load/load-patch-from-url';
+import { canNavigateAwayFromPatchFile } from '$lib/vfs/file-editor-navigation';
 import { getSharedPatchData } from '$lib/api/pb';
 import { VirtualFilesystem } from '$lib/vfs';
 import { deleteSearchParam, getSearchParam } from '$lib/utils/search-params';
@@ -234,9 +235,7 @@ export class PatchManager {
         const parsed: PatchSaveFormat = JSON.parse(save);
 
         if (parsed) {
-          await this.restoreFromSave(parsed);
-
-          return true;
+          return this.restoreFromSave(parsed);
         }
       }
     } catch {
@@ -253,7 +252,9 @@ export class PatchManager {
       const result = await loadPatchFromUrl(url);
 
       if (result.success) {
-        await this.restoreFromSave(result.data);
+        const restored = await this.restoreFromSave(result.data);
+        if (!restored) return { success: false, error: 'Patch load cancelled' };
+
         return { success: true };
       }
 
@@ -274,7 +275,9 @@ export class PatchManager {
   async restoreFromSave(
     save: PatchSaveFormat,
     options?: { skipAutosave?: boolean }
-  ): Promise<void> {
+  ): Promise<boolean> {
+    if (!(await canNavigateAwayFromPatchFile())) return false;
+
     // Apply migrations to upgrade old patch formats
     const migrated = migratePatch(save) as PatchSaveFormat;
 
@@ -358,12 +361,16 @@ export class PatchManager {
     if (!options?.skipAutosave) {
       this.performAutosave(false);
     }
+
+    return true;
   }
 
   /**
    * Create a new empty patch.
    */
-  createNewPatch(): void {
+  async createNewPatch(): Promise<boolean> {
+    if (!(await canNavigateAwayFromPatchFile())) return false;
+
     // Exit shared patch session so autosave resumes
     this._isSharedPatchSession = false;
 
@@ -399,16 +406,21 @@ export class PatchManager {
     deleteSearchParam('id');
     deleteSearchParam('src');
     deleteSearchParam('demo');
+
+    return true;
   }
 
   /**
    * Load a shared patch (after user confirms).
    */
-  async loadSharedPatch(save: PatchSaveFormat): Promise<void> {
-    await this.restoreFromSave(save, { skipAutosave: true });
+  async loadSharedPatch(save: PatchSaveFormat): Promise<boolean> {
+    const restored = await this.restoreFromSave(save, { skipAutosave: true });
+    if (!restored) return false;
 
     // Clear current patch name to prevent accidentally overwriting user's saved patches
     currentPatchName.set(null);
+
+    return true;
   }
 
   /**
@@ -419,7 +431,9 @@ export class PatchManager {
       const result = await loadPatchFromUrl(url);
 
       if (result.success) {
-        await this.loadSharedPatch(result.data);
+        const restored = await this.loadSharedPatch(result.data);
+        if (!restored) return { success: false, error: 'Patch load cancelled' };
+
         return { success: true };
       }
 

--- a/ui/src/lib/services/PatchManager.ts
+++ b/ui/src/lib/services/PatchManager.ts
@@ -34,6 +34,7 @@ export interface LoadPatchResult {
 
 export interface LoadUrlResult {
   success: boolean;
+  cancelled?: boolean;
   error?: string;
 }
 
@@ -432,7 +433,7 @@ export class PatchManager {
 
       if (result.success) {
         const restored = await this.loadSharedPatch(result.data);
-        if (!restored) return { success: false, error: 'Patch load cancelled' };
+        if (!restored) return { success: false, cancelled: true };
 
         return { success: true };
       }

--- a/ui/src/lib/vfs/PatchFileEditorSession.test.ts
+++ b/ui/src/lib/vfs/PatchFileEditorSession.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { HistoryManager } from '$lib/history';
+import { PatchFileEditorSession, isEditorSaveShortcut } from './PatchFileEditorSession';
+import { VirtualFilesystem } from './VirtualFilesystem';
+
+describe('PatchFileEditorSession', () => {
+  beforeEach(() => {
+    VirtualFilesystem.resetInstance();
+    HistoryManager.getInstance().clear();
+  });
+
+  it('keeps drafts isolated until explicit Save and records one global operation', () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const history = HistoryManager.getInstance();
+    vfs.createEmbeddedFile('patch://shader.glsl', 'float value = 1.0;');
+    history.clear();
+
+    const session = new PatchFileEditorSession(vfs);
+    session.open('patch://shader.glsl');
+    session.updateDraft('float value = 2.0;');
+
+    expect(session.isDirty).toBe(true);
+    expect(vfs.readEmbeddedFile('patch://shader.glsl')).toBe('float value = 1.0;');
+
+    expect(session.save()).toBe(true);
+    expect(vfs.readEmbeddedFile('patch://shader.glsl')).toBe('float value = 2.0;');
+    expect(history.peekUndo()).toBe('Write shader.glsl');
+
+    history.undo();
+    expect(session.syncSavedContent()).toBe('updated');
+    expect(session.draft).toBe('float value = 1.0;');
+  });
+
+  it('reports conflicts without replacing a dirty draft', () => {
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.createEmbeddedFile('patch://shader.glsl', 'float value = 1.0;');
+
+    const session = new PatchFileEditorSession(vfs);
+    session.open('patch://shader.glsl');
+    session.updateDraft('float draft = 2.0;');
+    vfs.writeEmbeddedFile('patch://shader.glsl', 'float restored = 3.0;');
+
+    expect(session.syncSavedContent()).toBe('conflict');
+    expect(session.draft).toBe('float draft = 2.0;');
+  });
+
+  it('only recognizes platform Save shortcuts', () => {
+    expect(isEditorSaveShortcut({ key: 's', metaKey: true, ctrlKey: false })).toBe(true);
+    expect(isEditorSaveShortcut({ key: 'S', metaKey: false, ctrlKey: true })).toBe(true);
+    expect(isEditorSaveShortcut({ key: 's', metaKey: false, ctrlKey: false })).toBe(false);
+  });
+
+  it('keeps JavaScript and User GLSL files read-only in Stage 2', () => {
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.createEmbeddedFile('patch://module.js', 'export {}');
+
+    const session = new PatchFileEditorSession(vfs);
+    expect(() => session.open('patch://module.js')).toThrow('not editable');
+  });
+});

--- a/ui/src/lib/vfs/PatchFileEditorSession.ts
+++ b/ui/src/lib/vfs/PatchFileEditorSession.ts
@@ -1,0 +1,86 @@
+import type { VirtualFilesystem } from './VirtualFilesystem';
+import { isEditablePatchGlslPath } from '$lib/glsl-include/vfs-paths';
+
+export type UnsavedChangesDecision = 'save' | 'discard' | 'cancel';
+
+export const isEditorSaveShortcut = (event: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey'>) =>
+  event.key.toLowerCase() === 's' && (event.metaKey || event.ctrlKey);
+
+/** Owns one Patch-file draft and keeps unsaved content outside the VFS. */
+export class PatchFileEditorSession {
+  path: string | null = null;
+  savedContent = '';
+  draft = '';
+  revision = 0;
+
+  constructor(private vfs: VirtualFilesystem) {}
+
+  get isOpen(): boolean {
+    return this.path !== null;
+  }
+
+  get isDirty(): boolean {
+    return this.draft !== this.savedContent;
+  }
+
+  open(path: string): void {
+    if (!isEditablePatchGlslPath(path)) {
+      throw new Error(`VFS: Patch GLSL file is not editable: ${path}`);
+    }
+
+    this.path = path;
+    this.savedContent = this.vfs.readEmbeddedFile(path);
+    this.draft = this.savedContent;
+    this.revision = this.vfs.getEntry(path)?.revision ?? 0;
+  }
+
+  updateDraft(content: string): void {
+    if (!this.path) throw new Error('VFS: No Patch file is open');
+
+    this.draft = content;
+  }
+
+  save(): boolean {
+    if (!this.path || !this.isDirty) return false;
+
+    this.vfs.writeEmbeddedFile(this.path, this.draft);
+    this.savedContent = this.draft;
+    this.revision = this.vfs.getEntry(this.path)?.revision ?? this.revision + 1;
+
+    return true;
+  }
+
+  discard(): void {
+    this.draft = this.savedContent;
+  }
+
+  close(): void {
+    this.path = null;
+    this.savedContent = '';
+    this.draft = '';
+    this.revision = 0;
+  }
+
+  rename(oldPath: string, newPath: string): void {
+    if (this.path === oldPath) this.path = newPath;
+  }
+
+  syncSavedContent(): 'unchanged' | 'updated' | 'deleted' | 'conflict' {
+    if (!this.path) return 'unchanged';
+
+    const entry = this.vfs.getEntry(this.path);
+    if (!entry) return this.isDirty ? 'conflict' : 'deleted';
+
+    const nextContent = this.vfs.readEmbeddedFile(this.path);
+    const nextRevision = entry.revision ?? 0;
+
+    if (nextContent === this.savedContent && nextRevision === this.revision) return 'unchanged';
+    if (this.isDirty) return 'conflict';
+
+    this.savedContent = nextContent;
+    this.draft = nextContent;
+    this.revision = nextRevision;
+
+    return 'updated';
+  }
+}

--- a/ui/src/lib/vfs/PatchFileOperations.ts
+++ b/ui/src/lib/vfs/PatchFileOperations.ts
@@ -193,7 +193,12 @@ export class PatchFileOperations {
       `Import ${plan.importedPaths.length} patch file${plan.importedPaths.length === 1 ? '' : 's'}`,
       () => {
         for (const path of plan.removedExistingPaths) {
+          const entry = this.access.entries.get(path);
           this.access.entries.delete(path);
+
+          if (entry && isEmbeddedVFSEntry(entry)) {
+            this.access.emitContentModified(path, (entry.revision ?? 0) + 1);
+          }
         }
 
         for (const [path, entry] of plan.stagedEntries) {

--- a/ui/src/lib/vfs/VirtualFilesystem.test.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.test.ts
@@ -542,6 +542,25 @@ describe('VirtualFilesystem patch files', () => {
     eventBus.removeEventListener('vfsContentModified', handleContentModified);
   });
 
+  it('keeps revisions monotonic when a cleared path is recreated', () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const eventBus = PatchiesEventBus.getInstance();
+    const revisions: number[] = [];
+    const handleContentModified = (event: VfsContentModifiedEvent) => {
+      if (event.path === 'patch://recreated.glsl') revisions.push(event.revision);
+    };
+
+    eventBus.addEventListener('vfsContentModified', handleContentModified);
+
+    vfs.createEmbeddedFile('patch://recreated.glsl', 'float value = 1.0;');
+    vfs.clear();
+    vfs.createEmbeddedFile('patch://recreated.glsl', 'float value = 2.0;');
+
+    expect(revisions).toEqual([1, 2, 3]);
+
+    eventBus.removeEventListener('vfsContentModified', handleContentModified);
+  });
+
   it('loads oversized embedded files for recovery but refuses to resolve them', async () => {
     const vfs = VirtualFilesystem.getInstance();
     const content = 'x'.repeat(256 * 1024 + 1);

--- a/ui/src/lib/vfs/VirtualFilesystem.test.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { HistoryManager } from '$lib/history';
 import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
 import type { VfsPathRenamedEvent } from '$lib/eventbus/events';
+import type { VfsContentModifiedEvent } from '$lib/eventbus/events';
 import { getPatchImportError, VirtualFilesystem } from './VirtualFilesystem';
 import type { EmbeddedVFSEntry } from './types';
 
@@ -307,6 +308,24 @@ describe('VirtualFilesystem patch files', () => {
     history.redo();
     expect(vfs.readEmbeddedFile('patch://utility.js')).toContain('2');
     expect(vfs.getEntry('patch://utility.js')).toMatchObject({ revision: 2 });
+  });
+
+  it('emits monotonic content revisions across Save, undo, and redo', () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const history = HistoryManager.getInstance();
+    const revisions: number[] = [];
+    const listener = (event: VfsContentModifiedEvent) => revisions.push(event.revision);
+
+    PatchiesEventBus.getInstance().addEventListener('vfsContentModified', listener);
+
+    vfs.createEmbeddedFile('patch://utility.glsl', 'float value = 1.0;');
+    vfs.writeEmbeddedFile('patch://utility.glsl', 'float value = 2.0;');
+    history.undo();
+    history.redo();
+
+    expect(revisions).toEqual([1, 2, 3, 4]);
+
+    PatchiesEventBus.getInstance().removeEventListener('vfsContentModified', listener);
   });
 
   it('restores local file bytes and metadata when replacement is undone and redone', async () => {

--- a/ui/src/lib/vfs/VirtualFilesystem.test.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.test.ts
@@ -521,6 +521,27 @@ describe('VirtualFilesystem patch files', () => {
     await expect((await vfs.resolve('user://shared.txt')).text()).resolves.toBe('patch-b');
   });
 
+  it('emits embedded deletion revisions for low-level remove and clear', () => {
+    const vfs = VirtualFilesystem.getInstance();
+    const eventBus = PatchiesEventBus.getInstance();
+    const deletions: VfsContentModifiedEvent[] = [];
+    const handleContentModified = (event: VfsContentModifiedEvent) => deletions.push(event);
+
+    vfs.createEmbeddedFile('patch://removed.glsl', 'float removed = 1.0;');
+    vfs.createEmbeddedFile('patch://cleared.glsl', 'float cleared = 1.0;');
+    eventBus.addEventListener('vfsContentModified', handleContentModified);
+
+    vfs.remove('patch://removed.glsl');
+    vfs.clear();
+
+    expect(deletions).toEqual([
+      { type: 'vfsContentModified', path: 'patch://removed.glsl', revision: 2 },
+      { type: 'vfsContentModified', path: 'patch://cleared.glsl', revision: 2 }
+    ]);
+
+    eventBus.removeEventListener('vfsContentModified', handleContentModified);
+  });
+
   it('loads oversized embedded files for recovery but refuses to resolve them', async () => {
     const vfs = VirtualFilesystem.getInstance();
     const content = 'x'.repeat(256 * 1024 + 1);

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -583,8 +583,6 @@ export class VirtualFilesystem {
     for (const file of deletedEmbeddedFiles) {
       this.emitContentModified(file.path, file.revision);
     }
-
-    this.contentRevisionClock.clear();
   }
 
   clearPersistedData(): void {

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -550,6 +550,9 @@ export class VirtualFilesystem {
 
   remove(path: string): void {
     const entry = this.entries.get(path);
+    const deletionRevision =
+      entry && isEmbeddedVFSEntry(entry) ? (entry.revision ?? 0) + 1 : undefined;
+
     this.entries.delete(path);
     this.permissions.delete(path);
 
@@ -558,12 +561,17 @@ export class VirtualFilesystem {
     }
 
     this.notifyChange();
+
+    if (deletionRevision !== undefined) this.emitContentModified(path, deletionRevision);
   }
 
   clear(): void {
+    const deletedEmbeddedFiles = [...this.entries].flatMap(([path, entry]) =>
+      isEmbeddedVFSEntry(entry) ? [{ path, revision: (entry.revision ?? 0) + 1 }] : []
+    );
+
     this.entries.clear();
     this.permissions.clear();
-    this.contentRevisionClock.clear();
     this.patchFiles.refreshValidation();
 
     const provider = this.getLocalProvider();
@@ -571,6 +579,12 @@ export class VirtualFilesystem {
     provider?.clearDirHandles();
 
     this.notifyChange();
+
+    for (const file of deletedEmbeddedFiles) {
+      this.emitContentModified(file.path, file.revision);
+    }
+
+    this.contentRevisionClock.clear();
   }
 
   clearPersistedData(): void {

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -53,6 +53,7 @@ export class VirtualFilesystem {
   private patchFiles: PatchFileOperations;
   private directoryReader: VfsDirectoryReader;
   private treeCodec = new VfsTreeCodec();
+  private contentRevisionClock = new Map<string, number>();
 
   readonly entries$: Readable<Map<string, VFSEntry>> = derived(this.versionStore, () =>
     this.getAllEntries()
@@ -327,6 +328,14 @@ export class VirtualFilesystem {
     const plan = this.entries.planDelete(requestedPaths);
     if (plan.paths.length === 0) return;
 
+    const deletedEmbeddedFiles = plan.paths.flatMap((path) => {
+      const entry = this.entries.get(path);
+
+      return entry && isEmbeddedVFSEntry(entry)
+        ? [{ path, revision: (entry.revision ?? 0) + 1 }]
+        : [];
+    });
+
     const linkedFolderPaths = plan.paths.filter(
       (path) => this.entries.get(path)?.provider === 'local-folder'
     );
@@ -355,6 +364,10 @@ export class VirtualFilesystem {
         this.permissions.deleteAll(plan.paths);
         setLinkedFoldersDeleted(true);
         this.notifyChange();
+
+        for (const file of deletedEmbeddedFiles) {
+          this.emitContentModified(file.path, file.revision);
+        }
       },
       {
         redo: () => setLinkedFoldersDeleted(true),
@@ -550,6 +563,7 @@ export class VirtualFilesystem {
   clear(): void {
     this.entries.clear();
     this.permissions.clear();
+    this.contentRevisionClock.clear();
     this.patchFiles.refreshValidation();
 
     const provider = this.getLocalProvider();
@@ -601,11 +615,13 @@ export class VirtualFilesystem {
           prior.revision !== entry.revision);
 
       if (hasVfsModified) {
-        PatchiesEventBus.getInstance().dispatch({
-          type: 'vfsContentModified',
-          path,
-          revision: entry.revision ?? 1
-        });
+        this.emitContentModified(path, entry.revision ?? 1);
+      }
+    }
+
+    for (const [path, entry] of previous) {
+      if (isEmbeddedVFSEntry(entry) && !this.entries.has(path)) {
+        this.emitContentModified(path, (entry.revision ?? 0) + 1);
       }
     }
   }
@@ -660,6 +676,13 @@ export class VirtualFilesystem {
   }
 
   private emitContentModified(path: string, revision: number): void {
-    PatchiesEventBus.getInstance().dispatch({ type: 'vfsContentModified', path, revision });
+    const monotonicRevision = Math.max(revision, (this.contentRevisionClock.get(path) ?? 0) + 1);
+    this.contentRevisionClock.set(path, monotonicRevision);
+
+    PatchiesEventBus.getInstance().dispatch({
+      type: 'vfsContentModified',
+      path,
+      revision: monotonicRevision
+    });
   }
 }

--- a/ui/src/lib/vfs/file-editor-navigation.ts
+++ b/ui/src/lib/vfs/file-editor-navigation.ts
@@ -1,0 +1,14 @@
+type UnsavedChangesGuard = () => Promise<boolean>;
+
+let activeGuard: UnsavedChangesGuard | null = null;
+
+export function registerUnsavedChangesGuard(guard: UnsavedChangesGuard): () => void {
+  activeGuard = guard;
+
+  return () => {
+    if (activeGuard === guard) activeGuard = null;
+  };
+}
+
+export const canNavigateAwayFromPatchFile = (): Promise<boolean> =>
+  activeGuard?.() ?? Promise.resolve(true);

--- a/ui/src/lib/vfs/worker-vfs-request-handler.test.ts
+++ b/ui/src/lib/vfs/worker-vfs-request-handler.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { VirtualFilesystem } from './VirtualFilesystem';
+import { EmbeddedProvider } from './providers/EmbeddedProvider';
 import {
   listVfsEntries,
   revokeWorkerVfsObjectUrls,
@@ -12,6 +13,7 @@ import {
 describe('worker VFS requests', () => {
   beforeEach(() => {
     VirtualFilesystem.resetInstance();
+    VirtualFilesystem.getInstance().registerProvider(new EmbeddedProvider());
   });
 
   afterEach(() => {
@@ -41,13 +43,24 @@ describe('worker VFS requests', () => {
     });
   });
 
-  it('keeps external URLs external and limits text requests to user paths', async () => {
+  it('keeps external URLs external and limits text requests to include namespaces', async () => {
+    const vfs = VirtualFilesystem.getInstance();
+    vfs.createEmbeddedFile(
+      'patch://world.glsl',
+      'float circle(vec2 point, float radius) { return length(point) - radius; }'
+    );
+
     expect(await resolveVfsUrl('node-1', '//cdn.example.com/file.png')).toEqual({
       url: '//cdn.example.com/file.png'
     });
 
+    expect(await resolveVfsText('patch://world.glsl')).toEqual({
+      text: 'float circle(vec2 point, float radius) { return length(point) - radius; }'
+    });
+
     expect(await resolveVfsText('obj://node/file.txt')).toEqual({
-      error: 'Invalid VFS path: "obj://node/file.txt". Only user:// paths are supported.'
+      error:
+        'Invalid VFS path: "obj://node/file.txt". Only patch:// and user:// paths are supported.'
     });
   });
 

--- a/ui/src/lib/vfs/worker-vfs-request-handler.ts
+++ b/ui/src/lib/vfs/worker-vfs-request-handler.ts
@@ -75,9 +75,9 @@ export async function searchVfsEntries(query: string, path: string): Promise<Vfs
 
 /** Resolve a text-only VFS request used by render-worker GLSL includes. */
 export async function resolveVfsText(path: string): Promise<VfsTextResponse> {
-  if (!path.startsWith('user://')) {
+  if (!path.startsWith('patch://') && !path.startsWith('user://')) {
     return {
-      error: `Invalid VFS path: "${path}". Only user:// paths are supported.`
+      error: `Invalid VFS path: "${path}". Only patch:// and user:// paths are supported.`
     };
   }
 

--- a/ui/src/objects/glsl/GLSLCanvasNode.svelte
+++ b/ui/src/objects/glsl/GLSLCanvasNode.svelte
@@ -438,12 +438,14 @@
 
   {#snippet console()}
     <!-- Always render VirtualConsole so it receives events even when hidden -->
+    <!-- We already have in-gutter errors, so we don't auto-show the console on new errors -->
     <div class="mt-3 w-full" class:hidden={!data.showConsole}>
       <VirtualConsole
         bind:this={consoleRef}
         {nodeId}
         placeholder="Shader compilation errors will appear here."
         maxHeight="200px"
+        shouldAutoShowConsoleOnError={false}
       />
     </div>
   {/snippet}

--- a/ui/src/objects/glsl/GLSLCanvasNode.svelte
+++ b/ui/src/objects/glsl/GLSLCanvasNode.svelte
@@ -438,14 +438,12 @@
 
   {#snippet console()}
     <!-- Always render VirtualConsole so it receives events even when hidden -->
-    <!-- We already have in-gutter errors, so we don't auto-show the console on new errors -->
     <div class="mt-3 w-full" class:hidden={!data.showConsole}>
       <VirtualConsole
         bind:this={consoleRef}
         {nodeId}
         placeholder="Shader compilation errors will appear here."
         maxHeight="200px"
-        shouldAutoShowConsoleOnError={false}
       />
     </div>
   {/snippet}

--- a/ui/src/workers/rendering/ShaderRendererFactory.test.ts
+++ b/ui/src/workers/rendering/ShaderRendererFactory.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RenderNode } from '$lib/rendering/types';
+
+vi.mock('$lib/glsl-include/worker-resolver', () => ({
+  createWorkerResolver: () => ({
+    resolveNpm: vi.fn(async () => ''),
+    resolveUrl: vi.fn(async () => ''),
+    resolveVfs: vi.fn(async (path: string) => {
+      throw new Error(`VFS: Path not found: ${path}`);
+    })
+  })
+}));
+
+import { ShaderRendererFactory } from './ShaderRendererFactory';
+
+describe('ShaderRendererFactory GLSL includes', () => {
+  const postMessage = vi.fn();
+
+  beforeEach(() => {
+    postMessage.mockClear();
+    vi.stubGlobal('self', { postMessage });
+  });
+
+  it('reports a missing include on the originating source line', async () => {
+    const owner = {
+      uniformDataByNode: new Map()
+    };
+    const factory = new ShaderRendererFactory(owner as never);
+    const node = {
+      id: 'glsl-1',
+      inputs: [],
+      outputs: [],
+      inletMap: new Map(),
+      backEdgeInlets: new Set(),
+      type: 'glsl',
+      data: {
+        code: 'float before = 1.0;\n#include "patch://non-existent-file"',
+        glUniformDefs: []
+      }
+    } as Extract<RenderNode, { type: 'glsl' }>;
+
+    await expect(factory.create(node, {} as never)).resolves.toBeNull();
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'shaderError',
+        nodeId: 'glsl-1',
+        error: 'Include error on line 2: VFS: Path not found: patch://non-existent-file.glsl',
+        lineErrors: {
+          2: ['VFS: Path not found: patch://non-existent-file.glsl']
+        }
+      })
+    );
+  });
+});

--- a/ui/src/workers/rendering/ShaderRendererFactory.ts
+++ b/ui/src/workers/rendering/ShaderRendererFactory.ts
@@ -52,12 +52,9 @@ export class ShaderRendererFactory {
 
         code = await processIncludes(code, createWorkerResolver(node.id));
       } catch (error) {
-        self.postMessage({
-          type: 'shaderError',
-          nodeId: node.id,
-          error: error instanceof Error ? error.message : String(error),
-          stack: error instanceof Error ? error.stack : undefined
-        });
+        const shaderError = error instanceof Error ? error : new Error(String(error));
+
+        this.postShaderError(node.id, shaderError);
 
         return null;
       } finally {

--- a/ui/src/workers/rendering/ShaderRendererFactory.ts
+++ b/ui/src/workers/rendering/ShaderRendererFactory.ts
@@ -93,7 +93,9 @@ export class ShaderRendererFactory {
       onError: (error) => this.postShaderError(node.id, error)
     });
 
-    return { render: (params: RenderParams) => command?.(params), cleanup: () => {} };
+    if (!command) return null;
+
+    return { render: (params: RenderParams) => command(params), cleanup: () => {} };
   }
 
   private async createShaderPark(

--- a/ui/src/workers/rendering/buildRenderGraph.test.ts
+++ b/ui/src/workers/rendering/buildRenderGraph.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FBONode, RenderGraph, RenderNode } from '$lib/rendering/types';
+import { buildRenderGraph } from './buildRenderGraph';
+
+describe('buildRenderGraph shader fallback', () => {
+  it('keeps the last working FBO when replacement shader compilation fails', async () => {
+    const render = vi.fn();
+    const existingFbo = {
+      id: 'glsl-1',
+      texture: { width: 640, height: 480 },
+      colorAttachments: [{ width: 640, height: 480 }],
+      framebuffer: {},
+      render,
+      dataFingerprint: '{"code":"working"}',
+      nodeType: 'glsl',
+      fboFormat: 'rgba8',
+      previewSize: [160, 120]
+    } as unknown as FBONode;
+
+    const node = {
+      id: 'glsl-1',
+      type: 'glsl',
+      data: { code: 'broken', glUniformDefs: [] },
+      inputs: [],
+      outputs: [],
+      inletMap: new Map(),
+      backEdgeInlets: new Set()
+    } as unknown as RenderNode;
+
+    const graph = {
+      nodes: [node],
+      edges: [],
+      sortedNodes: ['glsl-1'],
+      outputNodeId: null,
+      outputOutletIndex: 0,
+      backEdges: new Set(),
+      feedbackNodes: new Set()
+    } as unknown as RenderGraph;
+
+    const host = {
+      connectedVideoOutputNodeIds: new Set(),
+      renderGraph: graph,
+      fboNodes: new Map([['glsl-1', existingFbo]]),
+      cookState: {
+        markDirty: vi.fn(),
+        removeNode: vi.fn()
+      },
+      lastCookStatusSignatures: new Map(),
+      videoChannelRegistry: {
+        unsubscribeAll: vi.fn(),
+        getVirtualEdges: () => []
+      },
+      previewRenderer: {
+        removeNode: vi.fn(),
+        setPreviewEnabled: vi.fn(),
+        hasPreviewState: () => true,
+        hasEnabledPreviews: () => true
+      },
+      cleanupExpensiveTextmodeRenderers: vi.fn(),
+      rebuildCookingPolicies: vi.fn(),
+      resolveNodeSize: () => [640, 480],
+      computeNodeFingerprint: () => '{"code":"broken"}',
+      hasReusableRenderer: () => false,
+      createRenderer: async () => null,
+      destroyFboNode: vi.fn(),
+      destroyFeedbackResources: vi.fn(),
+      reportCookStatuses: vi.fn(),
+      resumeViewportManagedRenderers: vi.fn(),
+      shouldProcessPreviews: false,
+      outputNodeId: null,
+      outputOutletIndex: 0,
+      gl: {
+        MAX_DRAW_BUFFERS: 1,
+        MAX_COLOR_ATTACHMENTS: 2,
+        getParameter: () => 4
+      },
+      regl: {}
+    };
+
+    await buildRenderGraph(host as never, graph);
+
+    expect(host.fboNodes.get('glsl-1')).toBe(existingFbo);
+    expect(host.fboNodes.get('glsl-1')?.render).toBe(render);
+    expect(host.destroyFboNode).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/workers/rendering/buildRenderGraph.test.ts
+++ b/ui/src/workers/rendering/buildRenderGraph.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { FBONode, RenderGraph, RenderNode } from '$lib/rendering/types';
+import { CookStateManager } from './CookStateManager';
 import { buildRenderGraph } from './buildRenderGraph';
 
 describe('buildRenderGraph shader fallback', () => {
@@ -83,5 +84,101 @@ describe('buildRenderGraph shader fallback', () => {
     expect(host.fboNodes.get('glsl-1')).toBe(existingFbo);
     expect(host.fboNodes.get('glsl-1')?.render).toBe(render);
     expect(host.destroyFboNode).not.toHaveBeenCalled();
+  });
+
+  it('cooks a replacement renderer even if the old renderer cooks during compilation', async () => {
+    const replacementRender = vi.fn();
+    let finishCompilation!: (renderer: { render: () => void; cleanup: () => void }) => void;
+
+    const compilation = new Promise<{ render: () => void; cleanup: () => void }>((resolve) => {
+      finishCompilation = resolve;
+    });
+
+    const cookState = new CookStateManager();
+    cookState.registerNode('glsl-1', { mode: 'on-demand' });
+    cookState.markCooked('glsl-1', ['first-frame'], 0);
+
+    const existingFbo = {
+      id: 'glsl-1',
+      texture: { width: 640, height: 480 },
+      colorAttachments: [{ width: 640, height: 480 }],
+      framebuffer: {},
+      render: vi.fn(),
+      cleanup: vi.fn(),
+      dataFingerprint: '{"code":"old"}',
+      nodeType: 'glsl',
+      fboFormat: 'rgba8',
+      previewSize: [160, 120]
+    } as unknown as FBONode;
+
+    const node = {
+      id: 'glsl-1',
+      type: 'glsl',
+      data: { code: 'new', glUniformDefs: [] },
+      inputs: [],
+      outputs: [],
+      inletMap: new Map(),
+      backEdgeInlets: new Set()
+    } as unknown as RenderNode;
+
+    const graph = {
+      nodes: [node],
+      edges: [],
+      sortedNodes: ['glsl-1'],
+      outputNodeId: null,
+      outputOutletIndex: 0,
+      backEdges: new Set(),
+      feedbackNodes: new Set()
+    } as unknown as RenderGraph;
+
+    const host = {
+      connectedVideoOutputNodeIds: new Set(),
+      renderGraph: graph,
+      fboNodes: new Map([['glsl-1', existingFbo]]),
+      cookState,
+      lastCookStatusSignatures: new Map(),
+      videoChannelRegistry: {
+        unsubscribeAll: vi.fn(),
+        getVirtualEdges: () => []
+      },
+      previewRenderer: {
+        removeNode: vi.fn(),
+        setPreviewEnabled: vi.fn(),
+        hasPreviewState: () => true,
+        hasEnabledPreviews: () => true
+      },
+      cleanupExpensiveTextmodeRenderers: vi.fn(),
+      rebuildCookingPolicies: vi.fn(),
+      resolveNodeSize: () => [640, 480],
+      computeNodeFingerprint: () => '{"code":"new"}',
+      hasReusableRenderer: () => false,
+      createRenderer: () => compilation,
+      destroyFboNode: vi.fn(),
+      destroyFeedbackResources: vi.fn(),
+      resumeViewportManagedRenderers: vi.fn(),
+      shouldProcessPreviews: false,
+      outputNodeId: null,
+      outputOutletIndex: 0,
+      gl: {
+        MAX_DRAW_BUFFERS: 1,
+        MAX_COLOR_ATTACHMENTS: 2,
+        getParameter: () => 4
+      },
+      regl: {}
+    };
+
+    const oldCook = cookState.shouldCook('glsl-1');
+    const build = buildRenderGraph(host as never, graph);
+
+    cookState.markCooked('glsl-1', oldCook.reasons, 0);
+    finishCompilation({ render: replacementRender, cleanup: vi.fn() });
+
+    await build;
+    expect(host.fboNodes.get('glsl-1')?.render).toBe(replacementRender);
+
+    expect(cookState.shouldCook('glsl-1')).toEqual({
+      shouldCook: true,
+      reasons: ['config']
+    });
   });
 });

--- a/ui/src/workers/rendering/buildRenderGraph.ts
+++ b/ui/src/workers/rendering/buildRenderGraph.ts
@@ -25,6 +25,8 @@ interface PendingNode {
   fingerprint: string;
   fboFormat: FBOFormat;
   resolution?: FBOResolution;
+  existingFbo?: FBONode;
+  reusesFbo: boolean;
 }
 
 export const buildRenderGraph = async (
@@ -192,7 +194,9 @@ export const buildRenderGraph = async (
       prevFramebuffers,
       fingerprint,
       fboFormat,
-      resolution: nodeResolution
+      resolution: nodeResolution,
+      existingFbo,
+      reusesFbo: Boolean(canReuseFbo)
     });
   }
 
@@ -211,7 +215,9 @@ export const buildRenderGraph = async (
       prevFramebuffers,
       fingerprint,
       fboFormat,
-      resolution
+      resolution,
+      existingFbo,
+      reusesFbo
     } = pending[i];
 
     const renderer = results[i];
@@ -219,6 +225,13 @@ export const buildRenderGraph = async (
     // If the renderer function is null, we skip defining this node.
     if (renderer === null) {
       console.warn(`skipped node ${node.type} ${node.id} - no renderer available`);
+
+      if (existingFbo && reusesFbo) {
+        host.fboNodes.set(node.id, existingFbo);
+        host.cookState.markDirty(node.id, 'config');
+
+        continue;
+      }
 
       // Evict stale FBO entry so the old render function is not reused
       host.fboNodes.delete(node.id);

--- a/ui/src/workers/rendering/buildRenderGraph.ts
+++ b/ui/src/workers/rendering/buildRenderGraph.ts
@@ -184,8 +184,6 @@ export const buildRenderGraph = async (
       framebuffer = fbo.framebuffer;
     }
 
-    host.cookState.markDirty(node.id, existingFbo ? 'config' : 'first-frame');
-
     pending.push({
       node,
       colorAttachments,
@@ -284,6 +282,7 @@ export const buildRenderGraph = async (
     };
 
     host.fboNodes.set(node.id, fboNode);
+    host.cookState.markDirty(node.id, existingFbo ? 'config' : 'first-frame');
 
     // Do not send previews back to external texture nodes,
     // as the texture is managed by the node on the frontend.

--- a/ui/static/content/topics/glsl-imports.md
+++ b/ui/static/content/topics/glsl-imports.md
@@ -1,6 +1,6 @@
 # GLSL Imports
 
-Use `#include` to import GLSL functions from NPM packages, your files, or URLs. You do not need to copy shader code between nodes.
+Use `#include` to import GLSL functions from NPM packages, Patch files, User files, or URLs. You do not need to copy shader code between nodes.
 
 `#include` works in [glsl](/docs/objects/glsl), [swgl](/docs/objects/swgl), [regl](/docs/objects/regl), and [hydra](/docs/objects/hydra) inside `setFunction`. It also works in [three](/docs/objects/three) through the `await glsl` tagged template.
 
@@ -21,7 +21,7 @@ This example gets the `snoise` function from the [lygia](https://lygia.xyz) shad
 
 ## Import Sources
 
-You can import GLSL code from three sources:
+You can import GLSL code from four sources:
 
 ### NPM Packages
 
@@ -35,7 +35,22 @@ Use angle brackets to import from shader libraries, such as lygia:
 
 The `.glsl` extension is optional. `<lygia/generative/snoise>` and `<lygia/generative/snoise.glsl>` are equivalent.
 
-### Your Files
+### Patch Files
+
+Files under `patch://` are embedded in the current patch. They travel with the patch when you save or share it, and supported GLSL files are editable in the Files sidebar.
+
+Relative GLSL paths start from the `patch://` root when you include them from a node:
+
+```glsl
+#include "./utils.glsl"
+#include "patch://shaders/palette.glsl"
+```
+
+Inside an included Patch file, a relative path starts from that file's folder. The `.glsl` extension is optional.
+
+Create a Patch GLSL file in the sidebar with `Ctrl/Cmd + B > Files`, then use it from any supported shader node.
+
+### User Files
 
 Use double quotes and a `user://` path to import from [Virtual Filesystem](/docs/virtual-filesystem) files:
 
@@ -44,7 +59,7 @@ Use double quotes and a `user://` path to import from [Virtual Filesystem](/docs
 #include "user://sdf-functions.glsl"
 ```
 
-Add `.glsl` files in the sidebar (`Ctrl/Cmd + B > Files`). Then include them in any shader node.
+User files come from uploads, browser-local storage, or linked folders. They are not embedded as source in the patch and are read-only in the Files sidebar editor. Linked files may need permission again after you reopen the patch.
 
 ### URLs
 
@@ -60,13 +75,13 @@ Patchies caches URL imports in memory for the session. It gets each URL once.
 
 `#include` works in five visual objects. Most of them preprocess your shaders automatically.
 
-| Object | How it works |
-| --- | --- |
-| [glsl](/docs/objects/glsl) | Auto-preprocessed before shader compilation |
-| [swgl](/docs/objects/swgl) | Auto-preprocessed in `FP`, `VP`, and `Inc` fields |
-| [regl](/docs/objects/regl) | Auto-preprocessed in `frag` and `vert` fields |
-| [hydra](/docs/objects/hydra) | Auto-preprocessed inside `setFunction` GLSL strings |
-| [three](/docs/objects/three) | Use `await glsl` tagged template or `processIncludes()` |
+| Object                        | How it works                                               |
+| ----------------------------- | ---------------------------------------------------------- |
+| [glsl](/docs/objects/glsl)    | Auto-preprocessed before shader compilation               |
+| [swgl](/docs/objects/swgl)    | Auto-preprocessed in `FP`, `VP`, and `Inc` fields          |
+| [regl](/docs/objects/regl)    | Auto-preprocessed in `frag` and `vert` fields              |
+| [hydra](/docs/objects/hydra)  | Auto-preprocessed inside `setFunction` GLSL strings        |
+| [three](/docs/objects/three)  | Use `await glsl` tagged template or `processIncludes()`     |
 
 ### Hydra Usage
 
@@ -140,7 +155,7 @@ vec3 palette(float t) {
 4. In a `glsl` object, include and use the file:
 
 ```glsl
-#include "user://utils.glsl"
+#include "./utils.glsl"
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   fragColor = vec4(palette(uv.x + iTime * 0.2), 1.0);
@@ -148,7 +163,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 ```
 
 5. Create a second `glsl` object.
-6. Include the same file. Both nodes share the function.
+6. Include the same file. Both nodes share the function, and saving `utils.glsl` updates both nodes.
 
 ## Nested Includes
 
@@ -174,4 +189,4 @@ These requirements do not apply if your shaders do not import Lygia with `#inclu
 - [swgl](/docs/objects/swgl) — Create SwissGL shaders.
 - [regl](/docs/objects/regl) — Use WebGL with REGL.
 - [three](/docs/objects/three) — Create Three.js scenes.
-- [Virtual Filesystem](/docs/virtual-filesystem) — Manage files for `user://` imports.
+- [Virtual Filesystem](/docs/virtual-filesystem) — Understand `patch://` and `user://` files.

--- a/ui/static/content/topics/virtual-filesystem.md
+++ b/ui/static/content/topics/virtual-filesystem.md
@@ -1,6 +1,6 @@
 # Virtual Filesystem
 
-The virtual filesystem (VFS) stores images, videos, fonts, 3D models, and other patch assets.
+The virtual filesystem (VFS) gives patches stable paths for embedded source files, uploads, linked files, and other assets.
 
 ![Virtual filesystem with canvas demo](/content/images/canvas-vfs.webp)
 
@@ -11,6 +11,36 @@ This VFS includes assets for a canvas demo. Add a file to the patch or link it f
 Use the sidebar to manage patch files. Open it with `Ctrl/Cmd + B > Files`. You can also click "Open Sidebar" at the bottom right.
 
 See [Files](/docs/manage-files) for file management details.
+
+## Patch and User Files
+
+The namespace tells you who owns a file and whether it travels with the patch:
+
+| Namespace  | Use it for                                   | Embedded in the patch | Files sidebar editor |
+| ---------- | -------------------------------------------- | --------------------- | -------------------- |
+| `patch://` | Small source files owned by the patch        | Yes                   | GLSL files editable  |
+| `user://`  | Uploads, browser-local files, linked folders | No                    | Read-only            |
+
+Use `patch://` for a GLSL utility that should work when someone else opens your patch. Use `user://` for personal files and larger assets that live outside the patch, such as samples, videos, or a linked project folder.
+
+> **Important**: A linked `user://` file may need permission again after you reopen the patch. A `patch://` file needs no external permission.
+
+### GLSL Includes
+
+Relative GLSL includes resolve from `patch://`, so these two paths select the same file from a shader node:
+
+```glsl
+#include "./shaders/noise.glsl"
+#include "patch://shaders/noise.glsl"
+```
+
+Use an explicit User path to include a linked or uploaded file:
+
+```glsl
+#include "user://my-shaders/noise.glsl"
+```
+
+See [GLSL Imports](/docs/glsl-imports) for supported shader objects, nested includes, and examples.
 
 ## Loading Files in Code
 
@@ -30,6 +60,14 @@ const data = await vfs.get("user://data.json").json();
 ```
 
 VFS paths use the `user://` prefix for uploaded files. Patchies clears object URLs when it destroys the object.
+
+Relative paths in the JavaScript `vfs` API continue to resolve from `user://`. Use an explicit `patch://` path to read an embedded Patch file:
+
+```javascript
+const source = await vfs.get("patch://shaders/noise.glsl").text();
+```
+
+This differs from GLSL `#include`, where relative paths resolve from `patch://`.
 
 ## Browsing Files in Code
 
@@ -70,5 +108,6 @@ Use `vfs` in all [JavaScript Runner](/docs/javascript-runner)-based objects.
 ## See Also
 
 - [Files](/docs/manage-files) — Manage files in the sidebar.
+- [GLSL Imports](/docs/glsl-imports) — Share GLSL functions between shader nodes.
 - [JavaScript Runner](/docs/javascript-runner) — Use the full JSRunner API.
 - [Data Storage](/docs/data-storage) — Store persistent key-value data.


### PR DESCRIPTION
## Summary

- add a Files sidebar editor for embedded Patch GLSL files with explicit save, unsaved-change guards, keyboard shortcuts, and file actions
- resolve relative, `patch://`, and `user://` GLSL includes recursively and invalidate only dependent shader consumers after saves
- preserve the last working shader renderer when an edited include fails to compile
- update the virtual filesystem Stage 2 specification and add focused coverage for editing, includes, revisions, invalidation, and render fallback

## Verification

- `bun run check`
- `bun run test src/lib/glsl-include/preprocessor.test.ts src/lib/glsl-include/vfs-paths.test.ts src/lib/glsl-include/dependency-index.test.ts src/lib/vfs/PatchFileEditorSession.test.ts src/lib/canvas/GLSystem.test.ts src/workers/rendering/buildRenderGraph.test.ts src/lib/vfs/VirtualFilesystem.test.ts src/lib/vfs/file-reader.test.ts src/lib/vfs/worker-vfs-request-handler.test.ts src/workers/rendering/vfsWorkerUtils.test.ts` (51 tests)
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added editing for embedded Patch GLSL files, including creating, renaming, deleting, saving, and navigating files.
  * Added unsaved-change protection with Save, Discard, and Cancel options.
  * Improved GLSL `#include` support for relative, Patch, and User paths, including nested dependencies.
  * Added keyboard and Vim save commands in the code editor.

* **Bug Fixes**
  * Shader updates now rebuild only affected render nodes.
  * Improved shader include error reporting with source-line details.
  * Preserved existing rendering resources when replacement shaders fail.
  * Improved handling of file changes, undo/redo, imports, and canceled patch loading.

* **Documentation**
  * Updated virtual filesystem implementation status and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->