### PR TITLE
feat(vfs): expose editable object code in the objects namespace in vfs tree

### DIFF
--- a/docs/design-docs/specs/52-virtual-filesystem.md
+++ b/docs/design-docs/specs/52-virtual-filesystem.md
@@ -656,6 +656,10 @@ Run, blur, and navigation commit a single undo step for the editing gesture;
 Run alone requests execution. Undo and redo use node history and update both
 editors. Patch files retain their explicit save/discard drafts.
 
+Objects file editors retain the source object's editor type. Inline value widgets
+use the main editor's rerun policy and throttle, including automatic Hydra reruns
+while adjusting values.
+
 Object-file projection updates metadata only for changed sources. Unchanged
 sources are not re-encoded or rebuilt on each keystroke.
 

--- a/docs/design-docs/specs/52-virtual-filesystem.md
+++ b/docs/design-docs/specs/52-virtual-filesystem.md
@@ -137,7 +137,6 @@ class VirtualFilesystem {
 
   // Registration
   registerFile(path: string, entry: VFSEntry): void;
-  registerLocalFile(file: File): Promise<string>; // returns generated path like 'user://images/photo.jpg'
   registerUrl(url: string): Promise<string>; // returns generated path
 
   // Resolution
@@ -238,7 +237,7 @@ data: {
 
 **Drop/select flow:**
 
-1. User drops file → `vfs.registerLocalFile(file)` → returns path
+1. User drops file → `vfs.storeFile(file)` → returns path
 2. Store path in `node.data.vfsPath`
 3. Load image into GLSystem
 
@@ -378,7 +377,7 @@ The VFS has three namespaces:
 | ---------- | --------------------------------------- | ----------------------------------------------- | ------------------------------------- |
 | `patch://` | Embedded in the current patch           | Serialized under `files.patch`                  | Supported text files are editable     |
 | `user://`  | External or browser-local user resource | Handle, URL, or patch-scoped IndexedDB fallback | Read-only in the first editor release |
-| `obj://`   | Object-owned resource                   | Runtime-only; rebuilt from object state         | Not editable independently            |
+| `obj://`   | Object-owned resource                   | Runtime-only; rebuilt from object state         | Edit existing object code only            |
 
 An embedded entry uses the `embedded` provider and stores UTF-8 text directly:
 
@@ -406,7 +405,7 @@ The serialized text is a normal JSON string, not base64. Limits use UTF-8 byte l
 - 1 MiB maximum total embedded content per patch
 - UTF-8 text only
 
-The initial editable formats are:
+The editable formats under `patch://` are:
 
 - JavaScript: `.js`, `.mjs`
 - GLSL: `.gl`, `.glsl`, `.frag`, `.vert`, `.glslf`, `.glslv`
@@ -419,7 +418,13 @@ The Files tree shows namespace roots in this order:
 
 1. Patch (always visible)
 2. User (always visible)
-3. Objects (visible only when populated)
+3. Objects (always visible)
+
+Each root label has a tooltip on hover and keyboard focus:
+
+- **Patch:** Files saved inside this patch. They're included when you save or share it.
+- **User:** Files from your device or the web. The patch saves links, not the files themselves.
+- **Objects:** Code from the objects in this patch. Edits here also update the object.
 
 The drop target declares ownership:
 
@@ -432,7 +437,10 @@ Patch folder drops are atomic. Patchies embeds the complete folder only when eve
 
 New File is available in Patch and its folders. It creates empty content, requires an explicit supported extension, rejects case-sensitive duplicate paths, and opens the new file in the editor. An empty GLSL file shows a non-persisted example function placeholder so users know the file can contain reusable GLSL functions.
 
-### Editor Behavior
+### Editor Behavior (Patch Files)
+
+These draft and save rules apply to `patch://`. Objects files use the live editing
+behavior described under **Live object code namespace** below.
 
 Double-clicking an editable Patch file, or choosing **Edit** from its context menu, transforms the Files panel into a CodeMirror editor. Search results provide the same actions. On mobile, Edit appears in the selection toolbar. A single click continues to select a row.
 
@@ -609,3 +617,50 @@ Verification:
 7. Invalid paths, collisions, and failed rename staging preserve all prior persisted state.
 
 Release criterion: Patch VFS files are the only user-module source, and optional canvas mirrors edit them without adding runtime identity or duplicate ownership.
+
+## Live object code namespace
+
+`obj://` exposes an always-visible **Objects** root. Existing code-bearing objects
+appear as `<node-id>/<filename>`, including `glsl-4/shader.glsl` and `js-6/code.js`.
+A transport-independent representation maps object type, data field, filename,
+language, and source text. Remote sync can consume this representation without
+Svelte, XYFlow, or VFS storage dependencies.
+
+Object files are derived from current graph data, never serialized into the VFS
+tree. Listing, reading, search, and Files editing use this live projection.
+Typing updates the original data field immediately, with normal node undo history
+committed at editing boundaries. Graph edits, undo, replacement, and deletion
+refresh the projection. Objects without source code expose no files.
+
+Only existing source contents can be edited. Creating, uploading, replacing,
+renaming, moving, or deleting entries under `obj://` is rejected by the VFS and
+unavailable in desktop/mobile file controls. Object creation is out of scope.
+
+### Object editor synchronization and execution
+
+Existing object source is authoritative when it changes externally: an open or
+reopened Objects editor immediately refreshes from that source. Patch-file drafts
+retain their conflict protection.
+CodeMirror applies external values without emitting a user-edit callback.
+
+Shift+Enter commits the current editing gesture and invokes the object's registered
+Run handler after the editor state settles. It also reruns unchanged source.
+Cmd/Ctrl+S only commits the editing gesture; source changes have already propagated.
+Hosts without a mounted editor use the existing executeCode trigger.
+
+### Bidirectional live object editing
+
+Typing in an Objects file immediately updates its object data, just like typing
+in the main object editor. Objects files have no isolated unsaved draft. Save,
+Run, blur, and navigation commit a single undo step for the editing gesture;
+Run alone requests execution. Undo and redo use node history and update both
+editors. Patch files retain their explicit save/discard drafts.
+
+Object-file projection updates metadata only for changed sources. Unchanged
+sources are not re-encoded or rebuilt on each keystroke.
+
+### Object file highlighting
+
+The source representation supplies the filename and editor language for each
+object file. ChucK's `code.ck` uses JavaScript-style highlighting to match the
+current main ChucK editor; it does not yet use a dedicated ChucK grammar.

--- a/ui/src/lib/codemirror/patchies-completions.ts
+++ b/ui/src/lib/codemirror/patchies-completions.ts
@@ -905,7 +905,7 @@ const memberCompletions: Record<string, Completion[]> = {
       label: 'list',
       type: 'method',
       detail: '(path?: string) => Promise<VFSListEntry[]>',
-      info: 'List direct entries with path, name, and kind. Defaults to the user:// namespace.',
+      info: 'List direct entries with path, name, and kind. Defaults to user://.',
       apply: "list('.')"
     },
     {

--- a/ui/src/lib/components/CodeEditor.svelte
+++ b/ui/src/lib/components/CodeEditor.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { useViewport } from '@xyflow/svelte';
   import { EditorView, minimalSetup } from 'codemirror';
-  import { Compartment, EditorState, Prec, type Extension } from '@codemirror/state';
+  import { Annotation, Compartment, EditorState, Prec, type Extension } from '@codemirror/state';
   import { tokyoNight } from '@uiw/codemirror-theme-tokyo-night';
   import {
     keymap,
@@ -187,7 +187,7 @@
   let isAltNavigationActive = $state(false);
   let altHoveredDecoration: Element | null = null;
   const viewport = useViewport();
-  let isInternalUpdate = false; // Flag to prevent loops when user types
+  const externalValueUpdate = Annotation.define<boolean>();
   let valueOnFocus: string | null = null; // Track value at focus for undo commit
   let resolvedFontSize = $derived(fontSize ?? `${$editorFontSize}px`);
   let resolvedFontFamily = $derived(fontFamily ?? $editorFontFamily);
@@ -310,11 +310,7 @@
             {
               key: 'Shift-Enter',
               run: () => {
-                if (onsave) {
-                  onsave();
-                } else {
-                  onrun(editorView?.state.doc.toString());
-                }
+                onrun(editorView?.state.doc.toString());
 
                 return true;
               }
@@ -548,22 +544,17 @@
         }),
         inlineDecorationTheme,
         EditorView.updateListener.of((update) => {
-          if (update.docChanged) {
+          if (
+            update.docChanged &&
+            !update.transactions.some((transaction) => transaction.annotation(externalValueUpdate))
+          ) {
             const updatedValue = update.state.doc.toString();
-
-            // Set flag to prevent the $effect from triggering on user input
-            isInternalUpdate = true;
 
             if (onchange) {
               onchange(updatedValue);
             } else {
               value = updatedValue;
             }
-
-            // Reset flag after microtask to allow external updates
-            queueMicrotask(() => {
-              isInternalUpdate = false;
-            });
           }
         }),
         autocompleteComp.of($editorAutocompleteEnabled ? autocompletion() : []),
@@ -657,15 +648,12 @@
     // Only update if editor is mounted
     if (!editorView) return;
 
-    // Skip update if the change came from the editor itself (user typing)
-    // This prevents unnecessary XYFlow updates on every keystroke
-    if (isInternalUpdate) return;
-
     const currentDoc = editorView.state.doc.toString();
 
     // Only dispatch if the values are actually different
     if (currentDoc !== newValue) {
       editorView.dispatch({
+        annotations: externalValueUpdate.of(true),
         changes: {
           from: 0,
           to: editorView.state.doc.length,

--- a/ui/src/lib/components/FlowCanvasInner.svelte
+++ b/ui/src/lib/components/FlowCanvasInner.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+  import { get } from 'svelte/store';
+  import { codeSidebarTargets } from '../../stores/code-sidebar.store';
+  import { editObjectCodeFile } from '$lib/objects/object-code-files';
+  import { VirtualFilesystem } from '$lib/vfs/VirtualFilesystem';
   import { Volume2, Cable } from '@lucide/svelte/icons';
   import {
     SvelteFlow,
@@ -161,6 +165,7 @@
   // Initial nodes and edges
   let nodes = $state.raw<Node[]>([]);
   let edges = $state.raw<Edge[]>([]);
+  let unregisterObjectFiles: (() => void) | null = null;
   let unregisterCanvasMirrors: (() => void) | null = null;
 
   const runtimeServices = createDefaultRuntimeServices();
@@ -194,6 +199,12 @@
   // Event handlers for nodeOps (stored as variables for proper cleanup)
   const handleNodeReplace = (e: NodeReplaceEvent) => nodeOps.replaceNode(e);
   const handleVfsPathRenamed = (e: VfsPathRenamedEvent) => nodeOps.handleVfsPathRenamed(e);
+
+  // Keep object files in sync with graph edits, undo, and replacement.
+  $effect(() => {
+    VirtualFilesystem.getInstance().objectFiles.sync(nodes);
+  });
+
   // Event handler for code commit (undo tracking)
   const handleCodeCommit = (e: CodeCommitEvent) => {
     historyManager.record(
@@ -854,19 +865,24 @@
 
     // Check for ?startup= param to force-open startup modal at a specific tab
     const startupParam = params.get('startup');
+
     if (startupParam) {
       const validTabs = ['about', 'demos', 'sparks', 'shortcuts', 'thanks'] as const;
+
       if (validTabs.includes(startupParam as (typeof validTabs)[number])) {
         startupInitialTab = startupParam as (typeof validTabs)[number];
         showStartupModal = true;
+
         // The SvelteKit router is not initialized yet during this boot-time effect.
         // Use the browser history directly to remove this one-shot startup instruction.
         const startupUrl = new URL(window.location.href);
         startupUrl.searchParams.delete('startup');
+
         window.history.replaceState(window.history.state, '', startupUrl);
       }
     } else if (!isLoadingFromUrlParam) {
       const showStartupSetting = localStorage.getItem('patchies-show-startup-modal');
+
       // Default to true if not set (first time users), or respect user's preference
       if (showStartupSetting === null || showStartupSetting === 'true') {
         showStartupModal = true;
@@ -933,10 +949,57 @@
 
     eventBus.addEventListener('nodeReplace', handleNodeReplace);
     eventBus.addEventListener('vfsPathRenamed', handleVfsPathRenamed);
+
+    const objectVfs = VirtualFilesystem.getInstance();
+
+    unregisterObjectFiles = objectVfs.objectFiles.connect(
+      (file, content, options) => {
+        const object = getNode(file.objectId);
+        if (!object) throw new Error(`VFS: Object no longer exists: ${file.objectId}`);
+
+        const edit = editObjectCodeFile(object, file.filename, content);
+        const currentContent = object.data[edit.dataKey] as string;
+        const oldValue = options?.previousContent ?? currentContent;
+
+        if (currentContent !== content) updateNodeData(file.objectId, edit.updates);
+
+        if (options?.recordHistory !== false && oldValue !== content)
+          handleCodeCommit({
+            type: 'codeCommit',
+            nodeId: file.objectId,
+            dataKey: file.dataKey,
+            oldValue,
+            newValue: content
+          });
+
+        objectVfs.objectFiles.sync(nodes);
+      },
+      async (file) => {
+        await tick();
+
+        const object = getNode(file.objectId);
+        if (!object) throw new Error(`VFS: Object no longer exists: ${file.objectId}`);
+
+        const target = get(codeSidebarTargets).get(file.objectId);
+        if (target?.dataKey === file.dataKey && target.onrun) {
+          target.onrun(objectVfs.readCodeFile(`obj://${file.objectId}/${file.filename}`));
+          return;
+        }
+
+        updateNodeData(file.objectId, {
+          executeCode:
+            (typeof object.data.executeCode === 'number' ? object.data.executeCode : 0) + 1
+        });
+      }
+    );
+
+    objectVfs.objectFiles.sync(nodes);
+
     unregisterCanvasMirrors = VfsCanvasMirrors.register({
       getNodes: () => nodes,
       setNodes: (nextNodes) => (nodes = nextNodes)
     });
+
     eventBus.addEventListener('insertVfsFileToCanvas', handleInsertVfsFile);
     eventBus.addEventListener('insertPresetToCanvas', handleInsertPreset);
     eventBus.addEventListener('insertSampleToCanvas', handleInsertSample);
@@ -971,6 +1034,7 @@
     eventBus.removeEventListener('nodeReplace', handleNodeReplace);
     eventBus.removeEventListener('vfsPathRenamed', handleVfsPathRenamed);
     unregisterCanvasMirrors?.();
+    unregisterObjectFiles?.();
     eventBus.removeEventListener('insertVfsFileToCanvas', handleInsertVfsFile);
     eventBus.removeEventListener('insertPresetToCanvas', handleInsertPreset);
     eventBus.removeEventListener('insertSampleToCanvas', handleInsertSample);

--- a/ui/src/lib/components/sidebar/FileTreeView.svelte
+++ b/ui/src/lib/components/sidebar/FileTreeView.svelte
@@ -60,7 +60,8 @@
     type UnsavedChangesDecision
   } from '$lib/vfs/PatchFileEditorSession';
   import { registerUnsavedChangesGuard } from '$lib/vfs/file-editor-navigation';
-  import { isEditablePatchCodePath } from '$lib/vfs/patch-file-editor';
+  import { isObjectPath } from '$lib/vfs/ObjectFileProjection';
+  import { isEditableCodePath } from '$lib/vfs/patch-file-editor';
   import {
     getExpandedChildDirectories,
     getExpandedLinkedFolderPathsToLoad,
@@ -152,6 +153,15 @@
     }
   }
 
+  async function runEditor(code?: string): Promise<void> {
+    try {
+      await editorSession.run(code);
+      refreshEditor();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message.replace('VFS: ', '') : 'Run failed');
+    }
+  }
+
   function requestEditorNavigation(action: () => void | Promise<void>): Promise<boolean> {
     if (!editorSession.isDirty) {
       void action();
@@ -204,9 +214,11 @@
   }
 
   async function openEditor(path: string) {
-    if (!isEditablePatchCodePath(path)) return;
+    if (!isEditableCodePath(path)) return;
 
     await requestEditorNavigation(() => {
+      if (editorSession.path && isObjectPath(editorSession.path)) editorSession.save();
+
       editorSession = getPatchFileEditorSession(vfs, path);
       refreshEditor();
     });
@@ -220,7 +232,8 @@
   }
 
   function handleEditorContentModified(path: string, revision: number) {
-    if (editorSession.path !== path || editorSession.revision === revision) return;
+    if (editorSession.path !== path) return;
+    if (!isObjectPath(path) && editorSession.revision === revision) return;
 
     queueMicrotask(() => {
       const result = editorSession.syncSavedContent();
@@ -274,6 +287,8 @@
   $effect(() => editorSession.subscribe(refreshEditor));
 
   onDestroy(() => {
+    if (editorSession.path && isObjectPath(editorSession.path)) editorSession.save();
+
     unregisterNavigationGuard?.();
   });
 
@@ -583,7 +598,7 @@
   async function deleteSelectedFiles() {
     if (selectedPaths.size === 0) return;
 
-    const paths = [...selectedPaths].filter((path) => vfs.has(path));
+    const paths = [...selectedPaths].filter((path) => !isObjectPath(path) && vfs.has(path));
     if (!confirmModuleDependentMutation(paths, 'Delete')) return;
 
     try {
@@ -662,7 +677,7 @@
     // Namespace roots
     const patchRoot: TreeNode = { name: 'Patch', path: 'patch://', children: new Map() };
     const userRoot: TreeNode = { name: 'User', path: 'user://', children: new Map() };
-    const objRoot: TreeNode = { name: 'objects', path: 'obj://', children: new Map() };
+    const objRoot: TreeNode = { name: 'Objects', path: 'obj://', children: new Map() };
 
     for (const [path, entry] of entries) {
       const parsed = parseVFSPath(path);
@@ -715,10 +730,7 @@
     root.children!.set('patch', patchRoot);
     root.children!.set('user', userRoot);
 
-    // Only add objects namespace if it has children
-    if (objRoot.children && objRoot.children.size > 0) {
-      root.children!.set('objects', objRoot);
-    }
+    root.children!.set('objects', objRoot);
 
     return root;
   });
@@ -733,6 +745,7 @@
 
   function getSortedChildren(node: TreeNode): TreeNode[] {
     if (!node.children) return [];
+    if (node.name === 'root') return [...node.children.values()];
 
     return [...node.children.values()].sort((a, b) => {
       // Folders come before files
@@ -1025,7 +1038,7 @@
       const parent = showFileInput.endsWith('/') ? showFileInput : `${showFileInput}/`;
       const path = `${parent}${fileInputValue.trim()}`;
 
-      if (!isEditablePatchCodePath(path)) {
+      if (!isEditableCodePath(path)) {
         toast.error('New Patch files must use a supported JavaScript or GLSL extension');
         return;
       }
@@ -1496,6 +1509,7 @@
   {@const isPatchNamespace = node.path === 'patch://'}
   {@const isUserNamespace = node.path === 'user://'}
   {@const isObjectNamespace = node.path === 'obj://'}
+  {@const isObjectEntry = !!node.path && isObjectPath(node.path)}
   {@const isDropTarget = isInDropTarget(node.path)}
   {@const isNamespace = isPatchNamespace || isUserNamespace || isObjectNamespace}
   {@const isLinkedFolder = node.entry && isLocalFolder(node.entry)}
@@ -1509,7 +1523,8 @@
 
   {@const isRenaming = renamingPath === node.path}
   {@const showContextMenu = node.path && !isNamespace && !isLinkedFolder}
-  {@const isDraggable = (isFile || (isFolder && !isNamespace && !isLinkedFolder)) && node.path}
+  {@const isDraggable =
+    !isObjectEntry && (isFile || (isFolder && !isNamespace && !isLinkedFolder)) && node.path}
 
   {#if node.name !== 'root'}
     <ContextMenu.Root>
@@ -1524,89 +1539,138 @@
               : isSelected
                 ? 'bg-blue-900/40 hover:bg-blue-900/50'
                 : 'hover:bg-zinc-800'}"
-          ondragover={(e) => isFolder && node.path && handleFolderDragOver(e, node.path)}
-          ondrop={(e) => isFolder && handleFolderDrop(e)}
+          ondragover={(e) => {
+            if (isObjectEntry) {
+              e.stopPropagation();
+              dropTargetPath = null;
+              return;
+            }
+            if (isFolder && node.path) handleFolderDragOver(e, node.path);
+          }}
+          ondrop={(e) => {
+            if (isObjectEntry) {
+              e.preventDefault();
+              e.stopPropagation();
+              dropTargetPath = null;
+              return;
+            }
+            if (isFolder) void handleFolderDrop(e);
+          }}
         >
-          <button
-            class="flex flex-1 cursor-pointer items-center gap-1.5 py-1"
-            style="padding-left: {paddingLeft}px"
-            draggable={isDraggable ? 'true' : 'false'}
-            ondragstart={(e) => isDraggable && handleDragStart(e, node)}
-            ondblclick={() =>
-              node.path && isEditablePatchCodePath(node.path) && openEditor(node.path)}
-            onclick={async (e) => {
-              if (isRenaming) return;
-
-              if (isFolder && node.path && !isNamespace) {
-                // For non-namespace folders: select (without deselect) and toggle expand
-                selectedPaths.clear();
-                selectedPaths.add(node.path);
-                lastSelectedPath = node.path;
-
-                // Check if we're about to expand (before toggling)
-                const willExpand = !expandedPaths.has(node.path);
-                toggleExpanded(node.path);
-
-                // Load local folder contents when expanding
-                if (isLinkedFolder && willExpand) {
-                  await loadLocalFolderContents(node.path);
-                }
-              } else if (isFolder && node.path) {
-                // For namespace roots: just expand/collapse
-                toggleExpanded(node.path);
-              } else if (isFile && node.path) {
-                handleNodeClick(node.path, e);
-              }
-            }}
-          >
-            {#if isFolder}
-              {#if isExpanded}
-                <ChevronDown class="h-3 w-3 shrink-0 text-zinc-500" />
-              {:else}
-                <ChevronRight class="h-3 w-3 shrink-0 text-zinc-500" />
-              {/if}
-              {#if isPatchNamespace}
-                <Package class="h-3.5 w-3.5 shrink-0 text-emerald-400" />
-              {:else if isUserNamespace}
-                <User class="h-3.5 w-3.5 shrink-0 text-blue-400" />
-              {:else if isObjectNamespace}
-                <Box class="h-3.5 w-3.5 shrink-0 text-blue-400" />
-              {:else if isLinkedFolder}
-                <FolderSymlink class="h-3.5 w-3.5 shrink-0 text-cyan-400" />
-              {:else if isExpanded}
-                <FolderOpen class="h-3.5 w-3.5 shrink-0 text-yellow-500" />
-              {:else}
-                <Folder class="h-3.5 w-3.5 shrink-0 text-yellow-500" />
-              {/if}
-            {:else}
-              {@const fileIcon = getFileIcon(
-                node.entry?.mimeType || guessMimeType(node.entry?.filename || node.name)
-              )}
-              <span class="w-3"></span>
-              <fileIcon.icon class="h-3.5 w-3.5 shrink-0 {fileIcon.color}" />
-            {/if}
-
-            {#if isRenaming}
-              <!-- svelte-ignore a11y_autofocus -->
-              <input
-                type="text"
-                class="flex-1 truncate rounded bg-transparent px-1 font-mono text-zinc-300 ring-1 ring-blue-500 outline-none"
-                bind:value={renameInputValue}
-                onkeydown={handleRenameSubmit}
-                onclick={(e) => e.stopPropagation()}
-                autofocus
-              />
-            {:else}
-              <span
-                class="truncate font-mono {isNamespace
-                  ? 'font-medium text-zinc-200'
-                  : 'text-zinc-300'}"
-                title={node.entry?.filename || node.name}
+          {#if isNamespace}
+            <Tooltip.Root>
+              <Tooltip.Trigger
+                class="flex flex-1 cursor-pointer items-center gap-1.5 py-1"
+                style="padding-left: {paddingLeft}px"
+                onclick={() => node.path && toggleExpanded(node.path)}
+                aria-expanded={isExpanded}
               >
-                {node.entry?.filename || node.name}
-              </span>
-            {/if}
-          </button>
+                {#if isExpanded}
+                  <ChevronDown class="h-3 w-3 shrink-0 text-zinc-500" />
+                {:else}
+                  <ChevronRight class="h-3 w-3 shrink-0 text-zinc-500" />
+                {/if}
+                {#if isPatchNamespace}
+                  <Package class="h-3.5 w-3.5 shrink-0 text-emerald-400" />
+                {:else if isUserNamespace}
+                  <User class="h-3.5 w-3.5 shrink-0 text-blue-400" />
+                {:else}
+                  <Box class="h-3.5 w-3.5 shrink-0 text-blue-400" />
+                {/if}
+                <span class="truncate font-mono font-medium text-zinc-200">{node.name}</span>
+              </Tooltip.Trigger>
+              <Tooltip.Content side="right" class="max-w-64">
+                {#if isPatchNamespace}
+                  Files saved inside this patch. They're included when you save or share it.
+                {:else if isUserNamespace}
+                  Files from your device or the web. The patch saves links, not the files
+                  themselves.
+                {:else}
+                  Code from the objects in this patch. Edits here also update the object.
+                {/if}
+              </Tooltip.Content>
+            </Tooltip.Root>
+          {:else}
+            <button
+              class="flex flex-1 cursor-pointer items-center gap-1.5 py-1"
+              style="padding-left: {paddingLeft}px"
+              draggable={isDraggable ? 'true' : 'false'}
+              ondragstart={(e) => isDraggable && handleDragStart(e, node)}
+              ondblclick={() => node.path && isEditableCodePath(node.path) && openEditor(node.path)}
+              onclick={async (e) => {
+                if (isRenaming) return;
+
+                if (isFolder && node.path && !isNamespace) {
+                  // For non-namespace folders: select (without deselect) and toggle expand
+                  selectedPaths.clear();
+                  selectedPaths.add(node.path);
+                  lastSelectedPath = node.path;
+
+                  // Check if we're about to expand (before toggling)
+                  const willExpand = !expandedPaths.has(node.path);
+                  toggleExpanded(node.path);
+
+                  // Load local folder contents when expanding
+                  if (isLinkedFolder && willExpand) {
+                    await loadLocalFolderContents(node.path);
+                  }
+                } else if (isFolder && node.path) {
+                  // For namespace roots: just expand/collapse
+                  toggleExpanded(node.path);
+                } else if (isFile && node.path) {
+                  handleNodeClick(node.path, e);
+                }
+              }}
+            >
+              {#if isFolder}
+                {#if isExpanded}
+                  <ChevronDown class="h-3 w-3 shrink-0 text-zinc-500" />
+                {:else}
+                  <ChevronRight class="h-3 w-3 shrink-0 text-zinc-500" />
+                {/if}
+                {#if isPatchNamespace}
+                  <Package class="h-3.5 w-3.5 shrink-0 text-emerald-400" />
+                {:else if isUserNamespace}
+                  <User class="h-3.5 w-3.5 shrink-0 text-blue-400" />
+                {:else if isObjectNamespace}
+                  <Box class="h-3.5 w-3.5 shrink-0 text-blue-400" />
+                {:else if isLinkedFolder}
+                  <FolderSymlink class="h-3.5 w-3.5 shrink-0 text-cyan-400" />
+                {:else if isExpanded}
+                  <FolderOpen class="h-3.5 w-3.5 shrink-0 text-yellow-500" />
+                {:else}
+                  <Folder class="h-3.5 w-3.5 shrink-0 text-yellow-500" />
+                {/if}
+              {:else}
+                {@const fileIcon = getFileIcon(
+                  node.entry?.mimeType || guessMimeType(node.entry?.filename || node.name)
+                )}
+                <span class="w-3"></span>
+                <fileIcon.icon class="h-3.5 w-3.5 shrink-0 {fileIcon.color}" />
+              {/if}
+
+              {#if isRenaming}
+                <!-- svelte-ignore a11y_autofocus -->
+                <input
+                  type="text"
+                  class="flex-1 truncate rounded bg-transparent px-1 font-mono text-zinc-300 ring-1 ring-blue-500 outline-none"
+                  bind:value={renameInputValue}
+                  onkeydown={handleRenameSubmit}
+                  onclick={(e) => e.stopPropagation()}
+                  autofocus
+                />
+              {:else}
+                <span
+                  class="truncate font-mono {isNamespace
+                    ? 'font-medium text-zinc-200'
+                    : 'text-zinc-300'}"
+                  title={node.entry?.filename || node.name}
+                >
+                  {node.entry?.filename || node.name}
+                </span>
+              {/if}
+            </button>
+          {/if}
 
           {#if canHaveChildren && node.path}
             <div
@@ -1744,18 +1808,20 @@
 
       {#if showContextMenu}
         <ContextMenu.Content>
-          {#if node.path && isEditablePatchCodePath(node.path)}
+          {#if node.path && isEditableCodePath(node.path)}
             <ContextMenu.Item onclick={() => openEditor(node.path!)}>
               <FileCode class="mr-2 h-4 w-4" />
               Edit
             </ContextMenu.Item>
           {/if}
-          <ContextMenu.Item
-            onclick={() => handleRenameClick(node.path!, node.entry?.filename || node.name)}
-          >
-            <Pencil class="mr-2 h-4 w-4" />
-            Rename
-          </ContextMenu.Item>
+          {#if !isObjectEntry}
+            <ContextMenu.Item
+              onclick={() => handleRenameClick(node.path!, node.entry?.filename || node.name)}
+            >
+              <Pencil class="mr-2 h-4 w-4" />
+              Rename
+            </ContextMenu.Item>
+          {/if}
           <ContextMenu.Item onclick={() => handleCopyPath(node.path!)}>
             <Copy class="mr-2 h-4 w-4" />
             Copy Path
@@ -1766,14 +1832,16 @@
               Save to Disk…
             </ContextMenu.Item>
           {/if}
-          <ContextMenu.Separator />
-          <ContextMenu.Item
-            variant="destructive"
-            onclick={() => handleDeleteFromContextMenu(node.path!)}
-          >
-            <Trash2 class="mr-2 h-4 w-4" />
-            Delete
-          </ContextMenu.Item>
+          {#if !isObjectEntry}
+            <ContextMenu.Separator />
+            <ContextMenu.Item
+              variant="destructive"
+              onclick={() => handleDeleteFromContextMenu(node.path!)}
+            >
+              <Trash2 class="mr-2 h-4 w-4" />
+              Delete
+            </ContextMenu.Item>
+          {/if}
         </ContextMenu.Content>
       {/if}
     </ContextMenu.Root>
@@ -1853,7 +1921,7 @@
         class="px-2 py-1 font-mono text-xs text-zinc-600 italic"
         style="padding-left: {paddingLeft + 20}px"
       >
-        Drop files to add
+        {isObjectEntry ? 'No code objects in this patch' : 'Drop files to add'}
       </div>
     {:else}
       {#each getSortedChildren(node) as child (child.path)}
@@ -1878,6 +1946,7 @@
     onredo={() => editorSession.redoDraft()}
     onback={closeEditor}
     onsave={saveEditor}
+    onrun={runEditor}
     onrename={() => handleRenameClick(editorPath, editorPath.split('/').pop() ?? '')}
     oncopy={() => handleCopyPath(editorPath)}
     onexport={() => handleSaveToDisk(editorPath)}
@@ -1918,8 +1987,8 @@
             >
               <button
                 class="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 py-1 pl-2 text-left text-xs"
-                draggable="true"
-                ondblclick={() => isEditablePatchCodePath(result.path) && openEditor(result.path)}
+                draggable={!isObjectPath(result.path)}
+                ondblclick={() => isEditableCodePath(result.path) && openEditor(result.path)}
                 ondragstart={(e) => {
                   e.dataTransfer?.setData('application/x-vfs-path', result.path);
                   e.dataTransfer?.setData('text/plain', result.path);
@@ -1950,7 +2019,7 @@
 
                 <span class="truncate font-mono text-zinc-300">{result.name}</span>
               </button>
-              {#if isEditablePatchCodePath(result.path)}
+              {#if isEditableCodePath(result.path)}
                 <button
                   class="mr-1 cursor-pointer rounded p-1 text-zinc-500 opacity-100 hover:bg-zinc-700 hover:text-zinc-200 sm:opacity-0 sm:group-hover:opacity-100"
                   onclick={() => openEditor(result.path)}
@@ -1979,7 +2048,7 @@
           {selectedFileEntry?.filename || selectedFilePath.split('/').pop()}
         </span>
 
-        {#if isEditablePatchCodePath(selectedFilePath)}
+        {#if isEditableCodePath(selectedFilePath)}
           <button
             class="flex cursor-pointer items-center gap-1.5 rounded bg-emerald-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-600"
             onclick={() => openEditor(selectedFilePath)}
@@ -1989,74 +2058,75 @@
           </button>
         {/if}
 
-        <button
-          class="flex cursor-pointer items-center gap-1.5 rounded bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
-          onclick={handleInsertToCanvas}
-          title="Insert to Canvas"
-        >
-          <Plus class="h-3.5 w-3.5" />
-          <span>Insert</span>
-        </button>
-
-        <button
-          class="flex cursor-pointer items-center gap-1.5 rounded bg-zinc-700 px-3 py-1.5 text-xs text-zinc-200 hover:bg-zinc-600"
-          onclick={() => (showMoveDialog = true)}
-          title="Move to folder"
-        >
-          <FolderInput class="h-3.5 w-3.5" />
-          <span>Move</span>
-        </button>
-
-        <Popover.Root bind:open={mobileMoreOpen}>
-          <Popover.Trigger
-            class="flex cursor-pointer items-center rounded bg-zinc-700 p-1.5 text-zinc-200 hover:bg-zinc-600"
+        {#if !isObjectPath(selectedFilePath)}
+          <button
+            class="flex cursor-pointer items-center gap-1.5 rounded bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+            onclick={handleInsertToCanvas}
+            title="Insert to Canvas"
           >
-            <Ellipsis class="h-4 w-4" />
-          </Popover.Trigger>
-          <Popover.Content class="w-40 border-zinc-700 bg-zinc-900 p-1" side="top" align="end">
-            <button
-              class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800"
-              onclick={() => {
-                if (selectedFilePath) {
-                  const entry = vfs.getEntry(selectedFilePath);
-                  handleRenameClick(
-                    selectedFilePath,
-                    entry?.filename || selectedFilePath.split('/').pop() || ''
-                  );
-                }
-                mobileMoreOpen = false;
-              }}
-            >
-              <Pencil class="h-4 w-4 text-zinc-400" />
-              Rename
-            </button>
-            <button
-              class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800"
-              onclick={async () => {
-                if (selectedFilePath) {
-                  await handleCopyPath(selectedFilePath);
-                }
-                mobileMoreOpen = false;
-              }}
-            >
-              <Copy class="h-4 w-4 text-zinc-400" />
-              Copy Path
-            </button>
-            <button
-              class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-red-400 hover:bg-zinc-800"
-              onclick={async () => {
-                if (selectedFilePath) {
-                  await handleDeleteFromContextMenu(selectedFilePath);
-                }
-                mobileMoreOpen = false;
-              }}
-            >
-              <Trash2 class="h-4 w-4" />
-              Delete
-            </button>
-          </Popover.Content>
-        </Popover.Root>
+            <Plus class="h-3.5 w-3.5" />
+            <span>Insert</span>
+          </button>
 
+          <button
+            class="flex cursor-pointer items-center gap-1.5 rounded bg-zinc-700 px-3 py-1.5 text-xs text-zinc-200 hover:bg-zinc-600"
+            onclick={() => (showMoveDialog = true)}
+            title="Move to folder"
+          >
+            <FolderInput class="h-3.5 w-3.5" />
+            <span>Move</span>
+          </button>
+
+          <Popover.Root bind:open={mobileMoreOpen}>
+            <Popover.Trigger
+              class="flex cursor-pointer items-center rounded bg-zinc-700 p-1.5 text-zinc-200 hover:bg-zinc-600"
+            >
+              <Ellipsis class="h-4 w-4" />
+            </Popover.Trigger>
+            <Popover.Content class="w-40 border-zinc-700 bg-zinc-900 p-1" side="top" align="end">
+              <button
+                class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800"
+                onclick={() => {
+                  if (selectedFilePath) {
+                    const entry = vfs.getEntry(selectedFilePath);
+                    handleRenameClick(
+                      selectedFilePath,
+                      entry?.filename || selectedFilePath.split('/').pop() || ''
+                    );
+                  }
+                  mobileMoreOpen = false;
+                }}
+              >
+                <Pencil class="h-4 w-4 text-zinc-400" />
+                Rename
+              </button>
+              <button
+                class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800"
+                onclick={async () => {
+                  if (selectedFilePath) {
+                    await handleCopyPath(selectedFilePath);
+                  }
+                  mobileMoreOpen = false;
+                }}
+              >
+                <Copy class="h-4 w-4 text-zinc-400" />
+                Copy Path
+              </button>
+              <button
+                class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm text-red-400 hover:bg-zinc-800"
+                onclick={async () => {
+                  if (selectedFilePath) {
+                    await handleDeleteFromContextMenu(selectedFilePath);
+                  }
+                  mobileMoreOpen = false;
+                }}
+              >
+                <Trash2 class="h-4 w-4" />
+                Delete
+              </button>
+            </Popover.Content>
+          </Popover.Root>
+        {/if}
         <button
           class="ml-auto text-xs text-zinc-500 hover:text-zinc-300"
           onclick={() => {

--- a/ui/src/lib/components/sidebar/FileTreeView.svelte
+++ b/ui/src/lib/components/sidebar/FileTreeView.svelte
@@ -1936,6 +1936,7 @@
 {#if editorPath}
   <PatchFileEditorView
     path={editorPath}
+    nodeType={isObjectPath(editorPath) ? vfs.objectFiles.get(editorPath).nodeType : undefined}
     draft={editorDraft}
     dirty={editorDirty}
     onchange={(content) => {

--- a/ui/src/lib/components/sidebar/PatchFileEditorView.svelte
+++ b/ui/src/lib/components/sidebar/PatchFileEditorView.svelte
@@ -15,6 +15,7 @@
     onredo,
     onback,
     onsave,
+    onrun,
     onrename,
     oncopy,
     onexport,
@@ -28,6 +29,7 @@
     onredo: () => boolean;
     onback: () => void;
     onsave: () => void;
+    onrun: (code?: string) => void;
     onrename: () => void;
     oncopy: () => void;
     onexport: () => void;
@@ -39,7 +41,7 @@
 }`;
 
   let menuOpen = $state(false);
-  const displayPath = $derived(path.replace(/^patch:\/\//, ''));
+  const displayPath = $derived(path.replace(/^(?:patch|obj):\/\//, ''));
   const language = $derived(getPatchFileEditorLanguage(path));
   const placeholder = $derived(language === 'glsl' ? GLSL_PLACEHOLDER : '');
 
@@ -98,22 +100,26 @@
         <Ellipsis class="h-4 w-4" />
       </Popover.Trigger>
       <Popover.Content class="w-44 border-zinc-700 bg-zinc-900 p-1" align="end">
-        <button class="menu-item" onclick={() => runMenuAction(onrename)}>
-          <Pencil class="h-4 w-4" /> Rename
-        </button>
+        {#if !path.startsWith('obj://')}
+          <button class="menu-item" onclick={() => runMenuAction(onrename)}>
+            <Pencil class="h-4 w-4" /> Rename
+          </button>
+        {/if}
         <button class="menu-item" onclick={() => runMenuAction(oncopy)}>
           <Copy class="h-4 w-4" /> Copy Path
         </button>
-        <button class="menu-item" onclick={() => runMenuAction(onexport)}>
-          <File class="h-4 w-4" /> Save to Disk…
-        </button>
-        <div class="my-1 h-px bg-zinc-800"></div>
-        <button
-          class="menu-item text-red-400 hover:text-red-300"
-          onclick={() => runMenuAction(ondelete)}
-        >
-          <Trash2 class="h-4 w-4" /> Delete
-        </button>
+        {#if !path.startsWith('obj://')}
+          <button class="menu-item" onclick={() => runMenuAction(onexport)}>
+            <File class="h-4 w-4" /> Save to Disk…
+          </button>
+          <div class="my-1 h-px bg-zinc-800"></div>
+          <button
+            class="menu-item text-red-400 hover:text-red-300"
+            onclick={() => runMenuAction(ondelete)}
+          >
+            <Trash2 class="h-4 w-4" /> Delete
+          </button>
+        {/if}
       </Popover.Content>
     </Popover.Root>
   </div>
@@ -122,9 +128,15 @@
     <CodeEditor
       value={draft}
       {onchange}
+      oncommit={() => {
+        // Object edits are already live; blur commits one undo step. Patch files require explicit saving.
+        if (path.startsWith('obj://')) {
+          onsave();
+        }
+      }}
       {onundo}
       {onredo}
-      onrun={onsave}
+      {onrun}
       {onsave}
       {language}
       nodeType={language === 'javascript' ? 'js' : 'glsl'}

--- a/ui/src/lib/components/sidebar/PatchFileEditorView.svelte
+++ b/ui/src/lib/components/sidebar/PatchFileEditorView.svelte
@@ -8,6 +8,7 @@
 
   let {
     path,
+    nodeType,
     draft,
     dirty,
     onchange,
@@ -22,6 +23,7 @@
     ondelete
   }: {
     path: string;
+    nodeType?: string;
     draft: string;
     dirty: boolean;
     onchange: (content: string) => void;
@@ -139,7 +141,7 @@
       {onrun}
       {onsave}
       {language}
-      nodeType={language === 'javascript' ? 'js' : 'glsl'}
+      nodeType={nodeType ?? (language === 'javascript' ? 'js' : 'glsl')}
       {placeholder}
       class="h-full w-full resize-none"
     />

--- a/ui/src/lib/objects/object-code-files.ts
+++ b/ui/src/lib/objects/object-code-files.ts
@@ -1,0 +1,97 @@
+import type { SupportedLanguage } from '$lib/codemirror/types';
+
+/** Transport-independent source projection, shared by VFS and future sync hosts. */
+export interface CodeObject {
+  id: string;
+  type?: string;
+  data: Record<string, unknown>;
+}
+
+export interface ObjectCodeFile {
+  objectId: string;
+  filename: string;
+  dataKey: string;
+  language: SupportedLanguage;
+  content: string;
+}
+
+type SourceDefinition = readonly [string, string, SupportedLanguage];
+
+const definitions: Record<string, SourceDefinition> = {
+  glsl: ['code', 'shader.glsl', 'glsl'],
+  'wgpu.compute': ['code', 'shader.wgsl', 'wgsl'],
+  python: ['code', 'code.py', 'python'],
+  ruby: ['code', 'code.rb', 'ruby'],
+  peppermint: ['code', 'code.pep', 'peppermint'],
+  patchbay: ['code', 'code.patchbay', 'patchbay'],
+  asm: ['code', 'code.asm', 'assembly'],
+  uxn: ['code', 'code.tal', 'assembly'],
+  uiua: ['expr', 'code.ua', 'uiua'],
+  'chuck~': ['expr', 'code.ck', 'javascript'],
+  'csound~': ['expr', 'code.csd', 'plain']
+};
+
+for (const type of [
+  'js',
+  'p5',
+  'hydra',
+  'strudel',
+  'swgl',
+  'canvas',
+  'canvas.dom',
+  'textmode',
+  'textmode.dom',
+  'three',
+  'three.dom',
+  'dom',
+  'vue',
+  'pixi',
+  'pixi.dom',
+  'regl',
+  'shaderpark',
+  'worker',
+  'surface',
+  'dsp~',
+  'tone~',
+  'sonic~',
+  'elem~'
+]) {
+  definitions[type] = ['code', 'code.js', 'javascript'];
+}
+
+for (const type of [
+  'expr',
+  'filter',
+  'map',
+  'tap',
+  'scan',
+  'uniq',
+  'expr~',
+  'fexpr~',
+  'peek',
+  'bytebeat~'
+]) {
+  definitions[type] = ['expr', 'code.js', 'javascript'];
+}
+
+export function getObjectCodeFiles(object: CodeObject): ObjectCodeFile[] {
+  const definition = object.type ? definitions[object.type] : undefined;
+  if (!definition) return [];
+
+  const [dataKey, filename, language] = definition;
+  const content = object.data[dataKey];
+  if (typeof content !== 'string') return [];
+
+  return [{ objectId: object.id, filename, dataKey, language, content }];
+}
+
+/** Validates an existing source and returns a host-applicable data update. */
+export function editObjectCodeFile(object: CodeObject, filename: string, content: string) {
+  const file = getObjectCodeFiles(object).find((file) => file.filename === filename);
+  if (!file) throw new Error(`Object source not found: ${object.id}/${filename}`);
+
+  return { ...file, content, updates: { [file.dataKey]: content } };
+}
+
+export const getObjectCodeLanguage = (filename: string): SupportedLanguage =>
+  Object.values(definitions).find((definition) => definition[1] === filename)?.[2] ?? 'plain';

--- a/ui/src/lib/objects/object-code-files.ts
+++ b/ui/src/lib/objects/object-code-files.ts
@@ -9,6 +9,7 @@ export interface CodeObject {
 
 export interface ObjectCodeFile {
   objectId: string;
+  nodeType: string;
   filename: string;
   dataKey: string;
   language: SupportedLanguage;
@@ -75,14 +76,17 @@ for (const type of [
 }
 
 export function getObjectCodeFiles(object: CodeObject): ObjectCodeFile[] {
-  const definition = object.type ? definitions[object.type] : undefined;
+  const nodeType = object.type;
+  if (!nodeType) return [];
+
+  const definition = definitions[nodeType];
   if (!definition) return [];
 
   const [dataKey, filename, language] = definition;
   const content = object.data[dataKey];
   if (typeof content !== 'string') return [];
 
-  return [{ objectId: object.id, filename, dataKey, language, content }];
+  return [{ objectId: object.id, nodeType, filename, dataKey, language, content }];
 }
 
 /** Validates an existing source and returns a host-applicable data update. */

--- a/ui/src/lib/vfs/ObjectFileProjection.ts
+++ b/ui/src/lib/vfs/ObjectFileProjection.ts
@@ -1,0 +1,126 @@
+import {
+  getObjectCodeFiles,
+  type CodeObject,
+  type ObjectCodeFile
+} from '$lib/objects/object-code-files';
+import { VfsEntryIndex } from './VfsEntryIndex';
+import { VfsDirectoryReader } from './VfsDirectoryReader';
+
+export const isObjectPath = (path: string) => path.startsWith('obj://');
+
+export const assertMutableVfsPath = (path: string) => {
+  if (isObjectPath(path)) throw new Error('VFS: Objects only allows editing existing code');
+};
+
+export interface ObjectFileWriteOptions {
+  recordHistory?: boolean;
+  previousContent?: string;
+}
+
+/** Live graph projection; contains no persisted files or editor ownership. */
+export class ObjectFileProjection {
+  readonly entries = new VfsEntryIndex();
+  readonly reader = new VfsDirectoryReader(this.entries, () => undefined);
+
+  private files = new Map<string, ObjectCodeFile>();
+  private revision = 0;
+  private runSource?: (file: ObjectCodeFile) => void | Promise<void>;
+  private writeSource?: (
+    file: ObjectCodeFile,
+    content: string,
+    options?: ObjectFileWriteOptions
+  ) => void;
+
+  constructor(private changed: (path: string, revision: number) => void) {}
+
+  connect(
+    write: (file: ObjectCodeFile, content: string, options?: ObjectFileWriteOptions) => void,
+    run?: (file: ObjectCodeFile) => void | Promise<void>
+  ): () => void {
+    this.writeSource = write;
+    this.runSource = run;
+
+    return () => {
+      if (this.writeSource !== write) return;
+
+      this.writeSource = undefined;
+      this.runSource = undefined;
+      this.sync([]);
+    };
+  }
+
+  sync(objects: readonly CodeObject[]): void {
+    const next = new Map<string, ObjectCodeFile>(
+      objects.flatMap((object) =>
+        getObjectCodeFiles(object).map(
+          (file) => [`obj://${file.objectId}/${file.filename}`, file] as const
+        )
+      )
+    );
+
+    const paths = new Set([...this.files.keys(), ...next.keys()]);
+
+    const changes = [...paths].filter(
+      (path) => this.files.get(path)?.content !== next.get(path)?.content
+    );
+
+    if (changes.length === 0) return;
+
+    const revisions = new Map(changes.map((path) => [path, ++this.revision]));
+    const removedFolders = new Set<string>();
+
+    for (const path of changes) {
+      const file = next.get(path);
+
+      if (!file) {
+        const previous = this.files.get(path)!;
+        removedFolders.add(`obj://${previous.objectId}`);
+        this.entries.delete(path);
+        continue;
+      }
+
+      const folderPath = `obj://${file.objectId}`;
+      if (!this.entries.has(folderPath)) {
+        this.entries.set(folderPath, { provider: 'folder', filename: file.objectId });
+      }
+
+      this.entries.set(path, {
+        provider: 'object',
+        filename: file.filename,
+        mimeType: file.language === 'javascript' ? 'application/javascript' : 'text/plain',
+        size: new TextEncoder().encode(file.content).byteLength,
+        revision: revisions.get(path)
+      });
+    }
+
+    this.files = next;
+
+    for (const folder of removedFolders) {
+      if (!this.entries.hasDescendant(folder)) this.entries.delete(folder);
+    }
+
+    for (const [path, revision] of revisions) this.changed(path, revision);
+  }
+
+  get(path: string): ObjectCodeFile {
+    const file = this.files.get(path);
+    if (!file) throw new Error(`VFS: Object code file not found: ${path}`);
+
+    return file;
+  }
+
+  async run(path: string): Promise<void> {
+    const file = this.get(path);
+    if (!this.runSource) throw new Error('VFS: Object execution is unavailable');
+
+    await this.runSource(file);
+  }
+
+  write(path: string, content: string, options?: ObjectFileWriteOptions): void {
+    const file = this.get(path);
+    if (!this.writeSource) throw new Error('VFS: Object editor is unavailable');
+    if (file.content === content && options?.previousContent === undefined) return;
+
+    this.writeSource(file, content, options);
+  }
+}

--- a/ui/src/lib/vfs/ObjectFiles.test.ts
+++ b/ui/src/lib/vfs/ObjectFiles.test.ts
@@ -1,0 +1,273 @@
+import type { Node } from '@xyflow/svelte';
+import { HistoryManager } from '$lib/history';
+import { UpdateNodeDataCommand } from '$lib/history/commands/update-node-data.command';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { VirtualFilesystem } from './VirtualFilesystem';
+import { PatchFileEditorSession } from './PatchFileEditorSession';
+import {
+  getObjectCodeFiles,
+  editObjectCodeFile,
+  type CodeObject
+} from '$lib/objects/object-code-files';
+import {
+  listVfsEntries,
+  resolveVfsUrl,
+  revokeWorkerVfsObjectUrls
+} from './worker-vfs-request-handler';
+import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
+import { createVfsApi } from './user-api';
+
+const jsPath = 'obj://js-6/code.js';
+
+describe('live object files', () => {
+  let vfs: VirtualFilesystem;
+  let objects: CodeObject[];
+
+  beforeEach(() => {
+    VirtualFilesystem.resetInstance();
+    vfs = VirtualFilesystem.getInstance();
+    objects = [
+      { id: 'glsl-4', type: 'glsl', data: { code: 'void main() {}' } },
+      { id: 'js-6', type: 'js', data: { code: 'send(1)' } },
+      { id: 'slider-1', type: 'slider', data: { value: 1 } }
+    ];
+    vfs.objectFiles.connect((file, content) => {
+      objects = objects.map((object) =>
+        object.id === file.objectId
+          ? {
+              ...object,
+              data: {
+                ...object.data,
+                ...editObjectCodeFile(object, file.filename, content).updates
+              }
+            }
+          : object
+      );
+      vfs.objectFiles.sync(objects);
+    });
+    vfs.objectFiles.sync(objects);
+  });
+
+  it('lists and reads current sources through the main and worker APIs', async () => {
+    expect(await createVfsApi(() => {}).list('obj://')).toEqual([
+      { path: 'obj://glsl-4', name: 'glsl-4', kind: 'directory' },
+      { path: 'obj://js-6', name: 'js-6', kind: 'directory' }
+    ]);
+    expect(await listVfsEntries('obj://glsl-4')).toEqual({
+      entries: [{ path: 'obj://glsl-4/shader.glsl', name: 'shader.glsl', kind: 'file' }]
+    });
+
+    expect(await (await vfs.resolve(jsPath)).text()).toBe('send(1)');
+    expect(await vfs.search('shader', 'obj://')).toEqual([
+      { path: 'obj://glsl-4/shader.glsl', name: 'shader.glsl', kind: 'file' }
+    ]);
+    expect((await vfs.listChildrenPage('obj://', { limit: 1 })).nextOffset).toBe(1);
+    expect((await vfs.searchPage('code', 'obj://')).entries).toHaveLength(1);
+
+    const createUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:object-code');
+    const revokeUrl = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    expect(await resolveVfsUrl('worker-1', jsPath)).toEqual({ url: 'blob:object-code' });
+    expect(await (createUrl.mock.calls[0][0] as Blob).text()).toBe('send(1)');
+    revokeWorkerVfsObjectUrls('worker-1');
+    expect(revokeUrl).toHaveBeenCalledWith('blob:object-code');
+    vi.restoreAllMocks();
+  });
+
+  it('reads object text with the public fluent get API', async () => {
+    vi.stubGlobal('window', {});
+    const urls: string[] = [];
+
+    try {
+      const api = createVfsApi((url) => urls.push(url));
+      expect(await api.get(jsPath).text()).toBe('send(1)');
+    } finally {
+      urls.forEach((url) => URL.revokeObjectURL(url));
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('writes typing immediately to original fields and synchronizes external edits and deletion', () => {
+    const editor = new PatchFileEditorSession(vfs);
+    editor.open(jsPath);
+    editor.updateDraft('send(2)');
+
+    expect(vfs.readCodeFile(jsPath)).toBe('send(2)');
+    expect(objects[1].data.code).toBe('send(2)');
+    expect(editor.save()).toBe(true);
+    expect(objects[1].data.code).toBe('send(2)');
+    expect(editor.isDirty).toBe(false);
+
+    objects[1].data.code = 'send(3)';
+    vfs.objectFiles.sync(objects);
+    expect(editor.syncSavedContent()).toBe('updated');
+    expect(editor.draft).toBe('send(3)');
+
+    editor.updateDraft('local draft');
+    objects[1].data.code = 'external edit';
+    vfs.objectFiles.sync(objects);
+    expect(editor.syncSavedContent()).toBe('updated');
+    expect(editor.draft).toBe('external edit');
+
+    editor.discard();
+    editor.syncSavedContent();
+    vfs.objectFiles.sync([]);
+    expect(editor.syncSavedContent()).toBe('deleted');
+    expect(() => vfs.writeCodeFile(jsPath, 'cannot recreate')).toThrow();
+    expect(get(vfs.entries$).size).toBe(0);
+  });
+
+  it('closes safely if the object disappears during live editing', () => {
+    const editor = new PatchFileEditorSession(vfs);
+    editor.open(jsPath);
+    editor.updateDraft('live edit');
+    vfs.objectFiles.sync([]);
+
+    expect(() => editor.close()).not.toThrow();
+    expect(editor.isOpen).toBe(false);
+    expect(vfs.has(jsPath)).toBe(false);
+  });
+
+  it('refreshes cached object editors when reopened', () => {
+    const editor = new PatchFileEditorSession(vfs);
+    editor.open(jsPath);
+    editor.close();
+
+    objects[1].data.code = 'changed while closed';
+    vfs.objectFiles.sync(objects);
+    editor.open(jsPath);
+    expect(editor.draft).toBe('changed while closed');
+    expect(editor.isDirty).toBe(false);
+  });
+
+  it('saves the latest document before Run and reruns unchanged code', async () => {
+    const run = vi.fn((file) => {
+      expect(file.content).toBe('latest document');
+      expect(objects[1].data.code).toBe('latest document');
+    });
+    vfs.objectFiles.connect((file, content) => {
+      objects[1].data[file.dataKey] = content;
+      vfs.objectFiles.sync(objects);
+    }, run);
+    const editor = new PatchFileEditorSession(vfs);
+    editor.open(jsPath);
+    editor.updateDraft('older draft');
+    expect(objects[1].data.code).toBe('older draft');
+    expect(run).not.toHaveBeenCalled();
+
+    await editor.run('latest document');
+    await editor.run();
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(editor.isDirty).toBe(false);
+
+    editor.updateDraft('save only');
+    editor.save();
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps stable revisions for unrelated graph updates and emits changes on undo-like updates', () => {
+    const events: string[] = [];
+    const listener = (event: { path: string }) => events.push(event.path);
+    const bus = PatchiesEventBus.getInstance();
+    bus.addEventListener('vfsContentModified', listener);
+    const revision = vfs.getEntry(jsPath)?.revision;
+
+    objects[2].data.value = 2;
+    vfs.objectFiles.sync(objects);
+    expect(vfs.getEntry(jsPath)?.revision).toBe(revision);
+    expect(events).toEqual([]);
+
+    vfs.writeCodeFile(jsPath, 'new code');
+    objects[1].data.code = 'send(1)';
+    vfs.objectFiles.sync(objects);
+    expect(events).toEqual([jsPath, jsPath]);
+    expect(vfs.readCodeFile(jsPath)).toBe('send(1)');
+    bus.removeEventListener('vfsContentModified', listener);
+  });
+
+  it('groups live typing into one node undo step and propagates undo and redo', () => {
+    const history = HistoryManager.getInstance();
+    history.clear();
+    let nodes: Node[] = objects.map((object) => ({ ...object, position: { x: 0, y: 0 } }));
+    const accessors = {
+      getNodes: () => nodes,
+      setNodes: (next: Node[]) => {
+        nodes = next;
+        vfs.objectFiles.sync(nodes);
+      },
+      getEdges: () => [],
+      setEdges: () => {}
+    };
+    vfs.objectFiles.connect((file, content, options) => {
+      const command = new UpdateNodeDataCommand(
+        file.objectId,
+        file.dataKey,
+        options?.previousContent ?? file.content,
+        content,
+        accessors
+      );
+      command.execute();
+      if (options?.recordHistory !== false) history.record(command);
+    });
+    const editor = new PatchFileEditorSession(vfs);
+    editor.open(jsPath);
+    editor.updateDraft('send(');
+    editor.updateDraft('send(2');
+    editor.updateDraft('send(2)');
+    expect(nodes[1].data.code).toBe('send(2)');
+    expect(history.canUndo()).toBe(false);
+
+    expect(editor.undoDraft()).toBe(true);
+    expect(editor.draft).toBe('send(1)');
+    expect(nodes[1].data.code).toBe('send(1)');
+
+    expect(editor.redoDraft()).toBe(true);
+    expect(editor.draft).toBe('send(2)');
+    expect(nodes[1].data.code).toBe('send(2)');
+    history.clear();
+  });
+
+  it('rejects structural mutations atomically, including import and upload destinations', async () => {
+    vfs.createEmbeddedFile('patch://keep.js', 'keep');
+    const file = new File(['new'], 'new.js');
+
+    expect(() => vfs.createFolder('obj://js-6', 'folder')).toThrow();
+    expect(() =>
+      vfs.registerEntry('obj://new.js', { provider: 'local', filename: 'new.js' })
+    ).toThrow();
+    expect(() => vfs.createEmbeddedFile('obj://new.js')).toThrow();
+    expect(() => vfs.renamePath(jsPath, 'obj://js-6/new.js')).toThrow();
+    expect(() => vfs.renamePath('patch://keep.js', jsPath)).toThrow();
+    expect(() => vfs.deletePaths(['patch://keep.js', jsPath])).toThrow();
+    expect(() => vfs.remove(jsPath)).toThrow();
+
+    await expect(vfs.storeFile(file, undefined, 'obj://js-6')).rejects.toThrow();
+    await expect(vfs.registerUrl('https://example.com/new.js', 'obj://')).rejects.toThrow();
+    await expect(vfs.replaceFile(jsPath, file)).rejects.toThrow();
+    await expect(vfs.importToPatch([file], 'obj://')).rejects.toThrow();
+    expect(vfs.readEmbeddedFile('patch://keep.js')).toBe('keep');
+    expect(vfs.readCodeFile(jsPath)).toBe('send(1)');
+    expect(vfs.serialize()).not.toHaveProperty('obj');
+    expect(vfs.serialize()).not.toHaveProperty('objects');
+  });
+
+  it('provides reusable source descriptors and validated edits without VFS', () => {
+    const object = { id: 'uiua-1', type: 'uiua', data: { expr: '1 2 +' } };
+    expect(getObjectCodeFiles(object)).toEqual([
+      {
+        objectId: 'uiua-1',
+        filename: 'code.ua',
+        dataKey: 'expr',
+        language: 'uiua',
+        content: '1 2 +'
+      }
+    ]);
+    expect(editObjectCodeFile(object, 'code.ua', '3').updates).toEqual({ expr: '3' });
+    expect(object.data.expr).toBe('1 2 +');
+    expect(() => editObjectCodeFile(object, 'other.ua', '3')).toThrow();
+    expect(
+      getObjectCodeFiles({ id: 'module-1', type: 'js.module', data: { vfsPath: 'patch://a.js' } })
+    ).toEqual([]);
+  });
+});

--- a/ui/src/lib/vfs/ObjectFiles.test.ts
+++ b/ui/src/lib/vfs/ObjectFiles.test.ts
@@ -17,6 +17,10 @@ import {
 } from './worker-vfs-request-handler';
 import { PatchiesEventBus } from '$lib/eventbus/PatchiesEventBus';
 import { createVfsApi } from './user-api';
+import {
+  shouldRunOnValueWidgetChange,
+  valueWidgetRunThrottleMs
+} from '$lib/codemirror/value-widget-events';
 
 const jsPath = 'obj://js-6/code.js';
 
@@ -27,11 +31,13 @@ describe('live object files', () => {
   beforeEach(() => {
     VirtualFilesystem.resetInstance();
     vfs = VirtualFilesystem.getInstance();
+
     objects = [
       { id: 'glsl-4', type: 'glsl', data: { code: 'void main() {}' } },
       { id: 'js-6', type: 'js', data: { code: 'send(1)' } },
       { id: 'slider-1', type: 'slider', data: { value: 1 } }
     ];
+
     vfs.objectFiles.connect((file, content) => {
       objects = objects.map((object) =>
         object.id === file.objectId
@@ -44,8 +50,10 @@ describe('live object files', () => {
             }
           : object
       );
+
       vfs.objectFiles.sync(objects);
     });
+
     vfs.objectFiles.sync(objects);
   });
 
@@ -54,6 +62,7 @@ describe('live object files', () => {
       { path: 'obj://glsl-4', name: 'glsl-4', kind: 'directory' },
       { path: 'obj://js-6', name: 'js-6', kind: 'directory' }
     ]);
+
     expect(await listVfsEntries('obj://glsl-4')).toEqual({
       entries: [{ path: 'obj://glsl-4/shader.glsl', name: 'shader.glsl', kind: 'file' }]
     });
@@ -62,6 +71,7 @@ describe('live object files', () => {
     expect(await vfs.search('shader', 'obj://')).toEqual([
       { path: 'obj://glsl-4/shader.glsl', name: 'shader.glsl', kind: 'file' }
     ]);
+
     expect((await vfs.listChildrenPage('obj://', { limit: 1 })).nextOffset).toBe(1);
     expect((await vfs.searchPage('code', 'obj://')).entries).toHaveLength(1);
 
@@ -70,8 +80,10 @@ describe('live object files', () => {
 
     expect(await resolveVfsUrl('worker-1', jsPath)).toEqual({ url: 'blob:object-code' });
     expect(await (createUrl.mock.calls[0][0] as Blob).text()).toBe('send(1)');
+
     revokeWorkerVfsObjectUrls('worker-1');
     expect(revokeUrl).toHaveBeenCalledWith('blob:object-code');
+
     vi.restoreAllMocks();
   });
 
@@ -141,28 +153,61 @@ describe('live object files', () => {
     expect(editor.isDirty).toBe(false);
   });
 
+  it('preserves Hydra widget reruns for Objects files', async () => {
+    const path = 'obj://hydra-1/code.js';
+    const object = { id: 'hydra-1', type: 'hydra', data: { code: 'osc(10).out()' } };
+    const run = vi.fn();
+
+    vfs.objectFiles.connect((file, content) => {
+      object.data.code = content;
+      vfs.objectFiles.sync([object]);
+    }, run);
+
+    vfs.objectFiles.sync([object]);
+
+    const file = vfs.objectFiles.get(path);
+    expect(file.nodeType).toBe('hydra');
+    expect(shouldRunOnValueWidgetChange(file.language, file.nodeType)).toBe(true);
+    expect(valueWidgetRunThrottleMs(file.language, file.nodeType)).toBe(30);
+
+    const editor = new PatchFileEditorSession(vfs);
+    editor.open(path);
+
+    await editor.run('osc(20).out()');
+    expect(object.data.code).toBe('osc(20).out()');
+
+    expect(run).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ nodeType: 'hydra', content: 'osc(20).out()' })
+    );
+  });
+
   it('saves the latest document before Run and reruns unchanged code', async () => {
     const run = vi.fn((file) => {
       expect(file.content).toBe('latest document');
       expect(objects[1].data.code).toBe('latest document');
     });
+
     vfs.objectFiles.connect((file, content) => {
       objects[1].data[file.dataKey] = content;
       vfs.objectFiles.sync(objects);
     }, run);
+
     const editor = new PatchFileEditorSession(vfs);
     editor.open(jsPath);
     editor.updateDraft('older draft');
+
     expect(objects[1].data.code).toBe('older draft');
     expect(run).not.toHaveBeenCalled();
 
     await editor.run('latest document');
     await editor.run();
+
     expect(run).toHaveBeenCalledTimes(2);
     expect(editor.isDirty).toBe(false);
 
     editor.updateDraft('save only');
     editor.save();
+
     expect(run).toHaveBeenCalledTimes(2);
   });
 
@@ -170,6 +215,7 @@ describe('live object files', () => {
     const events: string[] = [];
     const listener = (event: { path: string }) => events.push(event.path);
     const bus = PatchiesEventBus.getInstance();
+
     bus.addEventListener('vfsContentModified', listener);
     const revision = vfs.getEntry(jsPath)?.revision;
 
@@ -257,6 +303,7 @@ describe('live object files', () => {
     expect(getObjectCodeFiles(object)).toEqual([
       {
         objectId: 'uiua-1',
+        nodeType: 'uiua',
         filename: 'code.ua',
         dataKey: 'expr',
         language: 'uiua',

--- a/ui/src/lib/vfs/PatchFileEditorSession.ts
+++ b/ui/src/lib/vfs/PatchFileEditorSession.ts
@@ -1,12 +1,14 @@
+import { HistoryManager } from '$lib/history';
+import { isObjectPath } from './ObjectFileProjection';
 import type { VirtualFilesystem } from './VirtualFilesystem';
-import { isEditablePatchCodePath } from './patch-file-editor';
+import { isEditableCodePath } from './patch-file-editor';
 
 export type UnsavedChangesDecision = 'save' | 'discard' | 'cancel';
 
 export const isEditorSaveShortcut = (event: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey'>) =>
   event.key.toLowerCase() === 's' && (event.metaKey || event.ctrlKey);
 
-/** Owns one Patch-file draft and keeps unsaved content outside the VFS. */
+/** Owns Patch-file drafts and live object-source editing gestures. */
 export class PatchFileEditorSession {
   private pathValue: string | null = null;
   private listeners = new Set<() => void>();
@@ -40,14 +42,14 @@ export class PatchFileEditorSession {
   }
 
   open(path: string): void {
-    if (!isEditablePatchCodePath(path)) {
-      throw new Error(`VFS: Patch code file is not editable: ${path}`);
+    if (!isEditableCodePath(path)) {
+      throw new Error(`VFS: Code file is not editable: ${path}`);
     }
 
     this.pathValue = path;
 
     if (!this.states().has(path)) {
-      const savedContent = this.vfs.readEmbeddedFile(path);
+      const savedContent = this.vfs.readCodeFile(path);
       this.states().set(path, {
         savedContent,
         draft: savedContent,
@@ -55,13 +57,34 @@ export class PatchFileEditorSession {
         draftUndoStack: [],
         draftRedoStack: []
       });
+    } else {
+      this.syncSavedContent();
+    }
+  }
+
+  async run(content = this.draft): Promise<void> {
+    this.updateDraft(content);
+    this.save();
+
+    if (this.pathValue && isObjectPath(this.pathValue)) {
+      await this.vfs.objectFiles.run(this.pathValue);
     }
   }
 
   updateDraft(content: string): void {
     const state = this.getState();
-    if (!state) throw new Error('VFS: No Patch file is open');
+    if (!state) throw new Error('VFS: No code file is open');
     if (state.draft === content) return;
+
+    if (this.pathValue && isObjectPath(this.pathValue)) {
+      state.editStart ??= state.savedContent;
+      this.vfs.objectFiles.write(this.pathValue, content, { recordHistory: false });
+      state.savedContent = content;
+      state.draft = content;
+      state.revision = this.vfs.getEntry(this.pathValue)?.revision ?? state.revision;
+      this.notify();
+      return;
+    }
 
     state.draftUndoStack.push(state.draft);
     state.draftRedoStack = [];
@@ -72,9 +95,27 @@ export class PatchFileEditorSession {
   save(): boolean {
     const path = this.pathValue;
     const state = this.getState();
-    if (!path || !state || !this.isDirty) return false;
+    if (!path || !state) return false;
 
-    this.vfs.writeEmbeddedFile(path, state.draft);
+    if (isObjectPath(path)) {
+      const previousContent = state.editStart;
+      if (
+        !this.vfs.has(path) ||
+        previousContent === undefined ||
+        previousContent === state.savedContent
+      ) {
+        state.editStart = undefined;
+        return false;
+      }
+
+      this.vfs.objectFiles.write(path, state.savedContent, { previousContent });
+      state.editStart = undefined;
+      return true;
+    }
+
+    if (!this.isDirty) return false;
+
+    this.vfs.writeCodeFile(path, state.draft);
     state.savedContent = state.draft;
     state.revision = this.vfs.getEntry(path)?.revision ?? state.revision + 1;
     this.notify();
@@ -93,6 +134,8 @@ export class PatchFileEditorSession {
   }
 
   close(): void {
+    if (this.pathValue && isObjectPath(this.pathValue)) this.save();
+
     this.pathValue = null;
     this.notify();
   }
@@ -123,18 +166,19 @@ export class PatchFileEditorSession {
 
     const entry = this.vfs.getEntry(path);
     if (!entry) {
-      if (this.isDirty) return 'conflict';
+      if (this.isDirty && !isObjectPath(path)) return 'conflict';
 
       this.states().delete(path);
       return 'deleted';
     }
 
-    const nextContent = this.vfs.readEmbeddedFile(path);
+    const nextContent = this.vfs.readCodeFile(path);
     const nextRevision = entry.revision ?? 0;
 
     if (nextContent === state.savedContent && nextRevision === state.revision) return 'unchanged';
-    if (this.isDirty) return 'conflict';
+    if (this.isDirty && !isObjectPath(path)) return 'conflict';
 
+    state.editStart = undefined;
     state.savedContent = nextContent;
     state.draft = nextContent;
     state.revision = nextRevision;
@@ -146,6 +190,13 @@ export class PatchFileEditorSession {
   }
 
   undoDraft(): boolean {
+    if (this.pathValue && isObjectPath(this.pathValue)) {
+      this.save();
+      const undone = HistoryManager.getInstance().undo() !== null;
+      this.syncSavedContent();
+      return undone;
+    }
+
     const state = this.getState();
     const previous = state?.draftUndoStack.pop();
     if (!state || previous === undefined) return false;
@@ -158,6 +209,12 @@ export class PatchFileEditorSession {
   }
 
   redoDraft(): boolean {
+    if (this.pathValue && isObjectPath(this.pathValue)) {
+      const redone = HistoryManager.getInstance().redo() !== null;
+      this.syncSavedContent();
+      return redone;
+    }
+
     const state = this.getState();
     const next = state?.draftRedoStack.pop();
     if (!state || next === undefined) return false;
@@ -192,6 +249,7 @@ type PatchFileEditorState = {
   savedContent: string;
   draft: string;
   revision: number;
+  editStart?: string;
   draftUndoStack: string[];
   draftRedoStack: string[];
 };

--- a/ui/src/lib/vfs/VirtualFilesystem.test.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.test.ts
@@ -52,13 +52,9 @@ describe('VirtualFilesystem patch files', () => {
   it('keeps object files runtime-only during serialization and hydration', async () => {
     const vfs = VirtualFilesystem.getInstance();
 
-    vfs.registerEntry('obj://script-1/source.js', {
-      provider: 'url',
-      filename: 'source.js',
-      url: '/source.js'
-    });
+    vfs.objectFiles.sync([{ id: 'script-1', type: 'js', data: { code: 'source' } }]);
 
-    expect(vfs.getEntry('obj://script-1/source.js')).toBeDefined();
+    expect(vfs.getEntry('obj://script-1/code.js')).toBeDefined();
     expect(vfs.serialize()).toEqual({});
 
     await vfs.hydrate({

--- a/ui/src/lib/vfs/VirtualFilesystem.ts
+++ b/ui/src/lib/vfs/VirtualFilesystem.ts
@@ -1,3 +1,4 @@
+import { ObjectFileProjection, isObjectPath, assertMutableVfsPath } from './ObjectFileProjection';
 // Virtual Filesystem Singleton
 
 import { match } from 'ts-pattern';
@@ -46,6 +47,11 @@ declare global {
 /** Stable public façade for virtual file operations and provider coordination. */
 export class VirtualFilesystem {
   private static instance: VirtualFilesystem | null = null;
+
+  readonly objectFiles = new ObjectFileProjection((path, revision) => {
+    this.notifyChange();
+    this.emitContentModified(path, revision);
+  });
 
   private entries = new VfsEntryIndex();
   private providers = new Map<string, VFSProvider>();
@@ -109,6 +115,8 @@ export class VirtualFilesystem {
   }
 
   registerEntry(path: string, entry: VFSEntry): void {
+    assertMutableVfsPath(path);
+
     this.patchFiles.validateEntry(path, entry);
     this.entries.set(path, entry);
     this.notifyChange();
@@ -130,13 +138,20 @@ export class VirtualFilesystem {
     return this.patchFiles.read(path);
   }
 
-  exportEmbeddedFile(path: string): File {
-    return this.patchFiles.export(path);
+  readCodeFile(path: string): string {
+    return isObjectPath(path) ? this.objectFiles.get(path).content : this.readEmbeddedFile(path);
   }
 
-  /** @deprecated Use storeFile() instead for clarity. */
-  async registerLocalFile(file: File): Promise<string> {
-    return this.storeFile(file);
+  writeCodeFile(path: string, content: string): void {
+    if (isObjectPath(path)) {
+      this.objectFiles.write(path, content);
+    } else {
+      this.writeEmbeddedFile(path, content);
+    }
+  }
+
+  exportEmbeddedFile(path: string): File {
+    return this.patchFiles.export(path);
   }
 
   async storeFile(
@@ -144,17 +159,21 @@ export class VirtualFilesystem {
     handle?: FileSystemFileHandle,
     targetFolder?: string
   ): Promise<string> {
+    assertMutableVfsPath(targetFolder ?? VFS_PREFIXES.USER);
+
     const path = generateUserPath(file.name, file.type, new Set(this.entries.keys()), targetFolder);
+
+    const isMedia =
+      file.type?.startsWith('audio/') ||
+      file.type?.startsWith('video/') ||
+      file.type?.startsWith('image/');
+
+    const mimeType = isMedia ? file.type : (guessMimeType(file.name) ?? file.type);
 
     const entry: VFSEntry = {
       provider: 'local',
       filename: file.name,
-      mimeType:
-        file.type?.startsWith('audio/') ||
-        file.type?.startsWith('video/') ||
-        file.type?.startsWith('image/')
-          ? file.type
-          : (guessMimeType(file.name) ?? file.type),
+      mimeType,
       size: file.size
     };
 
@@ -186,6 +205,8 @@ export class VirtualFilesystem {
   }
 
   async replaceFile(path: string, file: File, handle?: FileSystemFileHandle): Promise<void> {
+    assertMutableVfsPath(path);
+
     const entry = this.entries.get(path);
     if (!entry) {
       throw new Error(`VFS: Cannot replace file at non-existent path: ${path}`);
@@ -250,6 +271,8 @@ export class VirtualFilesystem {
   }
 
   async registerUrl(url: string, targetFolder?: string): Promise<string> {
+    assertMutableVfsPath(targetFolder ?? VFS_PREFIXES.USER);
+
     const filename = getFilenameFromUrl(url);
     const mimeType = guessMimeType(filename);
     const path = generateUserPath(filename, mimeType, new Set(this.entries.keys()), targetFolder);
@@ -270,6 +293,8 @@ export class VirtualFilesystem {
   }
 
   createFolder(parentPath: string, folderName: string): string {
+    assertMutableVfsPath(parentPath);
+
     const normalizedParent =
       parentPath.endsWith('/') && !parentPath.endsWith('://')
         ? parentPath.slice(0, -1)
@@ -288,12 +313,15 @@ export class VirtualFilesystem {
   }
 
   isFolder(path: string): boolean {
-    const provider = this.entries.get(path)?.provider;
+    const provider = this.getEntry(path)?.provider;
 
     return provider === 'folder' || provider === 'local-folder';
   }
 
   renamePath(oldPath: string, newPath: string): void {
+    assertMutableVfsPath(oldPath);
+    assertMutableVfsPath(newPath);
+
     const plan = this.entries.planRename(oldPath, newPath);
     const renamedPaths = new Map(plan.moves.map((move) => [move.oldPath, move.newPath]));
     const mirrorsBefore = VfsCanvasMirrors.snapshot();
@@ -303,13 +331,17 @@ export class VirtualFilesystem {
       if (!isEmbeddedVFSEntry(entry) || !/\.m?js$/.test(path)) continue;
 
       const nextPath = renamedPaths.get(path) ?? path;
+
       const content = rewriteJavaScriptModuleSpecifiers(
         entry.content,
         path,
         nextPath,
         renamedPaths
       );
-      if (content !== entry.content) rewrittenModules.set(nextPath, content);
+
+      if (content !== entry.content) {
+        rewrittenModules.set(nextPath, content);
+      }
     }
 
     const persist = (direction: 'forward' | 'backward') =>
@@ -333,6 +365,7 @@ export class VirtualFilesystem {
             size: new TextEncoder().encode(content).byteLength,
             revision: (entry.revision ?? 0) + 1
           } as typeof entry);
+
           this.emitContentModified(path, (entry.revision ?? 0) + 1);
         }
 
@@ -360,7 +393,10 @@ export class VirtualFilesystem {
   }
 
   deletePaths(requestedPaths: Iterable<string>): void {
-    const plan = this.entries.planDelete(requestedPaths);
+    const paths = [...requestedPaths];
+    paths.forEach(assertMutableVfsPath);
+
+    const plan = this.entries.planDelete(paths);
     if (plan.paths.length === 0) return;
     const mirrorsBefore = VfsCanvasMirrors.snapshot();
 
@@ -477,13 +513,22 @@ export class VirtualFilesystem {
     }
 
     entry.filename = handle.name;
+
     await this.getLocalProvider()?.storeDirHandle(path, handle);
+
     this.permissions.delete(path);
     this.notifyChange();
   }
 
   async resolve(path: string): Promise<File | Blob> {
+    if (isObjectPath(path)) {
+      const file = this.objectFiles.get(path);
+
+      return new File([file.content], file.filename, { type: this.getEntry(path)?.mimeType });
+    }
+
     const entry = this.entries.get(path);
+
     if (entry) {
       if (isEmbeddedVFSEntry(entry)) this.patchFiles.assertReadable(path);
 
@@ -509,15 +554,17 @@ export class VirtualFilesystem {
   }
 
   getEntryOrLinkedFile(path: string): VFSEntry | undefined {
-    return this.directoryReader.getEntry(path);
+    return isObjectPath(path)
+      ? this.objectFiles.reader.getEntry(path)
+      : this.directoryReader.getEntry(path);
   }
 
   getEntry(path: string): VFSEntry | undefined {
-    return this.entries.get(path);
+    return isObjectPath(path) ? this.objectFiles.entries.get(path) : this.entries.get(path);
   }
 
   has(path: string): boolean {
-    return this.entries.has(path);
+    return isObjectPath(path) ? this.objectFiles.entries.has(path) : this.entries.has(path);
   }
 
   isVFSPath(path: string): boolean {
@@ -525,22 +572,26 @@ export class VirtualFilesystem {
   }
 
   list(prefix?: string): string[] {
-    return this.entries.paths(prefix);
+    return [...this.entries.paths(prefix), ...this.objectFiles.entries.paths(prefix)];
+  }
+
+  getDirectoryReader(directory: string) {
+    return isObjectPath(directory) ? this.objectFiles.reader : this.directoryReader;
   }
 
   async listChildren(directory: string): Promise<VFSListEntry[]> {
-    return this.directoryReader.listChildren(directory);
+    return this.getDirectoryReader(directory).listChildren(directory);
   }
 
   async listChildrenPage(
     directory: string,
     options: { offset?: number; limit?: number } = {}
   ): Promise<VFSListPage> {
-    return this.directoryReader.listChildrenPage(directory, options);
+    return this.getDirectoryReader(directory).listChildrenPage(directory, options);
   }
 
   async search(query: string, directory: string): Promise<VFSListEntry[]> {
-    return this.directoryReader.search(query, directory);
+    return this.getDirectoryReader(directory).search(query, directory);
   }
 
   async searchPage(
@@ -548,11 +599,11 @@ export class VirtualFilesystem {
     directory: string,
     options: { offset?: number; limit?: number } = {}
   ): Promise<VFSSearchPage> {
-    return this.directoryReader.searchPage(query, directory, options);
+    return this.getDirectoryReader(directory).searchPage(query, directory, options);
   }
 
   getAllEntries(): Map<string, VFSEntry> {
-    return this.entries.toMap();
+    return new Map([...this.entries, ...this.objectFiles.entries]);
   }
 
   serialize(): VFSTree {
@@ -592,6 +643,8 @@ export class VirtualFilesystem {
   }
 
   remove(path: string): void {
+    assertMutableVfsPath(path);
+
     const entry = this.entries.get(path);
     const deletionRevision =
       entry && isEmbeddedVFSEntry(entry) ? (entry.revision ?? 0) + 1 : undefined;
@@ -750,6 +803,7 @@ const relativePath = (from: string, to: string): string => {
     .replace(/^[a-z]+:\/\//, '')
     .split('/')
     .slice(0, -1);
+
   const toParts = to.replace(/^[a-z]+:\/\//, '').split('/');
 
   while (fromParts[0] && fromParts[0] === toParts[0]) {
@@ -764,7 +818,10 @@ const relativePath = (from: string, to: string): string => {
 };
 
 const resolveModuleSpecifier = (specifier: string, importer: string): string | null => {
-  if (specifier.startsWith('patch://')) return withJavaScriptExtension(specifier);
+  if (specifier.startsWith('patch://')) {
+    return withJavaScriptExtension(specifier);
+  }
+
   if (
     specifier.startsWith('user://') ||
     specifier.startsWith('npm:') ||
@@ -779,8 +836,12 @@ const resolveModuleSpecifier = (specifier: string, importer: string): string | n
 
     for (const part of specifier.split('/')) {
       if (!part || part === '.') continue;
-      if (part === '..') parts.pop();
-      else parts.push(part);
+
+      if (part === '..') {
+        parts.pop();
+      } else {
+        parts.push(part);
+      }
     }
 
     return `${namespace}://${withJavaScriptExtension(parts.join('/'))}`;
@@ -807,22 +868,34 @@ const rewriteJavaScriptModuleSpecifiers = (
     .map(({ specifier, start, end }) => {
       const resolved = resolveModuleSpecifier(specifier, oldImporter);
       const renamed = resolved && renamedPaths.get(resolved);
+
       if (specifier.startsWith('./') || specifier.startsWith('../')) {
         if (!resolved) return null;
 
         const relative = relativePath(newImporter, renamed ?? resolved);
         const hadExtension = /\.m?js$/.test(specifier);
 
-        return { start, end, value: hadExtension ? relative : relative.replace(/\.js$/, '') };
+        return {
+          start,
+          end,
+          value: hadExtension ? relative : relative.replace(/\.js$/, '')
+        };
       }
 
       if (!renamed) return null;
-      if (specifier.startsWith('patch://')) return { start, end, value: renamed };
+
+      if (specifier.startsWith('patch://')) {
+        return { start, end, value: renamed };
+      }
 
       const root = renamed.slice('patch://'.length);
       const hadExtension = /\.m?js$/.test(specifier);
 
-      return { start, end, value: hadExtension ? root : root.replace(/\.js$/, '') };
+      return {
+        start,
+        end,
+        value: hadExtension ? root : root.replace(/\.js$/, '')
+      };
     })
     .filter(
       (replacement): replacement is { start: number; end: number; value: string } => !!replacement

--- a/ui/src/lib/vfs/patch-file-editor.ts
+++ b/ui/src/lib/vfs/patch-file-editor.ts
@@ -1,3 +1,4 @@
+import { getObjectCodeLanguage } from '$lib/objects/object-code-files';
 import type { SupportedLanguage } from '$lib/codemirror/types';
 
 const PATCH_GLSL_PATTERN = /^patch:\/\/.+\.(?:gl|glsl|frag|vert|glslf|glslv)$/;
@@ -10,4 +11,11 @@ export const isEditablePatchCodePath = (path: string): boolean =>
   PATCH_GLSL_PATTERN.test(path) || isEditablePatchJavaScriptPath(path);
 
 export const getPatchFileEditorLanguage = (path: string): SupportedLanguage =>
-  isEditablePatchJavaScriptPath(path) ? 'javascript' : 'glsl';
+  path.startsWith('obj://')
+    ? getObjectCodeLanguage(path.split('/').pop() ?? '')
+    : isEditablePatchJavaScriptPath(path)
+      ? 'javascript'
+      : 'glsl';
+
+export const isEditableCodePath = (path: string): boolean =>
+  isEditablePatchCodePath(path) || /^obj:\/\/[^/]+\/[^/]+$/.test(path);

--- a/ui/src/lib/vfs/types.ts
+++ b/ui/src/lib/vfs/types.ts
@@ -1,6 +1,6 @@
 // Virtual Filesystem Types
 
-export type VFSProviderType = 'url' | 'local' | 'folder' | 'local-folder' | 'embedded';
+export type VFSProviderType = 'url' | 'local' | 'folder' | 'local-folder' | 'embedded' | 'object';
 
 /**
  * Entry metadata stored in the VFS tree.


### PR DESCRIPTION
Expose existing object source files through `obj://` and an always-visible Objects root in Files, for example `obj://glsl-4/shader.glsl` and `obj://js-6/code.js`.

- Add reusable object source descriptors independent of VFS storage for future remote sync.
- Support listing, reading, searching, and editing existing source. Reject creation, uploads, renaming, moving, replacement, and deletion within Objects.
- Refresh open and cached editors when object code changes, and save edits through normal node undo history. Shift+Enter saves and runs the owning object; Cmd/Ctrl+S only saves.
- Keep object files derived from graph state rather than serializing a second copy in the patch.

Validation: the implementation task reported 205 passing VFS/CodeMirror tests, a clean typecheck, and targeted lint. PR creation also verified diff whitespace hygiene; those checks were not rerun here.

Current limitation: typing in Files remains a local draft until Save or Run. Immediate propagation from Files to the main object editor is a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Object code files are available through a live `obj://` namespace.
  - View, edit, save, and run object source files directly from the file tree and editor.
  - Object source files stay synchronized with canvas changes and external edits.
  - Objects and existing source files are always visible in the file tree.
  - Shift+Enter saves and runs object code; Cmd/Ctrl+S saves only.
- **Bug Fixes**
  - Improved editor synchronization prevents external updates from being treated as user edits.
  - Structural changes to object files are prevented while preserving source editing.
- **Breaking Changes**
  - Removed the deprecated local-file registration API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->